### PR TITLE
Added mouse event handlers and `AddWindowAtPoint`

### DIFF
--- a/src/Whim.Tests/LocationTests.cs
+++ b/src/Whim.Tests/LocationTests.cs
@@ -8,38 +8,38 @@ public class LocationTests
 	public void IsPointInside_ReturnsTrue_WhenPointIsInside()
 	{
 		Location location = new(0, 0, 10, 10);
-		Assert.True(location.IsPointInside(5, 5));
+		Assert.True(location.IsPointInside(new Point<int>(5, 5)));
 	}
 
 	[Fact]
 	public void IsPointInside_ReturnsFalse_WhenPointIsOutside()
 	{
 		Location location = new(0, 0, 10, 10);
-		Assert.False(location.IsPointInside(15, 15));
+		Assert.False(location.IsPointInside(new Point<int>(15, 15)));
 	}
 
 	[Fact]
 	public void IsPointInside_ReturnsFalse_WhenPointIsOutsideX()
 	{
 		Location location = new(0, 0, 10, 10);
-		Assert.False(location.IsPointInside(-5, 5));
+		Assert.False(location.IsPointInside(new Point<int>(-5, 5)));
 	}
 
 	[Fact]
 	public void IsPointInside_ReturnsFalse_WhenPointIsOutsideY()
 	{
 		Location location = new(0, 0, 10, 10);
-		Assert.False(location.IsPointInside(5, -5));
+		Assert.False(location.IsPointInside(new Point<int>(5, -5)));
 	}
 
 	[Fact]
 	public void IsPointInside_ReturnsTrue_WhenPointIsOnEdge()
 	{
 		Location location = new(0, 0, 10, 10);
-		Assert.True(location.IsPointInside(0, 0));
-		Assert.True(location.IsPointInside(10, 10));
-		Assert.True(location.IsPointInside(0, 10));
-		Assert.True(location.IsPointInside(10, 0));
+		Assert.True(location.IsPointInside(new Point<int>(0, 0)));
+		Assert.True(location.IsPointInside(new Point<int>(10, 10)));
+		Assert.True(location.IsPointInside(new Point<int>(0, 10)));
+		Assert.True(location.IsPointInside(new Point<int>(10, 0)));
 	}
 
 	[Fact]

--- a/src/Whim.Tests/LocationTests.cs
+++ b/src/Whim.Tests/LocationTests.cs
@@ -36,10 +36,24 @@ public class LocationTests
 	public void IsPointInside_ReturnsTrue_WhenPointIsOnEdge()
 	{
 		Location location = new(0, 0, 10, 10);
+
+		// Extreme boundaries.
 		Assert.True(location.IsPointInside(new Point<int>(0, 0)));
-		Assert.True(location.IsPointInside(new Point<int>(10, 10)));
-		Assert.True(location.IsPointInside(new Point<int>(0, 10)));
-		Assert.True(location.IsPointInside(new Point<int>(10, 0)));
+		Assert.False(location.IsPointInside(new Point<int>(10, 10)));
+		Assert.False(location.IsPointInside(new Point<int>(0, 10)));
+		Assert.False(location.IsPointInside(new Point<int>(10, 0)));
+
+		// Other boundaries.
+		Assert.True(location.IsPointInside(new Point<int>(5, 0)));
+		Assert.True(location.IsPointInside(new Point<int>(0, 5)));
+
+		// Internal points.
+		Assert.True(location.IsPointInside(new Point<int>(5, 5)));
+
+		// External points.
+		Assert.False(location.IsPointInside(new Point<int>(5, -5)));
+		Assert.False(location.IsPointInside(new Point<int>(-5, 5)));
+		Assert.False(location.IsPointInside(new Point<int>(-5, -5)));
 	}
 
 	[Fact]

--- a/src/Whim.Tests/TestMonitor.cs
+++ b/src/Whim.Tests/TestMonitor.cs
@@ -10,16 +10,15 @@ public class TestMonitor
 	[InlineData(1920, 1080, 192, 108, 0.1, 0.1)]
 	[InlineData(1920, 1080, 960, 270, 0.5, 0.25)]
 	[Theory]
