### PR TITLE
Refactor `CommandPaletteWindow` to facilitate testing

### DIFF
--- a/src/Whim.CommandPalette.Tests/CommandPaletteWindowViewModelTests.cs
+++ b/src/Whim.CommandPalette.Tests/CommandPaletteWindowViewModelTests.cs
@@ -410,16 +410,21 @@ public class CommandPaletteWindowViewModelTests
 		CommandPaletteWindowViewModel vm = new(configContext.Object, plugin, PaletteRowFactory);
 
 		vm.Activate(CreateMenuActivationConfig(3), null, null);
+		vm.Activate(CreateMenuActivationConfig(2), null, null);
 
 		// When
-		vm.Activate(CreateMenuActivationConfig(2), null, null);
+		vm.Activate(CreateMenuActivationConfig(3), null, null);
 		vm.UpdateMatches();
 
 		// Then
 		Assert.Equal(Visibility.Visible, vm.ListViewItemsWrapperVisibility);
 		Assert.Equal(Visibility.Collapsed, vm.NoMatchingCommandsTextBlockVisibility);
 		Assert.Equal(Visibility.Visible, vm.ListViewItemsVisibility);
-		Assert.Equal(2, vm.PaletteRows.Count);
+		Assert.Equal(3, vm.PaletteRows.Count);
+
+		// First and second element should have been updated
+		Assert.True(vm.PaletteRows[0] is PaletteRowStub stub && stub.IsUpdated);
+		Assert.True(vm.PaletteRows[1] is PaletteRowStub stub2 && stub2.IsUpdated);
 	}
 
 	[Fact]

--- a/src/Whim.CommandPalette.Tests/CommandPaletteWindowViewModelTests.cs
+++ b/src/Whim.CommandPalette.Tests/CommandPaletteWindowViewModelTests.cs
@@ -1,6 +1,7 @@
 using Moq;
 using FluentAssertions;
 using Xunit;
+using Microsoft.UI.Xaml;
 
 namespace Whim.CommandPalette.Tests;
 
@@ -361,25 +362,84 @@ public class CommandPaletteWindowViewModelTests
 	[Fact]
 	public void UpdateMatches_Menu_NoMatches()
 	{
-		// TODO
+		// Given
+		(Mock<IConfigContext> configContext, Mock<ICommandManager> commandManager, CommandPalettePlugin plugin) =
+			CreateStubs();
+
+		CommandPaletteWindowViewModel vm = new(configContext.Object, plugin, PaletteRowFactory);
+
+		vm.Activate(new CommandPaletteMenuActivationConfig(), null, null);
+
+		// When
+		vm.UpdateMatches();
+
+		// Then
+		Assert.Equal(Visibility.Visible, vm.ListViewItemsWrapperVisibility);
+		Assert.Equal(Visibility.Visible, vm.NoMatchingCommandsTextBlockVisibility);
+		Assert.Equal(Visibility.Collapsed, vm.ListViewItemsVisibility);
 	}
 
 	[Fact]
 	public void UpdateMatches_Menu_SomeMatches()
 	{
-		// TODO
+		// Given
+		(Mock<IConfigContext> configContext, Mock<ICommandManager> commandManager, CommandPalettePlugin plugin) =
+			CreateStubs();
+
+		CommandPaletteWindowViewModel vm = new(configContext.Object, plugin, PaletteRowFactory);
+
+		vm.Activate(CreateMenuActivationConfig(3), null, null);
+
+		// When
+		vm.UpdateMatches();
+
+		// Then
+		Assert.Equal(Visibility.Visible, vm.ListViewItemsWrapperVisibility);
+		Assert.Equal(Visibility.Collapsed, vm.NoMatchingCommandsTextBlockVisibility);
+		Assert.Equal(Visibility.Visible, vm.ListViewItemsVisibility);
+		Assert.Equal(3, vm.PaletteRows.Count);
 	}
 
 	[Fact]
 	public void UpdateMatches_Menu_RemoveUnused()
 	{
-		// TODO
+		// Given
+		(Mock<IConfigContext> configContext, Mock<ICommandManager> commandManager, CommandPalettePlugin plugin) =
+			CreateStubs();
+
+		CommandPaletteWindowViewModel vm = new(configContext.Object, plugin, PaletteRowFactory);
+
+		vm.Activate(CreateMenuActivationConfig(3), null, null);
+
+		// When
+		vm.Activate(CreateMenuActivationConfig(2), null, null);
+		vm.UpdateMatches();
+
+		// Then
+		Assert.Equal(Visibility.Visible, vm.ListViewItemsWrapperVisibility);
+		Assert.Equal(Visibility.Collapsed, vm.NoMatchingCommandsTextBlockVisibility);
+		Assert.Equal(Visibility.Visible, vm.ListViewItemsVisibility);
+		Assert.Equal(2, vm.PaletteRows.Count);
 	}
 
 	[Fact]
 	public void UpdateMatches_Free()
 	{
-		// TODO
+		// Given
+		(Mock<IConfigContext> configContext, Mock<ICommandManager> commandManager, CommandPalettePlugin plugin) =
+			CreateStubs();
+
+		CommandPaletteWindowViewModel vm = new(configContext.Object, plugin, PaletteRowFactory);
+
+		vm.Activate(new CommandPaletteFreeTextActivationConfig() { Callback = (text) => { } }, null, null);
+
+		// When
+		vm.UpdateMatches();
+
+		// Then
+		Assert.Equal(Visibility.Collapsed, vm.ListViewItemsWrapperVisibility);
+		Assert.Equal(Visibility.Collapsed, vm.NoMatchingCommandsTextBlockVisibility);
+		Assert.Equal(Visibility.Collapsed, vm.ListViewItemsVisibility);
 	}
 
 	private static PaletteRowText CreatePaletteRowText(string text)

--- a/src/Whim.CommandPalette.Tests/CommandPaletteWindowViewModelTests.cs
+++ b/src/Whim.CommandPalette.Tests/CommandPaletteWindowViewModelTests.cs
@@ -97,17 +97,24 @@ public class CommandPaletteWindowViewModelTests
 			new(configContext.Object, plugin, (rowItem) => new Mock<IPaletteRow>().Object);
 
 		Mock<IMonitor> monitor = new();
-		monitor.Setup(m => m.WorkingArea).Returns(new Location<int>() {X = 0, Y = 0, Height = 100, Width = 100});
+		monitor
+			.Setup(m => m.WorkingArea)
+			.Returns(
+				new Location<int>()
+				{
+					X = 0,
+					Y = 0,
+					Height = 100,
+					Width = 100
+				}
+			);
 
-		BaseCommandPaletteActivationConfig config = new() {
-			Hint = "Hint",
-			InitialText = "Initial text"
-		};
+		BaseCommandPaletteActivationConfig config = new() { Hint = "Hint", InitialText = "Initial text" };
 
 		IEnumerable<CommandItem> commandItems = new List<CommandItem>()
-				{
-					new CommandItem() { Command = new Command("id", "title", () => { }) }
-				};
+		{
+			new CommandItem() { Command = new Command("id", "title", () => { }) }
+		};
 
 		// When
 		Assert.Raises<EventArgs>(
@@ -134,11 +141,7 @@ public class CommandPaletteWindowViewModelTests
 
 		// When
 		// Then
-		Assert.Raises<EventArgs>(
-			h => vm.HideRequested += h,
-			h => vm.HideRequested -= h,
-			vm.RequestHide
-		);
+		Assert.Raises<EventArgs>(h => vm.HideRequested += h, h => vm.HideRequested -= h, vm.RequestHide);
 	}
 
 	[Fact]

--- a/src/Whim.CommandPalette.Tests/CommandPaletteWindowViewModelTests.cs
+++ b/src/Whim.CommandPalette.Tests/CommandPaletteWindowViewModelTests.cs
@@ -35,6 +35,11 @@ public class CommandPaletteWindowViewModelTests
 		return (configContext, commandManager, plugin);
 	}
 
+	private static IPaletteRow PaletteRowFactory(PaletteRowItem item)
+	{
+		return new PaletteRowStub() { Model = item };
+	}
+
 	[Fact]
 	public void Constructor()
 	{
@@ -51,8 +56,7 @@ public class CommandPaletteWindowViewModelTests
 			);
 
 		// When
