### PR TITLE
Change core classes to be internal where possible

### DIFF
--- a/src/Whim.Bar/BarWindow.xaml.cs
+++ b/src/Whim.Bar/BarWindow.xaml.cs
@@ -1,4 +1,4 @@
-﻿using System.Linq;
+using System.Linq;
 
 namespace Whim.Bar;
 
@@ -20,7 +20,7 @@ public sealed partial class BarWindow : Microsoft.UI.Xaml.Window
 
 		UIElementExtensions.InitializeComponent(this, "Whim.Bar", "BarWindow");
 
-		IWindow? window = Window.CreateWindow(this.GetHandle(), _configContext);
+		IWindow? window = IWindow.CreateWindow(this.GetHandle(), _configContext);
 		if (window == null)
 		{
 			throw new BarException("Window was unexpectedly null");

--- a/src/Whim.Runner/Whim.cs
+++ b/src/Whim.Runner/Whim.cs
@@ -12,7 +12,7 @@ internal class Whim
 	internal static void Start()
 	{
 		// Create an empty Whim config context.
-		IConfigContext configContext = new ConfigContext();
+		IConfigContext configContext = Engine.CreateConfigContext();
 		Exception? startupException = null;
 
 		try

--- a/src/Whim.TreeLayout/PhantomNode.cs
+++ b/src/Whim.TreeLayout/PhantomNode.cs
@@ -20,7 +20,7 @@ public class PhantomNode : LeafNode
 	{
 		PhantomWindow phantomWindow = new();
 
-		IWindow? windowModel = Whim.Window.CreateWindow(phantomWindow.GetHandle(), configContext);
+		IWindow? windowModel = Whim.IWindow.CreateWindow(phantomWindow.GetHandle(), configContext);
 
 		if (windowModel == null)
 		{

--- a/src/Whim/Commands/CommandManager.cs
+++ b/src/Whim/Commands/CommandManager.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 
 namespace Whim;
 
-public class CommandManager : ICommandManager
+internal class CommandManager : ICommandManager
 {
 	private readonly ICommandItems _commandItems;
 	private readonly IKeybindManager _keybindManager;

--- a/src/Whim/ConfigContext/ConfigContext.cs
+++ b/src/Whim/ConfigContext/ConfigContext.cs
@@ -11,7 +11,7 @@ namespace Whim;
 /// <c>ConfigContext</c> also contains other associated state and functionality, like the
 /// <see cref="Logger"/>.
 /// </summary>
-public class ConfigContext : IConfigContext
+internal class ConfigContext : IConfigContext
 {
 	public Logger Logger { get; set; }
 	public IWorkspaceManager WorkspaceManager { get; set; }

--- a/src/Whim/Engine.cs
+++ b/src/Whim/Engine.cs
@@ -1,0 +1,21 @@
+namespace Whim;
+
+/// <summary>
+/// Exposes the Whim <see cref="IConfigContext"/>.
+/// </summary>
+public static class Engine
+{
+	private static IConfigContext? _configContext;
+
+	/// <summary>
+	/// Get the <see cref="IConfigContext"/>.
+	/// </summary>
+	public static IConfigContext CreateConfigContext()
+	{
+		if (_configContext == null)
+		{
+			_configContext = new ConfigContext();
+		}
+		return _configContext;
+	}
+}

--- a/src/Whim/Monitor/Monitor.cs
+++ b/src/Whim/Monitor/Monitor.cs
@@ -1,9 +1,9 @@
-﻿namespace Whim;
+namespace Whim;
 
 /// <summary>
 /// Implementation of <see cref="IMonitor"/>.
 /// </summary>
-public class Monitor : IMonitor
+internal class Monitor : IMonitor
 {
 	/// <summary>
 	/// Internal representation of a screen, based on the WinForms Screen class.

--- a/src/Whim/Monitor/MonitorManager.cs
+++ b/src/Whim/Monitor/MonitorManager.cs
@@ -9,7 +9,7 @@ namespace Whim;
 /// <summary>
 /// Implementation of <see cref="IMonitorManager"/>.
 /// </summary>
-public class MonitorManager : IMonitorManager
+internal class MonitorManager : IMonitorManager
 {
 	private readonly IConfigContext _configContext;
 

--- a/src/Whim/Native/WindowExtensions.cs
+++ b/src/Whim/Native/WindowExtensions.cs
@@ -70,7 +70,7 @@ public static class WindowExtensions
 		UIElementExtensions.InitializeComponent(uiWindow, componentNamespace, componentPath);
 
 		HWND hwnd = new(WinRT.Interop.WindowNative.GetWindowHandle(uiWindow));
-		IWindow? window = Window.CreateWindow(GetHandle(uiWindow), configContext);
+		IWindow? window = IWindow.CreateWindow(GetHandle(uiWindow), configContext);
 		if (window == null)
 		{
 			throw new InitializeWindowException("Window was unexpectedly null");

--- a/src/Whim/Plugin/PluginManager.cs
+++ b/src/Whim/Plugin/PluginManager.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace Whim;
 
-public class PluginManager : IPluginManager
+internal class PluginManager : IPluginManager
 {
 	private readonly List<IPlugin> _plugins = new();
 	private bool disposedValue;

--- a/src/Whim/Router/FilterManager.cs
+++ b/src/Whim/Router/FilterManager.cs
@@ -4,7 +4,7 @@ using System.Text.RegularExpressions;
 
 namespace Whim;
 
-public class FilterManager : IFilterManager
+internal class FilterManager : IFilterManager
 {
 
 	#region Filters for specific properties

--- a/src/Whim/Router/RouterManager.cs
+++ b/src/Whim/Router/RouterManager.cs
@@ -1,9 +1,9 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Text.RegularExpressions;
 
 namespace Whim;
 
-public class RouterManager : IRouterManager
+internal class RouterManager : IRouterManager
 {
 	private readonly IConfigContext _configContext;
 	private readonly List<Router> _routers = new();

--- a/src/Whim/Window/IWindow.cs
+++ b/src/Whim/Window/IWindow.cs
@@ -1,3 +1,4 @@
+using System;
 using Windows.Win32.Foundation;
 
 namespace Whim;
@@ -110,4 +111,24 @@ public interface IWindow
 	/// Quits the window.
 	/// </summary>
 	public void Close();
+
+	/// <summary>
+	/// Create a new window. If the window cannot be created, <c>null</c> is returned.
+	/// </summary>
+	/// <param name="hwnd">The handle of the window.</param>
+	/// <param name="configContext">The configuration context.</param>
+	public static IWindow? CreateWindow(HWND hwnd, IConfigContext configContext)
+	{
+		Logger.Debug($"Registering window {hwnd.Value}");
+
+		try
+		{
+			return new Window(hwnd, configContext);
+		}
+		catch (Exception e)
+		{
+			Logger.Error($"Could not create a Window instance for {hwnd.Value}, {e.Message}");
+			return null;
+		}
+	}
 }

--- a/src/Whim/Window/Window.cs
+++ b/src/Whim/Window/Window.cs
@@ -7,7 +7,7 @@ using Windows.Win32.Foundation;
 
 namespace Whim;
 
-public class Window : IWindow
+internal class Window : IWindow
 {
 	private readonly IConfigContext _configContext;
 
@@ -126,7 +126,7 @@ public class Window : IWindow
 	/// <param name="hwnd"></param>
 	/// <param name="configContext"></param>
 	/// <exception cref="Win32Exception"></exception>
-	private Window(HWND hwnd, IConfigContext configContext)
+	internal Window(HWND hwnd, IConfigContext configContext)
 	{
 		_configContext = configContext;
 		Handle = hwnd;
@@ -157,21 +157,6 @@ public class Window : IWindow
 			// We throw the exception here to implicitly ignore this process.
 			throw ex;
 		};
-	}
-
-	public static Window? CreateWindow(HWND hwnd, IConfigContext configContext)
-	{
-		Logger.Debug($"Registering window {hwnd.Value}");
-
-		try
-		{
-			return new Window(hwnd, configContext);
-		}
-		catch (Exception e)
-		{
-			Logger.Error($"Could not create a Window instance for {hwnd.Value}, {e.Message}");
-			return null;
-		}
 	}
 
 	public override bool Equals(object? obj)

--- a/src/Whim/Window/WindowManager.cs
+++ b/src/Whim/Window/WindowManager.cs
@@ -7,7 +7,7 @@ using Windows.Win32.UI.WindowsAndMessaging;
 
 namespace Whim;
 
-public class WindowManager : IWindowManager
+internal class WindowManager : IWindowManager
 {
 	private readonly IConfigContext _configContext;
 
@@ -209,7 +209,7 @@ public class WindowManager : IWindowManager
 
 		Logger.Debug($"Registering window {hwnd.Value}");
 
-		Window? window = Window.CreateWindow(hwnd, _configContext);
+		IWindow? window = IWindow.CreateWindow(hwnd, _configContext);
 
 		if (window == null || _configContext.FilterManager.ShouldBeIgnored(window))
 		{

--- a/src/Whim/Workspace/Workspace.cs
+++ b/src/Whim/Workspace/Workspace.cs
@@ -1,10 +1,10 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
 namespace Whim;
 
-public class Workspace : IWorkspace
+internal class Workspace : IWorkspace
 {
 	private readonly IConfigContext _configContext;
 

--- a/src/Whim/Workspace/WorkspaceManager.cs
+++ b/src/Whim/Workspace/WorkspaceManager.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
@@ -8,7 +8,7 @@ namespace Whim;
 /// <summary>
 /// Implementation of <see cref="IWorkspaceManager"/>.
 /// </summary>
-public class WorkspaceManager : IWorkspaceManager
+internal class WorkspaceManager : IWorkspaceManager
 {
 	private readonly IConfigContext _configContext;
 


### PR DESCRIPTION
As part of #100, decreased the number of classes from the `Whim` namespace exposed to other projects. The static method `Window.CreateWindow` had to be moved to `IWindow` to provide external access.