### PR TITLE
Remove Windows Forms

### DIFF
--- a/src/Whim.TreeLayout.Tests/TestContains.cs
+++ b/src/Whim.TreeLayout.Tests/TestContains.cs
@@ -11,7 +11,7 @@ public class TestContains
 
 		foreach (IWindow window in testTreeEngine.GetWindows())
 		{
-			Assert.True(testTreeEngine.Engine.Contains(window));
+			Assert.Contains(window, testTreeEngine.Engine);
 		}
 	}
 

--- a/src/Whim/Location/ILocation.cs
+++ b/src/Whim/Location/ILocation.cs
@@ -40,3 +40,4 @@ public interface ILocation<T> : IPoint<T>
 	&& location.X + location.Width > point.X
 	&& location.Y + location.Height > point.Y;
 }
+

--- a/src/Whim/Location/IPoint.cs
+++ b/src/Whim/Location/IPoint.cs
@@ -1,3 +1,5 @@
+using Windows.Win32.Foundation;
+
 namespace Whim;
 
 public interface IPoint<T>
@@ -15,8 +17,8 @@ public interface IPoint<T>
 
 public static class PointHelpers
 {
-	public static System.Drawing.Point ToSystemPoint(this IPoint<int> point)
+	public static POINT ToSystemPoint(this IPoint<int> point)
 	{
-		return new System.Drawing.Point(point.X, point.Y);
+		return new POINT() { x = point.X, y = point.Y };
 	}
 }

--- a/src/Whim/Location/Location.cs
+++ b/src/Whim/Location/Location.cs
@@ -37,4 +37,6 @@ public class Location : ILocation<int>
 											 && location.Height == Height;
 
 	public override int GetHashCode() => HashCode.Combine(X, Y, Width, Height);
+
+	public static ILocation<int> Empty() => new Location(0, 0, 0, 0);
 }

--- a/src/Whim/Location/RectHelpers.cs
+++ b/src/Whim/Location/RectHelpers.cs
@@ -1,0 +1,13 @@
+﻿using Windows.Win32.Foundation;
+
+namespace Whim;
+
+public static class RectHelpers
+{
+	public static ILocation<int> ToLocation(this RECT rect) => new Location(
+		x: rect.left,
+		y: rect.top,
+		width: rect.right - rect.left,
+		height: rect.bottom - rect.top
+	);
+}

--- a/src/Whim/Monitor/Monitor.cs
+++ b/src/Whim/Monitor/Monitor.cs
@@ -1,6 +1,4 @@
-﻿using System.Windows.Forms;
-
-namespace Whim;
+﻿namespace Whim;
 
 /// <summary>
 /// Implementation of <see cref="IMonitor"/>.
