### PR TITLE
Fix menu activation when palette is already active

### DIFF
--- a/src/Whim.CommandPalette.Tests/CommandPaletteCommandsTests.cs
+++ b/src/Whim.CommandPalette.Tests/CommandPaletteCommandsTests.cs
@@ -18,6 +18,9 @@ public class CommandPaletteCommandsTests
 
 		configContext.SetupGet(x => x.WorkspaceManager).Returns(workspaceManager.Object);
 		workspaceManager.SetupGet(w => w.ActiveWorkspace).Returns(workspace.Object);
+		workspaceManager
+			.Setup(w => w.GetEnumerator())
+			.Returns(new List<IWorkspace>() { new Mock<IWorkspace>().Object }.GetEnumerator());
 
 		Mock<ICommandPalettePlugin> plugin = new();
 

--- a/src/Whim.CommandPalette.Tests/CommandPaletteWindowViewModelTests.cs
+++ b/src/Whim.CommandPalette.Tests/CommandPaletteWindowViewModelTests.cs
@@ -278,7 +278,7 @@ public class CommandPaletteWindowViewModelTests
 		vm.Activate(config, null);
 
 		// Then
-		Assert.Equal(expected, vm.IsVariantActive(config));
+		Assert.Equal(expected, vm.IsConfigActive(config));
 		Assert.Equal(showSaveButton ? Visibility.Visible : Visibility.Collapsed, vm.SaveButtonVisibility);
 	}
 

--- a/src/Whim.CommandPalette.Tests/SaveCommandTests.cs
+++ b/src/Whim.CommandPalette.Tests/SaveCommandTests.cs
@@ -1,0 +1,91 @@
+using Moq;
+using Xunit;
+
+namespace Whim.CommandPalette.Tests;
+
+public class SaveCommandTests
+{
+	[Fact]
+	public void CanExecute_WhenActiveVariantIsNull_ReturnsFalse()
+	{
+		// Given
+		Mock<ICommandPaletteWindowViewModel> viewModelMock = new();
+		viewModelMock.Setup(x => x.ActiveVariant).Returns((IVariantControl?)null);
+
+		// When
+		SaveCommand command = new(viewModelMock.Object);
+
+		// Then
+		Assert.False(command.CanExecute(null));
+	}
+
+	[Fact]
+	public void CanExecute_WhenActiveVariantIsNotNull_ReturnsTrue()
+	{
+		// Given
+		Mock<ICommandPaletteWindowViewModel> viewModelMock = new();
+		viewModelMock.Setup(x => x.ActiveVariant).Returns(new Mock<IVariantControl>().Object);
+
+		// When
+		SaveCommand command = new(viewModelMock.Object);
+
+		// Then
+		Assert.True(command.CanExecute(null));
+	}
+
+	[Fact]
+	public void Execute_WhenActiveVariantIsNull_ReturnsEarly()
+	{
+		// Given
+		Mock<ICommandPaletteWindowViewModel> viewModelMock = new();
+		viewModelMock.Setup(x => x.ActiveVariant).Returns((IVariantControl?)null);
+
+		// When
+		SaveCommand command = new(viewModelMock.Object);
+		command.Execute(null);
+
+		// Then
+		viewModelMock.Verify(x => x.RequestHide(), Times.Never);
+	}
+
+	[Fact]
+	public void Execute_DoesNotHide()
+	{
+		// Given
+		Mock<ICommandPaletteWindowViewModel> viewModelMock = new();
+		Mock<IVariantControl> variantMock = new();
+		Mock<IVariantViewModel> variantViewModelMock = new();
+
+		variantMock.Setup(x => x.ViewModel).Returns(variantViewModelMock.Object);
+		viewModelMock.Setup(x => x.ActiveVariant).Returns(variantMock.Object);
+		viewModelMock.Setup(x => x.ActivationConfig).Returns(new Mock<BaseVariantConfig>().Object);
+
+		// When
+		SaveCommand command = new(viewModelMock.Object);
+		command.Execute(null);
+
+		// Then
+		viewModelMock.Verify(x => x.RequestHide(), Times.Never);
+	}
+
+	[Fact]
+	public void Execute_Hides()
+	{
+		// Given
+		Mock<ICommandPaletteWindowViewModel> viewModelMock = new();
+		Mock<IVariantControl> variantMock = new();
+		Mock<IVariantViewModel> variantViewModelMock = new();
+
+		variantMock.Setup(x => x.ViewModel).Returns(variantViewModelMock.Object);
+		viewModelMock.Setup(x => x.ActiveVariant).Returns(variantMock.Object);
+		viewModelMock.Setup(x => x.ActivationConfig).Returns(new Mock<BaseVariantConfig>().Object);
+		viewModelMock.Setup(x => x.IsConfigActive(It.IsAny<BaseVariantConfig>())).Returns(true);
+
+		// When
+		SaveCommand command = new(viewModelMock.Object);
+		command.Execute(null);
+
+		// Then
+		viewModelMock.Verify(x => x.RequestHide(), Times.Once);
+	}
+}

