### PR TITLE
Floating windows can now be reinserted into `TreeLayoutEngine`

### DIFF
--- a/src/Whim.FloatingLayout/FloatingLayoutEngine.cs
+++ b/src/Whim.FloatingLayout/FloatingLayoutEngine.cs
@@ -85,7 +85,8 @@ public class FloatingLayoutEngine : BaseProxyLayoutEngine
 
 		if (window != null)
 		{
-			InnerLayoutEngine.Add(window);
+			ILocation<double> location = _windowToLocation[window];
+			InnerLayoutEngine.AddWindowAtPoint(window, location);
 			_windowToLocation.Remove(window);
 			_floatingLayoutConfig.MarkWindowAsDocked(window);
 		}

--- a/src/Whim.TreeLayout.Tests/TestAddWindow.cs
+++ b/src/Whim.TreeLayout.Tests/TestAddWindow.cs
@@ -81,4 +81,31 @@ public class TestAddWindow
 		Assert.Equal(0.3d, root[1].weight);
 		Assert.Equal(0.4d, root[2].weight);
 	}
+
+	/// <summary>
+	/// This is for when the currently window being added to the tree is also the last focused window.
+	/// This can occur when the window is being docked from a floating state.
+	/// </summary>
+	[Fact]
+	public void Add_CurrentlyFocusedWindow()
+	{
+		Mock<IWindow> window = new();
+
+		Mock<IWorkspace> workspace = new();
+		workspace.Setup(w => w.LastFocusedWindow).Returns(window.Object);
+
+		Mock<IWorkspaceManager> workspaceManager = new();
+		workspaceManager.Setup(w => w.ActiveWorkspace).Returns(workspace.Object);
+
+		Mock<IConfigContext> configContext = new();
+		configContext.Setup(x => x.WorkspaceManager).Returns(workspaceManager.Object);
+
+		TreeLayoutEngine engine = new(configContext.Object)
+		{
+			window.Object
+		};
+
+		Assert.Equal(engine.Root, new WindowNode(window.Object));
+		Assert.Single(engine);
+	}
 }

--- a/src/Whim.TreeLayout/TreeLayoutEngine.cs
+++ b/src/Whim.TreeLayout/TreeLayoutEngine.cs
@@ -73,7 +73,6 @@ public partial class TreeLayoutEngine : ILayoutEngine
 	public WindowNode? AddWindow(IWindow window, IWindow? focusedWindow = null)
 	{
 		Logger.Debug($"Adding window {window} to layout engine {Name}");
-		Count++;
 
 		// Get the focused window node
 		focusedWindow ??= _configContext.WorkspaceManager.ActiveWorkspace.LastFocusedWindow;
@@ -81,10 +80,10 @@ public partial class TreeLayoutEngine : ILayoutEngine
 		WindowNode node = new(window);
 		if (AddLeafNode(node, focusedWindow))
 		{
+			Count++;
 			return node;
 		}
 
-		Count--;
 		return null;
 	}
 
@@ -102,6 +101,16 @@ public partial class TreeLayoutEngine : ILayoutEngine
 	{
 		IWindow window = newLeaf.Window;
 
+		// Get the focused window node
+		focusedWindow ??= _configContext.WorkspaceManager.ActiveWorkspace.LastFocusedWindow;
+
+		// If the engine doesn't have the focused window, set the focused window to null.
+		// This can occur when the focused window was a floating window.
+		if (focusedWindow != null && !_windows.ContainsKey(focusedWindow))
+		{
+			focusedWindow = null;
+		}
+
 		// Add the window to the window-node map.
 		_windows.Add(window, newLeaf);
 
@@ -111,9 +120,6 @@ public partial class TreeLayoutEngine : ILayoutEngine
 			Root = newLeaf;
 			return true;
 		}
-
-		// Get the focused window node
-		focusedWindow ??= _configContext.WorkspaceManager.ActiveWorkspace.LastFocusedWindow;
 
 		Logger.Verbose($"Focused window is {focusedWindow}");
 		if (focusedWindow == null || !_windows.TryGetValue(focusedWindow, out LeafNode? focusedLeaf))


### PR DESCRIPTION
- `TreeLayoutEngine` no longer assumes that it manages the last focused window.
- `FloatingLayoutEngine` now tells the inner layout engine to add the window at the current location of the window.