-	public void ToUnitSquare(int width, int height, int pointX, int pointY, int expectedX, int expectedY)
+	public void ToUnitSquare(int width, int height, int pointX, int pointY, double expectedX, double expectedY)
 	{
 		// Given
-		Mock<Screen> screen = new();
-		screen.Setup(s => s.WorkingArea).Returns(new Rectangle(0, 0, width, height));
-
-		Monitor monitor = new(screen.Object);
+		Mock<IMonitor> monitor = new();
+		monitor.SetupGet(m => m.Width).Returns(width);
+		monitor.SetupGet(m => m.Height).Returns(height);
 
 		// When
-		IPoint<double> point = monitor.ToUnitSquare(new Point<int>(pointX, pointY));
+		IPoint<double> point = monitor.Object.ToUnitSquare(new Point<int>(pointX, pointY));
 
 		// Then
 		Assert.Equal(expectedX, point.X);

--- a/src/Whim.Tests/TestMonitor.cs
+++ b/src/Whim.Tests/TestMonitor.cs
@@ -1,0 +1,28 @@
+using Moq;
+using System.Drawing;
+using System.Windows.Forms;
+using Xunit;
+
+namespace Whim.Tests;
+
+public class TestMonitor
+{
+	[InlineData(1920, 1080, 192, 108, 0.1, 0.1)]
+	[InlineData(1920, 1080, 960, 270, 0.5, 0.25)]
+	[Theory]
+	public void ToUnitSquare(int width, int height, int pointX, int pointY, int expectedX, int expectedY)
+	{
+		// Given
+		Mock<Screen> screen = new();
+		screen.Setup(s => s.WorkingArea).Returns(new Rectangle(0, 0, width, height));
+
+		Monitor monitor = new(screen.Object);
+
+		// When
+		IPoint<double> point = monitor.ToUnitSquare(new Point<int>(pointX, pointY));
+
+		// Then
+		Assert.Equal(expectedX, point.X);
+		Assert.Equal(expectedY, point.Y);
+	}
+}

--- a/src/Whim.Tests/TestMonitor.cs
+++ b/src/Whim.Tests/TestMonitor.cs
@@ -1,6 +1,4 @@
 using Moq;
-using System.Drawing;
-using System.Windows.Forms;
 using Xunit;
 
 namespace Whim.Tests;

--- a/src/Whim.TreeLayout.Tests/TestAddWindow.cs
+++ b/src/Whim.TreeLayout.Tests/TestAddWindow.cs
@@ -8,7 +8,10 @@ public class TestAddWindow
 	[Fact]
 	public void Add_Root()
 	{
+		Mock<IWorkspace> workspace = new();
 		Mock<IWorkspaceManager> workspaceManager = new();
+		workspaceManager.Setup(w => w.ActiveWorkspace).Returns(workspace.Object);
+
 		Mock<IConfigContext> configContext = new();
 		configContext.Setup(x => x.WorkspaceManager).Returns(workspaceManager.Object);
 

--- a/src/Whim.TreeLayout.Tests/TestAddWindowAtPoint.cs
+++ b/src/Whim.TreeLayout.Tests/TestAddWindowAtPoint.cs
@@ -1,0 +1,151 @@
+using Moq;
+using Xunit;
+
+namespace Whim.TreeLayout.Tests;
+
+public class TestAddWindowAtPoint
+{
+	// Cases to add:
+	// 1. Root is null.
+	// 2. Couldn't find node at point.
+	// 3. There is no parent node.
+	// 4. There is a parent node.
+	// 5. Direction is horizontal.
+	// 6. Direction is vertical.
+	// 7. Adding phantom node.
+	// 8. Adding window node.
+
+	[Fact]
+	public void NullRoot()
+	{
+		TestTreeEngineEmpty emptyEngine = new();
+		Mock<IWindow> window = new();
+
+		emptyEngine.Engine.AddWindowAtPoint(window.Object, new Point<double>(0, 0), false);
+
+		Assert.True(emptyEngine.Engine.Root is WindowNode);
+	}
+
+	[Fact]
+	public void InvalidPoint()
+	{
+		TestTreeEngineEmpty emptyEngine = new();
+		Mock<IWindow> rootWindow = new();
+		emptyEngine.Engine.AddWindow(rootWindow.Object);
+
+		Mock<IWindow> pointWindow = new();
+		emptyEngine.Engine.AddWindowAtPoint(pointWindow.Object, new Point<double>(-10, -10), false);
+
+		Assert.Single(emptyEngine.Engine);
+	}
+
+	[Fact]
+	public void NoParent()
+	{
+		TestTreeEngineEmpty emptyEngine = new();
+		Mock<IWindow> rootWindow = new();
+		emptyEngine.Engine.AddWindow(rootWindow.Object);
+
+		Mock<IWindow> pointWindow = new();
+		emptyEngine.Engine.AddWindowAtPoint(pointWindow.Object, new Point<double>(0.5, 0.5), false);
+
+		Assert.True(emptyEngine.Engine.Root is SplitNode);
+		Assert.Equal(2, emptyEngine.Engine.Count);
+	}
+
+	[Fact]
+	public void Right()
+	{
+		TestTreeEngineEmpty emptyEngine = new();
+		Mock<IWindow> rootWindow = new();
+		emptyEngine.Engine.AddWindow(rootWindow.Object);
+
+		Mock<IWindow> windowWithParent = new();
+		emptyEngine.Engine.AddWindowAtPoint(windowWithParent.Object, new Point<double>(0.5, 0.5), false);
+
+		emptyEngine.Engine.AddNodeDirection = Direction.Left;
+		Mock<IWindow> pointWindow = new();
+		emptyEngine.Engine.AddWindowAtPoint(pointWindow.Object, new Point<double>(0.75, 0.75), false);
+
+		Assert.True(emptyEngine.Engine.Root is SplitNode);
+		Assert.Equal(3, emptyEngine.Engine.Count);
+
+		SplitNode rootNode = (SplitNode)emptyEngine.Engine.Root!;
+		Assert.Equal(pointWindow.Object, (rootNode[2].node as LeafNode)!.Window);
+
+		// Check the default direction is retained.
+		Assert.Equal(Direction.Left, emptyEngine.Engine.AddNodeDirection);
+	}
+
+	[Fact]
+	public void Left()
+	{
+		TestTreeEngineEmpty emptyEngine = new();
+		Mock<IWindow> rootWindow = new();
+		emptyEngine.Engine.AddWindow(rootWindow.Object);
+
+		Mock<IWindow> windowWithParent = new();
+		emptyEngine.Engine.AddWindowAtPoint(windowWithParent.Object, new Point<double>(0.5, 0.5), false);
+
+		emptyEngine.Engine.AddNodeDirection = Direction.Right;
+		Mock<IWindow> pointWindow = new();
+		emptyEngine.Engine.AddWindowAtPoint(pointWindow.Object, new Point<double>(0.6, 0.6), false);
+
+		Assert.True(emptyEngine.Engine.Root is SplitNode);
+		Assert.Equal(3, emptyEngine.Engine.Count);
+
+		SplitNode rootNode = (SplitNode)emptyEngine.Engine.Root!;
+		Assert.Equal(pointWindow.Object, (rootNode[1].node as LeafNode)!.Window);
+
+		// Check the default direction is retained.
+		Assert.Equal(Direction.Right, emptyEngine.Engine.AddNodeDirection);
+	}
+
+	[Fact]
+	public void Up()
+	{
+		TestTreeEngineEmpty emptyEngine = new();
+		emptyEngine.Engine.AddNodeDirection = Direction.Down;
+		Mock<IWindow> rootWindow = new();
+		emptyEngine.Engine.AddWindow(rootWindow.Object);
+
+		Mock<IWindow> windowWithParent = new();
+		emptyEngine.Engine.AddWindowAtPoint(windowWithParent.Object, new Point<double>(0.5, 0.5), false);
+
+		Mock<IWindow> pointWindow = new();
+		emptyEngine.Engine.AddWindowAtPoint(pointWindow.Object, new Point<double>(0.6, 0.6), false);
+
+		Assert.True(emptyEngine.Engine.Root is SplitNode);
+		Assert.Equal(3, emptyEngine.Engine.Count);
+
+		SplitNode rootNode = (SplitNode)emptyEngine.Engine.Root!;
+		Assert.Equal(pointWindow.Object, (rootNode[1].node as LeafNode)!.Window);
+
+		// Check the default direction is retained.
+		Assert.Equal(Direction.Down, emptyEngine.Engine.AddNodeDirection);
+	}
+
+	[Fact]
+	public void Down()
+	{
+		TestTreeEngineEmpty emptyEngine = new();
+		emptyEngine.Engine.AddNodeDirection = Direction.Up;
+		Mock<IWindow> rootWindow = new();
+		emptyEngine.Engine.AddWindow(rootWindow.Object);
+
+		Mock<IWindow> windowWithParent = new();
+		emptyEngine.Engine.AddWindowAtPoint(windowWithParent.Object, new Point<double>(0.5, 0.5), false);
+
+		Mock<IWindow> pointWindow = new();
+		emptyEngine.Engine.AddWindowAtPoint(pointWindow.Object, new Point<double>(0.75, 0.75), false);
+
+		Assert.True(emptyEngine.Engine.Root is SplitNode);
+		Assert.Equal(3, emptyEngine.Engine.Count);
+
+		SplitNode rootNode = (SplitNode)emptyEngine.Engine.Root!;
+		Assert.Equal(pointWindow.Object, (rootNode[2].node as LeafNode)!.Window);
+
+		// Check the default direction is retained.
+		Assert.Equal(Direction.Up, emptyEngine.Engine.AddNodeDirection);
+	}
+}

--- a/src/Whim.TreeLayout.Tests/TestAddWindowAtPoint.cs
+++ b/src/Whim.TreeLayout.Tests/TestAddWindowAtPoint.cs
@@ -5,16 +5,6 @@ namespace Whim.TreeLayout.Tests;
 
 public class TestAddWindowAtPoint
 {
-	// Cases to add:
-	// 1. Root is null.
-	// 2. Couldn't find node at point.
-	// 3. There is no parent node.
-	// 4. There is a parent node.
-	// 5. Direction is horizontal.
-	// 6. Direction is vertical.
-	// 7. Adding phantom node.
-	// 8. Adding window node.
-
 	[Fact]
 	public void NullRoot()
 	{

--- a/src/Whim.TreeLayout.Tests/TestClear.cs
+++ b/src/Whim.TreeLayout.Tests/TestClear.cs
@@ -1,0 +1,16 @@
+using Xunit;
+
+namespace Whim.TreeLayout.Tests;
+
+public class TestClear
+{
+	[Fact]
+	public void Clear()
+	{
+		TestTreeEngine testTreeEngine = new();
+
+		testTreeEngine.Engine.Clear();
+		Assert.Empty(testTreeEngine.Engine);
+		Assert.Null(testTreeEngine.Engine.Root);
+	}
+}

--- a/src/Whim.TreeLayout.Tests/TestContains.cs
+++ b/src/Whim.TreeLayout.Tests/TestContains.cs
@@ -1,0 +1,29 @@
+using Xunit;
+
+namespace Whim.TreeLayout.Tests;
+
+public class TestContains
+{
+	[Fact]
+	public void ContainsWindows()
+	{
+		TestTreeEngine testTreeEngine = new();
+
+		foreach (IWindow window in testTreeEngine.GetWindows())
+		{
+			Assert.True(testTreeEngine.Engine.Contains(window));
+		}
+	}
+
+	[StaFact]
+	public void ContainsPhantomWindows()
+	{
+		TestTreeEngine testTreeEngine = new();
+		testTreeEngine.ActiveWorkspace.Setup(w => w.LastFocusedWindow).Returns(testTreeEngine.LeftWindow.Object);
+		testTreeEngine.Engine.SplitFocusedWindow();
+
+		SplitNode root = (SplitNode)testTreeEngine.Engine.Root!;
+		SplitNode left = (SplitNode)root[0].node;
+		Assert.True(left[1].node is PhantomNode);
+	}
+}

--- a/src/Whim.TreeLayout.Tests/TestFlipAndMerge.cs
+++ b/src/Whim.TreeLayout.Tests/TestFlipAndMerge.cs
@@ -5,50 +5,34 @@ namespace Whim.TreeLayout.Tests;
 
 public class TestFlipAndMerge
 {
-	private readonly Mock<IWorkspace> _activeWorkspace = new();
-	private readonly Mock<IWorkspaceManager> _workspaceManager = new();
-	private readonly Mock<IMonitor> _focusedMonitor = new();
-	private readonly Mock<IMonitorManager> _monitorManager = new();
-	private readonly Mock<IConfigContext> _configContext = new();
-	private readonly TreeLayoutEngine _engine;
-
-	public TestFlipAndMerge()
-	{
-		_workspaceManager.Setup(x => x.ActiveWorkspace).Returns(_activeWorkspace.Object);
-		_monitorManager.Setup(x => x.FocusedMonitor).Returns(_focusedMonitor.Object);
-
-		_configContext.Setup(x => x.WorkspaceManager).Returns(_workspaceManager.Object);
-		_configContext.Setup(x => x.MonitorManager).Returns(_monitorManager.Object);
-
-		_engine = new(_configContext.Object);
-	}
+	private readonly TestTreeEngineEmpty _testTreeEngine = new();
 
 	[Fact]
 	public void FlipAndMerge()
 	{
-		_engine.AddNodeDirection = Direction.Right;
+		_testTreeEngine.Engine.AddNodeDirection = Direction.Right;
 
 		Mock<IWindow> left = new();
 		Mock<IWindow> right1 = new();
 		Mock<IWindow> right2 = new();
 		Mock<IWindow> right3 = new();
 
-		_engine.Add(left.Object);
-		_engine.AddNodeDirection = Direction.Right;
+		_testTreeEngine.Engine.Add(left.Object);
+		_testTreeEngine.Engine.AddNodeDirection = Direction.Right;
 
-		_engine.Add(right1.Object);
-		_engine.AddNodeDirection = Direction.Down;
-		_workspaceManager.Setup(w => w.ActiveWorkspace.LastFocusedWindow).Returns(right1.Object);
+		_testTreeEngine.Engine.Add(right1.Object);
+		_testTreeEngine.Engine.AddNodeDirection = Direction.Down;
+		_testTreeEngine.WorkspaceManager.Setup(w => w.ActiveWorkspace.LastFocusedWindow).Returns(right1.Object);
 
-		_engine.Add(right2.Object);
-		_workspaceManager.Setup(w => w.ActiveWorkspace.LastFocusedWindow).Returns(right2.Object);
-		_workspaceManager.Setup(w => w.ActiveWorkspace.LastFocusedWindow).Returns(right2.Object);
+		_testTreeEngine.Engine.Add(right2.Object);
+		_testTreeEngine.WorkspaceManager.Setup(w => w.ActiveWorkspace.LastFocusedWindow).Returns(right2.Object);
+		_testTreeEngine.WorkspaceManager.Setup(w => w.ActiveWorkspace.LastFocusedWindow).Returns(right2.Object);
 
-		_engine.Add(right3.Object);
+		_testTreeEngine.Engine.Add(right3.Object);
 
-		_engine.FlipAndMerge();
+		_testTreeEngine.Engine.FlipAndMerge();
 
-		SplitNode root = (SplitNode)_engine.Root!;
+		SplitNode root = (SplitNode)_testTreeEngine.Engine.Root!;
 		Assert.Equal(4, root.Count);
 		Assert.Equal(0.5, root[0].weight);
 
@@ -63,23 +47,23 @@ public class TestFlipAndMerge
 	[Fact]
 	public void FlipAndMerge_Root()
 	{
-		_engine.AddNodeDirection = Direction.Right;
+		_testTreeEngine.Engine.AddNodeDirection = Direction.Right;
 
 		Mock<IWindow> window1 = new();
 		Mock<IWindow> window2 = new();
 		Mock<IWindow> window3 = new();
 
-		_engine.Add(window1.Object);
-		_engine.AddNodeDirection = Direction.Right;
+		_testTreeEngine.Engine.Add(window1.Object);
+		_testTreeEngine.Engine.AddNodeDirection = Direction.Right;
 
-		_engine.Add(window2.Object);
-		_workspaceManager.Setup(w => w.ActiveWorkspace.LastFocusedWindow).Returns(window2.Object);
+		_testTreeEngine.Engine.Add(window2.Object);
+		_testTreeEngine.WorkspaceManager.Setup(w => w.ActiveWorkspace.LastFocusedWindow).Returns(window2.Object);
 
-		_engine.Add(window3.Object);
+		_testTreeEngine.Engine.Add(window3.Object);
 
-		_engine.FlipAndMerge();
+		_testTreeEngine.Engine.FlipAndMerge();
 
-		SplitNode root = (SplitNode)_engine.Root!;
+		SplitNode root = (SplitNode)_testTreeEngine.Engine.Root!;
 		Assert.Equal(3, root.Count);
 
 		double expectedWeight = 1d / 3;

--- a/src/Whim.TreeLayout.Tests/TestFocusWindowInDirection.cs
+++ b/src/Whim.TreeLayout.Tests/TestFocusWindowInDirection.cs
@@ -1,0 +1,50 @@
+using Moq;
+using Xunit;
+
+namespace Whim.TreeLayout.Tests;
+
+public class TestFocusWindowInDirection
+{
+	[Fact]
+	public void IllegalWindow()
+	{
+		TestTreeEngine testTreeEngine = new();
+
+		// Try to focus a window that doesn't exist.
+		Mock<IWindow> illegalWindow = new();
+		testTreeEngine.Engine.FocusWindowInDirection(Direction.Left, illegalWindow.Object);
+
+		// Verify that the window was not focused.
+		illegalWindow.Verify(w => w.Focus(), Times.Never);
+	}
+
+	[Fact]
+	public void NoAdjacentWindow()
+	{
+		TestTreeEngine testTreeEngine = new();
+
+		// Set the currently focused window.
+		testTreeEngine.ActiveWorkspace.Setup(w => w.LastFocusedWindow).Returns(testTreeEngine.RightBottomWindow.Object);
+
+		// Try to focus to the left of the left window.
+		testTreeEngine.Engine.FocusWindowInDirection(Direction.Left, testTreeEngine.LeftWindow.Object);
+
+		// Verify that the window was not focused.
+		testTreeEngine.LeftWindow.Verify(w => w.Focus(), Times.Never);
+	}
+
+	[Fact]
+	public void FocusLeftWindow()
+	{
+		TestTreeEngine testTreeEngine = new();
+
+		// Set the currently focused window.
+		testTreeEngine.ActiveWorkspace.Setup(w => w.LastFocusedWindow).Returns(testTreeEngine.RightBottomWindow.Object);
+
+		// Try to focus to the left of the right window.
+		testTreeEngine.Engine.FocusWindowInDirection(Direction.Left, testTreeEngine.RightBottomWindow.Object);
+
+		// Verify that the window was focused.
+		testTreeEngine.LeftWindow.Verify(w => w.Focus(), Times.Once);
+	}
+}

--- a/src/Whim.TreeLayout.Tests/TestGetNodeContainingPoint.cs
+++ b/src/Whim.TreeLayout.Tests/TestGetNodeContainingPoint.cs
@@ -1,0 +1,60 @@
+using Xunit;
+
+namespace Whim.TreeLayout.Tests;
+
+public class TestGetNodeContainingPoint
+{
+	private readonly TestTree _testTree = new();
+	private readonly ILocation<double> rootLocation = new NodeLocation() { X = 0, Y = 0, Width = 100, Height = 100 };
+
+	[InlineData(-5, 0)]
+	[InlineData(0, -5)]
+	[InlineData(100, 0)]
+	[InlineData(0, 100)]
+	[Theory]
+	public void Outside(double x, double y)
+	{
+		IPoint<double> searchPoint = new Point<double>(x, y);
+
+		Assert.Null(TreeLayoutEngine.GetNodeContainingPoint(root: _testTree.Root, rootLocation, searchPoint));
+	}
+
+	[InlineData(0, 0)]
+	[InlineData(0, 49)]
+	[InlineData(49, 49)]
+	[InlineData(49, 0)]
+	[InlineData(25, 25)]
+	[Theory]
+	public void Left(double x, double y)
+	{
+		IPoint<double> searchPoint = new Point<double>(x, y);
+
+		Assert.Same(_testTree.Left, TreeLayoutEngine.GetNodeContainingPoint(root: _testTree.Root, rootLocation, searchPoint));
+	}
+
+	[InlineData(50 + (25d / 2), 25)]
+	[InlineData(50 + (25d / 2), 24 + (25 * 0.7))]
+	[InlineData(74, 25)]
+	[InlineData(74, 25 + (24 * 0.7))]
+	[InlineData(65, 30)]
+	[Theory]
+	public void RightTopLeftBottomRightTop(double x, double y)
+	{
+		IPoint<double> searchPoint = new Point<double>(x, y);
+
+		Assert.Same(_testTree.RightTopLeftBottomRightTop, TreeLayoutEngine.GetNodeContainingPoint(root: _testTree.Root, rootLocation, searchPoint));
+	}
+
+	[InlineData(50 + (25d / 2), 25 + (25 * 0.7))]
+	[InlineData(50 + (25d / 2), 49)]
+	[InlineData(74, 25 + (25 * 0.7))]
+	[InlineData(74, 49)]
+	[InlineData(65, 45)]
+	[Theory]
+	public void RightTopLeftBottomRightBottom(double x, double y)
+	{
+		IPoint<double> searchPoint = new Point<double>(x, y);
+
+		Assert.Same(_testTree.RightTopLeftBottomRightBottom, TreeLayoutEngine.GetNodeContainingPoint(root: _testTree.Root, rootLocation, searchPoint));
+	}
+}

--- a/src/Whim.TreeLayout.Tests/TestGetNodes.cs
+++ b/src/Whim.TreeLayout.Tests/TestGetNodes.cs
@@ -30,6 +30,20 @@ public class TestGetNodes
 	}
 
 	[Fact]
+	public void GetFirstWindow()
+	{
+		TestTreeEngine engine = new();
+		Assert.NotNull(engine.Engine.GetFirstWindow());
+	}
+
+	[Fact]
+	public void GetFirstWindow_Null()
+	{
+		TestTreeEngineEmpty emptyEngine = new();
+		Assert.Null(emptyEngine.Engine.GetFirstWindow());
+	}
+
+	[Fact]
 	public void GetRightMostLeaf()
 	{
 		LeafNode? node = _tree.Right.GetRightMostLeaf();

--- a/src/Whim.TreeLayout.Tests/TestGetWindowLocations.cs
+++ b/src/Whim.TreeLayout.Tests/TestGetWindowLocations.cs
@@ -24,28 +24,10 @@ public class TestGetWindowLocations
 	[Fact]
 	public void DoLayout_NullRoot()
 	{
-		Mock<IMonitor> monitor = new();
-		monitor.Setup(m => m.Width).Returns(1920);
-		monitor.Setup(m => m.Height).Returns(1080);
-
-		Mock<IMonitorManager> monitorManager = new();
-		monitorManager.Setup(m => m.FocusedMonitor).Returns(monitor.Object);
-
-		Mock<IWorkspace> activeWorkspace = new();
-		Mock<IWorkspaceManager> workspaceManager = new();
-		workspaceManager.Setup(x => x.ActiveWorkspace).Returns(activeWorkspace.Object);
-
-		Mock<IWindowManager> windowManager = new();
-
-		Mock<IConfigContext> configContext = new();
-		configContext.Setup(x => x.MonitorManager).Returns(monitorManager.Object);
-		configContext.Setup(x => x.WorkspaceManager).Returns(workspaceManager.Object);
-		configContext.Setup(x => x.WindowManager).Returns(windowManager.Object);
-
+		TestTreeEngineEmpty testTreeEngine = new();
 		ILocation<int> screen = new Location(0, 0, 1920, 1080);
 
-		TreeLayoutEngine _engine = new TreeLayoutEngine(configContext.Object);
-		IEnumerable<IWindowLocation> actual = _engine.DoLayout(screen);
+		IEnumerable<IWindowLocation> actual = testTreeEngine.Engine.DoLayout(screen);
 
 		Assert.Empty(actual);
 	}

--- a/src/Whim.TreeLayout.Tests/TestSplitFocusedWindow.cs
+++ b/src/Whim.TreeLayout.Tests/TestSplitFocusedWindow.cs
@@ -5,49 +5,28 @@ namespace Whim.TreeLayout.Tests;
 
 public class TestSplitFocusedWindow
 {
-	private readonly Mock<IMonitor> _monitor = new();
-	private readonly Mock<IMonitorManager> _monitorManager = new();
-	private readonly Mock<IWorkspace> _activeWorkspace = new();
-	private readonly Mock<IWorkspaceManager> _workspaceManager = new();
-	private readonly Mock<IWindowManager> _windowManager = new();
-	private readonly Mock<IConfigContext> _configContext = new();
-	private readonly TreeLayoutEngine _engine;
-
-	public TestSplitFocusedWindow()
-	{
-		_monitor.Setup(m => m.Width).Returns(1920);
-		_monitor.Setup(m => m.Height).Returns(1080);
-
-		_monitorManager.Setup(m => m.FocusedMonitor).Returns(_monitor.Object);
-		_workspaceManager.Setup(x => x.ActiveWorkspace).Returns(_activeWorkspace.Object);
-
-		_configContext.Setup(x => x.MonitorManager).Returns(_monitorManager.Object);
-		_configContext.Setup(x => x.WorkspaceManager).Returns(_workspaceManager.Object);
-		_configContext.Setup(x => x.WindowManager).Returns(_windowManager.Object);
-
-		_engine = new TreeLayoutEngine(_configContext.Object);
-	}
+	private readonly TestTreeEngineEmpty _testTreeEngine = new();
 
 	[StaFact]
 	public void No_Focused_Window()
 	{
-		_engine.SplitFocusedWindow();
+		_testTreeEngine.Engine.SplitFocusedWindow();
 
-		Assert.True(_engine.Root is PhantomNode);
+		Assert.True(_testTreeEngine.Engine.Root is PhantomNode);
 	}
 
 	[StaFact]
 	public void Add_Single_Phantom()
 	{
-		_engine.AddNodeDirection = Direction.Right;
+		_testTreeEngine.Engine.AddNodeDirection = Direction.Right;
 
 		Mock<IWindow> window1 = new();
 
-		_engine.Add(window1.Object);
-		_activeWorkspace.Setup(w => w.LastFocusedWindow).Returns(window1.Object);
-		_engine.SplitFocusedWindow();
+		_testTreeEngine.Engine.Add(window1.Object);
+		_testTreeEngine.ActiveWorkspace.Setup(w => w.LastFocusedWindow).Returns(window1.Object);
+		_testTreeEngine.Engine.SplitFocusedWindow();
 
-		SplitNode root = (_engine.Root as SplitNode)!;
+		SplitNode root = (_testTreeEngine.Engine.Root as SplitNode)!;
 
 		var left = root[0];
 		var right = root[1];
@@ -62,17 +41,17 @@ public class TestSplitFocusedWindow
 	[StaFact]
 	public void Add_Multiple_Phantom()
 	{
-		_engine.AddNodeDirection = Direction.Right;
+		_testTreeEngine.Engine.AddNodeDirection = Direction.Right;
 
 		Mock<IWindow> window1 = new();
 
-		_engine.Add(window1.Object);
-		_engine.SplitFocusedWindow();
+		_testTreeEngine.Engine.Add(window1.Object);
+		_testTreeEngine.Engine.SplitFocusedWindow();
 
-		_activeWorkspace.Setup(a => a.LastFocusedWindow).Returns(window1.Object);
-		_engine.SplitFocusedWindow();
+		_testTreeEngine.ActiveWorkspace.Setup(a => a.LastFocusedWindow).Returns(window1.Object);
+		_testTreeEngine.Engine.SplitFocusedWindow();
 
-		SplitNode root = (_engine.Root as SplitNode)!;
+		SplitNode root = (_testTreeEngine.Engine.Root as SplitNode)!;
 		var left = root[0];
 		var middle = root[1];
 		var right = root[2];
@@ -90,19 +69,19 @@ public class TestSplitFocusedWindow
 	[StaFact]
 	public void Add_Nested_Phantom()
 	{
-		_engine.AddNodeDirection = Direction.Right;
+		_testTreeEngine.Engine.AddNodeDirection = Direction.Right;
 
 		Mock<IWindow> window1 = new();
 
-		_engine.Add(window1.Object);
-		_engine.SplitFocusedWindow();
+		_testTreeEngine.Engine.Add(window1.Object);
+		_testTreeEngine.Engine.SplitFocusedWindow();
 
-		SplitNode root = (_engine.Root as SplitNode)!;
+		SplitNode root = (_testTreeEngine.Engine.Root as SplitNode)!;
 		PhantomNode phantomRight = (root[1].node as PhantomNode)!;
-		_activeWorkspace.Setup(a => a.LastFocusedWindow).Returns(phantomRight.Window);
-		_engine.AddNodeDirection = Direction.Down;
+		_testTreeEngine.ActiveWorkspace.Setup(a => a.LastFocusedWindow).Returns(phantomRight.Window);
+		_testTreeEngine.Engine.AddNodeDirection = Direction.Down;
 
-		_engine.SplitFocusedWindow();
+		_testTreeEngine.Engine.SplitFocusedWindow();
 
 		var left = root[0];
 		var rightParent = root[1];
@@ -123,19 +102,19 @@ public class TestSplitFocusedWindow
 	[StaFact]
 	public void Replace_Phantom()
 	{
-		_engine.AddNodeDirection = Direction.Right;
+		_testTreeEngine.Engine.AddNodeDirection = Direction.Right;
 
 		Mock<IWindow> window1 = new();
 		Mock<IWindow> window2 = new();
 
-		_engine.Add(window1.Object);
+		_testTreeEngine.Engine.Add(window1.Object);
 
-		_engine.SplitFocusedWindow();
-		_activeWorkspace.Setup(a => a.LastFocusedWindow).Returns(window1.Object);
+		_testTreeEngine.Engine.SplitFocusedWindow();
+		_testTreeEngine.ActiveWorkspace.Setup(a => a.LastFocusedWindow).Returns(window1.Object);
 
-		_engine.Add(window2.Object);
+		_testTreeEngine.Engine.Add(window2.Object);
 
-		SplitNode root = (_engine.Root as SplitNode)!;
+		SplitNode root = (_testTreeEngine.Engine.Root as SplitNode)!;
 		Assert.Equal(0.5d, root[0].weight);
 		Assert.Equal(0.5d, root[1].weight);
 		Assert.Equal(window1.Object, ((WindowNode)(root[0].node)).Window);

--- a/src/Whim.TreeLayout.Tests/TestTreeEngine.cs
+++ b/src/Whim.TreeLayout.Tests/TestTreeEngine.cs
@@ -12,6 +12,7 @@ internal class TestTreeEngine
 	public Mock<IMonitorManager> MonitorManager = new();
 	public Mock<IWorkspace> ActiveWorkspace = new();
 	public Mock<IWorkspaceManager> WorkspaceManager = new();
+	public Mock<IWindowManager> WindowManager = new();
 	public Mock<IConfigContext> ConfigContext = new();
 
 	public SplitNode RootNode;
@@ -58,6 +59,7 @@ internal class TestTreeEngine
 		ConfigContext.Setup(x => x.MonitorManager).Returns(MonitorManager.Object);
 
 		WorkspaceManager.Setup(x => x.ActiveWorkspace).Returns(ActiveWorkspace.Object);
+		ConfigContext.Setup(x => x.WindowManager).Returns(WindowManager.Object);
 		ConfigContext.Setup(x => x.WorkspaceManager).Returns(WorkspaceManager.Object);
 
 		Engine = new(ConfigContext.Object);
@@ -126,5 +128,21 @@ internal class TestTreeEngine
 		RightNode = (RightBottomNode.Parent as SplitNode)!;
 
 		Engine.MoveWindowEdgeInDirection(Direction.Down, 0.05, RightTopLeftBottomRightTopWindow.Object);
+	}
+
+	public IWindow[] GetWindows()
+	{
+		return new[]
+		{
+			LeftWindow.Object,
+			RightTopLeftTopWindow.Object,
+			RightBottomWindow.Object,
+			RightTopRight1Window.Object,
+			RightTopRight2Window.Object,
+			RightTopRight3Window.Object,
+			RightTopLeftBottomLeftWindow.Object,
+			RightTopLeftBottomRightTopWindow.Object,
+			RightTopLeftBottomRightBottomWindow.Object
+		};
 	}
 }

--- a/src/Whim.TreeLayout.Tests/TestTreeEngineEmpty.cs
+++ b/src/Whim.TreeLayout.Tests/TestTreeEngineEmpty.cs
@@ -12,6 +12,7 @@ internal class TestTreeEngineEmpty
 	public Mock<IMonitorManager> MonitorManager = new();
 	public Mock<IWorkspace> ActiveWorkspace = new();
 	public Mock<IWorkspaceManager> WorkspaceManager = new();
+	public Mock<IWindowManager> WindowManager = new();
 	public Mock<IConfigContext> ConfigContext = new();
 
 	public TreeLayoutEngine Engine;
@@ -25,6 +26,7 @@ internal class TestTreeEngineEmpty
 
 		WorkspaceManager.Setup(x => x.ActiveWorkspace).Returns(ActiveWorkspace.Object);
 		ConfigContext.Setup(x => x.WorkspaceManager).Returns(WorkspaceManager.Object);
+		ConfigContext.Setup(x => x.WindowManager).Returns(WindowManager.Object);
 
 		Engine = new(ConfigContext.Object);
 		Engine.AddNodeDirection = Direction.Right;

--- a/src/Whim.TreeLayout.Tests/TestTreeEngineEmpty.cs
+++ b/src/Whim.TreeLayout.Tests/TestTreeEngineEmpty.cs
@@ -1,0 +1,32 @@
+using Moq;
+using Xunit;
+
+namespace Whim.TreeLayout.Tests;
+
+/// <summary>
+/// This is a populated TreeLayoutEngine, with the dimensions matching <see cref="TestTree"/>.
+/// </summary>
+internal class TestTreeEngineEmpty
+{
+	public Mock<IMonitor> Monitor = new();
+	public Mock<IMonitorManager> MonitorManager = new();
+	public Mock<IWorkspace> ActiveWorkspace = new();
+	public Mock<IWorkspaceManager> WorkspaceManager = new();
+	public Mock<IConfigContext> ConfigContext = new();
+
+	public TreeLayoutEngine Engine;
+
+	public TestTreeEngineEmpty()
+	{
+		Monitor.Setup(m => m.Width).Returns(1920);
+		Monitor.Setup(m => m.Height).Returns(1080);
+		MonitorManager.Setup(m => m.FocusedMonitor).Returns(Monitor.Object);
+		ConfigContext.Setup(x => x.MonitorManager).Returns(MonitorManager.Object);
+
+		WorkspaceManager.Setup(x => x.ActiveWorkspace).Returns(ActiveWorkspace.Object);
+		ConfigContext.Setup(x => x.WorkspaceManager).Returns(WorkspaceManager.Object);
+
+		Engine = new(ConfigContext.Object);
+		Engine.AddNodeDirection = Direction.Right;
+	}
+}

--- a/src/Whim.TreeLayout/NodeLocation.cs
+++ b/src/Whim.TreeLayout/NodeLocation.cs
@@ -49,13 +49,11 @@ public class NodeLocation : ILocation<double>
 		Height = location.Height;
 	}
 
-	/// <param name="x">The x-coordinate of the point to check.</param>
-	/// <param name="y">The y-coordinate of the point to check.</param>
+	/// <param name="point">The point to check.</param>
 	/// <returns>
-	/// <see langword="true"/> if the location given by <paramref name="x"/> and <paramref name="y"/>
-	/// is inside this location.
+	/// <see langword="true"/> if the location given by <paramref name="point"/> is inside the location.
 	/// </returns>
-	public bool IsPointInside(double x, double y) => ILocation<double>.IsPointInside(this, x, y);
+	public bool IsPointInside(IPoint<double> point) => ILocation<double>.IsPointInside(this, point);
 
 	// override object.Equals
 	public override bool Equals(object? obj)

--- a/src/Whim.TreeLayout/SplitNode.cs
+++ b/src/Whim.TreeLayout/SplitNode.cs
@@ -108,8 +108,19 @@ public class SplitNode : Node, IEnumerable<(double Weight, Node Node)>
 			return;
 		}
 
+		int newNodeIndex = index + (direction.IsPositiveIndex() ? 1 : 0);
+
+		// Bound the index.
+		if (newNodeIndex < 0)
+		{
+			newNodeIndex = 0;
+		}
+		else if (newNodeIndex > _children.Count)
+		{
+			newNodeIndex = _children.Count;
+		}
+
 		// Insert the node.
-		int newNodeIndex = index + (direction.IsPositiveIndex() ? 1 : -1);
 		_children.Insert(newNodeIndex, newNode);
 		newNode.Parent = this;
 

--- a/src/Whim.TreeLayout/TreeLayoutEngine.cs
+++ b/src/Whim.TreeLayout/TreeLayoutEngine.cs
@@ -64,13 +64,16 @@ public partial class TreeLayoutEngine : ILayoutEngine
 	/// </summary>
 	/// <param name="window">The window to add.</param>
 	/// <returns>The node that represents the window.</returns>
-	public WindowNode? AddWindow(IWindow window)
+	public WindowNode? AddWindow(IWindow window, IWindow? focusedWindow = null)
 	{
 		Logger.Debug($"Adding window {window.Title} to layout engine {Name}");
 		Count++;
 
+		// Get the focused window node
+		focusedWindow ??= _configContext.WorkspaceManager.ActiveWorkspace.LastFocusedWindow;
+
 		WindowNode node = new(window);
-		if (AddLeafNode(node))
+		if (AddLeafNode(node, focusedWindow))
 		{
 			return node;
 		}
@@ -84,8 +87,12 @@ public partial class TreeLayoutEngine : ILayoutEngine
 	/// in the direction specified by this instance's <see cref="AddNodeDirection"/> property.
 	/// </summary>
 	/// <param name="newLeaf">The node to add.</param>
+	/// <param name="window">
+	/// The focused window. If <paramref name="focusedWindow"/> is null, then
+	/// the focused window is set to the <see cref="IWorkspace.LastFocusedWindow"/>.
+	/// </param>
 	/// <returns>True if the node was added, false otherwise.</returns>
-	private bool AddLeafNode(LeafNode newLeaf)
+	private bool AddLeafNode(LeafNode newLeaf, IWindow? focusedWindow = null)
 	{
 		IWindow window = newLeaf.Window;
 
@@ -100,7 +107,7 @@ public partial class TreeLayoutEngine : ILayoutEngine
 		}
 
 		// Get the focused window node
-		IWindow? focusedWindow = _configContext.WorkspaceManager.ActiveWorkspace.LastFocusedWindow;
+		focusedWindow ??= _configContext.WorkspaceManager.ActiveWorkspace.LastFocusedWindow;
 
 		Logger.Verbose($"Focused window is {focusedWindow}");
 		if (focusedWindow == null || !_windows.TryGetValue(focusedWindow, out LeafNode? focusedLeaf))
@@ -216,6 +223,12 @@ public partial class TreeLayoutEngine : ILayoutEngine
 
 		_windows.Remove(window);
 		Count--;
+
+		if (removingNode is PhantomNode phantomNode)
+		{
+			_phantomWindows.Remove(phantomNode.Window);
+			_configContext.WorkspaceManager.ActiveWorkspace.UnregisterPhantomWindow(this, phantomNode.Window);
+		}
 
 		// Remove the node from the tree.
 		if (removingNode.Parent == null)
@@ -492,7 +505,7 @@ public partial class TreeLayoutEngine : ILayoutEngine
 			}),
 		};
 
-		return GetNodeContainingPoint(Root, new NodeLocation() { Height = 1, Width = 1 }, adjacentLocation, node);
+		return GetNodeContainingPoint(Root, new NodeLocation() { Height = 1, Width = 1 }, adjacentLocation);
 	}
 
 	/// <summary>
@@ -539,9 +552,19 @@ public partial class TreeLayoutEngine : ILayoutEngine
 		_configContext.WorkspaceManager.ActiveWorkspace.DoLayout();
 	}
 
+	/// <summary>
+	/// Split the focused window in two, and insert a phantom window in the direction
+	/// of <see cref="AddNodeDirection"/>.
+	/// </summary>
 	public void SplitFocusedWindow()
 	{
 		Logger.Debug($"Splitting focused window in layout engine {Name}");
+		SplitFocusedWindow(null);
+	}
+
+	private void SplitFocusedWindow(IWindow? focusedWindow = null)
+	{
+		Logger.Debug($"Splitting focused window in layout engine {Name} with focused window {focusedWindow}");
 
 		// Create the phantom window.
 		PhantomNode? phantomNode = PhantomNode.CreatePhantomNode(_configContext);
@@ -552,7 +575,7 @@ public partial class TreeLayoutEngine : ILayoutEngine
 		}
 
 		// Try add the phantom node.
-		if (!AddLeafNode(phantomNode))
+		if (!AddLeafNode(phantomNode, focusedWindow))
 		{
 			phantomNode.Close();
 			Logger.Error($"Could not add phantom node for layout engine {Name}");
@@ -572,6 +595,73 @@ public partial class TreeLayoutEngine : ILayoutEngine
 		foreach (IWindow window in _phantomWindows)
 		{
 			window.Hide();
+		}
+	}
+
+	public void MoveWindowToPoint(IWindow window, IPoint<double> point, bool isPhantom)
+	{
+		// TODO: Still has some weird issues when there's 3 vert, and we drag the top
+		// to the third such that the top is just mm below the third's top.
+
+		if (Root == null)
+		{
+			// Add the window normally.
+			MoveWindowToPointAddWindow(window, isPhantom, null);
+			return;
+		}
+
+		// Find the node at the point.
+		LeafNode? node = GetNodeContainingPoint(Root, new NodeLocation() { Height = 1, Width = 1 }, point);
+		if (node == null)
+		{
+			Logger.Error($"Could not find node containing point {point} in layout engine {Name}");
+			return;
+		}
+
+		// Get the parent node.
+		SplitNode? parent = node.Parent;
+
+		// Get the direction.
+		bool isHorizontal = parent?.IsHorizontal ?? AddNodeDirection.IsHorizontal();
+
+		// Get the node's location.
+		ILocation<double> nodeLocation = GetNodeLocation(node);
+
+		// Save the old direction. This is because AddWindow relies on AddNodeDirection
+		// to determine the direction.
+		Direction oldAddNodeDirection = AddNodeDirection;
+
+		// Update AddNodeDirection with the direction based on the point.
+		if (isHorizontal)
+		{
+			AddNodeDirection = point.X < nodeLocation.X + (nodeLocation.Width / 2)
+				? Direction.Left
+				: Direction.Right;
+		}
+		else
+		{
+			AddNodeDirection = point.Y < nodeLocation.Y + (nodeLocation.Height / 2)
+				? Direction.Up
+				: Direction.Down;
+		}
+
+		MoveWindowToPointAddWindow(window, isPhantom, node.Window);
+
+		// Restore the old direction.
+		AddNodeDirection = oldAddNodeDirection;
+	}
+
+	private void MoveWindowToPointAddWindow(IWindow window, bool isPhantom, IWindow? focusedWindow)
+	{
+		if (isPhantom)
+		{
+			// We don't actually care about this phantom window, as we'll spawn a new one.
+			window.Close();
+			SplitFocusedWindow(focusedWindow);
+		}
+		else
+		{
+			AddWindow(window, focusedWindow);
 		}
 	}
 }

--- a/src/Whim.TreeLayout/TreeLayoutEngine.cs
+++ b/src/Whim.TreeLayout/TreeLayoutEngine.cs
@@ -598,11 +598,8 @@ public partial class TreeLayoutEngine : ILayoutEngine
 		}
 	}
 
-	public void MoveWindowToPoint(IWindow window, IPoint<double> point, bool isPhantom)
+	public void AddWindowAtPoint(IWindow window, IPoint<double> point, bool isPhantom)
 	{
-		// TODO: Still has some weird issues when there's 3 vert, and we drag the top
-		// to the third such that the top is just mm below the third's top.
-
 		if (Root == null)
 		{
 			// Add the window normally.

--- a/src/Whim.TreeLayout/TreeLayoutEngine.cs
+++ b/src/Whim.TreeLayout/TreeLayoutEngine.cs
@@ -348,12 +348,17 @@ public partial class TreeLayoutEngine : ILayoutEngine
 		Logger.Debug($"Clearing layout engine {Name}");
 		Root = null;
 		_windows.Clear();
+
+		HidePhantomWindows();
+		_phantomWindows.Clear();
+
+		Count = 0;
 	}
 
 	public bool Contains(IWindow item)
 	{
 		Logger.Debug($"Checking if layout engine {Name} contains window {item.Title}");
-		return _windows.ContainsKey(item);
+		return _windows.ContainsKey(item) || _phantomWindows.Contains(item);
 	}
 
 	public void CopyTo(IWindow[] array, int arrayIndex)

--- a/src/Whim.TreeLayout/TreeLayoutEngine.cs
+++ b/src/Whim.TreeLayout/TreeLayoutEngine.cs
@@ -624,8 +624,8 @@ public partial class TreeLayoutEngine : ILayoutEngine
 		// Get the node's location.
 		ILocation<double> nodeLocation = GetNodeLocation(node);
 
-		// Save the old direction. This is because AddWindow relies on AddNodeDirection
-		// to determine the direction.
+		// Save the old direction. AddWindow relies on AddNodeDirection to determine the direction.
+		// However, we want to retain the user's current direction after the window is added.
 		Direction oldAddNodeDirection = AddNodeDirection;
 
 		// Update AddNodeDirection with the direction based on the point.

--- a/src/Whim.TreeLayout/TreeLayoutEngineHelpers.cs
+++ b/src/Whim.TreeLayout/TreeLayoutEngineHelpers.cs
@@ -15,8 +15,7 @@ public partial class TreeLayoutEngine
 	/// <returns>The node which contains the given <paramref name="searchPoint"/>.</returns>
 	public static LeafNode? GetNodeContainingPoint(Node root,
 												ILocation<double> rootLocation,
-												IPoint<double> searchPoint
-												)
+												IPoint<double> searchPoint)
 	{
 		if (root is LeafNode leaf)
 		{
@@ -34,7 +33,7 @@ public partial class TreeLayoutEngine
 
 		foreach ((double weight, Node child) in parent)
 		{
-			// Set up the width/height of the child.
+			// Scale the width/height of the child.
 			if (parent.IsHorizontal)
 			{
 				childLocation.Width = weight * rootLocation.Width;

--- a/src/Whim.TreeLayout/TreeLayoutEngineHelpers.cs
+++ b/src/Whim.TreeLayout/TreeLayoutEngineHelpers.cs
@@ -12,18 +12,15 @@ public partial class TreeLayoutEngine
 	/// relative location of the point.
 	/// </param>
 	/// <param name="searchPoint">The point of the leaf node to search for.</param>
-	/// <param name="originalNode">
-	/// The leaf node to search for. The returned node cannot be the same as this node.
-	/// </param>
 	/// <returns>The node which contains the given <paramref name="searchPoint"/>.</returns>
 	public static LeafNode? GetNodeContainingPoint(Node root,
 												ILocation<double> rootLocation,
-												ILocation<double> searchPoint,
-												LeafNode originalNode)
+												IPoint<double> searchPoint
+												)
 	{
 		if (root is LeafNode leaf)
 		{
-			return leaf == originalNode ? null : leaf;
+			return leaf;
 		}
 
 		if (root is not SplitNode splitNode)
@@ -47,12 +44,11 @@ public partial class TreeLayoutEngine
 				childLocation.Height = weight * rootLocation.Height;
 			}
 
-			if (childLocation.IsPointInside(searchPoint.X, searchPoint.Y))
+			if (childLocation.IsPointInside(searchPoint))
 			{
 				LeafNode? result = GetNodeContainingPoint(root: child,
 											  rootLocation: childLocation,
-											  searchPoint: searchPoint,
-											  originalNode: originalNode);
+											  searchPoint: searchPoint);
 				if (result != null)
 				{
 					return result;

--- a/src/Whim.TreeLayout/TreeLayoutEngineHelpers.cs
+++ b/src/Whim.TreeLayout/TreeLayoutEngineHelpers.cs
@@ -17,7 +17,7 @@ public partial class TreeLayoutEngine
 												ILocation<double> rootLocation,
 												IPoint<double> searchPoint)
 	{
-		if (root is LeafNode leaf)
+		if (root is LeafNode leaf && rootLocation.IsPointInside(searchPoint))
 		{
 			return leaf;
 		}

--- a/src/Whim/Binds/KeybindManager.cs
+++ b/src/Whim/Binds/KeybindManager.cs
@@ -28,7 +28,6 @@ public class KeybindManager : IKeybindManager
 	{
 		Logger.Debug("Initializing keybind manager...");
 		_unhookKeyboardHook = PInvoke.SetWindowsHookEx(WINDOWS_HOOK_ID.WH_KEYBOARD_LL, _keyboardHook, null, 0);
-		// TODO: mouse
 	}
 
 	/// <summary>

--- a/src/Whim/Layout/BaseStackLayoutEngine.cs
+++ b/src/Whim/Layout/BaseStackLayoutEngine.cs
@@ -67,5 +67,7 @@ public abstract class BaseStackLayoutEngine : ILayoutEngine
 
 	public abstract void MoveWindowEdgeInDirection(Direction edge, double delta, IWindow window);
 
+	public abstract void MoveWindowToPoint(IWindow window, IPoint<double> point, bool isPhantom);
+
 	public void HidePhantomWindows() { }
 }

--- a/src/Whim/Layout/BaseStackLayoutEngine.cs
+++ b/src/Whim/Layout/BaseStackLayoutEngine.cs
@@ -67,7 +67,7 @@ public abstract class BaseStackLayoutEngine : ILayoutEngine
 
 	public abstract void MoveWindowEdgeInDirection(Direction edge, double delta, IWindow window);
 
-	public abstract void MoveWindowToPoint(IWindow window, IPoint<double> point, bool isPhantom);
+	public abstract void AddWindowAtPoint(IWindow window, IPoint<double> point, bool isPhantom);
 
 	public void HidePhantomWindows() { }
 }

--- a/src/Whim/Layout/ColumnLayoutEngine.cs
+++ b/src/Whim/Layout/ColumnLayoutEngine.cs
@@ -113,7 +113,7 @@ public class ColumnLayoutEngine : BaseStackLayoutEngine
 		// Not implemented.
 	}
 
-	public override void MoveWindowToPoint(IWindow window, IPoint<double> point, bool _isPhantom)
+	public override void AddWindowAtPoint(IWindow window, IPoint<double> point, bool _isPhantom)
 	{
 		// Calculate the index of the window in the stack.
 		int idx = (int)Math.Round(point.X / (double)_stack.Count, MidpointRounding.AwayFromZero);

--- a/src/Whim/Layout/ColumnLayoutEngine.cs
+++ b/src/Whim/Layout/ColumnLayoutEngine.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 namespace Whim;
@@ -110,6 +111,29 @@ public class ColumnLayoutEngine : BaseStackLayoutEngine
 	public override void MoveWindowEdgeInDirection(Direction edge, double delta, IWindow window)
 	{
 		// Not implemented.
+	}
+
+	public override void MoveWindowToPoint(IWindow window, IPoint<double> point, bool _isPhantom)
+	{
+		// Calculate the index of the window in the stack.
+		int idx = (int)Math.Round(point.X / (double)_stack.Count, MidpointRounding.AwayFromZero);
+
+		// Bound idx.
+		if (idx < 0)
+		{
+			idx = 0;
+		}
+		else if (idx > _stack.Count)
+		{
+			idx = _stack.Count;
+		}
+
+		if (!LeftToRight)
+		{
+			idx = _stack.Count - idx;
+		}
+
+		_stack.Insert(idx, window);
 	}
 
 	/// <summary>

--- a/src/Whim/Layout/ILayoutEngine.cs
+++ b/src/Whim/Layout/ILayoutEngine.cs
@@ -62,7 +62,7 @@ public interface ILayoutEngine : ICollection<IWindow>, ICommandable
 	/// <param name="window">The window to move.</param>
 	/// <param name="point">The point to move the window to.</param>
 	/// <param name="isPhantom">Whether the window is a phantom window.</param>
-	public void MoveWindowToPoint(IWindow window, IPoint<double> point, bool isPhantom = false);
+	public void AddWindowAtPoint(IWindow window, IPoint<double> point, bool isPhantom = false);
 
 	/// <summary>
 	/// Checks to see if the <paramref name="root"/> <cref name="ILayoutEngine"/>

--- a/src/Whim/Layout/ILayoutEngine.cs
+++ b/src/Whim/Layout/ILayoutEngine.cs
@@ -56,6 +56,15 @@ public interface ILayoutEngine : ICollection<IWindow>, ICommandable
 	public void HidePhantomWindows();
 
 	/// <summary>
+	/// Move the <paramref name="window"/> to the <paramref name="point"/>.
+	/// The point has a coordinate space of [0, 1] for both x and y.
+	/// </summary>
+	/// <param name="window">The window to move.</param>
+	/// <param name="point">The point to move the window to.</param>
+	/// <param name="isPhantom">Whether the window is a phantom window.</param>
+	public void MoveWindowToPoint(IWindow window, IPoint<double> point, bool isPhantom = false);
+
+	/// <summary>
 	/// Checks to see if the <paramref name="root"/> <cref name="ILayoutEngine"/>
 	/// or a child layout engine is type <typeparamref name="T"/>.
 	/// </summary>

--- a/src/Whim/Layout/ProxyLayoutEngine.cs
+++ b/src/Whim/Layout/ProxyLayoutEngine.cs
@@ -51,6 +51,8 @@ public abstract class BaseProxyLayoutEngine : ILayoutEngine
 
 	public void HidePhantomWindows() => _innerLayoutEngine.HidePhantomWindows();
 
+	public void MoveWindowToPoint(IWindow window, IPoint<double> point, bool isPhantom) => _innerLayoutEngine.MoveWindowToPoint(window, point, isPhantom);
+
 	/// <summary>
 	/// Checks to see if the <paramref name="root"/> <cref name="ILayoutEngine"/>
 	/// or a child layout engine is type <typeparamref name="T"/>.
@@ -65,9 +67,9 @@ public abstract class BaseProxyLayoutEngine : ILayoutEngine
 	/// </returns>
 	public static T? GetLayoutEngine<T>(ILayoutEngine root) where T : ILayoutEngine
 	{
-		if (root is T)
+		if (root is T t)
 		{
-			return (T)root;
+			return t;
 		}
 
 		if (root is BaseProxyLayoutEngine proxy && proxy._innerLayoutEngine != null)

--- a/src/Whim/Layout/ProxyLayoutEngine.cs
+++ b/src/Whim/Layout/ProxyLayoutEngine.cs
@@ -51,7 +51,7 @@ public abstract class BaseProxyLayoutEngine : ILayoutEngine
 
 	public void HidePhantomWindows() => _innerLayoutEngine.HidePhantomWindows();
 
-	public void MoveWindowToPoint(IWindow window, IPoint<double> point, bool isPhantom) => _innerLayoutEngine.MoveWindowToPoint(window, point, isPhantom);
+	public void AddWindowAtPoint(IWindow window, IPoint<double> point, bool isPhantom) => _innerLayoutEngine.AddWindowAtPoint(window, point, isPhantom);
 
 	/// <summary>
 	/// Checks to see if the <paramref name="root"/> <cref name="ILayoutEngine"/>

--- a/src/Whim/Location/ILocation.cs
+++ b/src/Whim/Location/ILocation.cs
@@ -3,18 +3,8 @@ namespace Whim;
 /// <summary>
 /// The location of an item, where the origin is in the top-left of the primary monitor.
 /// </summary>
-public interface ILocation<T>
+public interface ILocation<T> : IPoint<T>
 {
-	/// <summary>
-	/// The x-coordinate of the left of the item.
-	/// </summary>
-	public T X { get; }
-
-	/// <summary>
-	/// The y-coordinate of the top of the item.
-	/// </summary>
-	public T Y { get; }
-
 	/// <summary>
 	/// The width of the item, in pixels.
 	/// </summary>
@@ -28,27 +18,25 @@ public interface ILocation<T>
 	/// <summary>
 	/// Indicates whether the specified point is inside this item's bounding box.
 	/// </summary>
-	public bool IsPointInside(T x, T y);
+	public bool IsPointInside(IPoint<T> point);
 
-	/// <param name="x">The x-coordinate of the point to check.</param>
-	/// <param name="y">The y-coordinate of the point to check.</param>
+	/// <param name="point">The point to check.</param>
 	/// <returns>
 	/// <see langword="true"/> if the location given by <paramref name="x"/> and <paramref name="y"/>
 	/// is inside <paramref name="location"/>.
 	/// </returns>
-	public static bool IsPointInside(ILocation<int> location, int x, int y) => location.X <= x
-	&& location.Y <= y
-	&& location.X + location.Width >= x
-	&& location.Y + location.Height >= y;
+	public static bool IsPointInside(ILocation<int> location, IPoint<int> point) => location.X <= point.X
+	&& location.Y <= point.Y
+	&& location.X + location.Width > point.X
+	&& location.Y + location.Height > point.Y;
 
-	/// <param name="x">The x-coordinate of the point to check.</param>
-	/// <param name="y">The y-coordinate of the point to check.</param>
+	/// <param name="point">The point to check.</param>
 	/// <returns>
 	/// <see langword="true"/> if the location given by <paramref name="x"/> and <paramref name="y"/>
 	/// is inside <paramref name="location"/>.
 	/// </returns>
-	public static bool IsPointInside(ILocation<double> location, double x, double y) => location.X <= x
-	&& location.Y <= y
-	&& location.X + location.Width > x
-	&& location.Y + location.Height > y;
+	public static bool IsPointInside(ILocation<double> location, IPoint<double> point) => location.X <= point.X
+	&& location.Y <= point.Y
+	&& location.X + location.Width > point.X
+	&& location.Y + location.Height > point.Y;
 }

--- a/src/Whim/Location/IPoint.cs
+++ b/src/Whim/Location/IPoint.cs
@@ -1,0 +1,22 @@
+namespace Whim;
+
+public interface IPoint<T>
+{
+	/// <summary>
+	/// The x-coordinate of the left of the item.
+	/// </summary>
+	public T X { get; }
+
+	/// <summary>
+	/// The y-coordinate of the top of the item.
+	/// </summary>
+	public T Y { get; }
+}
+
+public static class PointHelpers
+{
+	public static System.Drawing.Point ToSystemPoint(this IPoint<int> point)
+	{
+		return new System.Drawing.Point(point.X, point.Y);
+	}
+}

--- a/src/Whim/Location/Location.cs
+++ b/src/Whim/Location/Location.cs
@@ -20,7 +20,7 @@ public class Location : ILocation<int>
 		Height = height;
 	}
 
-	public bool IsPointInside(int x, int y) => ILocation<int>.IsPointInside(this, x, y);
+	public bool IsPointInside(IPoint<int> point) => ILocation<int>.IsPointInside(this, point);
 
 	public override string ToString() => $"(X: {X}, Y: {Y}, Width: {Width}, Height: {Height})";
 

--- a/src/Whim/Location/Point.cs
+++ b/src/Whim/Location/Point.cs
@@ -1,0 +1,18 @@
+namespace Whim;
+
+public class Point<T> : IPoint<T>
+{
+	public T X { get; }
+	public T Y { get; }
+
+	public Point(T x, T y)
+	{
+		X = x;
+		Y = y;
+	}
+
+	public override string ToString()
+	{
+		return $"({X}, {Y})";
+	}
+}

--- a/src/Whim/Monitor/IMonitor.cs
+++ b/src/Whim/Monitor/IMonitor.cs
@@ -15,3 +15,20 @@ public interface IMonitor : ILocation<int>
 	/// </summary>
 	public bool IsPrimary { get; }
 }
+
+public static class MonitorHelpers
+{
+	/// <summary>
+	/// Translate the <paramref name="point"/> from the <see cref="IMonitor"/>'s coordinate system to the
+	/// unit square.
+	/// </summary>
+	/// <param name="point">The point to translate.</param>
+	/// <returns>The translated point, where x and y are in the range [0, 1].</returns>
+	public static IPoint<double> ToUnitSquare(this IMonitor monitor, IPoint<int> point)
+	{
+		var x = (double)point.X / monitor.Width;
+		var y = (double)point.Y / monitor.Height;
+		return new Point<double>(x, y);
+	}
+}
+

--- a/src/Whim/Monitor/IMonitorManager.cs
+++ b/src/Whim/Monitor/IMonitorManager.cs
@@ -26,10 +26,9 @@ public interface IMonitorManager : IEnumerable<IMonitor>, ICommandable, IDisposa
 	/// <summary>
 	/// Returns the <see cref="IMonitor"/> at the given <i>x</i> and <i>y</i> coordinates.
 	/// </summary>
-	/// <param name="x"></param>
-	/// <param name="y"></param>
+	/// <param name="point">Point defined in terms of the real monitor coordinates.</param>
 	/// <returns></returns>
-	public IMonitor GetMonitorAtPoint(int x, int y);
+	public IMonitor GetMonitorAtPoint(IPoint<int> point);
 
 	public event EventHandler<MonitorsChangedEventArgs>? MonitorsChanged;
 

--- a/src/Whim/Monitor/Monitor.cs
+++ b/src/Whim/Monitor/Monitor.cs
@@ -31,7 +31,7 @@ public class Monitor : IMonitor
 	public int Y => Screen.WorkingArea.Y;
 	public bool IsPrimary => Screen.Primary;
 
-	public bool IsPointInside(int x, int y) => ILocation<int>.IsPointInside(this, x, y);
+	public bool IsPointInside(IPoint<int> point) => ILocation<int>.IsPointInside(this, point);
 
 	public override string ToString() => Screen.ToString();
 }

--- a/src/Whim/Monitor/MonitorManager.cs
+++ b/src/Whim/Monitor/MonitorManager.cs
@@ -140,15 +140,15 @@ public class MonitorManager : IMonitorManager
 		return _monitors;
 	}
 
