### PR TITLE
Command palette now handles empty keybinds

### DIFF
--- a/src/Whim.CommandPalette/PaletteRow.xaml
+++ b/src/Whim.CommandPalette/PaletteRow.xaml
@@ -48,6 +48,7 @@
 		<TextBlock x:Name="CommandTitle" />
 
 		<Border
+			x:Name="CommandKeybindBorder"
 			Grid.Column="1"
 			Padding="2,0,2,0"
 			HorizontalAlignment="Right"

--- a/src/Whim.CommandPalette/PaletteRow.xaml.cs
+++ b/src/Whim.CommandPalette/PaletteRow.xaml.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.UI.Xaml.Controls;
+﻿using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Documents;
 using System.Collections.Generic;
 
@@ -28,6 +29,7 @@ internal sealed partial class PaletteRow : UserControl
 		Logger.Debug("Updating with a new item");
 		Model = item;
 		SetTitle();
+		SetKeybinds();
 	}
 
 	/// <summary>
@@ -75,12 +77,16 @@ internal sealed partial class PaletteRow : UserControl
 
 		if (Model.Match.Keys != null)
 		{
-			CommandKeybind.Text = Model.Match.Keys;
-			CommandKeybindBorder.Visibility = Microsoft.UI.Xaml.Visibility.Visible;
+			string keys = Model.Match.Keys;
+			if (CommandKeybind.Text != keys)
+			{
+				CommandKeybind.Text = keys;
+				CommandKeybindBorder.Visibility = Visibility.Visible;
+			}
 		}
-		else
+		else if (CommandKeybindBorder.Visibility != Visibility.Collapsed)
 		{
-			CommandKeybindBorder.Visibility = Microsoft.UI.Xaml.Visibility.Collapsed;
+			CommandKeybindBorder.Visibility = Visibility.Collapsed;
 		}
 	}
 }

--- a/src/Whim.CommandPalette/PaletteRow.xaml.cs
+++ b/src/Whim.CommandPalette/PaletteRow.xaml.cs
@@ -72,9 +72,15 @@ internal sealed partial class PaletteRow : UserControl
 	private void SetKeybinds()
 	{
 		Logger.Debug("Setting keybinds");
+
 		if (Model.Match.Keys != null)
 		{
 			CommandKeybind.Text = Model.Match.Keys;
+			CommandKeybindBorder.Visibility = Microsoft.UI.Xaml.Visibility.Visible;
+		}
+		else
+		{
+			CommandKeybindBorder.Visibility = Microsoft.UI.Xaml.Visibility.Collapsed;
 		}
 	}
 }


### PR DESCRIPTION
- The border is now hidden when there are no keybinds.
- Fixed the keybinds not matching the model for each row.