### PR TITLE
Fix missing triggered layouts

### DIFF
--- a/src/Whim/ConfigContext/ConfigContext.cs
+++ b/src/Whim/ConfigContext/ConfigContext.cs
@@ -39,6 +39,7 @@ public class ConfigContext : IConfigContext
 	public void Initialize()
 	{
 		Logger.Debug("Initializing config context...");
+		MonitorManager.Initialize();
 		WindowManager.Initialize();
 		WorkspaceManager.Initialize();
 		KeybindManager.Initialize();

--- a/src/Whim/Monitor/IMonitorManager.cs
+++ b/src/Whim/Monitor/IMonitorManager.cs
@@ -19,6 +19,11 @@ public interface IMonitorManager : IEnumerable<IMonitor>, ICommandable, IDisposa
 	public IMonitor FocusedMonitor { get; }
 
 	/// <summary>
+	/// Initialize the windows event hooks.
+	/// </summary>
+	public void Initialize();
+
+	/// <summary>
 	/// Returns the <see cref="IMonitor"/> at the given <i>x</i> and <i>y</i> coordinates.
 	/// </summary>
 	/// <param name="x"></param>

--- a/src/Whim/Monitor/MonitorManager.cs
+++ b/src/Whim/Monitor/MonitorManager.cs
@@ -62,6 +62,21 @@ public class MonitorManager : IMonitorManager
 		SystemEvents.DisplaySettingsChanging += SystemEvents_DisplaySettingsChanging;
 	}
 
+	public void Initialize()
+	{
+		_configContext.WindowManager.WindowFocused += WindowManager_WindowFocused;
+	}
+
+	public void WindowManager_WindowFocused(object? sender, WindowEventArgs e)
+	{
+		IMonitor? monitor = _configContext.WorkspaceManager.GetMonitorForWindow(e.Window);
+
+		if (monitor != null)
+		{
+			FocusedMonitor = monitor;
+		}
+	}
+
 	private void SystemEvents_DisplaySettingsChanging(object? sender, EventArgs e)
 	{
 		// Get the new monitors.

--- a/src/Whim/Window/IWindowManager.cs
+++ b/src/Whim/Window/IWindowManager.cs
@@ -10,10 +10,7 @@ public interface IWindowManager : ICommandable, IDisposable
 	/// <summary>
 	/// Initialize the windows event hooks.
 	/// </summary>
-	/// <returns>
-	/// <see langword="true"/> when the hooks have all been registered successfully, otherwise
-	/// <see langword="false"/>
-	/// </returns>
+	/// <returns></returns>
 	public void Initialize();
 
 	/// <summary>

--- a/src/Whim/Window/WindowManager.cs
+++ b/src/Whim/Window/WindowManager.cs
@@ -140,18 +140,18 @@ public class WindowManager : IWindowManager
 	/// <param name="dwmsEventTime"></param>
 	private void WindowsEventHook(HWINEVENTHOOK hWinEventHook, uint eventType, HWND hwnd, int idObject, int idChild, uint idEventThread, uint dwmsEventTime)
 	{
-		if (!IsEventWindowValid(idChild, idObject, hwnd)
-			|| Win32Helper.IsSplashScreen(hwnd)
-			|| !Win32Helper.IsStandardWindow(hwnd)
-			|| !Win32Helper.HasNoVisibleOwner(hwnd))
-		{
-			return;
-		}
+		if (!IsEventWindowValid(idChild, idObject, hwnd)) { return; }
 
 		// Handle registering and unregistering of windows.
 		if (eventType == PInvoke.EVENT_OBJECT_SHOW)
 		{
-			RegisterWindow(hwnd);
+			if (!Win32Helper.IsSplashScreen(hwnd)
+				&& Win32Helper.IsStandardWindow(hwnd)
+				&& Win32Helper.HasNoVisibleOwner(hwnd))
+			{
+				RegisterWindow(hwnd);
+			}
+
 			return;
 		}
 		else if (eventType == PInvoke.EVENT_OBJECT_DESTROY)

--- a/src/Whim/Workspace/IWorkspace.cs
+++ b/src/Whim/Workspace/IWorkspace.cs
@@ -63,5 +63,10 @@ public interface IWorkspace : ICommandable
 	/// </summary>
 	/// <param name="window"></param>
 	public bool RemoveWindow(IWindow window);
+
+	/// <summary>
+	/// Deactivates the workspace.
+	/// </summary>
+	public void Deactivate();
 	#endregion
 }

--- a/src/Whim/Workspace/IWorkspaceManager.cs
+++ b/src/Whim/Workspace/IWorkspaceManager.cs
@@ -117,6 +117,11 @@ public interface IWorkspaceManager : IEnumerable<IWorkspace>, ICommandable
 	public IWorkspace? GetWorkspaceForMonitor(IMonitor monitor);
 
 	/// <summary>
+	/// Retrieves the monitor for the given window.
+	/// </summary>
+	public IMonitor? GetMonitorForWindow(IWindow window);
+
+	/// <summary>
 	/// Adds a proxy layout engine to the workspace manager.
 	/// A proxy layout engine is used by plugins to add layout functionality to
 	/// all workspaces.

--- a/src/Whim/Workspace/Workspace.cs
+++ b/src/Whim/Workspace/Workspace.cs
@@ -211,4 +211,12 @@ public class Workspace : IWorkspace
 	}
 
 	public override string ToString() => Name;