-		CommandPaletteWindowViewModel vm =
-			new(configContext.Object, plugin, (rowItem) => new Mock<IPaletteRow>().Object);
+		CommandPaletteWindowViewModel vm = new(configContext.Object, plugin, PaletteRowFactory);
 
 		// Then
 		Assert.Single(vm.PaletteRows);
@@ -65,8 +69,7 @@ public class CommandPaletteWindowViewModelTests
 		(Mock<IConfigContext> configContext, Mock<ICommandManager> commandManager, CommandPalettePlugin plugin) =
 			CreateStubs();
 
-		CommandPaletteWindowViewModel vm =
-			new(configContext.Object, plugin, (rowItem) => new Mock<IPaletteRow>().Object);
+		CommandPaletteWindowViewModel vm = new(configContext.Object, plugin, PaletteRowFactory);
 
 		// When
 		Assert.Raises<EventArgs>(
@@ -88,8 +91,7 @@ public class CommandPaletteWindowViewModelTests
 		(Mock<IConfigContext> configContext, Mock<ICommandManager> commandManager, CommandPalettePlugin plugin) =
 			CreateStubs();
 
-		CommandPaletteWindowViewModel vm =
-			new(configContext.Object, plugin, (rowItem) => new Mock<IPaletteRow>().Object);
+		CommandPaletteWindowViewModel vm = new(configContext.Object, plugin, PaletteRowFactory);
 
 		Mock<IMonitor> monitor = new();
 		monitor
@@ -131,8 +133,7 @@ public class CommandPaletteWindowViewModelTests
 		(Mock<IConfigContext> configContext, Mock<ICommandManager> commandManager, CommandPalettePlugin plugin) =
 			CreateStubs();
 
-		CommandPaletteWindowViewModel vm =
-			new(configContext.Object, plugin, (rowItem) => new Mock<IPaletteRow>().Object);
+		CommandPaletteWindowViewModel vm = new(configContext.Object, plugin, PaletteRowFactory);
 
 		// When
 		// Then
@@ -146,8 +147,7 @@ public class CommandPaletteWindowViewModelTests
 		(Mock<IConfigContext> configContext, Mock<ICommandManager> commandManager, CommandPalettePlugin plugin) =
 			CreateStubs();
 
-		CommandPaletteWindowViewModel vm =
-			new(configContext.Object, plugin, (rowItem) => new Mock<IPaletteRow>().Object);
+		CommandPaletteWindowViewModel vm = new(configContext.Object, plugin, PaletteRowFactory);
 
 		// When
 		bool? result = null;
@@ -176,8 +176,7 @@ public class CommandPaletteWindowViewModelTests
 			new() { InitialText = "Hello, world!", Callback = (text) => callbackText = text };
 		plugin.Config.ActivationConfig = config;
 
-		CommandPaletteWindowViewModel vm =
-			new(configContext.Object, plugin, (rowItem) => new Mock<IPaletteRow>().Object);
+		CommandPaletteWindowViewModel vm = new(configContext.Object, plugin, PaletteRowFactory);
 
 		vm.Activate(config, new List<CommandItem>(), null);
 
@@ -217,8 +216,7 @@ public class CommandPaletteWindowViewModelTests
 
 		plugin.Config.ActivationConfig = new CommandPaletteMenuActivationConfig();
 
-		CommandPaletteWindowViewModel vm =
-			new(configContext.Object, plugin, (rowItem) => new Mock<IPaletteRow>().Object);
+		CommandPaletteWindowViewModel vm = new(configContext.Object, plugin, PaletteRowFactory);
 
 		// When
 		bool result = vm.OnKeyDown(this, key);
@@ -246,8 +244,7 @@ public class CommandPaletteWindowViewModelTests
 
 		plugin.Config.ActivationConfig = new CommandPaletteMenuActivationConfig();
 
-		CommandPaletteWindowViewModel vm =
-			new(configContext.Object, plugin, (rowItem) => new Mock<IPaletteRow>().Object);
+		CommandPaletteWindowViewModel vm = new(configContext.Object, plugin, PaletteRowFactory);
 
 		// When
 		bool result = vm.OnKeyDown(this, Windows.System.VirtualKey.A);
@@ -264,8 +261,7 @@ public class CommandPaletteWindowViewModelTests
 		(Mock<IConfigContext> configContext, Mock<ICommandManager> commandManager, CommandPalettePlugin plugin) =
 			CreateStubs();
 
-		CommandPaletteWindowViewModel vm =
-			new(configContext.Object, plugin, (rowItem) => new Mock<IPaletteRow>().Object);
+		CommandPaletteWindowViewModel vm = new(configContext.Object, plugin, PaletteRowFactory);
 
 		// When
 		vm.PopulateItems(
@@ -286,8 +282,7 @@ public class CommandPaletteWindowViewModelTests
 		(Mock<IConfigContext> configContext, Mock<ICommandManager> commandManager, CommandPalettePlugin plugin) =
 			CreateStubs();
 
-		CommandPaletteWindowViewModel vm =
-			new(configContext.Object, plugin, (rowItem) => new Mock<IPaletteRow>().Object);
+		CommandPaletteWindowViewModel vm = new(configContext.Object, plugin, PaletteRowFactory);
 
 		// When
 		vm.PopulateItems(
@@ -305,8 +300,7 @@ public class CommandPaletteWindowViewModelTests
 		(Mock<IConfigContext> configContext, Mock<ICommandManager> commandManager, CommandPalettePlugin plugin) =
 			CreateStubs();
 
-		CommandPaletteWindowViewModel vm =
-			new(configContext.Object, plugin, (rowItem) => new Mock<IPaletteRow>().Object);
+		CommandPaletteWindowViewModel vm = new(configContext.Object, plugin, PaletteRowFactory);
 
 		vm.PopulateItems(
 			new List<CommandItem>() { new CommandItem() { Command = new Command("id", "title", () => { }) }, }
@@ -323,14 +317,33 @@ public class CommandPaletteWindowViewModelTests
 	}
 
 	[Fact]
+	public void PopulateItems_RemoveExtra()
+	{
+		// Given
+		(Mock<IConfigContext> configContext, Mock<ICommandManager> commandManager, CommandPalettePlugin plugin) =
+			CreateStubs();
+
+		CommandPaletteWindowViewModel vm = new(configContext.Object, plugin, PaletteRowFactory);
+
+		vm.PopulateItems(
+			new List<CommandItem>() { new CommandItem() { Command = new Command("id", "title", () => { }) }, }
+		);
+
+		// When
+		vm.PopulateItems(new List<CommandItem>());
+
+		// Then
+		Assert.Empty(vm._allCommands);
+	}
+
+	[Fact]
 	public void PopulateItems_SkipEqualCommand()
 	{
 		// Given
 		(Mock<IConfigContext> configContext, Mock<ICommandManager> commandManager, CommandPalettePlugin plugin) =
 			CreateStubs();
 
-		CommandPaletteWindowViewModel vm =
-			new(configContext.Object, plugin, (rowItem) => new Mock<IPaletteRow>().Object);
+		CommandPaletteWindowViewModel vm = new(configContext.Object, plugin, PaletteRowFactory);
 
 		Command command = new("id", "title", () => { });
 		CommandItem commandItem = new() { Command = command };
@@ -352,6 +365,12 @@ public class CommandPaletteWindowViewModelTests
 
 	[Fact]
 	public void UpdateMatches_Menu_SomeMatches()
+	{
+		// TODO
+	}
+
+	[Fact]
+	public void UpdateMatches_Menu_RemoveUnused()
 	{
 		// TODO
 	}
@@ -411,7 +430,7 @@ public class CommandPaletteWindowViewModelTests
 				}
 			);
 
-		vm.Activate(config, new List<CommandItem>(), null);
+		vm.Activate(config, null, null);
 
 		// When
 		Assert.Raises<EventArgs>(h => vm.HideRequested += h, h => vm.HideRequested -= h, vm.ExecuteCommand);

--- a/src/Whim.CommandPalette.Tests/CommandPaletteWindowViewModelTests.cs
+++ b/src/Whim.CommandPalette.Tests/CommandPaletteWindowViewModelTests.cs
@@ -229,6 +229,35 @@ public class CommandPaletteWindowViewModelTests
 	}
 
 	[Fact]
+	public void OnKeyDown_UnhandledKeys()
+	{
+		// Given
+		(Mock<IConfigContext> configContext, Mock<ICommandManager> commandManager, CommandPalettePlugin plugin) =
+			CreateStubs();
+
+		IEnumerable<CommandItem> items = new List<CommandItem>()
+		{
+			new CommandItem() { Command = new Command("id", "title", () => { }) },
+			new CommandItem() { Command = new Command("id2", "title2", () => { }) },
+			new CommandItem() { Command = new Command("id3", "title3", () => { }) }
+		};
+
+		commandManager.Setup(cm => cm.GetEnumerator()).Returns(items.GetEnumerator());
+
+		plugin.Config.ActivationConfig = new CommandPaletteMenuActivationConfig();
+
+		CommandPaletteWindowViewModel vm =
+			new(configContext.Object, plugin, (rowItem) => new Mock<IPaletteRow>().Object);
+
+		// When
+		bool result = vm.OnKeyDown(this, Windows.System.VirtualKey.A);
+
+		// Then
+		Assert.Equal(0, vm.SelectedIndex);
+		Assert.False(result);
+	}
+
+	[Fact]
 	public void UpdateMatches()
 	{
 		// TODO

--- a/src/Whim.CommandPalette.Tests/CommandPaletteWindowViewModelTests.cs
+++ b/src/Whim.CommandPalette.Tests/CommandPaletteWindowViewModelTests.cs
@@ -125,7 +125,20 @@ public class CommandPaletteWindowViewModelTests
 	[Fact]
 	public void RequestHide()
 	{
-		// TODO
+		// Given
+		(Mock<IConfigContext> configContext, Mock<ICommandManager> commandManager, CommandPalettePlugin plugin) =
+			CreateStubs();
+
+		CommandPaletteWindowViewModel vm =
+			new(configContext.Object, plugin, (rowItem) => new Mock<IPaletteRow>().Object);
+
+		// When
+		// Then
+		Assert.Raises<EventArgs>(
+			h => vm.HideRequested += h,
+			h => vm.HideRequested -= h,
+			vm.RequestHide
+		);
 	}
 
 	[Fact]

--- a/src/Whim.CommandPalette.Tests/CommandPaletteWindowViewModelTests.cs
+++ b/src/Whim.CommandPalette.Tests/CommandPaletteWindowViewModelTests.cs
@@ -258,13 +258,146 @@ public class CommandPaletteWindowViewModelTests
 	}
 
 	[Fact]
-	public void UpdateMatches()
+	public void PopulateItems_CannotExecute()
+	{
+		// Given
+		(Mock<IConfigContext> configContext, Mock<ICommandManager> commandManager, CommandPalettePlugin plugin) =
+			CreateStubs();
+
+		CommandPaletteWindowViewModel vm =
+			new(configContext.Object, plugin, (rowItem) => new Mock<IPaletteRow>().Object);
+
+		// When
+		vm.PopulateItems(
+			new List<CommandItem>()
+			{
+				new CommandItem() { Command = new Command("id", "title", () => { }, () => false) },
+			}
+		);
+
+		// Then
+		Assert.Empty(vm._allCommands);
+	}
+
+	[Fact]
+	public void PopulateItems_AddNew()
+	{
+		// Given
+		(Mock<IConfigContext> configContext, Mock<ICommandManager> commandManager, CommandPalettePlugin plugin) =
+			CreateStubs();
+
+		CommandPaletteWindowViewModel vm =
+			new(configContext.Object, plugin, (rowItem) => new Mock<IPaletteRow>().Object);
+
+		// When
+		vm.PopulateItems(
+			new List<CommandItem>() { new CommandItem() { Command = new Command("id", "title", () => { }) }, }
+		);
+
+		// Then
+		Assert.Single(vm._allCommands);
+	}
+
+	[Fact]
+	public void PopulateItems_UpdateExisting()
+	{
+		// Given
+		(Mock<IConfigContext> configContext, Mock<ICommandManager> commandManager, CommandPalettePlugin plugin) =
+			CreateStubs();
+
+		CommandPaletteWindowViewModel vm =
+			new(configContext.Object, plugin, (rowItem) => new Mock<IPaletteRow>().Object);
+
+		vm.PopulateItems(
+			new List<CommandItem>() { new CommandItem() { Command = new Command("id", "title", () => { }) }, }
+		);
+
+		// When
+		vm.PopulateItems(
+			new List<CommandItem>() { new CommandItem() { Command = new Command("id", "new title", () => { }) }, }
+		);
+
+		// Then
+		Assert.Single(vm._allCommands);
+		Assert.Equal("new title", vm._allCommands[0].Command.Title);
+	}
+
+	[Fact]
+	public void PopulateItems_SkipEqualCommand()
+	{
+		// Given
+		(Mock<IConfigContext> configContext, Mock<ICommandManager> commandManager, CommandPalettePlugin plugin) =
+			CreateStubs();
+
+		CommandPaletteWindowViewModel vm =
+			new(configContext.Object, plugin, (rowItem) => new Mock<IPaletteRow>().Object);
+
+		Command command = new ("id", "title", () => { });
+		CommandItem commandItem = new() {Command = command};
+		vm.PopulateItems(
+			new List<CommandItem>() { commandItem, }
+		);
+
+		// When
+		vm.PopulateItems(
+			new List<CommandItem>() { new CommandItem() { Command = command }, }
+		);
+
+		// Then
+		Assert.Single(vm._allCommands);
+		Assert.Equal(commandItem, vm._allCommands[0]);
+	}
+
+	[Fact]
+	public void UpdateMatches_Menu_NoMatches()
 	{
 		// TODO
 	}
 
 	[Fact]
-	public void ExecuteCommand()
+	public void UpdateMatches_Menu_SomeMatches()
+	{
+		// TODO
+	}
+
+	[Fact]
+	public void UpdateMatches_Free()
+	{
+		// TODO
+	}
+
+	[Fact]
+	public void LoadMatches_AddRows()
+	{
+		// TODO
+	}
+
+	[Fact]
+	public void LoadMatches_UpdateRows()
+	{
+		// TODO
+	}
+
+	[Fact]
+	public void LoadMatches_RestoreRows()
+	{
+		// TODO
+	}
+
+	[Fact]
+	public void ExecuteCommand_Free()
+	{
+		// TODO
+	}
+
+	[Fact]
+	public void ExecuteCommand_Menu()
+	{
+		// TODO
+	}
+
+	[Fact]
+	public void ExecuteCommand_Menu_Hide()
 	{
 		// TODO
 	}

--- a/src/Whim.CommandPalette.Tests/CommandPaletteWindowViewModelTests.cs
+++ b/src/Whim.CommandPalette.Tests/CommandPaletteWindowViewModelTests.cs
@@ -1,0 +1,69 @@
+using Moq;
+using Xunit;
+
+namespace Whim.CommandPalette.Tests;
+
+[System.Diagnostics.CodeAnalysis.SuppressMessage(
+	"Reliability",
+	"CA2000:Dispose objects before losing scope",
+	Justification = "Unnecessary for tests"
+)]
+public class CommandPaletteWindowViewModelTests
+{
+	[Fact]
+	public void Constructor()
+	{
+		// Given
+		Mock<ICommandManager> commandManager = new();
+		commandManager
+			.Setup(cm => cm.GetEnumerator())
+			.Returns(
+				new List<CommandItem>()
+				{
+					new CommandItem() { Command = new Command("id", "title", () => { }) }
+				}.GetEnumerator()
+			);
+
+		Mock<IConfigContext> configContext = new();
+		configContext.Setup(c => c.CommandManager).Returns(commandManager.Object);
+
+		CommandPalettePlugin plugin = new(configContext.Object, new());
+
+		// When
+		CommandPaletteWindowViewModel vm =
+			new(configContext.Object, plugin, (rowItem) => new Mock<IPaletteRow>().Object);
+
+		// Then
+		Assert.Single(vm.PaletteRows);
+	}
+
+	[Fact]
+	public void Activate()
+	{
+		// TODO
+	}
+
+	[Fact]
+	public void RequestHide()
+	{
+		// TODO
+	}
+
+	[Fact]
+	public void OnKeyDown()
+	{
+		// TODO
+	}
+
+	[Fact]
+	public void UpdateMatches()
+	{
+		// TODO
+	}
+
+	[Fact]
+	public void ExecuteCommand()
+	{
+		// TODO
+	}
+}

--- a/src/Whim.CommandPalette.Tests/PaletteRowStub.cs
+++ b/src/Whim.CommandPalette.Tests/PaletteRowStub.cs
@@ -1,0 +1,13 @@
+namespace Whim.CommandPalette.Tests;
+
+internal class PaletteRowStub : IPaletteRow
+{
+	public required PaletteRowItem Model { get; set; }
+
+	public void Initialize() { }
+
+	public void Update(PaletteRowItem item)
+	{
+		Model = item;
+	}
+}

--- a/src/Whim.CommandPalette.Tests/PaletteRowStub.cs
+++ b/src/Whim.CommandPalette.Tests/PaletteRowStub.cs
@@ -2,6 +2,8 @@ namespace Whim.CommandPalette.Tests;
 
 internal class PaletteRowStub : IPaletteRow
 {
+	public bool IsUpdated { get; private set; }
+
 	public required PaletteRowItem Model { get; set; }
 
 	public void Initialize() { }
@@ -9,5 +11,6 @@ internal class PaletteRowStub : IPaletteRow
 	public void Update(PaletteRowItem item)
 	{
 		Model = item;
+		IsUpdated = true;
 	}
 }

--- a/src/Whim.CommandPalette/CommandPalettePlugin.cs
+++ b/src/Whim.CommandPalette/CommandPalettePlugin.cs
@@ -73,7 +73,7 @@ public class CommandPalettePlugin : ICommandPalettePlugin
 	/// </summary>
 	public void Hide()
 	{
-		_commandPaletteWindow?.Hide();
+		_commandPaletteWindow?.Hide(_configContext);
 	}
 
 	/// <summary>

--- a/src/Whim.CommandPalette/CommandPalettePlugin.cs
+++ b/src/Whim.CommandPalette/CommandPalettePlugin.cs
@@ -73,7 +73,7 @@ public class CommandPalettePlugin : ICommandPalettePlugin
 	/// </summary>
 	public void Hide()
 	{
-		_commandPaletteWindow?.Hide(_configContext);
+		_commandPaletteWindow?.Hide();
 	}
 
 	/// <summary>

--- a/src/Whim.CommandPalette/CommandPaletteWindow.xaml
+++ b/src/Whim.CommandPalette/CommandPaletteWindow.xaml
@@ -16,6 +16,8 @@
 		<TextBox
 			x:Name="TextEntry"
 			KeyDown="TextEntry_KeyDown"
+			PlaceholderText="{x:Bind Path=ViewModel.PlaceholderText, Mode=OneWay}"
+			Text="{x:Bind Path=ViewModel.Text, Mode=OneWay}"
 			TextChanged="TextEntry_TextChanged" />
 
 		<RelativePanel x:Name="ListViewItemsWrapper" Grid.Row="1">
@@ -33,9 +35,11 @@
 				IsItemClickEnabled="True"
 				IsTabStop="False"
 				ItemClick="CommandListItems_ItemClick"
+				ItemsSource="{x:Bind Path=ViewModel.PaletteRows, Mode=OneWay}"
 				RelativePanel.AlignLeftWithPanel="True"
 				RelativePanel.AlignRightWithPanel="True"
 				RelativePanel.AlignTopWithPanel="True"
+				SelectedIndex="{x:Bind Path=ViewModel.SelectedIndex, Mode=TwoWay}"
 				SelectionMode="Single" />
 		</RelativePanel>
 	</Grid>

--- a/src/Whim.CommandPalette/CommandPaletteWindow.xaml.cs
+++ b/src/Whim.CommandPalette/CommandPaletteWindow.xaml.cs
@@ -21,8 +21,7 @@ internal sealed partial class CommandPaletteWindow : Microsoft.UI.Xaml.Window
 		ViewModel.SetWindowPosRequested += ViewModel_SetWindowPosRequested;
 
 		_window = this.InitializeBorderlessWindow(_configContext, "Whim.CommandPalette", "CommandPaletteWindow");
-		// TODO: Undo
-		// this.SetIsShownInSwitchers(false);
+		this.SetIsShownInSwitchers(false);
 		Activated += CommandPaletteWindow_Activated;
 		Title = CommandPaletteConfig.Title;
 	}