@@ -8,18 +6,16 @@ namespace Whim;
 public class Monitor : IMonitor
 {
 	/// <summary>
-	/// Internal WinForms <see cref="System.Windows.Forms.Screen"/>.
+	/// Internal representation of a screen, based on the WinForms Screen class.
+	/// This has been ported to <see cref="Screen"/>.
 	/// </summary>
 	internal Screen Screen { get; }
 
 	/// <summary>
 	///
 	/// </summary>
-	/// <param name="screen">
-	/// Internal WinForms <see cref="System.Windows.Forms.Screen"/> from which
-	/// <see cref="Monitor"/> exposes information.
-	/// </param>
-	public Monitor(Screen screen)
+	/// <param name="screen"></param>
+	internal Monitor(Screen screen)
 	{
 		Screen = screen;
 	}

--- a/src/Whim/Monitor/MonitorManager.cs
+++ b/src/Whim/Monitor/MonitorManager.cs
@@ -3,7 +3,6 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
-using System.Windows.Forms;
 
 namespace Whim;
 
@@ -143,7 +142,7 @@ public class MonitorManager : IMonitorManager
 	public IMonitor GetMonitorAtPoint(IPoint<int> point)
 	{
 		Logger.Debug($"Getting monitor at point {point}");
-		Screen screen = Screen.FromPoint(point.ToSystemPoint());
+		Screen screen = Screen.FromPoint(point);
 
 		IMonitor? monitor = _monitors.FirstOrDefault(m => m.Name == screen.DeviceName);
 		if (monitor == null)

--- a/src/Whim/Monitor/Screen.AllScreens.cs
+++ b/src/Whim/Monitor/Screen.AllScreens.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using System.Collections.Generic;
+using Windows.Win32;
+using Windows.Win32.Foundation;
+using Windows.Win32.Graphics.Gdi;
+using Windows.Win32.UI.WindowsAndMessaging;
+
+namespace Whim;
+
+internal partial class Screen
+{
+	// This identifier is just for us, so that we don't try to call the multimon
+	// functions if we just need the primary monitor... this is safer for
+	// non-multimon OSes.
+	private static readonly HMONITOR PRIMARY_MONITOR = unchecked((HMONITOR)(int)0xBAADF00D);
+
+	/// <summary>
+	///  Static counter of desktop size changes.
+	/// </summary>
+	private static int s_desktopChangedCount = -1;
+
+	/// <summary>
+	///  Used to lock this class before syncing to SystemEvents.
+	/// </summary>
+	private static readonly object s_syncLock = new();
+
+	private class MonitorEnumCallback
+	{
+		public List<Screen> Screens { get; } = new();
+
+		public unsafe virtual BOOL Callback(HMONITOR monitor, HDC hdc, RECT* rect, LPARAM param)
+		{
+			Screens.Add(new Screen(monitor, hdc));
+			return (BOOL)true;
+		}
+	}
+
+	private static readonly bool s_multiMonitorSupport = PInvoke.GetSystemMetrics(SYSTEM_METRICS_INDEX.SM_CMONITORS) != 0;
+
+	/// <summary>
+	/// Used to store the screens until <see cref="OnDisplaySettingsChanging" /> invalidates it.
+	/// </summary>
+	private static Screen[]? s_screens;
+
+	internal unsafe static Screen[] AllScreens
+	{
+		get
+		{
+			if (s_screens is null)
+			{
+				if (s_multiMonitorSupport)
+				{
+					MonitorEnumCallback closure = new();
+					MONITORENUMPROC proc = new(closure.Callback);
+					PInvoke.EnumDisplayMonitors(null, null, proc, (LPARAM)0);
+
+					if (closure.Screens.Count > 0)
+					{
+						Screen[] temp = new Screen[closure.Screens.Count];
+						closure.Screens.CopyTo(temp, 0);
+						s_screens = temp;
+					}
+					else
+					{
+						s_screens = new Screen[] { new Screen(PRIMARY_MONITOR) };
+					}
+				}
+				else
+				{
+					Screen? primaryScreen = PrimaryScreen;
+
+					s_screens = primaryScreen != null ? new Screen[] { primaryScreen } : Array.Empty<Screen>();
+				}
+			}
+
+			return s_screens;
+		}
+	}
+}

--- a/src/Whim/Monitor/Screen.cs
+++ b/src/Whim/Monitor/Screen.cs
@@ -1,10 +1,6 @@
 ﻿using Microsoft.Win32;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading;
-using System.Threading.Tasks;
 using Windows.Win32;
 using Windows.Win32.Foundation;
 using Windows.Win32.Graphics.Gdi;

--- a/src/Whim/Monitor/Screen.cs
+++ b/src/Whim/Monitor/Screen.cs
@@ -1,0 +1,255 @@
+﻿using Microsoft.Win32;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Windows.Win32;
+using Windows.Win32.Foundation;
+using Windows.Win32.Graphics.Gdi;
+using Windows.Win32.UI.WindowsAndMessaging;
+
+namespace Whim;
+
+internal partial class Screen
+{
+	private readonly HMONITOR _hmonitor;
+
+	private readonly ILocation<int> _bounds;
+
+	private ILocation<int> _workingArea = Location.Empty();
+
+	public readonly bool Primary;
+
+	private readonly int _bitDepth;
+
+	/// <summary>
+	///  Instance-based counter used to invalidate <see cref="WorkingArea"/>.
+	/// </summary>
+	private int _currentDesktopChangedCount = -1;
+
+	/// <summary>
+	///  Device name associated with this monitor
+	/// </summary>
+	public string DeviceName { get; }
+
+	internal Screen(HMONITOR monitor) : this(monitor, default) { }
+
+	internal unsafe Screen(HMONITOR monitor, HDC hdc)
+	{
+		HDC screenDC = hdc;
+
+		if (!s_multiMonitorSupport || monitor == PRIMARY_MONITOR)
+		{
+			// Single monitor system.
+			_bounds = new Location(
+				x: PInvoke.GetSystemMetrics(SYSTEM_METRICS_INDEX.SM_XVIRTUALSCREEN),
+				y: PInvoke.GetSystemMetrics(SYSTEM_METRICS_INDEX.SM_YVIRTUALSCREEN),
+				width: PInvoke.GetSystemMetrics(SYSTEM_METRICS_INDEX.SM_CXVIRTUALSCREEN),
+				height: PInvoke.GetSystemMetrics(SYSTEM_METRICS_INDEX.SM_CYVIRTUALSCREEN)
+			);
+
+			Primary = true;
+			DeviceName = "DISPLAY";
+		}
+		else
+		{
+			// Multiple monitor system.
+			MONITORINFOEXW info = new() { __AnonymousBase_winuser_L13571_C43 = new MONITORINFO() { cbSize = (uint)sizeof(MONITORINFOEXW) } };
+			MonitorInfo.GetMonitorInfo(monitor, ref info);
+			_bounds = info.GetLocation();
+			Primary = info.IsPrimary();
+
+			DeviceName = info.GetDeviceName();
+
+			if (hdc.IsNull)
+			{
+				fixed (char* p = DeviceName)
+				{
+					screenDC = (HDC)PInvoke.CreateDCW((PCWSTR)p, null, null).Value;
+				}
+			}
+		}
+
+		_hmonitor = monitor;
+
+		_bitDepth = PInvoke.GetDeviceCaps(screenDC, GET_DEVICE_CAPS_INDEX.BITSPIXEL);
+		_bitDepth *= PInvoke.GetDeviceCaps(screenDC, GET_DEVICE_CAPS_INDEX.PLANES);
+
+		if (hdc != screenDC)
+		{
+			PInvoke.DeleteDC((CreatedHDC)screenDC.Value);
+		}
+	}
+
+	/// <summary>
+	///  Gets the
+	///  primary display.
+	/// </summary>
+	public static Screen? PrimaryScreen
+	{
+		get
+		{
+			if (s_multiMonitorSupport)
+			{
+				Screen[] screens = AllScreens;
+				for (int i = 0; i < screens.Length; i++)
+				{
+					if (screens[i].Primary)
+					{
+						return screens[i];
+					}
+				}
+
+				return null;
+			}
+			else
+			{
+				return new Screen(PRIMARY_MONITOR, default);
+			}
+		}
+	}
+
+	/// <summary>
+	///  Gets the working area of the screen.
+	/// </summary>
+	public unsafe ILocation<int> WorkingArea
+	{
+		get
+		{
+			// If the static Screen class has a different desktop change count than this instance
+			// then update the count and recalculate our working area.
+			if (_currentDesktopChangedCount != DesktopChangedCount)
+			{
+				Interlocked.Exchange(ref _currentDesktopChangedCount, DesktopChangedCount);
+
+				if (!s_multiMonitorSupport || _hmonitor == (IntPtr)PRIMARY_MONITOR)
+				{
+					// Single monitor system
+					unsafe
+					{
+						RECT rect = new();
+						PInvoke.SystemParametersInfo(SYSTEM_PARAMETERS_INFO_ACTION.SPI_GETWORKAREA, 0, &rect, 0);
+						_workingArea = rect.ToLocation();
+					}
+				}
+				else
+				{
+					// Multiple monitor System
+					MONITORINFO info = new()
+					{
+						cbSize = (uint)sizeof(MONITORINFO)
+					};
+					PInvoke.GetMonitorInfo(_hmonitor, ref info);
+					_workingArea = info.rcWork.ToLocation();
+				}
+			}
+
+			return _workingArea;
+		}
+	}
+
+	/// <summary>
+	///  Screen instances call this property to determine
+	///  if their WorkingArea cache needs to be invalidated.
+	/// </summary>
+	private static int DesktopChangedCount
+	{
+		get
+		{
+			if (s_desktopChangedCount == -1)
+			{
+				lock (s_syncLock)
+				{
+					//now that we have a lock, verify (again) our changecount...
+					if (s_desktopChangedCount == -1)
+					{
+						//sync the UserPreference.Desktop change event.  We'll keep count
+						//of desktop changes so that the WorkingArea property on Screen
+						//instances know when to invalidate their cache.
+						SystemEvents.UserPreferenceChanged += new UserPreferenceChangedEventHandler(OnUserPreferenceChanged);
+
+						s_desktopChangedCount = 0;
+					}
+				}
+			}
+
+			return s_desktopChangedCount;
+		}
+	}
+
+	/// <summary>
+	///  Called by the SystemEvents class when our display settings have
+	///  changed.  Here, we increment a static counter that Screen instances
+	///  can check against to invalidate their cache.
+	/// </summary>
+	private static void OnUserPreferenceChanged(object sender, UserPreferenceChangedEventArgs e)
+	{
+		if (e.Category == UserPreferenceCategory.Desktop)
+		{
+			Interlocked.Increment(ref s_desktopChangedCount);
+		}
+	}
+
+	/// <summary>
+	///  Specifies a value that indicates whether the specified object is equal to
+	///  this one.
+	/// </summary>
+	public override bool Equals(object? obj)
+	{
+		if (obj is Screen comp)
+		{
+			if (_hmonitor == comp._hmonitor)
+			{
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/// <summary>
+	///  Computes and retrieves a hash code for an object.
+	/// </summary>
+	public override int GetHashCode() => (int)(nint)_hmonitor;
+
+	/// <summary>
+	///  Called by the SystemEvents class when our display settings are
+	///  changing.  We cache screen information and at this point we must
+	///  invalidate our cache.
+	/// </summary>
+	private static void OnDisplaySettingsChanging(object? sender, EventArgs e)
+	{
+		// Now that we've responded to this event, we don't need it again until
+		// someone re-queries. We will re-add the event at that time.
+		SystemEvents.DisplaySettingsChanging -= new EventHandler(OnDisplaySettingsChanging);
+
+		// Display settings changed, so the set of screens we have is invalid.
+		s_screens = null;
+	}
+
+	/// <summary>
+	///  Retrieves a string representing this object.
+	/// </summary>
+	public override string ToString()
+	{
+		return GetType().Name + "[Bounds=" + _bounds.ToString() + " WorkingArea=" + WorkingArea.ToString() + " Primary=" + Primary.ToString() + " DeviceName=" + DeviceName;
+	}
+
+	/// <summary>
+	///  Retrieves a <see cref="Screen"/>
+	///  for the monitor that contains the specified point.
+	/// </summary>
+	public static Screen FromPoint(IPoint<int> point)
+	{
+		if (s_multiMonitorSupport)
+		{
+			return new Screen(PInvoke.MonitorFromPoint(point.ToSystemPoint(), MONITOR_FROM_FLAGS.MONITOR_DEFAULTTONEAREST));
+		}
+		else
+		{
+			return new Screen(PRIMARY_MONITOR);
+		}
+	}
+}

--- a/src/Whim/Native/MonitorInfo.cs
+++ b/src/Whim/Native/MonitorInfo.cs
@@ -1,0 +1,34 @@
+using System.Runtime.InteropServices;
+using Windows.Win32;
+using Windows.Win32.Graphics.Gdi;
+
+namespace Whim;
+
+internal static class MonitorInfo
+{
+	[DllImport("User32", ExactSpelling = true, EntryPoint = "GetMonitorInfoW")]
+	[DefaultDllImportSearchPaths(DllImportSearchPath.System32)] private static extern unsafe bool GetMonitorInfo(HMONITOR hMonitor, MONITORINFOEXW* lpmi);
+
+	internal static unsafe bool GetMonitorInfo(HMONITOR monitor, ref MONITORINFOEXW lpmi)
+	{
+		fixed (MONITORINFOEXW* lmpiLocal = &lpmi)
+		{
+			return GetMonitorInfo(monitor, lmpiLocal);
+		}
+	}
+
+	internal static ILocation<int> GetLocation(this MONITORINFOEXW monitor)
+	{
+		return monitor.__AnonymousBase_winuser_L13571_C43.rcMonitor.ToLocation();
+	}
+
+	internal static string GetDeviceName(this MONITORINFOEXW monitor)
+	{
+		return monitor.szDevice.ToString();
+	}
+
+	internal static bool IsPrimary(this MONITORINFOEXW monitor)
+	{
+		return (monitor.__AnonymousBase_winuser_L13571_C43.dwFlags & (uint)MONITOR_FROM_FLAGS.MONITOR_DEFAULTTOPRIMARY) != 0;
+	}
+}

--- a/src/Whim/Native/Win32Helper.cs
+++ b/src/Whim/Native/Win32Helper.cs
@@ -5,7 +5,6 @@ using Windows.Win32.Graphics.Dwm;
 using Windows.Win32.UI.WindowsAndMessaging;
 using Windows.Win32.UI.Accessibility;
 using System.Runtime.InteropServices;
-using System;
 
 namespace Whim;
 
@@ -355,7 +354,7 @@ public static class Win32Helper
 			RECT extendedFrameRect = new();
 			uint size = (uint)Marshal.SizeOf<RECT>();
 			HRESULT res = PInvoke.DwmGetWindowAttribute(hwnd,
-							Windows.Win32.Graphics.Dwm.DWMWINDOWATTRIBUTE.DWMWA_EXTENDED_FRAME_BOUNDS,
+							DWMWINDOWATTRIBUTE.DWMWA_EXTENDED_FRAME_BOUNDS,
 							&extendedFrameRect,
 							size);
 

--- a/src/Whim/NativeMethods.txt
+++ b/src/Whim/NativeMethods.txt
@@ -57,3 +57,15 @@ GetShellWindow
 GetWindow
 
 GetCursorPos
+
+EnumDisplayMonitors
+GetSystemMetrics
+SystemParametersInfo
+MONITORENUMPROC
+MONITORINFOF_PRIMARY
+MONITORINFOEXW
+GetMonitorInfo
+GetDeviceCaps
+CreateDC
+DeleteDC
+MonitorFromPoint

--- a/src/Whim/Whim.csproj
+++ b/src/Whim/Whim.csproj
@@ -2,13 +2,13 @@
 
 	<PropertyGroup>
 		<TargetFramework>net6.0-windows</TargetFramework>
-		<UseWindowsForms>true</UseWindowsForms>
 		<Nullable>enable</Nullable>
 		<WarningsAsErrors>Nullable</WarningsAsErrors>
 		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 	</PropertyGroup>
 
 	<ItemGroup>
+		<PackageReference Include="Microsoft.Win32.SystemEvents" Version="6.0.0" />
 		<PackageReference Include="Microsoft.Windows.CsWin32" Version="0.1.619-beta">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Whim/Workspace/Workspace.cs
+++ b/src/Whim/Workspace/Workspace.cs
@@ -375,6 +375,8 @@ public class Workspace : IWorkspace
 
 	public void Deactivate()
 	{
+		Logger.Debug($"Deactivating workspace {Name}");
+
 		foreach (IWindow window in Windows)
 		{
 			window.Hide();

--- a/src/Whim/Workspace/WorkspaceManager.cs
+++ b/src/Whim/Workspace/WorkspaceManager.cs
@@ -384,8 +384,7 @@ public class WorkspaceManager : IWorkspaceManager
 			return;
 		}
 
-		// If the active workspace contains the window, and can't remove it, error out.
-		if (targetWorkspace != ActiveWorkspace && !ActiveWorkspace.RemoveWindow(window))
+		if (!ActiveWorkspace.RemoveWindow(window))
 		{
 			Logger.Error($"Could not remove window {window} from workspace {ActiveWorkspace}");
 			return;


### PR DESCRIPTION
This pulls the `Screen` class from `System.Windows.Forms`, and no longer depends on Windows Forms.