### PR TITLE
Moving windows to a hidden workspace now hides the window

### DIFF
--- a/src/Whim.Tests/WorkspaceManagerTests.cs
+++ b/src/Whim.Tests/WorkspaceManagerTests.cs
@@ -547,8 +547,10 @@ public class WorkspaceManagerTests
 		workspace.Verify(w => w.RemoveWindow(window.Object), Times.Once());
 		workspace2.Verify(w => w.AddWindow(window.Object), Times.Once());
 
+		// Verify that the window was hidden.
+		window.Verify(w => w.Hide(), Times.Once());
+
 		// Verify that DoLayout was called.
-		workspace.Verify(w => w.DoLayout(), Times.Once());
 		workspace2.Verify(w => w.DoLayout(), Times.Once());
 	}
 

--- a/src/Whim/Workspace/WorkspaceManager.cs
+++ b/src/Whim/Workspace/WorkspaceManager.cs
@@ -345,7 +345,10 @@ internal class WorkspaceManager : IWorkspaceManager
 		ActiveWorkspace.RemoveWindow(window);
 		workspace.AddWindow(window);
 
-		LayoutAllActiveWorkspaces();
+		// Hide the window from the current layout. If the new workspace is active, then the
+		// window will be shown as part of DoLayout().
+		window.Hide();
+		workspace.DoLayout();
 	}
 
 	public void MoveWindowToMonitor(IMonitor monitor, IWindow? window = null)


### PR DESCRIPTION
Moving a window to a hidden workspace will now hide the window.