@@ -43,8 +42,7 @@ internal sealed partial class CommandPaletteWindow : Microsoft.UI.Xaml.Window
 		if (e.WindowActivationState == WindowActivationState.Deactivated)
 		{
 			// Hide the window when it loses focus.
-			// TODO: Undo
-			// ViewModel.RequestHide();
+			ViewModel.RequestHide();
 		}
 	}
 

--- a/src/Whim.CommandPalette/CommandPaletteWindow.xaml.cs
+++ b/src/Whim.CommandPalette/CommandPaletteWindow.xaml.cs
@@ -74,6 +74,15 @@ internal sealed partial class CommandPaletteWindow : Microsoft.UI.Xaml.Window
 	}
 
 	/// <summary>
+	/// Hide the command palette.
+	/// </summary>
+	public void Hide()
+	{
+		Logger.Debug("Hiding command palette");
+		ViewModel.RequestHide();
+	}
+
+	/// <summary>
 	/// Toggle the visibility of the command palette.
 	/// </summary>
 	public void Toggle()

--- a/src/Whim.CommandPalette/CommandPaletteWindow.xaml.cs
+++ b/src/Whim.CommandPalette/CommandPaletteWindow.xaml.cs
@@ -105,8 +105,7 @@ internal sealed partial class CommandPaletteWindow : Microsoft.UI.Xaml.Window
 
 	private void TextEntry_TextChanged(object sender, TextChangedEventArgs e)
 	{
-		string query = TextEntry.Text;
-		ViewModel.Text = query;
+		ViewModel.Text = TextEntry.Text;
 		ViewModel.UpdateMatches();
 	}
 