-	public IMonitor GetMonitorAtPoint(int x, int y)
+	public IMonitor GetMonitorAtPoint(IPoint<int> point)
 	{
-		Logger.Debug($"Getting monitor at point ({x}, {y})");
-		Screen screen = Screen.FromPoint(new System.Drawing.Point(x, y));
+		Logger.Debug($"Getting monitor at point {point}");
+		Screen screen = Screen.FromPoint(point.ToSystemPoint());
 
 		IMonitor? monitor = _monitors.FirstOrDefault(m => m.Name == screen.DeviceName);
 		if (monitor == null)
 		{
-			Logger.Error($"No monitor found at point ({x}, {y})");
+			Logger.Error($"No monitor found at point {point}");
 			return _monitors[0];
 		}
 

--- a/src/Whim/Native/Win32Helper.cs
+++ b/src/Whim/Native/Win32Helper.cs
@@ -320,7 +320,7 @@ public static class Win32Helper
 	/// <summary>
 	/// Returns the window's offset.<br/>
 	/// This is based on the issue raised at https://github.com/workspacer/workspacer/issues/139,
-	/// and the associated frix from https://github.com/workspacer/workspacer/pull/146
+	/// and the associated fix from https://github.com/workspacer/workspacer/pull/146.
 	/// </summary>
 	/// <param name="hwnd"></param>
 	/// <returns></returns>

--- a/src/Whim/NativeMethods.txt
+++ b/src/Whim/NativeMethods.txt
@@ -55,3 +55,5 @@ WINDOW_EX_STYLE
 GetDesktopWindow
 GetShellWindow
 GetWindow
+
+GetCursorPos

--- a/src/Whim/Window/IWindow.cs
+++ b/src/Whim/Window/IWindow.cs
@@ -55,7 +55,7 @@ public interface IWindow
 	/// <summary>
 	/// Indicates whether the mouse is moving the window.
 	/// </summary>
-	public bool IsMouseMoving { get; internal set; }
+	public bool IsMouseMoving { get; set; }
 
 	/// <summary>
 	/// Moves the focus to this window.

--- a/src/Whim/Window/IWindow.cs
+++ b/src/Whim/Window/IWindow.cs
@@ -55,7 +55,7 @@ public interface IWindow
 	/// <summary>
 	/// Indicates whether the mouse is moving the window.
 	/// </summary>
-	public bool IsMouseMoving { get; }
+	public bool IsMouseMoving { get; internal set; }
 
 	/// <summary>
 	/// Moves the focus to this window.

--- a/src/Whim/Window/Window.cs
+++ b/src/Whim/Window/Window.cs
@@ -40,7 +40,7 @@ public class Window : IWindow
 
 	public bool IsMaximized => PInvoke.IsZoomed(Handle);
 
-	public bool IsMouseMoving { get; set; }
+	public bool IsMouseMoving { get; set; } = false;
 
 	public void BringToTop()
 	{

--- a/src/Whim/Window/Window.cs
+++ b/src/Whim/Window/Window.cs
@@ -40,7 +40,7 @@ public class Window : IWindow
 
 	public bool IsMaximized => PInvoke.IsZoomed(Handle);
 
-	public bool IsMouseMoving { get; internal set; }
+	public bool IsMouseMoving { get; set; }
 
 	public void BringToTop()
 	{

--- a/src/Whim/Window/WindowManager.cs
+++ b/src/Whim/Window/WindowManager.cs
@@ -35,7 +35,7 @@ public class WindowManager : IWindowManager
 
 	private IWindow? _mouseMoveWindow;
 
-	private readonly object _mouseMoveLock = new object();
+	private readonly object _mouseMoveLock = new();
 
 
 	/// <summary>
@@ -279,10 +279,22 @@ public class WindowManager : IWindowManager
 			{
 				Logger.Verbose($"Window move for {_mouseMoveWindow} ended");
 				_mouseMoveWindow.IsMouseMoving = false;
+				MoveWindowToLocation(_mouseMoveWindow);
+
 				_mouseMoveWindow = null;
-				_configContext.WorkspaceManager.ActiveWorkspace.DoLayout();
 			}
 		}
+	}
+
+	private void MoveWindowToLocation(IWindow window)
+	{
+		if (!PInvoke.GetCursorPos(out POINT point))
+		{
+			return;
+		}
+
+		_configContext.WorkspaceManager.MoveWindowToPoint(window, new Point<int>(point.x, point.y));
+		_configContext.WorkspaceManager.ActiveWorkspace.DoLayout();
 	}
 
 	public void TriggerWindowUpdated(WindowUpdateEventArgs args)

--- a/src/Whim/Workspace/IWorkspace.cs
+++ b/src/Whim/Workspace/IWorkspace.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 
 namespace Whim;
@@ -108,6 +107,14 @@ public interface IWorkspace : ICommandable
 	/// used.
 	/// </param>
 	public void MoveWindowEdgeInDirection(Direction edge, double delta, IWindow? window = null);
+
+	/// <summary>
+	/// Moves the given <paramref name="window"/> to the given <paramref name="point"/>.
+	/// </summary>
+	/// <param name="window">The window to move.</param>
+	/// <param name="point">The point to move the window to.</param>
+	/// <param name="isPhantom">Indicates whether the window being moved is a phantom window.</param>
+	public void MoveWindowToPoint(IWindow window, IPoint<double> point, bool isPhantom = false);
 	#endregion
 
 	#region Phantom Windows

--- a/src/Whim/Workspace/IWorkspaceManager.cs
+++ b/src/Whim/Workspace/IWorkspaceManager.cs
@@ -178,6 +178,13 @@ public interface IWorkspaceManager : IEnumerable<IWorkspace>, ICommandable
 	/// </param>
 	public void MoveWindowToNextMonitor(IWindow? window = null);
 
+	/// <summary>
+	/// Moves the given <paramref name="window"/> to the given <paramref name="point"/>.
+	/// </summary>
+	/// <param name="window">The window to move.</param>
+	/// <param name="point">The point to move the window to.</param>
+	public void MoveWindowToPoint(IWindow window, IPoint<int> point);
+
 	#region Phantom Windows
 	/// <summary>
 	/// Register a phantom window for the given <paramref name="workspace"/>.

--- a/src/Whim/Workspace/Workspace.cs
+++ b/src/Whim/Workspace/Workspace.cs
@@ -367,7 +367,7 @@ public class Workspace : IWorkspace
 
 		foreach (ILayoutEngine layoutEngine in _layoutEngines)
 		{
-			layoutEngine.MoveWindowToPoint(window, point, isPhantom);
+			layoutEngine.AddWindowAtPoint(window, point, isPhantom);
 		}
 	}
 