--- a/src/Whim.CommandPalette.Tests/Variants/Menu/MenuVariantViewModelTests.cs
+++ b/src/Whim.CommandPalette.Tests/Variants/Menu/MenuVariantViewModelTests.cs
@@ -17,7 +17,7 @@ public class MenuVariantViewModelTests
 		configContext.Setup(c => c.CommandManager).Returns(commandManager.Object);
 
 		Mock<ICommandPaletteWindowViewModel> windowViewModel = new();
-		windowViewModel.Setup(wvm => wvm.IsVariantActive(It.IsAny<BaseVariantConfig>())).Returns(true);
+		windowViewModel.Setup(wvm => wvm.IsConfigActive(It.IsAny<BaseVariantConfig>())).Returns(true);
 		windowViewModel.Setup(wvm => wvm.Text).Returns("ti");
 
 		return (configContext, commandManager, windowViewModel);
@@ -271,7 +271,7 @@ public class MenuVariantViewModelTests
 	}
 
 	[Fact]
-	public void ExecuteCommand_Reuse()
+	public void ExecuteCommand_ReuseShouldNotHide()
 	{
 		// Given
 		(
@@ -279,7 +279,7 @@ public class MenuVariantViewModelTests
 			Mock<ICommandManager> commandManager,
 			Mock<ICommandPaletteWindowViewModel> windowViewModel
 		) = CreateStubs();
-		windowViewModel.Setup(wvm => wvm.IsVariantActive(It.IsAny<BaseVariantConfig>())).Returns(false);
+		windowViewModel.Setup(wvm => wvm.IsConfigActive(It.IsAny<BaseVariantConfig>())).Returns(false);
 
 		string callbackText = string.Empty;
 		IEnumerable<CommandItem> items = new List<CommandItem>()
@@ -291,7 +291,7 @@ public class MenuVariantViewModelTests
 
 		MenuVariantViewModel vm = new(configContext.Object, windowViewModel.Object, MenuRowFactory);
 		vm.Activate(new MenuVariantConfig() { Commands = items });
-		windowViewModel.Setup(wvm => wvm.IsVariantActive(It.IsAny<BaseVariantConfig>())).Returns(false);
+		windowViewModel.Setup(wvm => wvm.IsConfigActive(It.IsAny<BaseVariantConfig>())).Returns(false);
 
 		// When
 		vm.ExecuteCommand();

--- a/src/Whim.CommandPalette/CommandPaletteWindowViewModel.cs
+++ b/src/Whim.CommandPalette/CommandPaletteWindowViewModel.cs
@@ -178,7 +178,7 @@ internal class CommandPaletteWindowViewModel : ICommandPaletteWindowViewModel
 
 	public double GetViewMaxHeight() => ActiveVariant?.GetViewMaxHeight() ?? 0;
 
-	public bool IsVariantActive(BaseVariantConfig config) => _activationConfig == config;
+	public bool IsConfigActive(BaseVariantConfig config) => _activationConfig == config;
 
 	protected virtual void OnPropertyChanged(string? propertyName)
 	{

--- a/src/Whim.CommandPalette/CommandPaletteWindowViewModel.cs
+++ b/src/Whim.CommandPalette/CommandPaletteWindowViewModel.cs
@@ -8,11 +8,12 @@ namespace Whim.CommandPalette;
 internal class CommandPaletteWindowViewModel : ICommandPaletteWindowViewModel
 {
 	private readonly IConfigContext _configContext;
-	private BaseVariantConfig _activationConfig;
 
 	private readonly IVariantControl _menuVariant;
 	private readonly IVariantControl _freeTextVariant;
 	private readonly IVariantControl _selectVariant;
+
+	public BaseVariantConfig ActivationConfig { get; private set; }
 
 	public IVariantControl? ActiveVariant { get; private set; }
 
@@ -98,7 +99,7 @@ internal class CommandPaletteWindowViewModel : ICommandPaletteWindowViewModel
 	{
 		_configContext = configContext;
 		Plugin = plugin;
-		_activationConfig =
+		ActivationConfig =
 			Plugin.Config.ActivationConfig ?? new MenuVariantConfig() { Commands = configContext.CommandManager };
 
 		_menuVariant = menuVariant ?? new MenuVariantControl(configContext, this);
@@ -129,15 +130,15 @@ internal class CommandPaletteWindowViewModel : ICommandPaletteWindowViewModel
 			return null;
 		}
 
-		_activationConfig = config;
+		ActivationConfig = config;
 		Monitor = monitor ?? _configContext.MonitorManager.FocusedMonitor;
 
 		SaveButtonVisibility = ActiveVariant.ViewModel.ShowSaveButton ? Visibility.Visible : Visibility.Collapsed;
-		Text = _activationConfig.InitialText ?? "";
-		PlaceholderText = _activationConfig.Hint ?? "Start typing...";
+		Text = ActivationConfig.InitialText ?? "";
+		PlaceholderText = ActivationConfig.Hint ?? "Start typing...";
 		MaxHeight = (int)(Monitor.WorkingArea.Height * Plugin.Config.MaxHeightPercent / 100.0);
 
-		ActiveVariant.ViewModel.Activate(_activationConfig);
+		ActiveVariant.ViewModel.Activate(ActivationConfig);
 		SetWindowPosRequested?.Invoke(this, EventArgs.Empty);
 
 		return ActiveVariant.Control;
@@ -178,7 +179,7 @@ internal class CommandPaletteWindowViewModel : ICommandPaletteWindowViewModel
 
 	public double GetViewMaxHeight() => ActiveVariant?.GetViewMaxHeight() ?? 0;
 
-	public bool IsConfigActive(BaseVariantConfig config) => _activationConfig == config;
+	public bool IsConfigActive(BaseVariantConfig config) => ActivationConfig == config;
 
 	protected virtual void OnPropertyChanged(string? propertyName)
 	{

--- a/src/Whim.CommandPalette/ICommandPaletteWindowViewModel.cs
+++ b/src/Whim.CommandPalette/ICommandPaletteWindowViewModel.cs
@@ -12,6 +12,7 @@ internal interface ICommandPaletteWindowViewModel : INotifyPropertyChanged
 	string Text { get; set; }
 	string PlaceholderText { get; set; }
 	bool IsVisible { get; }
+	BaseVariantConfig ActivationConfig { get; }
 	IVariantControl? ActiveVariant { get; }
 	CommandPalettePlugin Plugin { get; }
 	Visibility SaveButtonVisibility { get; }

--- a/src/Whim.CommandPalette/ICommandPaletteWindowViewModel.cs
+++ b/src/Whim.CommandPalette/ICommandPaletteWindowViewModel.cs
@@ -25,5 +25,5 @@ internal interface ICommandPaletteWindowViewModel : INotifyPropertyChanged
 	void OnKeyDown(VirtualKey key);
 	void Update();
 	double GetViewMaxHeight();
-	bool IsVariantActive(BaseVariantConfig config);
+	bool IsConfigActive(BaseVariantConfig config);
 }

--- a/src/Whim.CommandPalette/SaveCommand.cs
+++ b/src/Whim.CommandPalette/SaveCommand.cs
@@ -27,7 +27,18 @@ internal class SaveCommand : System.Windows.Input.ICommand
 
 	public void Execute(object? parameter)
 	{
-		_viewModel.ActiveVariant?.ViewModel.Save();
-		_viewModel.RequestHide();
+		if (_viewModel.ActiveVariant == null || _viewModel.ActivationConfig == null)
+		{
+			return;
+		}
+
+		BaseVariantConfig config = _viewModel.ActivationConfig;
+		_viewModel.ActiveVariant.ViewModel.Save();
+
+		// Only hide the palette if the active config is the same as the one that was used to activate it.
+		if (_viewModel.IsConfigActive(config))
+		{
+			_viewModel.RequestHide();
+		}
 	}
 }

--- a/src/Whim.CommandPalette/SaveCommand.cs
+++ b/src/Whim.CommandPalette/SaveCommand.cs
@@ -27,7 +27,7 @@ internal class SaveCommand : System.Windows.Input.ICommand
 
 	public void Execute(object? parameter)
 	{
-		if (_viewModel.ActiveVariant == null || _viewModel.ActivationConfig == null)
+		if (_viewModel.ActiveVariant == null)
 		{
 			return;
 		}

--- a/src/Whim.CommandPalette/Variants/Menu/MenuVariantViewModel.cs
+++ b/src/Whim.CommandPalette/Variants/Menu/MenuVariantViewModel.cs
@@ -111,6 +111,7 @@ internal class MenuVariantViewModel : IVariantViewModel
 	{
 		if (activationConfig is MenuVariantConfig menuVariantConfig)
 		{
+			Logger.Verbose("Activating menu variant");
 			_activationConfig = menuVariantConfig;
 			PopulateItems(menuVariantConfig.Commands);
 			Update();
@@ -186,16 +187,18 @@ internal class MenuVariantViewModel : IVariantViewModel
 			return;
 		}
 
+		Logger.Verbose($"Executing command at index {SelectedIndex}");
 		IVariantItem<CommandItem> paletteItem = MenuRows[SelectedIndex].Item;
 		CommandItem match = paletteItem.Data;
 
 		// Since the palette window is reused, there's a chance that the _activationConfig
 		// will have been wiped by a free form child command.
+		MenuVariantConfig currentConfig = _activationConfig;
 
+		currentConfig.Matcher.OnMatchExecuted(paletteItem);
 		match.Command.TryExecute();
-		_activationConfig.Matcher.OnMatchExecuted(paletteItem);
 
-		if (_commandPaletteWindowViewModel.IsVariantActive(_activationConfig))
+		if (_commandPaletteWindowViewModel.IsConfigActive(currentConfig))
 		{
 			_commandPaletteWindowViewModel.RequestHide();
 		}
@@ -233,10 +236,7 @@ internal class MenuVariantViewModel : IVariantViewModel
 			idx++;
 		}
 
-		for (; idx < _allItems.Count; idx++)
-		{
-			_allItems.RemoveAt(_allItems.Count - 1);
-		}
+		_allItems.RemoveRange(idx, _allItems.Count - idx);
 	}
 
 	/// <summary>


### PR DESCRIPTION
Fixes a bug where a menu config would fail to cause another menu activation, due to closing the same window reference.