### PR TITLE
Create `TreeLayoutPlugin`

### DIFF
--- a/src/Whim.FloatingLayout/FloatingLayoutPlugin.cs
+++ b/src/Whim.FloatingLayout/FloatingLayoutPlugin.cs
@@ -42,7 +42,7 @@ public class FloatingLayoutPlugin : IFloatingLayoutPlugin
 	{
 		// Get the currently active floating layout engine.
 		ILayoutEngine rootEngine = _configContext.WorkspaceManager.ActiveWorkspace.ActiveLayoutEngine;
-		FloatingLayoutEngine? floatingLayoutEngine = ILayoutEngine.GetLayoutEngine<FloatingLayoutEngine>(rootEngine);
+		FloatingLayoutEngine? floatingLayoutEngine = rootEngine.GetLayoutEngine<FloatingLayoutEngine>();
 		if (floatingLayoutEngine == null)
 		{
 			Logger.Error("Could not find floating layout engine");
@@ -61,7 +61,7 @@ public class FloatingLayoutPlugin : IFloatingLayoutPlugin
 	{
 		// Get the currently active floating layout engine.
 		ILayoutEngine rootEngine = _configContext.WorkspaceManager.ActiveWorkspace.ActiveLayoutEngine;
-		FloatingLayoutEngine? floatingLayoutEngine = ILayoutEngine.GetLayoutEngine<FloatingLayoutEngine>(rootEngine);
+		FloatingLayoutEngine? floatingLayoutEngine = rootEngine.GetLayoutEngine<FloatingLayoutEngine>();
 		if (floatingLayoutEngine == null)
 		{
 			Logger.Error("Could not find floating layout engine");
@@ -80,7 +80,7 @@ public class FloatingLayoutPlugin : IFloatingLayoutPlugin
 	{
 		// Get the currently active floating layout engine.
 		ILayoutEngine rootEngine = _configContext.WorkspaceManager.ActiveWorkspace.ActiveLayoutEngine;
-		FloatingLayoutEngine? floatingLayoutEngine = ILayoutEngine.GetLayoutEngine<FloatingLayoutEngine>(rootEngine);
+		FloatingLayoutEngine? floatingLayoutEngine = rootEngine.GetLayoutEngine<FloatingLayoutEngine>();
 		if (floatingLayoutEngine == null)
 		{
 			Logger.Error("Could not find floating layout engine");

--- a/src/Whim.Tests/ILayoutEngineTests.cs
+++ b/src/Whim.Tests/ILayoutEngineTests.cs
@@ -1,0 +1,45 @@
+using Moq;
+using Xunit;
+
+namespace Whim.Tests;
+
+public class ILayoutEngineTests
+{
+	[Fact]
+	public void GetLayoutEngine_Immediate()
+	{
+		ILayoutEngine columnLayoutEngine = new ColumnLayoutEngine();
+		Assert.Equal(columnLayoutEngine, columnLayoutEngine.GetLayoutEngine<ColumnLayoutEngine>());
+	}
+
+	[Fact]
+	public void GetLayoutEngine_Proxy()
+	{
+		ILayoutEngine columnLayoutEngine = new ColumnLayoutEngine();
+		ILayoutEngine proxyLayoutEngine = new ProxyLayoutEngine(engine => engine)(columnLayoutEngine);
+		Assert.Equal(columnLayoutEngine, proxyLayoutEngine.GetLayoutEngine<ColumnLayoutEngine>());
+	}
+
+	[Fact]
+	public void ContainsEqual_Immediate()
+	{
+		ILayoutEngine columnLayoutEngine = new ColumnLayoutEngine();
+		Assert.True(columnLayoutEngine.ContainsEqual(columnLayoutEngine));
+	}
+
+	[Fact]
+	public void ContainsEqual_Fail()
+	{
+		Mock<ILayoutEngine> columnLayoutEngineMock = new();
+		Mock<ILayoutEngine> columnLayoutEngineMock2 = new();
+		Assert.False(columnLayoutEngineMock.Object.ContainsEqual(columnLayoutEngineMock2.Object));
+	}
+
+	[Fact]
+	public void ContainsEqual_Proxy()
+	{
+		ILayoutEngine columnLayoutEngine = new ColumnLayoutEngine();
+		ILayoutEngine proxyLayoutEngine = new ProxyLayoutEngine(engine => engine)(columnLayoutEngine);
+		Assert.True(proxyLayoutEngine.ContainsEqual(columnLayoutEngine));
+	}
+}

--- a/src/Whim.TreeLayout.Bar/ToggleDirectionCommand.cs
+++ b/src/Whim.TreeLayout.Bar/ToggleDirectionCommand.cs
@@ -3,7 +3,7 @@
 namespace Whim.TreeLayout.Bar;
 
 /// <summary>
-/// Command for toggling <see cref="TreeLayoutEngine.AddNodeDirection"/>.
+/// Command for toggling <see cref="ITreeLayoutEngine.AddNodeDirection"/>.
 /// </summary>
 public class ToggleDirectionCommand : System.Windows.Input.ICommand
 {

--- a/src/Whim.TreeLayout.Bar/TreeLayoutEngineWidgetViewModel.cs
+++ b/src/Whim.TreeLayout.Bar/TreeLayoutEngineWidgetViewModel.cs
@@ -27,7 +27,7 @@ public class TreeLayoutEngineWidgetViewModel : INotifyPropertyChanged, IDisposab
 
 	/// <summary>
 	/// The direction in which windows will be added. If this is <see langword="null"/>, then the
-	/// monitor for this widget is not focused, or does not have a <see cref="TreeLayoutEngine"/>
+	/// monitor for this widget is not focused, or does not have a <see cref="ITreeLayoutEngine"/>
 	/// as the active layout engine.
 	/// </summary>
 	private Direction? DirectionValue
@@ -88,7 +88,7 @@ public class TreeLayoutEngineWidgetViewModel : INotifyPropertyChanged, IDisposab
 		}
 
 		ILayoutEngine rootEngine = _configContext.WorkspaceManager.ActiveWorkspace.ActiveLayoutEngine;
-		TreeLayoutEngine? engine = rootEngine.GetLayoutEngine<TreeLayoutEngine>();
+		ITreeLayoutEngine? engine = rootEngine.GetLayoutEngine<TreeLayoutEngine>();
 
 		if (engine is null)
 		{
@@ -110,7 +110,7 @@ public class TreeLayoutEngineWidgetViewModel : INotifyPropertyChanged, IDisposab
 		}
 
 		ILayoutEngine rootEngine = _configContext.WorkspaceManager.ActiveWorkspace.ActiveLayoutEngine;
-		TreeLayoutEngine? engine = rootEngine.GetLayoutEngine<TreeLayoutEngine>();
+		ITreeLayoutEngine? engine = rootEngine.GetLayoutEngine<TreeLayoutEngine>();
 
 		if (engine is null)
 		{

--- a/src/Whim.TreeLayout.Bar/TreeLayoutEngineWidgetViewModel.cs
+++ b/src/Whim.TreeLayout.Bar/TreeLayoutEngineWidgetViewModel.cs
@@ -88,7 +88,7 @@ public class TreeLayoutEngineWidgetViewModel : INotifyPropertyChanged, IDisposab
 		}
 
 		ILayoutEngine rootEngine = _configContext.WorkspaceManager.ActiveWorkspace.ActiveLayoutEngine;
-		TreeLayoutEngine? engine = ILayoutEngine.GetLayoutEngine<TreeLayoutEngine>(rootEngine);
+		TreeLayoutEngine? engine = rootEngine.GetLayoutEngine<TreeLayoutEngine>();
 
 		if (engine is null)
 		{
@@ -110,7 +110,7 @@ public class TreeLayoutEngineWidgetViewModel : INotifyPropertyChanged, IDisposab
 		}
 
 		ILayoutEngine rootEngine = _configContext.WorkspaceManager.ActiveWorkspace.ActiveLayoutEngine;
-		TreeLayoutEngine? engine = ILayoutEngine.GetLayoutEngine<TreeLayoutEngine>(rootEngine);
+		TreeLayoutEngine? engine = rootEngine.GetLayoutEngine<TreeLayoutEngine>();
 
 		if (engine is null)
 		{

--- a/src/Whim.TreeLayout.Tests/TestTreeLayoutCommands.cs
+++ b/src/Whim.TreeLayout.Tests/TestTreeLayoutCommands.cs
@@ -1,0 +1,61 @@
+using Moq;
+using Xunit;
+
+namespace Whim.TreeLayout.Tests;
+
+public class TestTreeLayoutCommands
+{
+	private static Mock<ITreeLayoutPlugin> CreateCommands()
+	{
+		Mock<ITreeLayoutPlugin> plugin = new();
+		return plugin;
+	}
+
+	[Fact]
+	public void TestAddTreeDirectionLeftCommand()
+	{
+		Mock<ITreeLayoutPlugin> plugin = CreateCommands();
+		TreeLayoutCommands commands = new(plugin.Object);
+		CommandItem item = commands.AddTreeDirectionLeftCommand;
+
+		item.Command.TryExecute();
+
+		plugin.Verify(x => x.SetAddWindowDirection(Direction.Left), Times.Once);
+	}
+
+	[Fact]
+	public void TestAddTreeDirectionRightCommand()
+	{
+		Mock<ITreeLayoutPlugin> plugin = CreateCommands();
+		TreeLayoutCommands commands = new(plugin.Object);
+		CommandItem item = commands.AddTreeDirectionRightCommand;
+
+		item.Command.TryExecute();
+
+		plugin.Verify(x => x.SetAddWindowDirection(Direction.Right), Times.Once);
+	}
+
+	[Fact]
+	public void TestAddTreeDirectionUpCommand()
+	{
+		Mock<ITreeLayoutPlugin> plugin = CreateCommands();
+		TreeLayoutCommands commands = new(plugin.Object);
+		CommandItem item = commands.AddTreeDirectionUpCommand;
+
+		item.Command.TryExecute();
+
+		plugin.Verify(x => x.SetAddWindowDirection(Direction.Up), Times.Once);
+	}
+
+	[Fact]
+	public void TestAddTreeDirectionDownCommand()
+	{
+		Mock<ITreeLayoutPlugin> plugin = CreateCommands();
+		TreeLayoutCommands commands = new(plugin.Object);
+		CommandItem item = commands.AddTreeDirectionDownCommand;
+
+		item.Command.TryExecute();
+
+		plugin.Verify(x => x.SetAddWindowDirection(Direction.Down), Times.Once);
+	}
+}

--- a/src/Whim.TreeLayout.Tests/TestTreeLayoutPlugin.cs
+++ b/src/Whim.TreeLayout.Tests/TestTreeLayoutPlugin.cs
@@ -1,0 +1,40 @@
+using Moq;
+using Xunit;
+
+namespace Whim.TreeLayout.Tests;
+
+public class TestTreeLayoutPlugin
+{
+	public static (Mock<IConfigContext>, Mock<IWorkspaceManager>, Mock<IWorkspace>, Mock<ITreeLayoutEngine>) CreateMocks()
+	{
+		Mock<IConfigContext> configContext = new();
+		Mock<IWorkspaceManager> workspaceManager = new();
+		Mock<IWorkspace> workspace = new();
+		Mock<ITreeLayoutEngine> layoutEngine = new();
+
+		configContext.Setup(x => x.WorkspaceManager).Returns(workspaceManager.Object);
+		workspaceManager.Setup(x => x.ActiveWorkspace).Returns(workspace.Object);
+		workspace.Setup(x => x.ActiveLayoutEngine).Returns(layoutEngine.Object);
+		layoutEngine.Setup(x => x.GetLayoutEngine<ITreeLayoutEngine>()).Returns(layoutEngine.Object);
+
+		return (configContext, workspaceManager, workspace, layoutEngine);
+	}
+
+	[Fact]
+	public void TestGetTreeLayoutEngine()
+	{
+		(Mock<IConfigContext> configContext, _, _, _) = CreateMocks();
+		TreeLayoutPlugin plugin = new(configContext.Object);
+		ITreeLayoutEngine? engine = plugin.GetTreeLayoutEngine();
+		Assert.NotNull(engine);
+	}
+
+	[Fact]
+	public void TestSetAddWindowDirection()
+	{
+		(Mock<IConfigContext> configContext, _, _, Mock<ITreeLayoutEngine> layoutEngine) = CreateMocks();
+		TreeLayoutPlugin plugin = new(configContext.Object);
+		plugin.SetAddWindowDirection(Direction.Left);
+		layoutEngine.VerifySet(x => x.AddNodeDirection = Direction.Left);
+	}
+}

--- a/src/Whim.TreeLayout/ITreeLayoutEngine.cs
+++ b/src/Whim.TreeLayout/ITreeLayoutEngine.cs
@@ -1,0 +1,68 @@
+﻿namespace Whim.TreeLayout;
+
+/// <summary>
+/// A tree layout engine allows users to create arbitrary window grid layouts.
+/// </summary>
+public interface ITreeLayoutEngine : ILayoutEngine
+{
+	/// <summary>
+	/// The direction which we will use for any following operations.
+	/// </summary>
+	Direction AddNodeDirection { get; set; }
+
+	/// <summary>
+	/// The root node of the tree.
+	/// </summary>
+	Node? Root { get; }
+
+	/// <summary>
+	/// Add the <paramref name="window"/> to the layout engine.
+	/// The direction it is added in is determined by this instance's <see cref="AddNodeDirection"/> property.
+	/// </summary>
+	/// <param name="window">The window to add.</param>
+	new void Add(IWindow window);
+
+	/// <summary>
+	/// Add the <paramref name="window"/> to the layout engine, in a
+	/// <paramref name="direction"/> to the currently focused window.
+	/// </summary>
+	/// <param name="window">The window to add.</param>
+	/// <param name="direction">
+	/// The direction to add the window, in relation to the currently focused window.
+	/// </param>
+	void Add(IWindow window, Direction direction);
+
+	/// <summary>
+	/// Adds a window to the layout engine, and returns the node that represents it.
+	/// The <paramref name="window"/> is added in the direction specified by this instance's
+	/// <see cref="AddNodeDirection"/> property.
+	/// </summary>
+	/// <param name="window">The window to add.</param>
+	/// <param name="focusedWindow">The currently focused window from whom to get the node.</param>
+	/// <returns>The node that represents the window.</returns>
+	WindowNode? AddWindow(IWindow window, IWindow? focusedWindow = null);
+
+	/// <summary>
+	/// Flip the direction of the <see cref="SplitNode"/> parent of the currently focused window, and merge it with
+	/// the grandparent <see cref="SplitNode"/>.
+	/// </summary>
+	void FlipAndMerge();
+
+	/// <summary>
+	/// Gets the adjacent node in the given <paramref name="direction"/>.
+	/// </summary>
+	/// <param name="node">The node to get the adjacent node for.</param>
+	/// <param name="direction">The direction to get the adjacent node in.</param>
+	/// <returns>
+	/// The adjacent node in the given <paramref name="direction"/>.
+	/// <see langword="null"/> if there is no adjacent node in the given <paramref name="direction"/>,
+	/// or an error occurred.
+	/// </returns>
+	LeafNode? GetAdjacentNode(LeafNode node, Direction direction);
+
+	/// <summary>
+	/// Split the focused window in two, and insert a phantom window in the direction
+	/// of <see cref="AddNodeDirection"/>.
+	/// </summary>
+	void SplitFocusedWindow();
+}

--- a/src/Whim.TreeLayout/ITreeLayoutPlugin.cs
+++ b/src/Whim.TreeLayout/ITreeLayoutPlugin.cs
@@ -1,0 +1,23 @@
+namespace Whim.TreeLayout;
+
+/// <summary>
+/// TreeLayoutPlugin provides commands and functionality for the <see cref="TreeLayoutEngine"/>.
+/// TreeLayoutPlugin does not load the <see cref="TreeLayoutEngine"/> - that is done when creating
+/// a workspace via <see cref="IWorkspace.CreateWorkspace"/>, or in <see cref="IWorkspaceManager.WorkspaceFactory"/>.
+/// </summary>
+public interface ITreeLayoutPlugin : IPlugin
+{
+	/// <summary>
+	/// Returns a <see cref="TreeLayoutEngine"/> if the layout engine is or contains a tree layout engine.
+	/// Otherwise, returns null.
+	/// </summary>
+	public TreeLayoutEngine? GetTreeLayoutEngine();
+
+	/// <summary>
+	/// Set the direction in which to add new windows to the tree layout.
+	///
+	/// This will only work if the layout engine is or contains a tree layout engine.
+	/// </summary>
+	/// <param name="direction">The direction.</param>
+	public void SetAddWindowDirection(Direction direction);
+}

--- a/src/Whim.TreeLayout/ITreeLayoutPlugin.cs
+++ b/src/Whim.TreeLayout/ITreeLayoutPlugin.cs
@@ -1,17 +1,17 @@
 namespace Whim.TreeLayout;
 
 /// <summary>
-/// TreeLayoutPlugin provides commands and functionality for the <see cref="TreeLayoutEngine"/>.
-/// TreeLayoutPlugin does not load the <see cref="TreeLayoutEngine"/> - that is done when creating
+/// TreeLayoutPlugin provides commands and functionality for the <see cref="ITreeLayoutEngine"/>.
+/// TreeLayoutPlugin does not load the <see cref="ITreeLayoutEngine"/> - that is done when creating
 /// a workspace via <see cref="IWorkspace.CreateWorkspace"/>, or in <see cref="IWorkspaceManager.WorkspaceFactory"/>.
 /// </summary>
 public interface ITreeLayoutPlugin : IPlugin
 {
 	/// <summary>
-	/// Returns a <see cref="TreeLayoutEngine"/> if the layout engine is or contains a tree layout engine.
+	/// Returns a <see cref="ITreeLayoutEngine"/> if the layout engine is or contains a tree layout engine.
 	/// Otherwise, returns null.
 	/// </summary>
-	public TreeLayoutEngine? GetTreeLayoutEngine();
+	public ITreeLayoutEngine? GetTreeLayoutEngine();
 
 	/// <summary>
 	/// Set the direction in which to add new windows to the tree layout.

--- a/src/Whim.TreeLayout/LeafNode.cs
+++ b/src/Whim.TreeLayout/LeafNode.cs
@@ -1,7 +1,7 @@
 namespace Whim.TreeLayout;
 
 /// <summary>
-/// A leaf node in the <see cref="TreeLayoutEngine"/>
+/// A leaf node in the <see cref="ITreeLayoutEngine"/>
 /// </summary>
 public abstract class LeafNode : Node
 {

--- a/src/Whim.TreeLayout/PhantomNode.cs
+++ b/src/Whim.TreeLayout/PhantomNode.cs
@@ -3,7 +3,7 @@ namespace Whim.TreeLayout;
 /// <summary>
 /// A phantom node represents a phantom window within the layout tree.
 /// Unlike a <see cref="WindowNode"/>, a phantom node is specific to the
-/// <see cref="TreeLayoutEngine"/> instance.
+/// <see cref="ITreeLayoutEngine"/> instance.
 /// As such phantom nodes have to manage the window itself, instead of relying
 /// on the <see cref="IWindowManager"/>.
 /// </summary>

--- a/src/Whim.TreeLayout/TreeLayoutCommands.cs
+++ b/src/Whim.TreeLayout/TreeLayoutCommands.cs
@@ -1,0 +1,78 @@
+using System.Collections;
+using System.Collections.Generic;
+
+namespace Whim.TreeLayout;
+
+/// <summary>
+/// The commands for the tree layout plugin.
+/// </summary>
+public class TreeLayoutCommands : IEnumerable<CommandItem>
+{
+	private readonly ITreeLayoutPlugin _plugin;
+	private string Name => _plugin.Name;
+
+	/// <summary>
+	/// Initializes a new instance of the <see cref="TreeLayoutCommands"/> class.
+	/// </summary>
+	/// <param name="plugin">The plugin.</param>
+	public TreeLayoutCommands(ITreeLayoutPlugin plugin)
+	{
+		_plugin = plugin;
+	}
+
+	/// <inheritdoc/>
+	public IEnumerator<CommandItem> GetEnumerator()
+	{
+		yield return AddTreeDirectionLeftCommand;
+		yield return AddTreeDirectionRightCommand;
+		yield return AddTreeDirectionUpCommand;
+		yield return AddTreeDirectionDownCommand;
+	}
+
+	/// <inheritdoc/>
+	IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+	/// <summary>
+	/// Add tree direction left command.
+	/// </summary>
+	public CommandItem AddTreeDirectionLeftCommand => new(
+		new Command(
+			identifier: $"{Name}.add_tree_direction_left",
+			title: "Add windows to the left of the current window",
+			callback: () => _plugin.SetAddWindowDirection(Direction.Left)
+		)
+	);
+
+	/// <summary>
+	/// Add tree direction right command.
+	/// </summary>
+	public CommandItem AddTreeDirectionRightCommand => new(
+		new Command(
+			identifier: $"{Name}.add_tree_direction_right",
+			title: "Add windows to the right of the current window",
+			callback: () => _plugin.SetAddWindowDirection(Direction.Right)
+		)
+	);
+
+	/// <summary>
+	/// Add tree direction up command.
+	/// </summary>
+	public CommandItem AddTreeDirectionUpCommand => new(
+		new Command(
+			identifier: $"{Name}.add_tree_direction_up",
+			title: "Add windows above the current window",
+			callback: () => _plugin.SetAddWindowDirection(Direction.Up)
+		)
+	);
+
+	/// <summary>
+	/// Add tree direction down command.
+	/// </summary>
+	public CommandItem AddTreeDirectionDownCommand => new(
+		new Command(
+			identifier: $"{Name}.add_tree_direction_down",
+			title: "Add windows below the current window",
+			callback: () => _plugin.SetAddWindowDirection(Direction.Down)
+		)
+	);
+}

--- a/src/Whim.TreeLayout/TreeLayoutEngine.cs
+++ b/src/Whim.TreeLayout/TreeLayoutEngine.cs
@@ -4,10 +4,8 @@ using System.Linq;
 
 namespace Whim.TreeLayout;
 
-/// <summary>
-/// A tree layout engine allows users to create arbitrary window grid layouts.
-/// </summary>
-public partial class TreeLayoutEngine : ILayoutEngine
+/// <inheritdoc />
+public partial class TreeLayoutEngine : ITreeLayoutEngine
 {
 	private readonly IConfigContext _configContext;
 	private readonly Dictionary<IWindow, LeafNode> _windows = new();
@@ -41,35 +39,17 @@ public partial class TreeLayoutEngine : ILayoutEngine
 		Name = name;
 	}
 
-	/// <summary>
-	/// Add the <paramref name="window"/> to the layout engine, in a
-	/// <paramref name="direction"/> to the currently focused window.
-	/// </summary>
-	/// <param name="window">The window to add.</param>
-	/// <param name="direction">
-	/// The direction to add the window, in relation to the currently focused window.
-	/// </param>
+	/// <inheritdoc/>
 	public void Add(IWindow window, Direction direction)
 	{
 		AddNodeDirection = direction;
 		Add(window);
 	}
 
-	/// <summary>
-	/// Add the <paramref name="window"/> to the layout engine.
-	/// The direction it is added in is determined by this instance's <see cref="AddNodeDirection"/> property.
-	/// </summary>
-	/// <param name="window">The window to add.</param>
+	/// <inheritdoc/>
 	public void Add(IWindow window) => AddWindow(window);
 
-	/// <summary>
-	/// Adds a window to the layout engine, and returns the node that represents it.
-	/// The <paramref name="window"/> is added in the direction specified by this instance's
-	/// <see cref="AddNodeDirection"/> property.
-	/// </summary>
-	/// <param name="window">The window to add.</param>
-	/// <param name="focusedWindow">The currently focused window from whom to get the node.</param>
-	/// <returns>The node that represents the window.</returns>
+	/// <inheritdoc/>
 	public WindowNode? AddWindow(IWindow window, IWindow? focusedWindow = null)
 	{
 		Logger.Debug($"Adding window {window} to layout engine {Name}");
@@ -217,11 +197,7 @@ public partial class TreeLayoutEngine : ILayoutEngine
 		_configContext.WorkspaceManager.ActiveWorkspace.RemovePhantomWindow(this, phantomNode.Window);
 	}
 
-	/// <summary>
-	/// Removes the <paramref name="window"/> from the layout engine.
-	/// </summary>
-	/// <param name="window">The window to remove.</param>
-	/// <returns><see langword="true"/> if the window was removed, <see langword="false"/> otherwise.</returns>
+	/// <inheritdoc/>
 	public bool Remove(IWindow window)
 	{
 		Logger.Debug($"Removing window {window} from layout engine {Name}");
@@ -487,16 +463,7 @@ public partial class TreeLayoutEngine : ILayoutEngine
 		parentNode.AdjustChildWeight(adjacentAncestorNode, -relativeDelta);
 	}
 
-	/// <summary>
-	/// Gets the adjacent node in the given <paramref name="direction"/>.
-	/// </summary>
-	/// <param name="node">The node to get the adjacent node for.</param>
-	/// <param name="direction">The direction to get the adjacent node in.</param>
-	/// <returns>
-	/// The adjacent node in the given <paramref name="direction"/>.
-	/// <see langword="null"/> if there is no adjacent node in the given <paramref name="direction"/>,
-	/// or an error occurred.
-	/// </returns>
+	/// <inheritdoc/>
 	public LeafNode? GetAdjacentNode(LeafNode node, Direction direction)
 	{
 		Logger.Debug($"Getting node in direction {direction} for window {node}");

--- a/src/Whim.TreeLayout/TreeLayoutPlugin.cs
+++ b/src/Whim.TreeLayout/TreeLayoutPlugin.cs
@@ -1,0 +1,46 @@
+using System.Collections.Generic;
+
+namespace Whim.TreeLayout;
+
+/// <inheritdoc/>
+public class TreeLayoutPlugin : ITreeLayoutPlugin
+{
+	private readonly IConfigContext _configContext;
+
+	/// <inheritdoc/>
+	public string Name => "whim.tree_layout";
+
+	/// <summary>
+	/// Initializes a new instance of the <see cref="TreeLayoutPlugin"/> class.
+	/// </summary>
+	public TreeLayoutPlugin(IConfigContext configContext)
+	{
+		_configContext = configContext;
+	}
+
+	/// <inheritdoc />
+	public void PreInitialize() { }
+
+	/// <inheritdoc />
+	public void PostInitialize() { }
+
+	/// <inheritdoc />
+	public IEnumerable<CommandItem> Commands => new TreeLayoutCommands(this);
+
+	/// <inheritdoc/>
+	public TreeLayoutEngine? GetTreeLayoutEngine()
+	{
+		ILayoutEngine rootEngine = _configContext.WorkspaceManager.ActiveWorkspace.ActiveLayoutEngine;
+		return ILayoutEngine.GetLayoutEngine<TreeLayoutEngine>(rootEngine);
+	}
+
+	/// <inheritdoc />
+	public void SetAddWindowDirection(Direction direction)
+	{
+		TreeLayoutEngine? engine = GetTreeLayoutEngine();
+		if (engine != null)
+		{
+			engine.AddNodeDirection = direction;
+		}
+	}
+}

--- a/src/Whim.TreeLayout/TreeLayoutPlugin.cs
+++ b/src/Whim.TreeLayout/TreeLayoutPlugin.cs
@@ -28,16 +28,16 @@ public class TreeLayoutPlugin : ITreeLayoutPlugin
 	public IEnumerable<CommandItem> Commands => new TreeLayoutCommands(this);
 
 	/// <inheritdoc/>
-	public TreeLayoutEngine? GetTreeLayoutEngine()
+	public ITreeLayoutEngine? GetTreeLayoutEngine()
 	{
 		ILayoutEngine rootEngine = _configContext.WorkspaceManager.ActiveWorkspace.ActiveLayoutEngine;
-		return ILayoutEngine.GetLayoutEngine<TreeLayoutEngine>(rootEngine);
+		return rootEngine.GetLayoutEngine<ITreeLayoutEngine>();
 	}
 
 	/// <inheritdoc />
 	public void SetAddWindowDirection(Direction direction)
 	{
-		TreeLayoutEngine? engine = GetTreeLayoutEngine();
+		ITreeLayoutEngine? engine = GetTreeLayoutEngine();
 		if (engine != null)
 		{
 			engine.AddNodeDirection = direction;

--- a/src/Whim/Layout/ILayoutEngine.cs
+++ b/src/Whim/Layout/ILayoutEngine.cs
@@ -66,54 +66,46 @@ public interface ILayoutEngine : ICollection<IWindow>
 	public void AddWindowAtPoint(IWindow window, IPoint<double> point, bool isPhantom = false);
 
 	/// <summary>
-	/// Checks to see if the <paramref name="root"/> layout engine or a child layout engine is type
+	/// Checks to see if this <see cref="ILayoutEngine"/> or a child layout engine is type
 	/// <typeparamref name="T"/>.
 	/// </summary>
 	/// <typeparam name="T">The type of layout engine to check for.</typeparam>
-	/// <param name="root">
-	/// The root layout engine to check. If this is a proxy layout engine, it'll check its child
-	/// proxy layout engines.
-	/// </param>
 	/// <returns>
 	/// The layout engine with type <typeparamref name="T"/>, or null if none is found.
 	/// </returns>
-	public static T? GetLayoutEngine<T>(ILayoutEngine root) where T : ILayoutEngine
+	public T? GetLayoutEngine<T>() where T : ILayoutEngine
 	{
-		if (root is T layoutEngine)
+		if (this is T layoutEngine)
 		{
 			return layoutEngine;
 		}
 
-		if (root is BaseProxyLayoutEngine proxy)
+		if (this is BaseProxyLayoutEngine proxy)
 		{
-			return BaseProxyLayoutEngine.GetLayoutEngine<T>(proxy);
+			return proxy.GetLayoutEngine<T>();
 		}
 
 		return default;
 	}
 
 	/// <summary>
-	/// Checks to see if the <paramref name="root"/> layout engine or a child layout engine is
+	/// Checks to see if this <see cref="ILayoutEngine"/> or a child layout engine is
 	/// <paramref name="layoutEngine"/>.
 	/// </summary>
-	/// <param name="root">
-	/// The root layout engine to check. If this is a proxy layout engine, it'll check its child
-	/// proxy layout engines.
-	/// </param>
 	/// <param name="layoutEngine">The layout engine to check for.</param>
 	/// <returns>
 	/// <cref name="true"/> if the layout engine is found, <cref name="false"/> otherwise.
 	/// </returns>
-	public static bool ContainsEqual(ILayoutEngine root, ILayoutEngine layoutEngine)
+	public bool ContainsEqual(ILayoutEngine layoutEngine)
 	{
-		if (root == layoutEngine)
+		if (this == layoutEngine)
 		{
 			return true;
 		}
 
-		if (root is BaseProxyLayoutEngine proxy)
+		if (this is BaseProxyLayoutEngine proxy)
 		{
-			return BaseProxyLayoutEngine.ContainsEqual(proxy, layoutEngine);
+			return proxy.ContainsEqual(layoutEngine);
 		}
 
 		return false;

--- a/src/Whim/Layout/ProxyLayoutEngine.cs
+++ b/src/Whim/Layout/ProxyLayoutEngine.cs
@@ -83,54 +83,46 @@ public abstract class BaseProxyLayoutEngine : ILayoutEngine
 	public virtual void AddWindowAtPoint(IWindow window, IPoint<double> point, bool isPhantom) => InnerLayoutEngine.AddWindowAtPoint(window, point, isPhantom);
 
 	/// <summary>
-	/// Checks to see if the <paramref name="root"/> <cref name="ILayoutEngine"/>
+	/// Checks to see if this <cref name="ILayoutEngine"/>
 	/// or a child layout engine is type <typeparamref name="T"/>.
 	/// </summary>
 	/// <typeparam name="T">The type of layout engine to check for.</typeparam>
-	/// <param name="root">
-	/// The root layout engine to check. If this is a proxy layout engine, it'll check its child
-	/// proxy layout engines.
-	/// </param>
 	/// <returns>
 	/// The layout engine with type <typeparamref name="T"/>, or null if none is found.
 	/// </returns>
-	public static T? GetLayoutEngine<T>(ILayoutEngine root) where T : ILayoutEngine
+	public T? GetLayoutEngine<T>() where T : ILayoutEngine
 	{
-		if (root is T t)
+		if (this is T t)
 		{
 			return t;
 		}
 
-		if (root is BaseProxyLayoutEngine proxy && proxy.InnerLayoutEngine != null)
+		if (InnerLayoutEngine != null)
 		{
-			return BaseProxyLayoutEngine.GetLayoutEngine<T>(proxy.InnerLayoutEngine);
+			return InnerLayoutEngine.GetLayoutEngine<T>();
 		}
 
 		return default;
 	}
 
 	/// <summary>
-	/// Checks to see if the <paramref name="root"/> <cref name="ILayoutEngine"/>
+	/// Checks to see if this <cref name="ILayoutEngine"/>
 	/// or a child layout engine is equal to <paramref name="layoutEngine"/>.
 	/// </summary>
-	/// <param name="root">
-	/// The root layout engine to check. If this is a proxy layout engine, it'll check its child
-	/// proxy layout engines.
-	/// </param>
 	/// <param name="layoutEngine">The layout engine to check for.</param>
 	/// <returns>
 	/// <cref name="true"/> if the layout engine is found, <cref name="false"/> otherwise.
 	/// </returns>
-	public static bool ContainsEqual(ILayoutEngine root, ILayoutEngine layoutEngine)
+	public bool ContainsEqual(ILayoutEngine layoutEngine)
 	{
-		if (root == layoutEngine)
+		if (this == layoutEngine)
 		{
 			return true;
 		}
 
-		if (root is BaseProxyLayoutEngine proxy && proxy.InnerLayoutEngine != null)
+		if (InnerLayoutEngine != null)
 		{
-			return BaseProxyLayoutEngine.ContainsEqual(proxy.InnerLayoutEngine, layoutEngine);
+			return InnerLayoutEngine.ContainsEqual(layoutEngine);
 		}
 
 		return false;

--- a/src/Whim/Workspace/Workspace.cs
+++ b/src/Whim/Workspace/Workspace.cs
@@ -135,7 +135,7 @@ internal class Workspace : IWorkspace
 			_windows.Contains(window) ||
 			(_phantomWindows.TryGetValue(window, out ILayoutEngine? layoutEngine)
 			&& layoutEngine != null
-			&& ILayoutEngine.ContainsEqual(ActiveLayoutEngine, layoutEngine))
+			&& ActiveLayoutEngine.ContainsEqual(layoutEngine))
 		)
 		{
 			LastFocusedWindow = window;
@@ -300,7 +300,7 @@ internal class Workspace : IWorkspace
 			return false;
 		}
 
-		if (!ILayoutEngine.ContainsEqual(ActiveLayoutEngine, layoutEngine))
+		if (!ActiveLayoutEngine.ContainsEqual(layoutEngine))
 		{
 			Logger.Error($"Phantom window {window} is not in the active layout engine {ActiveLayoutEngine}");
 			return false;
@@ -414,7 +414,7 @@ internal class Workspace : IWorkspace
 	{
 		Logger.Debug($"Adding phantom window {window} in workspace {Name}");
 
-		if (ILayoutEngine.ContainsEqual(engine, ActiveLayoutEngine))
+		if (engine.ContainsEqual(ActiveLayoutEngine))
 		{
 			Logger.Error($"Layout engine {engine} is not active in workspace {Name}");
 			return;
@@ -435,7 +435,7 @@ internal class Workspace : IWorkspace
 	{
 		Logger.Debug($"Removing phantom window {window} in workspace {Name}");
 
-		if (ILayoutEngine.ContainsEqual(engine, ActiveLayoutEngine))
+		if (engine.ContainsEqual(ActiveLayoutEngine))
 		{
 			Logger.Error($"Layout engine {engine} is not active in workspace {Name}");
 			return;
@@ -470,7 +470,7 @@ internal class Workspace : IWorkspace
 	/// <returns>True when the workspace contains the provided <paramref name="window"/>.</returns>
 	public bool ContainsWindow(IWindow window) => _windows.Contains(window) || (
 		_phantomWindows.TryGetValue(window, out ILayoutEngine? phantomEngine)
-		&& ILayoutEngine.ContainsEqual(ActiveLayoutEngine, phantomEngine)
+		&& ActiveLayoutEngine.ContainsEqual(phantomEngine)
 	);
 
 	protected virtual void Dispose(bool disposing)


### PR DESCRIPTION
## Core

- `ILayoutEngine.GetLayoutEngine` and `ILayoutEngine.ContainsEqual`, and the associated methods for `ProxyLayoutEngine` are now instance methods. This makes them mockable.
- Added tests for the aforementioned methods.

## `TreeLayout`

- Created `TreeLayoutPlugin`.
- Created `TreeLayoutCommands`, with commands for changing `AddNodeDirection`.
- Created `ITreeLayoutEngine` to facilitate mocking.
- Switched to referring to `ITreeLayoutEngine` instead of `TreeLayoutEngine`.