--- a/src/Whim/Workspace/Workspace.cs
+++ b/src/Whim/Workspace/Workspace.cs
@@ -352,6 +352,25 @@ public class Workspace : IWorkspace
 		DoLayout();
 	}
 
+	public void MoveWindowToPoint(IWindow window, IPoint<double> point, bool isPhantom)
+	{
+		Logger.Debug($"Moving window {window} to point {point}");
+
+		// Double check isPhantom.
+		if (_phantomWindows.ContainsKey(window) && !isPhantom)
+		{
+			Logger.Error($"Window {window} is a phantom window but is not being moved to a phantom point");
+			return;
+		}
+
+		_windows.Add(window);
+
+		foreach (ILayoutEngine layoutEngine in _layoutEngines)
+		{
+			layoutEngine.MoveWindowToPoint(window, point, isPhantom);
+		}
+	}
+
 	public override string ToString() => Name;
 
 	public void Deactivate()

--- a/src/Whim/Workspace/Workspace.cs
+++ b/src/Whim/Workspace/Workspace.cs
@@ -70,6 +70,11 @@ public class Workspace : IWorkspace
 		IEnumerable<IWindowLocation> locations = ActiveLayoutEngine.DoLayout(new Location(0, 0, monitor.Width, monitor.Height));
 		foreach (IWindowLocation loc in locations)
 		{
+			if (loc.Window.IsMouseMoving)
+			{
+				continue;
+			}
+
 			// Adjust the window location to the monitor's coordinates
 			loc.Location = new Location(x: loc.Location.X + monitor.X,
 										y: loc.Location.Y + monitor.Y,


### PR DESCRIPTION
**Changes:**

- `ILocation` now inherits from `IPoint`.
- `ILocation.IsPointInside` now accepts `IPoint`, instead of two parameters.
- `ILocation.IsPointInside` now uses less than, instead of less or equal for the upper bound.
- Fixed index error in `SplitNode.Add`.
- `TreeLayoutEngine` methods `AddWindow`, `AddLeafNode`, and `SplitFocusedWindow` now accept an optional `focusedWindow` parameter.

**Added:**

- `WindowManager` now handles mouse events, and calls `IWorkspaceManager.MoveWindowToPoint`.
- `AddWindowAtPoint` in all layout engines.
- `IMonitor.ToUnitSquare` to scale a point from inside the monitor to the unit square.
- Increased test coverage of `TreeLayoutEngine`, including:
  - `Clear`
  - `Contains`
  - `FocusWindowInDirection`
  - `GetNodeContainingPoint`
  - `GetFirstWindow`
- `TestTreeEngineEmpty` to reduce the boilerplate necessary for setting up tests.
