### PR TITLE
Prevent illegal phantom window behavior

### DIFF
--- a/src/Whim.TreeLayout/TreeLayoutEngine.cs
+++ b/src/Whim.TreeLayout/TreeLayoutEngine.cs
@@ -267,7 +267,7 @@ public partial class TreeLayoutEngine : ILayoutEngine
 		}
 
 
-		foreach (var item in GetWindowLocations(Root, location))
+		foreach (TreeLayoutWindowLocation? item in GetWindowLocations(Root, location))
 		{
 			if (item.Node is LeafNode leafNode)
 			{

--- a/src/Whim.TreeLayout/TreeLayoutEngine.cs
+++ b/src/Whim.TreeLayout/TreeLayoutEngine.cs
@@ -8,6 +8,8 @@ public partial class TreeLayoutEngine : ILayoutEngine
 {
 	private readonly IConfigContext _configContext;
 	private readonly Dictionary<IWindow, LeafNode> _windows = new();
+	private readonly HashSet<IWindow> _phantomWindows = new();
+
 	public Node? Root { get; private set; }
 
 	/// <summary>
@@ -192,6 +194,7 @@ public partial class TreeLayoutEngine : ILayoutEngine
 	{
 		parent.Replace(phantomNode, windowNode);
 		phantomNode.Close();
+		_phantomWindows.Remove(phantomNode.Window);
 		_configContext.WorkspaceManager.ActiveWorkspace.UnregisterPhantomWindow(this, phantomNode.Window);
 	}
 
@@ -546,8 +549,19 @@ public partial class TreeLayoutEngine : ILayoutEngine
 			return;
 		}
 
+		_phantomWindows.Add(phantomNode.Window);
 		_configContext.WorkspaceManager.ActiveWorkspace.RegisterPhantomWindow(this, phantomNode.Window);
 		_configContext.WorkspaceManager.ActiveWorkspace.DoLayout();
 		phantomNode.Focus();
+	}
+
+	public void HidePhantomWindows()
+	{
+		Logger.Debug($"Hiding phantom windows in layout engine {Name}");
+
+		foreach (IWindow window in _phantomWindows)
+		{
+			window.Hide();
+		}
 	}
 }

--- a/src/Whim/Layout/BaseStackLayoutEngine.cs
+++ b/src/Whim/Layout/BaseStackLayoutEngine.cs
@@ -66,4 +66,6 @@ public abstract class BaseStackLayoutEngine : ILayoutEngine
 	public abstract void SwapWindowInDirection(Direction direction, IWindow window);
 
 	public abstract void MoveWindowEdgeInDirection(Direction edge, double delta, IWindow window);
+
+	public void HidePhantomWindows() { }
 }

--- a/src/Whim/Layout/ILayoutEngine.cs
+++ b/src/Whim/Layout/ILayoutEngine.cs
@@ -51,6 +51,11 @@ public interface ILayoutEngine : ICollection<IWindow>, ICommandable
 	public void MoveWindowEdgeInDirection(Direction edge, double fractionDelta, IWindow window);
 
 	/// <summary>
+	/// Hides all phantom windows belonging to the layout engine.
+	/// </summary>
+	public void HidePhantomWindows();
+
+	/// <summary>
 	/// Checks to see if the <paramref name="root"/> <cref name="ILayoutEngine"/>
 	/// or a child layout engine is type <typeparamref name="T"/>.
 	/// </summary>

--- a/src/Whim/Layout/ProxyLayoutEngine.cs
+++ b/src/Whim/Layout/ProxyLayoutEngine.cs
@@ -49,6 +49,8 @@ public abstract class BaseProxyLayoutEngine : ILayoutEngine
 
 	public abstract IEnumerable<IWindowLocation> DoLayout(ILocation<int> location);
 
+	public void HidePhantomWindows() => _innerLayoutEngine.HidePhantomWindows();
+
 	/// <summary>
 	/// Checks to see if the <paramref name="root"/> <cref name="ILayoutEngine"/>
 	/// or a child layout engine is type <typeparamref name="T"/>.

--- a/src/Whim/Workspace/Workspace.cs
+++ b/src/Whim/Workspace/Workspace.cs
@@ -149,6 +149,7 @@ public class Workspace : IWorkspace
 			)
 		);
 
+		_layoutEngines[prevIdx].HidePhantomWindows();
 		DoLayout();
 	}
 

--- a/src/Whim/Workspace/Workspace.cs
+++ b/src/Whim/Workspace/Workspace.cs
@@ -136,7 +136,7 @@ public class Workspace : IWorkspace
 
 		// If the LastFocusedWindow is a phantom window, remove it.
 		// This is because phantom windows belong to a specific layout engine.
-		if (LastFocusedWindow != null && _phantomWindows.TryGetValue(LastFocusedWindow, out ILayoutEngine? prevLayoutEngine))
+		if (LastFocusedWindow != null && _phantomWindows.ContainsKey(LastFocusedWindow))
 		{
 			LastFocusedWindow = null;
 		}

--- a/src/Whim/Workspace/WorkspaceManager.cs
+++ b/src/Whim/Workspace/WorkspaceManager.cs
@@ -24,6 +24,11 @@ public class WorkspaceManager : IWorkspaceManager
 	private readonly Dictionary<IWindow, IWorkspace> _windowWorkspaceMap = new();
 
 	/// <summary>
+	/// All the phantom windows that are currently registered.
+	/// </summary>
+	private readonly HashSet<IWindow> _phantomWindows = new();
+
+	/// <summary>
 	/// Maps monitors to their active workspace.
 	/// </summary>
 	private readonly Dictionary<IMonitor, IWorkspace> _monitorWorkspaceMap = new();
@@ -281,6 +286,12 @@ public class WorkspaceManager : IWorkspaceManager
 			return;
 		}
 
+		if (_phantomWindows.Contains(window))
+		{
+			Logger.Error($"Window {window} is a phantom window and cannot be moved");
+			return;
+		}
+
 		Logger.Debug($"Moving window {window} to workspace {workspace}");
 
 		if (ActiveWorkspace == workspace)
@@ -352,12 +363,14 @@ public class WorkspaceManager : IWorkspaceManager
 	public void RegisterPhantomWindow(IWorkspace workspace, IWindow window)
 	{
 		Logger.Debug($"Registering phantom window {window} to workspace {workspace}");
+		_phantomWindows.Add(window);
 		_windowWorkspaceMap[window] = workspace;
 	}
 
 	public void UnregisterPhantomWindow(IWindow window)
 	{
 		Logger.Debug($"Unregistering phantom window {window}");
+		_phantomWindows.Remove(window);
 		_windowWorkspaceMap.Remove(window);
 	}
 	#endregion


### PR DESCRIPTION
**Changes:**

- You can no longer move phantom windows between monitors.
- Phantom windows are hidden when switching layout engine.