--- a/src/Whim.CommandPalette/CommandPaletteWindow.xaml.cs
+++ b/src/Whim.CommandPalette/CommandPaletteWindow.xaml.cs
@@ -96,7 +96,7 @@ internal sealed partial class CommandPaletteWindow : Microsoft.UI.Xaml.Window
 	/// <param name="e"></param>
 	private void TextEntry_KeyDown(object sender, Microsoft.UI.Xaml.Input.KeyRoutedEventArgs e)
 	{
-		bool scrollIntoView = ViewModel.OnKeyDown(sender, e);
+		bool scrollIntoView = ViewModel.OnKeyDown(sender, e.Key);
 		if (scrollIntoView)
 		{
 			ListViewItems.ScrollIntoView(ListViewItems.SelectedItem);

--- a/src/Whim.CommandPalette/CommandPaletteWindow.xaml.cs
+++ b/src/Whim.CommandPalette/CommandPaletteWindow.xaml.cs
@@ -2,48 +2,40 @@
 using Microsoft.UI.Xaml.Controls;
 using System;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 
 namespace Whim.CommandPalette;
 
 internal sealed partial class CommandPaletteWindow : Microsoft.UI.Xaml.Window
 {
 	private readonly IConfigContext _configContext;
-	private readonly CommandPalettePlugin _plugin;
-
 	private readonly IWindow _window;
-	private IMonitor? _monitor;
-	public bool IsVisible => _monitor != null;
 
-	private int _maxHeight;
-
-	private readonly ObservableCollection<PaletteRow> _paletteRows = new();
-	private readonly List<PaletteRow> _unusedRows = new();
-
-	/// <summary>
-	/// The current commands from which the matches shown in <see cref="ListViewItems"/> are drawn.
-	/// </summary>
-	private readonly List<CommandItem> _allCommands = new();
-
-	private BaseCommandPaletteActivationConfig? _activationConfig;
+	public CommandPaletteWindowViewModel ViewModel { get; private set; }
 
 	public CommandPaletteWindow(IConfigContext configContext, CommandPalettePlugin plugin)
 	{
 		_configContext = configContext;
-		_plugin = plugin;
-		_activationConfig = _plugin.Config.ActivationConfig;
+
+		ViewModel = new(_configContext, plugin);
+		ViewModel.HideRequested += ViewModel_HideRequested;
+		ViewModel.SetWindowPosRequested += ViewModel_SetWindowPosRequested;
 
 		_window = this.InitializeBorderlessWindow(_configContext, "Whim.CommandPalette", "CommandPaletteWindow");
-		this.SetIsShownInSwitchers(false);
-
+		// TODO: Undo
+		// this.SetIsShownInSwitchers(false);
 		Activated += CommandPaletteWindow_Activated;
-
 		Title = CommandPaletteConfig.Title;
-		ListViewItems.ItemsSource = _paletteRows;
+	}
 
-		// Populate the commands to reduce the first render time.
-		PopulateItems(_configContext.CommandManager);
-		UpdateMatches();
+	private void ViewModel_HideRequested(object? sender, EventArgs e)
+	{
+		Logger.Debug("Hiding command palette");
+		_window.Hide();
+	}
+
+	private void ViewModel_SetWindowPosRequested(object? sender, EventArgs e)
+	{
+		SetWindowPos();
 	}
 
 	private void CommandPaletteWindow_Activated(object sender, WindowActivatedEventArgs e)
@@ -51,7 +43,8 @@ internal sealed partial class CommandPaletteWindow : Microsoft.UI.Xaml.Window
 		if (e.WindowActivationState == WindowActivationState.Deactivated)
 		{
 			// Hide the window when it loses focus.
-			Hide();
+			// TODO: Undo
+			// ViewModel.RequestHide();
 		}
 	}
 
@@ -72,42 +65,12 @@ internal sealed partial class CommandPaletteWindow : Microsoft.UI.Xaml.Window
 	)
 	{
 		Logger.Debug("Activating command palette");
-		ResetState();
+		ViewModel.Activate(config, items, monitor);
 
-		_activationConfig = config;
-		_monitor = monitor ?? _configContext.MonitorManager.FocusedMonitor;
-
-		TextEntry.Text = _activationConfig.InitialText;
 		TextEntry.SelectAll();
-		TextEntry.PlaceholderText = _activationConfig.Hint ?? "Start typing...";
-		_maxHeight = (int)(_monitor.WorkingArea.Height * _plugin.Config.MaxHeightPercent / 100.0);
-
-		PopulateItems(items ?? Array.Empty<CommandItem>());
-		UpdateMatches();
-
 		Activate();
 		TextEntry.Focus(FocusState.Programmatic);
 		_window.FocusForceForeground();
-	}
-
-	/// <summary>
-	/// Hide the command palette. Wipe the query text and clear the matches.
-	/// </summary>
-	public void Hide()
-	{
-		Logger.Debug("Hiding command palette");
-		_window.Hide();
-		ResetState();
-	}
-
-	/// <summary>
-	/// Reset the window's state.
-	/// </summary>
-	public void ResetState()
-	{
-		_monitor = null;
-		TextEntry.Text = "";
-		_allCommands.Clear();
 	}
 
 	/// <summary>
@@ -116,49 +79,13 @@ internal sealed partial class CommandPaletteWindow : Microsoft.UI.Xaml.Window
 	public void Toggle()
 	{
 		Logger.Debug("Toggling command palette");
-		if (IsVisible)
+		if (ViewModel.IsVisible)
 		{
-			Hide();
+			ViewModel.RequestHide();
 		}
 		else
 		{
 			Activate();
-		}
-	}
-
-	/// <summary>
-	/// Populate <see cref="_allCommands"/> with all the current commands.
-	/// </summary>
-	private void PopulateItems(IEnumerable<CommandItem> items)
-	{
-		Logger.Debug($"Populating the current list of all commands.");
-
-		int idx = 0;
-		foreach ((ICommand command, IKeybind? keybind) in items)
-		{
-			if (!command.CanExecute())
-			{
-				continue;
-			}
-
-			if (idx < _allCommands.Count)
-			{
-				if (_allCommands[idx].Command != command)
-				{
-					_allCommands[idx] = new CommandItem() { Command = command, Keybind = keybind };
-				}
-			}
-			else
-			{
-				_allCommands.Add(new CommandItem() { Command = command, Keybind = keybind });
-			}
-
-			idx++;
-		}
-
-		for (; idx < _allCommands.Count; idx++)
-		{
-			_allCommands.RemoveAt(_allCommands.Count - 1);
 		}
 	}
 
@@ -169,133 +96,18 @@ internal sealed partial class CommandPaletteWindow : Microsoft.UI.Xaml.Window
 	/// <param name="e"></param>
 	private void TextEntry_KeyDown(object sender, Microsoft.UI.Xaml.Input.KeyRoutedEventArgs e)
 	{
-		Logger.Debug("Command palette key down: {0}", e.Key.ToString());
-		int selectedIndex = ListViewItems.SelectedIndex;
-		switch (e.Key)
+		bool scrollIntoView = ViewModel.OnKeyDown(sender, e);
+		if (scrollIntoView)
 		{
-			case Windows.System.VirtualKey.Down when ListViewItems.Items.Count > 0:
-				// Go down the command palette's list.
-				ListViewItems.SelectedIndex = (selectedIndex + 1) % _paletteRows.Count;
-				ListViewItems.ScrollIntoView(ListViewItems.SelectedItem);
-				break;
-
-			case Windows.System.VirtualKey.Up when ListViewItems.Items.Count > 0:
-				// Go up the command palette's list.
-				ListViewItems.SelectedIndex = (selectedIndex + _paletteRows.Count - 1) % _paletteRows.Count;
-				ListViewItems.ScrollIntoView(ListViewItems.SelectedItem);
-				break;
-
-			case Windows.System.VirtualKey.Enter:
-				ExecuteCommand();
-				break;
-
-			case Windows.System.VirtualKey.Escape:
-				Hide();
-				break;
-
-			default:
-				break;
+			ListViewItems.ScrollIntoView(ListViewItems.SelectedItem);
 		}
 	}
 
 	private void TextEntry_TextChanged(object sender, TextChangedEventArgs e)
 	{
-		UpdateMatches();
-	}
-
-	/// <summary>
-	/// Update the matches shown to the user.
-	/// Effort has been made to reduce the amount of time spent executing this method.
-	/// </summary>
-	private void UpdateMatches()
-	{
-		Logger.Debug("Updating command palette matches");
 		string query = TextEntry.Text;
-		int matchesCount = 0;
-
-		if (_activationConfig is CommandPaletteMenuActivationConfig menuActivationConfig)
-		{
-			matchesCount = LoadMatches(query, menuActivationConfig);
-
-			ListViewItemsWrapper.Visibility = Visibility.Visible;
-			if (matchesCount == 0)
-			{
-				NoMatchingCommandsTextBlock.Visibility = Visibility.Visible;
-				ListViewItems.Visibility = Visibility.Collapsed;
-			}
-			else
-			{
-				NoMatchingCommandsTextBlock.Visibility = Visibility.Collapsed;
-				ListViewItems.Visibility = Visibility.Visible;
-			}
-		}
-		else
-		{
-			NoMatchingCommandsTextBlock.Visibility = Visibility.Collapsed;
-			ListViewItemsWrapper.Visibility = Visibility.Collapsed;
-		}
-
-		RemoveUnusedRows(matchesCount);
-
-		Logger.Verbose($"Command palette match count: {_paletteRows.Count}");
-		ListViewItems.SelectedIndex = _paletteRows.Count > 0 ? 0 : -1;
-		SetWindowPos();
-	}
-
-	/// <summary>
-	/// Load the matches into the command palette rows.
-	/// </summary>
-	/// <param name="query">The query text string.</param>
-	/// <param name="menuActivationConfig"></param>
-	/// <returns>The number of processed matches.</returns>
-	private int LoadMatches(string query, CommandPaletteMenuActivationConfig menuActivationConfig)
-	{
-		int matchesCount = 0;
-
-		foreach (PaletteRowItem item in menuActivationConfig.Matcher.Match(query, _allCommands))
-		{
-			Logger.Verbose($"Matched {item.CommandItem.Command.Title}");
-			if (matchesCount < _paletteRows.Count)
-			{
-				// Update the existing row.
-				_paletteRows[matchesCount].Update(item);
-			}
-			else if (_unusedRows.Count > 0)
-			{
-				// Restoring the unused row.
-				PaletteRow row = _unusedRows[^1];
-				row.Update(item);
-
-				_paletteRows.Add(row);
-				_unusedRows.RemoveAt(_unusedRows.Count - 1);
-			}
-			else
-			{
-				// Add a new row.
-				PaletteRow row = new(item);
-				_paletteRows.Add(row);
-				row.Initialize();
-			}
-			matchesCount++;
-
-			Logger.Verbose($"Finished updating {item.CommandItem.Command.Title}");
-		}
-
-		return matchesCount;
-	}
-
-	/// <summary>
-	/// If there are more items than we have space for, remove the last ones.
-	/// </summary>
-	/// <param name="idx"></param>
-	private void RemoveUnusedRows(int idx)
-	{
-		int count = _paletteRows.Count;
-		for (; idx < count; idx++)
-		{
-			_unusedRows.Add(_paletteRows[^1]);
-			_paletteRows.RemoveAt(_paletteRows.Count - 1);
-		}
+		ViewModel.Text = query;
+		ViewModel.UpdateMatches();
 	}
 
 	/// <summary>
@@ -303,14 +115,14 @@ internal sealed partial class CommandPaletteWindow : Microsoft.UI.Xaml.Window
 	/// </summary>
 	private void SetWindowPos()
 	{
-		if (_monitor == null)
+		if (ViewModel.Monitor == null)
 		{
 			Logger.Error("Attempted to activate the command palette without a monitor.");
 			return;
 		}
 
-		int width = _plugin.Config.MaxWidthPixels;
-		int height = _maxHeight;
+		int width = ViewModel.Plugin.Config.MaxWidthPixels;
+		int height = ViewModel.MaxHeight;
 
 		if (NoMatchingCommandsTextBlock.Visibility == Visibility.Visible)
 		{
@@ -322,21 +134,21 @@ internal sealed partial class CommandPaletteWindow : Microsoft.UI.Xaml.Window
 			if (container is ListViewItem item)
 			{
 				int fullHeight = (int)(TextEntry.ActualHeight + (item.ActualHeight * ListViewItems.Items.Count));
-				height = Math.Min(_maxHeight, fullHeight);
+				height = Math.Min(ViewModel.MaxHeight, fullHeight);
 			}
 		}
 
-		int scaleFactor = _monitor.ScaleFactor;
+		int scaleFactor = ViewModel.Monitor.ScaleFactor;
 		double scale = scaleFactor / 100.0;
 		height = (int)(height * scale);
 
-		int x = (_monitor.WorkingArea.Width / 2) - (width / 2);
-		int y = (int)(_monitor.WorkingArea.Height * _plugin.Config.YPositionPercent / 100.0);
+		int x = (ViewModel.Monitor.WorkingArea.Width / 2) - (width / 2);
+		int y = (int)(ViewModel.Monitor.WorkingArea.Height * ViewModel.Plugin.Config.YPositionPercent / 100.0);
 
 		ILocation<int> windowLocation = new Location<int>()
 		{
-			X = _monitor.WorkingArea.X + x,
-			Y = _monitor.WorkingArea.Y + y,
+			X = ViewModel.Monitor.WorkingArea.X + x,
+			Y = ViewModel.Monitor.WorkingArea.Y + y,
 			Width = width,
 			Height = height
 		};
@@ -351,7 +163,7 @@ internal sealed partial class CommandPaletteWindow : Microsoft.UI.Xaml.Window
 				Location = windowLocation,
 				WindowSize = WindowSize.Normal
 			},
-			monitor: _monitor,
+			monitor: ViewModel.Monitor,
 			hwndInsertAfter: _window.Handle
 		);
 	}
