### PR TITLE
Loads existing windows during Whim startup

### DIFF
--- a/src/Whim/ConfigContext/ConfigContext.cs
+++ b/src/Whim/ConfigContext/ConfigContext.cs
@@ -57,6 +57,7 @@ internal class ConfigContext : IConfigContext
 		WorkspaceManager.Initialize();
 		CommandManager.Initialize();
 
+		WindowManager.PostInitialize();
 		PluginManager.PostInitialize();
 	}
 

--- a/src/Whim/Native/Win32Helper.cs
+++ b/src/Whim/Native/Win32Helper.cs
@@ -360,4 +360,21 @@ public static class Win32Helper
 			}
 		}
 	}
+
+	/// <summary>
+	/// Enumerates over all the <see cref="HWND"/> of all the top-level windows.
+	/// </summary>
+	/// <returns></returns>
+	public static IEnumerable<HWND> GetAllWindows()
+	{
+		List<HWND> windows = new();
+
+		PInvoke.EnumWindows((handle, param) =>
+		{
+			windows.Add(handle);
+			return (BOOL)true;
+		}, 0);
+
+		return windows;
+	}
 }

--- a/src/Whim/NativeMethods.txt
+++ b/src/Whim/NativeMethods.txt
@@ -33,6 +33,7 @@ GetWindowThreadProcessId
 GetWindowText
 GetClassName
 GetWindowRect
+EnumWindows
 
 SetWindowsHookEx
 CallNextHookEx

--- a/src/Whim/Router/FilterManager.cs
+++ b/src/Whim/Router/FilterManager.cs
@@ -20,7 +20,7 @@ internal class FilterManager : IFilterManager
 
 	public FilterManager()
 	{
-		AddDefaultFilters(this);
+		IFilterManager.AddDefaultFilters(this);
 	}
 
 	public void Add(Filter filter)
@@ -37,7 +37,7 @@ internal class FilterManager : IFilterManager
 		_filters.Clear();
 		if (!clearDefaults)
 		{
-			AddDefaultFilters(this);
+			IFilterManager.AddDefaultFilters(this);
 		}
 	}
 
@@ -72,14 +72,5 @@ internal class FilterManager : IFilterManager
 		Regex regex = new(title);
 		_filters.Add(window => regex.IsMatch(window.Title));
 		return this;
-	}
-
-	/// <summary>
-	/// Populates the provided <see cref="IFilterManager"/> with the default
-	/// filters.
-	/// </summary>
-	public static void AddDefaultFilters(IFilterManager router)
-	{
-		router.IgnoreProcessName("SearchUI.exe");
 	}
 }

--- a/src/Whim/Router/IFilterManager.cs
+++ b/src/Whim/Router/IFilterManager.cs
@@ -55,4 +55,13 @@ public interface IFilterManager
 	/// </summary>
 	/// <param name="match"></param>
 	public IFilterManager IgnoreTitleMatch(string match);
+
+	/// <summary>
+	/// Populates the provided <see cref="IFilterManager"/> with the default
+	/// filters.
+	/// </summary>
+	public static void AddDefaultFilters(IFilterManager router)
+	{
+		router.IgnoreProcessName("SearchUI.exe");
+	}
 }