+
+	public void Deactivate()
+	{
+		foreach (IWindow window in Windows)
+		{
+			window.Hide();
+		}
+	}
 }

--- a/src/Whim/Workspace/WorkspaceManager.cs
+++ b/src/Whim/Workspace/WorkspaceManager.cs
@@ -157,6 +157,9 @@ public class WorkspaceManager : IWorkspaceManager
 		// Get the old workspace for the event.
 		_monitorWorkspaceMap.TryGetValue(monitor, out IWorkspace? oldWorkspace);
 
+		// Hide all the windows from the old workspace.
+		oldWorkspace?.Deactivate();
+
 		// Change the workspace.
 		_monitorWorkspaceMap[monitor] = workspace;
 

--- a/src/Whim/Workspace/WorkspaceManager.cs
+++ b/src/Whim/Workspace/WorkspaceManager.cs
@@ -42,7 +42,7 @@ public class WorkspaceManager : IWorkspaceManager
 	/// <summary>
 	/// The active workspace.
 	/// </summary>
-	public IWorkspace? ActiveWorkspace { get; private set; }
+	public IWorkspace? ActiveWorkspace { get => _monitorWorkspaceMap[_configContext.MonitorManager.FocusedMonitor]; }
 
 	private readonly List<ProxyLayoutEngine> _proxyLayoutEngines = new();
 	public IEnumerable<ProxyLayoutEngine> ProxyLayoutEngines { get => _proxyLayoutEngines; }
@@ -69,9 +69,6 @@ public class WorkspaceManager : IWorkspaceManager
 			Activate(_workspaces[idx], monitor);
 			idx++;
 		}
-
-		// Set the active workspace.
-		ActiveWorkspace = _workspaces[0];
 
 		// Subscribe to <see cref="IWindowManager"/> events.
 		_configContext.WindowManager.WindowRegistered += WindowManager_WindowRegistered;
@@ -226,6 +223,11 @@ public class WorkspaceManager : IWorkspaceManager
 	public IWorkspace? GetWorkspaceForMonitor(IMonitor monitor)
 	{
 		return _monitorWorkspaceMap[monitor];
+	}
+
+	public IMonitor? GetMonitorForWindow(IWindow window)
+	{
+		return _windowWorkspaceMap.TryGetValue(window, out IWorkspace? workspace) ? GetMonitorForWorkspace(workspace) : null;
 	}
 
 	public void TriggerActiveLayoutEngineChanged(ActiveLayoutEngineChangedEventArgs args)


### PR DESCRIPTION
Resolves #14 

- `MonitorManager` now listens to `IWindowManager.WindowFocused`.
- We now apply the strict checks for window validity just for `EVENT_OBJECT_SHOW` (registering windows). This fixed a bug where closing windows did not trigger a layout.
- `IWorkspace` now has a `Deactivate` method to hide all its windows.
- `IWorkspaceManager` now exposes `GetMonitorForWindow`.
- `WorkspaceManager.ActiveWorkspace` is now derived from `IMonitorManager.FocusedMonitor`.