@@ -360,33 +172,6 @@ internal sealed partial class CommandPaletteWindow : Microsoft.UI.Xaml.Window
 	{
 		Logger.Debug("Command palette item clicked");
 		ListViewItems.SelectedItem = e.ClickedItem;
-		ExecuteCommand();
-	}
-
-	private void ExecuteCommand()
-	{
-		Logger.Debug("Executing command");
-
-		if (_activationConfig is CommandPaletteFreeTextActivationConfig freeTextActivationConfig)
-		{
-			freeTextActivationConfig.Callback(TextEntry.Text);
-			Hide();
-			return;
-		}
-		else if (_activationConfig is CommandPaletteMenuActivationConfig menuActivationConfig)
-		{
-			CommandItem match = _paletteRows[ListViewItems.SelectedIndex].Model.CommandItem;
-
-			// Since the palette window is reused, there's a chance that the _activationConfig
-			// will have been wiped by a free form child command.
-			BaseCommandPaletteActivationConfig currentConfig = _activationConfig;
-			match.Command.TryExecute();
-			menuActivationConfig.Matcher.OnMatchExecuted(match);
-
-			if (_activationConfig == currentConfig)
-			{
-				Hide();
-			}
-		}
+		ViewModel.ExecuteCommand();
 	}
 }