--- a/src/Whim/Router/IRouterManager.cs
+++ b/src/Whim/Router/IRouterManager.cs
@@ -11,6 +11,14 @@ public delegate IWorkspace? Router(IWindow window);
 public interface IRouterManager
 {
 	/// <summary>
+	/// When <see langword="true"/>, windows are routed to the active workspace.
+	/// When <see langword="false"/>, windows are routed to the active workspace on the monitor they are on.
+	/// Defaults to <see langword="false"/>.
+	/// This is overridden by any other routers in this <see cref="IRouterManager"/>.
+	/// </summary>
+	public bool RouteToActiveWorkspace { get; set; }
+
+	/// <summary>
 	/// Routes a window to a workspace.
 	/// </summary>
 	/// <param name="window"></param>

--- a/src/Whim/Router/RouterManager.cs
+++ b/src/Whim/Router/RouterManager.cs
@@ -8,6 +8,8 @@ internal class RouterManager : IRouterManager
 	private readonly IConfigContext _configContext;
 	private readonly List<Router> _routers = new();
 
+	public bool RouteToActiveWorkspace { get; set; }
+
 	public RouterManager(IConfigContext configContext)
 	{
 		_configContext = configContext;

--- a/src/Whim/Window/IWindow.cs
+++ b/src/Whim/Window/IWindow.cs
@@ -24,6 +24,16 @@ public interface IWindow
 	public string WindowClass { get; }
 
 	/// <summary>
+	/// The location of the window.
+	/// </summary>
+	public ILocation<int> Location { get; }
+
+	/// <summary>
+	/// The center of the window.
+	/// </summary>
+	public IPoint<int> Center { get; }
+
+	/// <summary>
 	/// The process ID of the window.
 	/// </summary>
 	public int ProcessId { get; }

--- a/src/Whim/Window/IWindowManager.cs
+++ b/src/Whim/Window/IWindowManager.cs
@@ -14,6 +14,11 @@ public interface IWindowManager : IDisposable
 	public void Initialize();
 
 	/// <summary>
+	/// Register the top-level windows.
+	/// </summary>
+	public void PostInitialize();
+
+	/// <summary>
 	/// Event for when a window is registered by the <see cref="IWindowManager"/>.
 	/// </summary>
 	public event EventHandler<WindowEventArgs>? WindowRegistered;

--- a/src/Whim/Window/Window.cs
+++ b/src/Whim/Window/Window.cs
@@ -33,6 +33,19 @@ internal class Window : IWindow
 	}
 
 	/// <inheritdoc/>
+	public IPoint<int> Center
+	{
+		get
+		{
+			ILocation<int> location = Location;
+			return new Point<int>(
+				location.X + (location.Width / 2),
+				location.Y + (location.Height / 2)
+			);
+		}
+	}
+
+	/// <inheritdoc/>
 	public int ProcessId { get; }
 
 	/// <inheritdoc/>

--- a/src/Whim/Window/WindowManager.cs
+++ b/src/Whim/Window/WindowManager.cs
@@ -77,7 +77,7 @@ internal class WindowManager : IWindowManager
 	{
 		foreach (HWND hwnd in Win32Helper.GetAllWindows())
 		{
-			RegisterWindow(hwnd);
+			RegisterWindow(hwnd, keepOnMonitor: true);
 		}
 	}
 
@@ -204,8 +204,14 @@ internal class WindowManager : IWindowManager
 	/// <see cref="IWindowManager"/>.
 	/// </summary>
 	/// <param name="hwnd"></param>
+	/// <param name="keepOnMonitor">
+	/// Whether the window should be kept on the monitor it was registered on.
+	/// This parameter is ignored if the <see cref="IConfigContext.RouterManager"/>
+	/// specifies the target workspace, or if the <see cref="IConfigContext.FilterManager"/>
+	/// filters the window.
+	/// </param>
 	/// <returns></returns>
-	private IWindow? RegisterWindow(HWND hwnd)
+	private IWindow? RegisterWindow(HWND hwnd, bool keepOnMonitor = false)
 	{
 		if (Win32Helper.IsSplashScreen(hwnd)
 			|| Win32Helper.IsCloakedWindow(hwnd)
@@ -233,14 +239,14 @@ internal class WindowManager : IWindowManager
 
 		Logger.Debug($"Registered {window}");
 
-		OnWindowRegistered(window);
+		OnWindowRegistered(window, keepOnMonitor);
 		return window;
 	}
 
-	private void OnWindowRegistered(IWindow window)
+	private void OnWindowRegistered(IWindow window, bool keepOnMonitor)
 	{
 		Logger.Debug($"Window registered: {window}");
-		(_configContext.WorkspaceManager as WorkspaceManager)?.WindowRegistered(window);
+		(_configContext.WorkspaceManager as WorkspaceManager)?.WindowRegistered(window, keepOnMonitor);
 		WindowRegistered?.Invoke(this, new WindowEventArgs(window));
 	}
 

--- a/src/Whim/Window/WindowManager.cs
+++ b/src/Whim/Window/WindowManager.cs
@@ -73,6 +73,14 @@ internal class WindowManager : IWindowManager
 		}
 	}
 
+	public void PostInitialize()
+	{
+		foreach (HWND hwnd in Win32Helper.GetAllWindows())
+		{
+			RegisterWindow(hwnd);
+		}
+	}
+
 	protected virtual void Dispose(bool disposing)
 	{
 		if (!disposedValue)
@@ -157,7 +165,6 @@ internal class WindowManager : IWindowManager
 			{
 				return;
 			}
-			OnWindowRegistered(window);
 		}
 
 		Logger.Verbose($"Windows event 0x{eventType:X4} for {window}");
@@ -225,6 +232,8 @@ internal class WindowManager : IWindowManager
 		}
 
 		Logger.Debug($"Registered {window}");
+
+		OnWindowRegistered(window);
 		return window;
 	}
 

--- a/src/Whim/Workspace/WorkspaceManager.cs
+++ b/src/Whim/Workspace/WorkspaceManager.cs
@@ -216,14 +216,13 @@ internal class WorkspaceManager : IWorkspaceManager
 	internal void WindowRegistered(IWindow window)
 	{
 		Logger.Debug($"Registering window {window}");
-
 		IWorkspace? workspace = _configContext.RouterManager.RouteWindow(window);
 
-		if (workspace == null)
+		if (!_configContext.RouterManager.RouteToActiveWorkspace && workspace == null)
 		{
 			workspace = GetWorkspaceForWindowLocation(window);
-			workspace ??= ActiveWorkspace;
 		}
+		workspace ??= ActiveWorkspace;
 
 		if (workspace == null)
 		{

--- a/src/Whim/Workspace/WorkspaceManager.cs
+++ b/src/Whim/Workspace/WorkspaceManager.cs
@@ -213,23 +213,15 @@ internal class WorkspaceManager : IWorkspaceManager
 	/// Called when a window has been registered by the <see cref="IWindowManager"/>.
 	/// </summary>
 	/// <param name="window">The window that was registered.</param>
-	/// <param name="keepOnMonitor">
-	/// Whether the window should be kept on the monitor it was registered on.
-	/// This parameter is ignored if the <see cref="IRouterManager"/> specifies the target workspace.
-	/// </param>
-	internal void WindowRegistered(IWindow window, bool keepOnMonitor)
+	internal void WindowRegistered(IWindow window)
 	{
 		Logger.Debug($"Registering window {window}");
 
 		IWorkspace? workspace = _configContext.RouterManager.RouteWindow(window);
 
-		if (workspace is null)
+		if (workspace == null)
 		{
-			if (keepOnMonitor)
-			{
-				workspace = GetWorkspaceForWindowLocation(window);
-			}
-
+			workspace = GetWorkspaceForWindowLocation(window);
 			workspace ??= ActiveWorkspace;
 		}
 


### PR DESCRIPTION
- Loads all windows on startup.
- Minimized windows are ignored.
- Windows are now by default loaded into Whim on the monitor they appear on.
- Added option `IRouterManager.RouteToActiveWorkspace` which routes all new windows to the active workspace.