--- a/src/Whim.CommandPalette/CommandPaletteWindowViewModel.cs
+++ b/src/Whim.CommandPalette/CommandPaletteWindowViewModel.cs
@@ -26,7 +26,7 @@ internal class CommandPaletteWindowViewModel : INotifyPropertyChanged
 	/// Factory to create palette rows to make it possible to use xunit.
 	/// It turns out it's annoying to test the Windows App SDK with xunit.
 	/// </summary>
-	private Func<PaletteRowItem, IPaletteRow> _paletteRowFactory;
+	private readonly Func<PaletteRowItem, IPaletteRow> _paletteRowFactory;
 
 	public CommandPalettePlugin Plugin { get; }
 
@@ -136,9 +136,9 @@ internal class CommandPaletteWindowViewModel : INotifyPropertyChanged
 
 	public event PropertyChangedEventHandler? PropertyChanged;
 
-	public event EventHandler? HideRequested;
+	public event EventHandler<EventArgs>? HideRequested;
 
-	public event EventHandler? SetWindowPosRequested;
+	public event EventHandler<EventArgs>? SetWindowPosRequested;
 
 	public CommandPaletteWindowViewModel(
 		IConfigContext configContext,
@@ -167,11 +167,7 @@ internal class CommandPaletteWindowViewModel : INotifyPropertyChanged
 	/// When the text is empty, typically all items are shown.
 	/// </param>
 	/// <param name="monitor">The monitor to display the command palette on.</param>
-	public void Activate(
-		BaseCommandPaletteActivationConfig config,
-		IEnumerable<CommandItem>? items = null,
-		IMonitor? monitor = null
-	)
+	public void Activate(BaseCommandPaletteActivationConfig config, IEnumerable<CommandItem>? items, IMonitor? monitor)
 	{
 		ResetState();
 

--- a/src/Whim.CommandPalette/CommandPaletteWindowViewModel.cs
+++ b/src/Whim.CommandPalette/CommandPaletteWindowViewModel.cs
@@ -6,9 +6,8 @@ using System.ComponentModel;
 
 namespace Whim.CommandPalette;
 
-internal class CommandPaletteWindowViewModel : INotifyPropertyChanged, IDisposable
+internal class CommandPaletteWindowViewModel : INotifyPropertyChanged
 {
-	private bool _disposedValue;
 	private readonly IConfigContext _configContext;
 	private BaseCommandPaletteActivationConfig _activationConfig;
 
@@ -391,34 +390,5 @@ internal class CommandPaletteWindowViewModel : INotifyPropertyChanged, IDisposab
 	protected virtual void OnPropertyChanged(string? propertyName)
 	{
 		PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
-	}
-
-	protected virtual void Dispose(bool disposing)
-	{
-		if (!_disposedValue)
-		{
-			if (disposing)
-			{
-				// TODO: dispose managed state (managed objects)
-			}
-
-			// TODO: free unmanaged resources (unmanaged objects) and override finalizer
-			// TODO: set large fields to null
-			_disposedValue = true;
-		}
-	}
-
-	// // TODO: override finalizer only if 'Dispose(bool disposing)' has code to free unmanaged resources
-	// ~CommandPaletteWindowViewModel()
-	// {
-	//     // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
-	//     Dispose(disposing: false);
-	// }
-
-	public void Dispose()
-	{
-		// Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
-		Dispose(disposing: true);
-		GC.SuppressFinalize(this);
 	}
 }

--- a/src/Whim.CommandPalette/CommandPaletteWindowViewModel.cs
+++ b/src/Whim.CommandPalette/CommandPaletteWindowViewModel.cs
@@ -273,7 +273,7 @@ internal class CommandPaletteWindowViewModel : INotifyPropertyChanged
 	}
 
 	/// <summary>
-	/// Update the matches shown to the user. <br />
+	/// Update the matches shown to the user, with the current <see cref="_activationConfig"/>.
 	///
 	/// This method has been optimized to reduce the execution time.
 	/// </summary>

--- a/src/Whim.CommandPalette/CommandPaletteWindowViewModel.cs
+++ b/src/Whim.CommandPalette/CommandPaletteWindowViewModel.cs
@@ -239,13 +239,13 @@ internal class CommandPaletteWindowViewModel : INotifyPropertyChanged
 	/// Handles key presses.
 	/// </summary>
 	/// <param name="sender"></param>
-	/// <param name="e"></param>
+	/// <param name="key"></param>
 	/// <returns><see langword="true"/> when the selected item should scroll into view.</returns>
-	public bool OnKeyDown(object sender, Microsoft.UI.Xaml.Input.KeyRoutedEventArgs e)
+	public bool OnKeyDown(object sender, Windows.System.VirtualKey key)
 	{
-		Logger.Debug("Command palette key down: {0}", e.Key.ToString());
+		Logger.Debug("Command palette key down: {0}", key.ToString());
 
-		switch (e.Key)
+		switch (key)
 		{
 			case Windows.System.VirtualKey.Down when PaletteRows.Count > 0:
 				// Go down the command palette's list.

--- a/src/Whim.CommandPalette/CommandPaletteWindowViewModel.cs
+++ b/src/Whim.CommandPalette/CommandPaletteWindowViewModel.cs
@@ -20,7 +20,7 @@ internal class CommandPaletteWindowViewModel : INotifyPropertyChanged
 	/// <summary>
 	/// The current commands from which the matches shown in <see cref="PaletteRows"/> are drawn.
 	/// </summary>
-	private readonly List<CommandItem> _allCommands = new();
+	internal readonly List<CommandItem> _allCommands = new();
 
 	/// <summary>
 	/// Factory to create palette rows to make it possible to use xunit.
@@ -202,7 +202,7 @@ internal class CommandPaletteWindowViewModel : INotifyPropertyChanged
 	/// <summary>
 	/// Populate <see cref="_allCommands"/> with all the current commands.
 	/// </summary>
-	private void PopulateItems(IEnumerable<CommandItem> items)
+	internal void PopulateItems(IEnumerable<CommandItem> items)
 	{
 		Logger.Debug($"Populating the current list of all commands.");
 
@@ -318,7 +318,7 @@ internal class CommandPaletteWindowViewModel : INotifyPropertyChanged
 	/// <param name="query">The query text string.</param>
 	/// <param name="menuActivationConfig"></param>
 	/// <returns>The number of processed matches.</returns>
-	private int LoadMatches(string query, CommandPaletteMenuActivationConfig menuActivationConfig)
+	internal int LoadMatches(string query, CommandPaletteMenuActivationConfig menuActivationConfig)
 	{
 		int matchesCount = 0;
 

--- a/src/Whim.CommandPalette/CommandPaletteWindowViewModel.cs
+++ b/src/Whim.CommandPalette/CommandPaletteWindowViewModel.cs
@@ -1,0 +1,424 @@
+using Microsoft.UI.Xaml;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+
+namespace Whim.CommandPalette;
+
+internal class CommandPaletteWindowViewModel : INotifyPropertyChanged, IDisposable
+{
+	private bool _disposedValue;
+	private readonly IConfigContext _configContext;
+	private BaseCommandPaletteActivationConfig _activationConfig;
+
+	/// <summary>
+	/// The rows which are currently unused and can be reused for new matches.
+	/// Keeping these around avoids the need to create new rows every time the palette is shown.
+	/// </summary>
+	private readonly List<PaletteRow> _unusedRows = new();
+
+	/// <summary>
+	/// The current commands from which the matches shown in <see cref="PaletteRows"/> are drawn.
+	/// </summary>
+	private readonly List<CommandItem> _allCommands = new();
+
+	public CommandPalettePlugin Plugin { get; }
+
+	public int MaxHeight { get; set; }
+
+	private IMonitor? _monitor;
+	public IMonitor? Monitor
+	{
+		get => _monitor;
+		private set
+		{
+			if (Monitor != value)
+			{
+				_monitor = value;
+				OnPropertyChanged(nameof(IsVisible));
+			}
+		}
+	}
+
+	private string _text = "";
+	public string Text
+	{
+		get => _text;
+		set
+		{
+			if (Text != value)
+			{
+				_text = value;
+				OnPropertyChanged(nameof(Text));
+			}
+		}
+	}
+
+	private string _placeholderText = "";
+	public string PlaceholderText
+	{
+		get => _placeholderText;
+		set
+		{
+			if (PlaceholderText != value)
+			{
+				_placeholderText = value;
+				OnPropertyChanged(nameof(PlaceholderText));
+			}
+		}
+	}
+
+	private int _selectedIndex;
+	public int SelectedIndex
+	{
+		get => _selectedIndex;
+		set
+		{
+			if (SelectedIndex != value)
+			{
+				_selectedIndex = value;
+				OnPropertyChanged(nameof(SelectedIndex));
+			}
+		}
+	}
+
+	private Visibility _listViewItemsWrapperVisibility = Visibility.Visible;
+	public Visibility ListViewItemsWrapperVisibility
+	{
+		get => _listViewItemsWrapperVisibility;
+		set
+		{
+			if (ListViewItemsWrapperVisibility != value)
+			{
+				_listViewItemsWrapperVisibility = value;
+				OnPropertyChanged(nameof(ListViewItemsWrapperVisibility));
+			}
+		}
+	}
+
+	private Visibility _listViewItemsVisibility = Visibility.Visible;
+	public Visibility ListViewItemsVisibility
+	{
+		get => _listViewItemsVisibility;
+		set
+		{
+			if (ListViewItemsVisibility != value)
+			{
+				_listViewItemsVisibility = value;
+				OnPropertyChanged(nameof(ListViewItemsVisibility));
+			}
+		}
+	}
+
+	private Visibility _noMatchingCommandsTextBlockVisibility = Visibility.Collapsed;
+	public Visibility NoMatchingCommandsTextBlockVisibility
+	{
+		get => _noMatchingCommandsTextBlockVisibility;
+		set
+		{
+			if (NoMatchingCommandsTextBlockVisibility != value)
+			{
+				_noMatchingCommandsTextBlockVisibility = value;
+				OnPropertyChanged(nameof(NoMatchingCommandsTextBlockVisibility));
+			}
+		}
+	}
+
+	public bool IsVisible => Monitor != null;
+
+	public readonly ObservableCollection<PaletteRow> PaletteRows = new();
+
+	public event PropertyChangedEventHandler? PropertyChanged;
+
+	public event EventHandler? HideRequested;
+
+	public event EventHandler? SetWindowPosRequested;
+
+	public CommandPaletteWindowViewModel(IConfigContext configContext, CommandPalettePlugin plugin)
+	{
+		_configContext = configContext;
+		Plugin = plugin;
+		_activationConfig = Plugin.Config.ActivationConfig;
+
+		// Populate the commands to reduce the first render time.
+		PopulateItems(_configContext.CommandManager);
+		UpdateMatches();
+	}
+
+	/// <summary>
+	/// Activate the command palette.
+	/// </summary>
+	/// <param name="config">The configuration for activation.</param>
+	/// <param name="items">
+	/// The items to activate the command palette with. These items will be passed to the
+	/// <see cref="ICommandPaletteMatcher"/> to filter the results.
+	/// When the text is empty, typically all items are shown.
+	/// </param>
+	/// <param name="monitor">The monitor to display the command palette on.</param>
+	public void Activate(
+		BaseCommandPaletteActivationConfig config,
+		IEnumerable<CommandItem>? items = null,
+		IMonitor? monitor = null
+	)
+	{
+		ResetState();
+
+		_activationConfig = config;
+		Monitor = monitor ?? _configContext.MonitorManager.FocusedMonitor;
+
+		Text = _activationConfig.InitialText ?? "";
+		PlaceholderText = _activationConfig.Hint ?? "Start typing...";
+		MaxHeight = (int)(Monitor.WorkingArea.Height * Plugin.Config.MaxHeightPercent / 100.0);
+
+		PopulateItems(items ?? Array.Empty<CommandItem>());
+		UpdateMatches();
+	}
+
+	public void RequestHide()
+	{
+		Logger.Debug("Request to hide the command palette window");
+		HideRequested?.Invoke(this, EventArgs.Empty);
+		ResetState();
+	}
+
+	/// <summary>
+	/// Reset the window's state.
+	/// </summary>
+	private void ResetState()
+	{
+		_monitor = null;
+		_text = "";
+		_allCommands.Clear();
+	}
+
+	/// <summary>
+	/// Populate <see cref="_allCommands"/> with all the current commands.
+	/// </summary>
+	private void PopulateItems(IEnumerable<CommandItem> items)
+	{
+		Logger.Debug($"Populating the current list of all commands.");
+
+		int idx = 0;
+		foreach ((ICommand command, IKeybind? keybind) in items)
+		{
+			if (!command.CanExecute())
+			{
+				continue;
+			}
+
+			if (idx < _allCommands.Count)
+			{
+				if (_allCommands[idx].Command != command)
+				{
+					_allCommands[idx] = new CommandItem() { Command = command, Keybind = keybind };
+				}
+			}
+			else
+			{
+				_allCommands.Add(new CommandItem() { Command = command, Keybind = keybind });
+			}
+
+			idx++;
+		}
+
+		for (; idx < _allCommands.Count; idx++)
+		{
+			_allCommands.RemoveAt(_allCommands.Count - 1);
+		}
+	}
+
+	/// <summary>
+	/// Handles key presses.
+	/// </summary>
+	/// <param name="sender"></param>
+	/// <param name="e"></param>
+	/// <returns><see langword="true"/> when the selected item should scroll into view.</returns>
+	public bool OnKeyDown(object sender, Microsoft.UI.Xaml.Input.KeyRoutedEventArgs e)
+	{
+		Logger.Debug("Command palette key down: {0}", e.Key.ToString());
+
+		switch (e.Key)
+		{
+			case Windows.System.VirtualKey.Down when PaletteRows.Count > 0:
+				// Go down the command palette's list.
+				SelectedIndex = (SelectedIndex + 1) % PaletteRows.Count;
+				return true;
+
+			case Windows.System.VirtualKey.Up when PaletteRows.Count > 0:
+				// Go up the command palette's list.
+				SelectedIndex = (SelectedIndex + PaletteRows.Count - 1) % PaletteRows.Count;
+				return true;
+
+			case Windows.System.VirtualKey.Enter:
+				ExecuteCommand();
+				break;
+
+			case Windows.System.VirtualKey.Escape:
+				RequestHide();
+				break;
+
+			default:
+				break;
+		}
+
+		return false;
+	}
+
+	/// <summary>
+	/// Update the matches shown to the user. <br />
+	///
+	/// This method has been optimized to reduce the execution time.
+	/// </summary>
+	public void UpdateMatches()
+	{
+		Logger.Debug("Updating command palette matches");
+		string query = Text;
+		int matchesCount = 0;
+
+		if (_activationConfig is CommandPaletteMenuActivationConfig menuActivationConfig)
+		{
+			matchesCount = LoadMatches(query, menuActivationConfig);
+
+			ListViewItemsWrapperVisibility = Visibility.Visible;
+			if (matchesCount == 0)
+			{
+				NoMatchingCommandsTextBlockVisibility = Visibility.Visible;
+				ListViewItemsVisibility = Visibility.Collapsed;
+			}
+			else
+			{
+				NoMatchingCommandsTextBlockVisibility = Visibility.Collapsed;
+				ListViewItemsVisibility = Visibility.Visible;
+			}
+		}
+		else
+		{
+			NoMatchingCommandsTextBlockVisibility = Visibility.Collapsed;
+			ListViewItemsWrapperVisibility = Visibility.Collapsed;
+		}
+
+		RemoveUnusedRows(matchesCount);
+
+		Logger.Verbose($"Command palette match count: {PaletteRows.Count}");
+		SelectedIndex = PaletteRows.Count > 0 ? 0 : -1;
+		SetWindowPosRequested?.Invoke(this, EventArgs.Empty);
+	}
+
+	/// <summary>
+	/// Load the matches into the command palette rows.
+	/// </summary>
+	/// <param name="query">The query text string.</param>
+	/// <param name="menuActivationConfig"></param>
+	/// <returns>The number of processed matches.</returns>
+	private int LoadMatches(string query, CommandPaletteMenuActivationConfig menuActivationConfig)
+	{
+		int matchesCount = 0;
+
+		foreach (PaletteRowItem item in menuActivationConfig.Matcher.Match(query, _allCommands))
+		{
+			Logger.Verbose($"Matched {item.CommandItem.Command.Title}");
+			if (matchesCount < PaletteRows.Count)
+			{
+				// Update the existing row.
+				PaletteRows[matchesCount].Update(item);
+			}
+			else if (_unusedRows.Count > 0)
+			{
+				// Restoring the unused row.
+				PaletteRow row = _unusedRows[^1];
+				row.Update(item);
+
+				PaletteRows.Add(row);
+				_unusedRows.RemoveAt(_unusedRows.Count - 1);
+			}
+			else
+			{
+				// Add a new row.
+				PaletteRow row = new(item);
+				PaletteRows.Add(row);
+				row.Initialize();
+			}
+			matchesCount++;
+
+			Logger.Verbose($"Finished updating {item.CommandItem.Command.Title}");
+		}
+
+		return matchesCount;
+	}
+
+	/// <summary>
+	/// If there are more items than we have space for, remove the last ones.
+	/// </summary>
+	/// <param name="idx"></param>
+	private void RemoveUnusedRows(int idx)
+	{
+		int count = PaletteRows.Count;
+		for (; idx < count; idx++)
+		{
+			_unusedRows.Add(PaletteRows[^1]);
+			PaletteRows.RemoveAt(PaletteRows.Count - 1);
+		}
+	}
+
+	public void ExecuteCommand()
+	{
+		Logger.Debug("Executing command");
+
+		if (_activationConfig is CommandPaletteFreeTextActivationConfig freeTextActivationConfig)
+		{
+			freeTextActivationConfig.Callback(Text);
+			RequestHide();
+			return;
+		}
+		else if (_activationConfig is CommandPaletteMenuActivationConfig menuActivationConfig)
+		{
+			CommandItem match = PaletteRows[SelectedIndex].Model.CommandItem;
+
+			// Since the palette window is reused, there's a chance that the _activationConfig
+			// will have been wiped by a free form child command.
+			BaseCommandPaletteActivationConfig currentConfig = _activationConfig;
+			match.Command.TryExecute();
+			menuActivationConfig.Matcher.OnMatchExecuted(match);
+
+			if (_activationConfig == currentConfig)
+			{
+				RequestHide();
+			}
+		}
+	}
+
+	protected virtual void OnPropertyChanged(string? propertyName)
+	{
+		PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+	}
+
+	protected virtual void Dispose(bool disposing)
+	{
+		if (!_disposedValue)
+		{
+			if (disposing)
+			{
+				// TODO: dispose managed state (managed objects)
+			}
+
+			// TODO: free unmanaged resources (unmanaged objects) and override finalizer
+			// TODO: set large fields to null
+			_disposedValue = true;
+		}
+	}
+
+	// // TODO: override finalizer only if 'Dispose(bool disposing)' has code to free unmanaged resources
+	// ~CommandPaletteWindowViewModel()
+	// {
+	//     // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+	//     Dispose(disposing: false);
+	// }
+
+	public void Dispose()
+	{
+		// Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+		Dispose(disposing: true);
+		GC.SuppressFinalize(this);
+	}
+}

--- a/src/Whim.CommandPalette/IPaletteRow.cs
+++ b/src/Whim.CommandPalette/IPaletteRow.cs
@@ -1,0 +1,10 @@
+namespace Whim.CommandPalette;
+
+internal interface IPaletteRow
+{
+	public PaletteRowItem Model { get; }
+
+	public void Initialize();
+
+	public void Update(PaletteRowItem item);
+}

--- a/src/Whim.CommandPalette/PaletteRow.xaml.cs
+++ b/src/Whim.CommandPalette/PaletteRow.xaml.cs
@@ -8,7 +8,7 @@ namespace Whim.CommandPalette;
 /// <summary>
 /// A palette row is a single command title, and an optional associated keybind.
 /// </summary>
-internal sealed partial class PaletteRow : UserControl
+internal sealed partial class PaletteRow : UserControl, IPaletteRow
 {
 	public PaletteRowItem Model { get; private set; }
 


### PR DESCRIPTION
Moved most command palette logic from `CommandPaletteWindow` to `CommandPaletteWindowViewModel`, and added tests for `CommandPaletteWindowViewModel`.