### PR TITLE
Add checkboxes support

### DIFF
--- a/src/Whim.CommandPalette.Tests/CommandPaletteCommandsTests.cs
+++ b/src/Whim.CommandPalette.Tests/CommandPaletteCommandsTests.cs
@@ -153,6 +153,6 @@ public class CommandPaletteCommandsTests
 		(Mock<IConfigContext> configContext, _, _, Mock<ICommandPalettePlugin> plugin) = CreateMocks();
 		CommandPaletteCommands commands = new(configContext.Object, plugin.Object);
 
-		Assert.Equal(4, commands.Count());
+		Assert.Equal(5, commands.Count());
 	}
 }

--- a/src/Whim.CommandPalette.Tests/CommandPaletteCommandsTests.cs
+++ b/src/Whim.CommandPalette.Tests/CommandPaletteCommandsTests.cs
@@ -1,3 +1,4 @@
+using FluentAssertions;
 using Moq;
 using Xunit;
 
@@ -5,26 +6,44 @@ namespace Whim.CommandPalette.Tests;
 
 public class CommandPaletteCommandsTests
 {
-	private static (
-		Mock<IConfigContext>,
-		Mock<IWorkspaceManager>,
-		Mock<IWorkspace>,
-		Mock<ICommandPalettePlugin>
-	) CreateMocks()
+	private class MocksBuilder
 	{
-		Mock<IConfigContext> configContext = new();
-		Mock<IWorkspaceManager> workspaceManager = new();
-		Mock<IWorkspace> workspace = new();
+		public Mock<IConfigContext> ConfigContext { get; }
+		public Mock<IWorkspaceManager> WorkspaceManager { get; }
+		public Mock<IWorkspace> Workspace { get; }
+		public Mock<IWorkspace> OtherWorkspace { get; }
+		public Mock<ICommandPalettePlugin> Plugin { get; }
+		public Mock<IWindow>[] Windows { get; }
+		public IWindow[] WindowsArray => Windows.Select(w => w.Object).ToArray();
 
-		configContext.SetupGet(x => x.WorkspaceManager).Returns(workspaceManager.Object);
-		workspaceManager.SetupGet(w => w.ActiveWorkspace).Returns(workspace.Object);
-		workspaceManager
-			.Setup(w => w.GetEnumerator())
-			.Returns(new List<IWorkspace>() { new Mock<IWorkspace>().Object }.GetEnumerator());
+		public MocksBuilder()
+		{
+			ConfigContext = new();
+			WorkspaceManager = new();
+			Workspace = new();
+			Workspace.SetupGet(w => w.Name).Returns("Workspace");
+			OtherWorkspace = new();
+			OtherWorkspace.SetupGet(w => w.Name).Returns("Other workspace");
 
-		Mock<ICommandPalettePlugin> plugin = new();
+			ConfigContext.SetupGet(x => x.WorkspaceManager).Returns(WorkspaceManager.Object);
+			WorkspaceManager.SetupGet(w => w.ActiveWorkspace).Returns(Workspace.Object);
+			WorkspaceManager
+				.Setup(w => w.GetEnumerator())
+				.Returns(new List<IWorkspace>() { Workspace.Object, OtherWorkspace.Object }.GetEnumerator());
 
-		return (configContext, workspaceManager, workspace, plugin);
+			Plugin = new();
+
+			Windows = new Mock<IWindow>[3];
+			Windows[0] = new();
+			Windows[0].SetupGet(w => w.Title).Returns("Window 0");
+			Windows[1] = new();
+			Windows[1].SetupGet(w => w.Title).Returns("Window 1");
+			Windows[2] = new();
+			Windows[2].SetupGet(w => w.Title).Returns("Window 2");
+
+			Workspace.SetupGet(w => w.Windows).Returns(new List<IWindow>() { Windows[0].Object, Windows[1].Object });
+			OtherWorkspace.SetupGet(w => w.Windows).Returns(new List<IWindow>() { Windows[2].Object });
+		}
 	}
 
 	private static List<FreeTextVariantConfig> VerifyFreeTextActivated(Mock<ICommandPalettePlugin> plugin)
@@ -44,46 +63,47 @@ public class CommandPaletteCommandsTests
 	[Fact]
 	public void ToggleCommandPaletteCommand()
 	{
-		(Mock<IConfigContext> configContext, _, _, Mock<ICommandPalettePlugin> plugin) = CreateMocks();
-		CommandPaletteCommands commands = new(configContext.Object, plugin.Object);
+		// Given
+		MocksBuilder mocks = new();
+		CommandPaletteCommands commands = new(mocks.ConfigContext.Object, mocks.Plugin.Object);
 
+		// When
 		commands.ToggleCommandPaletteCommand.Command.TryExecute();
-		plugin.Verify(x => x.Activate(null), Times.Once);
+
+		// Then
+		mocks.Plugin.Verify(x => x.Activate(null), Times.Once);
 	}
 
 	[Fact]
 	public void RenameWorkspaceCommand()
 	{
-		(Mock<IConfigContext> configContext, _, _, Mock<ICommandPalettePlugin> plugin) = CreateMocks();
-		CommandPaletteCommands commands = new(configContext.Object, plugin.Object);
+		// Given
+		MocksBuilder mocks = new();
+		CommandPaletteCommands commands = new(mocks.ConfigContext.Object, mocks.Plugin.Object);
 
-		List<FreeTextVariantConfig> configs = VerifyFreeTextActivated(plugin);
+		List<FreeTextVariantConfig> configs = VerifyFreeTextActivated(mocks.Plugin);
 		commands.RenameWorkspaceCommand.Command.TryExecute();
 
 		// Verify that the plugin was activated.
-		plugin.Verify(x => x.Activate(It.IsAny<FreeTextVariantConfig>()), Times.Once);
+		mocks.Plugin.Verify(x => x.Activate(It.IsAny<FreeTextVariantConfig>()), Times.Once);
 
 		// Call the callback.
 		configs[0].Callback("New workspace name");
 
 		// Verify that the workspace name was changed.
-		configContext.VerifySet(x => x.WorkspaceManager.ActiveWorkspace.Name = "New workspace name", Times.Once);
+		mocks.ConfigContext.VerifySet(x => x.WorkspaceManager.ActiveWorkspace.Name = "New workspace name", Times.Once);
 	}
 
 	[Fact]
 	public void CreateWorkspaceCommand()
 	{
-		(
-			Mock<IConfigContext> configContext,
-			Mock<IWorkspaceManager> workspaceManager,
-			_,
-			Mock<ICommandPalettePlugin> plugin
-		) = CreateMocks();
-		CommandPaletteCommands commands = new(configContext.Object, plugin.Object);
+		// Given
+		MocksBuilder mocks = new();
+		CommandPaletteCommands commands = new(mocks.ConfigContext.Object, mocks.Plugin.Object);
 
 		// Set up the workspace factory.
 		Mock<IWorkspace> newWorkspace = new();
-		workspaceManager
+		mocks.WorkspaceManager
 			.SetupGet(x => x.WorkspaceFactory)
 			.Returns(
 				(_, name) =>
@@ -93,17 +113,17 @@ public class CommandPaletteCommandsTests
 				}
 			);
 
-		List<FreeTextVariantConfig> configs = VerifyFreeTextActivated(plugin);
+		List<FreeTextVariantConfig> configs = VerifyFreeTextActivated(mocks.Plugin);
 		commands.CreateWorkspaceCommand.Command.TryExecute();
 
 		// Verify that the plugin was activated.
-		plugin.Verify(x => x.Activate(It.IsAny<FreeTextVariantConfig>()), Times.Once);
+		mocks.Plugin.Verify(x => x.Activate(It.IsAny<FreeTextVariantConfig>()), Times.Once);
 
 		// Call the callback.
 		configs[0].Callback("New workspace name");
 
 		// Verify that the workspace was created.
-		configContext.Verify(x => x.WorkspaceManager.Add(newWorkspace.Object), Times.Once);
+		mocks.ConfigContext.Verify(x => x.WorkspaceManager.Add(newWorkspace.Object), Times.Once);
 
 		// Verify the workspace name.
 		Assert.Equal("New workspace name", newWorkspace.Object.Name);
@@ -112,47 +132,159 @@ public class CommandPaletteCommandsTests
 	[Fact]
 	public void MoveWindowToWorkspaceCommand()
 	{
-		(
-			Mock<IConfigContext> configContext,
-			Mock<IWorkspaceManager> workspaceManager,
-			_,
-			Mock<ICommandPalettePlugin> plugin
-		) = CreateMocks();
-		CommandPaletteCommands commands = new(configContext.Object, plugin.Object);
+		// Given
+		MocksBuilder mocks = new();
+		CommandPaletteCommands commands = new(mocks.ConfigContext.Object, mocks.Plugin.Object);
 
-		List<FreeTextVariantConfig> freeTextConfigs = VerifyFreeTextActivated(plugin);
-		List<MenuVariantConfig> menuConfigs = VerifyMenuActivated(plugin);
+		List<FreeTextVariantConfig> freeTextConfigs = VerifyFreeTextActivated(mocks.Plugin);
+		List<MenuVariantConfig> menuConfigs = VerifyMenuActivated(mocks.Plugin);
 
+		// When
 		commands.MoveWindowToWorkspaceCommand.Command.TryExecute();
 
 		// Verify that the plugin was menu activated.
-		plugin.Verify(x => x.Activate(It.IsAny<MenuVariantConfig>()), Times.Once);
+		mocks.Plugin.Verify(x => x.Activate(It.IsAny<MenuVariantConfig>()), Times.Once);
 	}
 
 	[Fact]
 	public void MoveWindowToWorkspaceCommandCreator()
 	{
-		(
-			Mock<IConfigContext> configContext,
-			Mock<IWorkspaceManager> workspaceManager,
-			Mock<IWorkspace> workspace,
-			Mock<ICommandPalettePlugin> plugin
-		) = CreateMocks();
-		CommandPaletteCommands commands = new(configContext.Object, plugin.Object);
+		// Given
+		MocksBuilder mocks = new();
+		CommandPaletteCommands commands = new(mocks.ConfigContext.Object, mocks.Plugin.Object);
 
-		CommandItem item = commands.MoveWindowToWorkspaceCommandCreator(workspace.Object);
+		// When
+		CommandItem item = commands.MoveWindowToWorkspaceCommandCreator(mocks.Workspace.Object);
 		item.Command.TryExecute();
 
 		// Verify that MoveWindowToWorkspace was called with the workspace.
-		workspaceManager.Verify(x => x.MoveWindowToWorkspace(workspace.Object, null), Times.Once);
+		mocks.WorkspaceManager.Verify(x => x.MoveWindowToWorkspace(mocks.Workspace.Object, null), Times.Once);
+	}
+
+	[Fact]
+	public void CreateMoveWindowsToWorkspaceOptions()
+	{
+		// Given
+		MocksBuilder mocks = new();
+
+		// When
+		CommandPaletteCommands commands = new(mocks.ConfigContext.Object, mocks.Plugin.Object);
+		SelectOption[] options = commands.CreateMoveWindowsToWorkspaceOptions();
+
+		// Then
+		Assert.Equal(3, options.Length);
+		Assert.Equal("Window 0", options[0].Title);
+		Assert.Equal("Window 1", options[1].Title);
+		Assert.Equal("Window 2", options[2].Title);
+		options.Should().OnlyContain(x => x.IsEnabled);
+		options.Should().OnlyContain(x => !x.IsSelected);
+	}
+
+	[Fact]
+	public void MoveMultipleWindowsToWorkspaceCreator()
+	{
+		// Given
+		MocksBuilder mocks = new();
+
+		// When
+		CommandPaletteCommands commands = new(mocks.ConfigContext.Object, mocks.Plugin.Object);
+		CommandItem item = commands.MoveMultipleWindowsToWorkspaceCreator(mocks.WindowsArray, mocks.Workspace.Object);
+
+		// Then
+		item.Command.TryExecute();
+		mocks.WorkspaceManager.Verify(
+			x => x.MoveWindowToWorkspace(mocks.Workspace.Object, mocks.Windows[0].Object),
+			Times.Once
+		);
+		mocks.WorkspaceManager.Verify(
+			x => x.MoveWindowToWorkspace(mocks.Workspace.Object, mocks.Windows[1].Object),
+			Times.Once
+		);
+	}
+
+	[Fact]
+	public void MoveMultipleWindowsToWorkspaceCallback()
+	{
+		// Given
+		MocksBuilder mocks = new();
+		List<SelectOption> options =
+			new()
+			{
+				new SelectOption()
+				{
+					Id = "0",
+					Title = "Window 0",
+					IsSelected = true
+				},
+				new SelectOption()
+				{
+					Id = "1",
+					Title = "Window 1",
+					IsSelected = false
+				},
+				new SelectOption()
+				{
+					Id = "2",
+					Title = "Window 2",
+					IsSelected = true
+				},
+			};
+
+		// When
+		CommandPaletteCommands commands = new(mocks.ConfigContext.Object, mocks.Plugin.Object);
+		commands.MoveMultipleWindowsToWorkspaceCallback(options);
+
+		// Then
+		string[] expectedWorkspaces = new string[] { "Workspace", "Other workspace" };
+		mocks.Plugin.Verify(
+			x =>
+				x.Activate(
+					It.Is<MenuVariantConfig>(
+						c =>
+							c.Hint == "Select workspace"
+							&& c.Commands.Select(y => y.Command.Title).SequenceEqual(expectedWorkspaces)
+					)
+				),
+			Times.Once
+		);
+	}
+
+	[Fact]
+	public void MoveMultipleWindowsToWorkspace()
+	{
+		// Given
+		MocksBuilder mocks = new();
+
+		// When
+		CommandPaletteCommands commands = new(mocks.ConfigContext.Object, mocks.Plugin.Object);
+		CommandItem item = commands.MoveMultipleWindowsToWorkspace;
+
+		// Then
+		item.Command.TryExecute();
+		mocks.Plugin.Verify(
+			x =>
+				x.Activate(
+					It.Is<SelectVariantConfig>(
+						c =>
+							c.Hint == "Select windows"
+							&& c.Options
+								.Select(y => y.Title)
+								.SequenceEqual(new string[] { "Window 0", "Window 1", "Window 2" })
+							&& c.AllowMultiSelect
+					)
+				),
+			Times.Once
+		);
 	}
 
 	[Fact]
 	public void GetEnumerator()
 	{
-		(Mock<IConfigContext> configContext, _, _, Mock<ICommandPalettePlugin> plugin) = CreateMocks();
-		CommandPaletteCommands commands = new(configContext.Object, plugin.Object);
+		// Given
+		MocksBuilder mocks = new();
+		CommandPaletteCommands commands = new(mocks.ConfigContext.Object, mocks.Plugin.Object);
 
+		// Then
 		Assert.Equal(5, commands.Count());
 	}
 }

--- a/src/Whim.CommandPalette.Tests/Variants/Select/SelectVariantViewModelTests.cs
+++ b/src/Whim.CommandPalette.Tests/Variants/Select/SelectVariantViewModelTests.cs
@@ -190,7 +190,7 @@ public class SelectVariantViewModelTests
 		List<SelectOption>,
 		Mock<IMatcher<SelectOption>>,
 		List<Mock<IVariantRowView<SelectOption, SelectVariantRowViewModel>>>
-	) CreateOptionsStubs()
+	) CreateOptionsStubs(bool allowMultiSelect = false)
 	{
 		Mock<ICommandPaletteWindowViewModel> commandPaletteWindowViewModelMock = CreateStubs();
 		commandPaletteWindowViewModelMock.Setup(c => c.Text).Returns("ti");
@@ -247,7 +247,7 @@ public class SelectVariantViewModelTests
 				Callback = callbackMock.Object,
 				Options = options,
 				Matcher = matcherMock.Object,
-				AllowMultiSelect = false
+				AllowMultiSelect = allowMultiSelect
 			};
 
 		return (
@@ -368,7 +368,7 @@ public class SelectVariantViewModelTests
 	}
 
 	[Fact]
-	public void UpdateSelectedItem_SingleSelect_NotSelected()
+	public void UpdateSelectedItem_SingleSelect()
 	{
 		// Given
 		(
@@ -393,6 +393,36 @@ public class SelectVariantViewModelTests
 		Assert.False(options[2].IsSelected);
 		matcherMock.Verify(m => m.OnMatchExecuted(It.IsAny<IVariantRowModel<SelectOption>>()), Times.Once);
 		commandPaletteWindowViewModelMock.Verify(c => c.RequestFocusTextBox(), Times.Once);
+	}
+
+	[Fact]
+	public void UpdateSelectedItem_MultiSelect()
+	{
+		// Given
+		(
+			SelectVariantViewModel selectVariantViewModel,
+			SelectVariantConfig activationConfig,
+			_,
+			Mock<ICommandPaletteWindowViewModel> commandPaletteWindowViewModelMock,
+			List<SelectOption> options,
+			Mock<IMatcher<SelectOption>> matcherMock,
+			_
+		) = CreateOptionsStubs(allowMultiSelect: true);
+		selectVariantViewModel.Activate(activationConfig);
+
+		// When
+		selectVariantViewModel.SelectedIndex = 1;
+		selectVariantViewModel.UpdateSelectedItem();
+
+		selectVariantViewModel.SelectedIndex = 2;
+		selectVariantViewModel.UpdateSelectedItem();
+
+		// Then
+		Assert.False(options[0].IsSelected);
+		Assert.True(options[1].IsSelected);
+		Assert.True(options[2].IsSelected);
+		matcherMock.Verify(m => m.OnMatchExecuted(It.IsAny<IVariantRowModel<SelectOption>>()), Times.Exactly(2));
+		commandPaletteWindowViewModelMock.Verify(c => c.RequestFocusTextBox(), Times.Exactly(2));
 	}
 
 	[Fact]

--- a/src/Whim.CommandPalette/CommandPaletteCommands.cs
+++ b/src/Whim.CommandPalette/CommandPaletteCommands.cs
@@ -186,9 +186,9 @@ public class CommandPaletteCommands : IEnumerable<CommandItem>
 	{
 		IEnumerable<string> selectedWindowNames = options.Where(o => o.IsSelected).Select(o => o.Title);
 
-		IEnumerable<IWindow> windows = _configContext.WorkspaceManager.SelectMany(w => w.Windows).Where(
-			w => selectedWindowNames.Contains(w.Title)
-		);
+		IEnumerable<IWindow> windows = _configContext.WorkspaceManager
+			.SelectMany(w => w.Windows)
+			.Where(w => selectedWindowNames.Contains(w.Title));
 
 		IEnumerable<CommandItem> items = _configContext.WorkspaceManager.Select(
 			w => MoveMultipleWindowsToWorkspaceCreator(windows, w)

--- a/src/Whim.CommandPalette/CommandPaletteCommands.cs
+++ b/src/Whim.CommandPalette/CommandPaletteCommands.cs
@@ -135,7 +135,7 @@ public class CommandPaletteCommands : IEnumerable<CommandItem>
 	/// <summary>
 	/// Creates the select options for moving multiple windows to a workspace.
 	/// </summary>
-	public SelectOption[] CreateMoveWindowsToWorkspaceSelectOptions()
+	public SelectOption[] CreateMoveWindowsToWorkspaceOptions()
 	{
 		// All the windows in all the workspaces.
 		IEnumerable<IWindow> windows = _configContext.WorkspaceManager
@@ -186,19 +186,13 @@ public class CommandPaletteCommands : IEnumerable<CommandItem>
 	{
 		IEnumerable<string> selectedWindowNames = options.Where(o => o.IsSelected).Select(o => o.Title);
 
-		IEnumerable<IWindow> windows = _configContext.WorkspaceManager.ActiveWorkspace.Windows.Where(
+		IEnumerable<IWindow> windows = _configContext.WorkspaceManager.SelectMany(w => w.Windows).Where(
 			w => selectedWindowNames.Contains(w.Title)
 		);
 
-		IWorkspace activeWorkspace = _configContext.WorkspaceManager.ActiveWorkspace;
-		List<CommandItem> items = new();
-		foreach (IWorkspace workspace in _configContext.WorkspaceManager)
-		{
-			if (workspace != activeWorkspace)
-			{
-				items.Add(MoveMultipleWindowsToWorkspaceCreator(windows, workspace));
-			}
-		}
+		IEnumerable<CommandItem> items = _configContext.WorkspaceManager.Select(
+			w => MoveMultipleWindowsToWorkspaceCreator(windows, w)
+		);
 
 		_commandPalettePlugin.Activate(new MenuVariantConfig() { Hint = "Select workspace", Commands = items });
 	}
@@ -217,7 +211,7 @@ public class CommandPaletteCommands : IEnumerable<CommandItem>
 						new SelectVariantConfig()
 						{
 							Hint = "Select windows",
-							Options = CreateMoveWindowsToWorkspaceSelectOptions(),
+							Options = CreateMoveWindowsToWorkspaceOptions(),
 							AllowMultiSelect = true,
 							Callback = MoveMultipleWindowsToWorkspaceCallback
 						}

--- a/src/Whim.CommandPalette/CommandPaletteCommands.cs
+++ b/src/Whim.CommandPalette/CommandPaletteCommands.cs
@@ -113,14 +113,112 @@ public class CommandPaletteCommands : IEnumerable<CommandItem>
 				title: "Move window to workspace",
 				callback: () =>
 				{
-					IEnumerable<CommandItem> items = _configContext.WorkspaceManager.Select(
-						w => MoveWindowToWorkspaceCommandCreator(w)
-					);
+					IWorkspace activeWorkspace = _configContext.WorkspaceManager.ActiveWorkspace;
+					List<CommandItem> items = new();
+					foreach (IWorkspace workspace in _configContext.WorkspaceManager)
+					{
+						if (workspace != activeWorkspace)
+						{
+							items.Add(MoveWindowToWorkspaceCommandCreator(workspace));
+						}
+					}
 
 					_commandPalettePlugin.Activate(
 						new MenuVariantConfig() { Hint = "Select workspace", Commands = items }
 					);
 				}
+			)
+		};
+
+			private string MoveMultipleWindowsToWorkspaceCommandIdentifier => $"{Name}.move_multiple_windows_to_workspace";
+
+	/// <summary>
+	/// Creates the select options for moving multiple windows to a workspace.
+	/// </summary>
+	public SelectOption[] CreateMoveWindowsToWorkspaceSelectOptions()
+	{
+		// The windows active in the current workspace.
+		IEnumerable<IWindow> activeWindows = _configContext.WorkspaceManager.ActiveWorkspace.Windows;
+
+		return activeWindows
+			.Select(
+				w =>
+					new SelectOption()
+					{
+						Id = $"{MoveMultipleWindowsToWorkspaceCommandIdentifier}.windows.{w.Title}",
+						Title = w.Title,
+						IsEnabled = true,
+						IsSelected = false
+					}
+			)
+			.ToArray();
+	}
+
+	/// <summary>
+	/// Move multiple windows to workspace command creator.
+	/// </summary>
+	/// <param name="windows"></param>
+	/// <param name="workspace"></param>
+	/// <returns>The move multiple windows to workspace command.</returns>
+	public CommandItem MoveMultipleWindowsToWorkspaceCreator(IEnumerable<IWindow> windows, IWorkspace workspace) =>
+		new()
+		{
+			Command = new Command(
+				identifier: $"{MoveMultipleWindowsToWorkspaceCommandIdentifier}.workspaces.{workspace.Name}",
+				title: workspace.Name,
+				callback: () =>
+				{
+					foreach (IWindow window in windows)
+					{
+						_configContext.WorkspaceManager.MoveWindowToWorkspace(workspace, window);
+					}
+				}
+			)
+		};
+
+	/// <summary>
+	/// Callback to activate a menu variant to select the workspace to move the windows to.
+	/// </summary>
+	public void MoveMultipleWindowsToWorkspaceCallback(IEnumerable<SelectOption> options)
+	{
+		IEnumerable<string> selectedWindowNames = options.Where(o => o.IsSelected).Select(o => o.Title);
+
+		IEnumerable<IWindow> windows = _configContext.WorkspaceManager.ActiveWorkspace.Windows.Where(
+			w => selectedWindowNames.Contains(w.Title)
+		);
+
+		IWorkspace activeWorkspace = _configContext.WorkspaceManager.ActiveWorkspace;
+		List<CommandItem> items = new();
+		foreach (IWorkspace workspace in _configContext.WorkspaceManager)
+		{
+			if (workspace != activeWorkspace)
+			{
+				items.Add(MoveMultipleWindowsToWorkspaceCreator(windows, workspace));
+			}
+		}
+
+		_commandPalettePlugin.Activate(new MenuVariantConfig() { Hint = "Select workspace", Commands = items });
+	}
+
+	/// <summary>
+	/// Moves the current window to a given workspace.
+	/// </summary>
+	public CommandItem MoveMultipleWindowsToWorkspace =>
+		new()
+		{
+			Command = new Command(
+				identifier: MoveMultipleWindowsToWorkspaceCommandIdentifier,
+				title: "Move multiple windows to workspace",
+				callback: () =>
+					_commandPalettePlugin.Activate(
+						new SelectVariantConfig()
+						{
+							Hint = "Select windows",
+							Options = CreateMoveWindowsToWorkspaceSelectOptions(),
+							AllowMultiSelect = true,
+							Callback = MoveMultipleWindowsToWorkspaceCallback
+						}
+					)
 			)
 		};
 
@@ -131,6 +229,7 @@ public class CommandPaletteCommands : IEnumerable<CommandItem>
 		yield return RenameWorkspaceCommand;
 		yield return CreateWorkspaceCommand;
 		yield return MoveWindowToWorkspaceCommand;
+		yield return MoveMultipleWindowsToWorkspace;
 	}
 
 	/// <inheritdoc />

--- a/src/Whim.CommandPalette/CommandPaletteCommands.cs
+++ b/src/Whim.CommandPalette/CommandPaletteCommands.cs
@@ -130,17 +130,20 @@ public class CommandPaletteCommands : IEnumerable<CommandItem>
 			)
 		};
 
-			private string MoveMultipleWindowsToWorkspaceCommandIdentifier => $"{Name}.move_multiple_windows_to_workspace";
+	private string MoveMultipleWindowsToWorkspaceCommandIdentifier => $"{Name}.move_multiple_windows_to_workspace";
 
 	/// <summary>
 	/// Creates the select options for moving multiple windows to a workspace.
 	/// </summary>
 	public SelectOption[] CreateMoveWindowsToWorkspaceSelectOptions()
 	{
-		// The windows active in the current workspace.
-		IEnumerable<IWindow> activeWindows = _configContext.WorkspaceManager.ActiveWorkspace.Windows;
+		// All the windows in all the workspaces.
+		IEnumerable<IWindow> windows = _configContext.WorkspaceManager
+			.Select(w => w.Windows)
+			.SelectMany(w => w)
+			.OrderBy(w => w.Title);
 
-		return activeWindows
+		return windows
 			.Select(
 				w =>
 					new SelectOption()

--- a/src/Whim.CommandPalette/Variants/FreeText/FreeTextVariantView.xaml.cs
+++ b/src/Whim.CommandPalette/Variants/FreeText/FreeTextVariantView.xaml.cs
@@ -4,7 +4,7 @@ namespace Whim.CommandPalette;
 
 internal sealed partial class FreeTextVariantView : UserControl
 {
-	public static double ViewHeight => 24;
+	public static double ViewHeight => 36;
 
 	public FreeTextVariantViewModel ViewModel { get; }
 

--- a/src/Whim.CommandPalette/Variants/Menu/MenuVariantRowView.xaml.cs
+++ b/src/Whim.CommandPalette/Variants/Menu/MenuVariantRowView.xaml.cs
@@ -8,7 +8,7 @@ namespace Whim.CommandPalette;
 /// </summary>
 internal sealed partial class MenuVariantRowView : UserControl, IVariantRowView<CommandItem, MenuVariantRowViewModel>
 {
-	public static double MenuRowHeight => 24;
+	public static double MenuRowHeight => 36;
 
 	public MenuVariantRowViewModel ViewModel { get; }
 

--- a/src/Whim.CommandPalette/Variants/Select/CheckBoxRowView.xaml
+++ b/src/Whim.CommandPalette/Variants/Select/CheckBoxRowView.xaml
@@ -1,0 +1,18 @@
+﻿<UserControl
+	x:Class="Whim.CommandPalette.CheckBoxRowView"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:local="using:Whim.CommandPalette"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	mc:Ignorable="d">
+
+	<CheckBox IsChecked="{x:Bind Path=ViewModel.IsSelected, Mode=TwoWay}" IsEnabled="{x:Bind Path=ViewModel.IsEnabled}">
+		<TextBlock
+			x:Name="OptionTitle"
+			RelativePanel.AlignBottomWithPanel="True"
+			RelativePanel.AlignLeftWithPanel="True"
+			RelativePanel.AlignRightWithPanel="True"
+			RelativePanel.AlignTopWithPanel="True" />
+	</CheckBox>
+</UserControl>

--- a/src/Whim.CommandPalette/Variants/Select/CheckBoxRowView.xaml.cs
+++ b/src/Whim.CommandPalette/Variants/Select/CheckBoxRowView.xaml.cs
@@ -1,0 +1,43 @@
+using Microsoft.UI.Xaml.Controls;
+
+namespace Whim.CommandPalette;
+
+/// <summary>
+/// A palette row is a single command title, and an optional associated keybind.
+/// </summary>
+internal sealed partial class CheckBoxRowView
+	: UserControl,
+		IVariantRowView<SelectOption, SelectVariantRowViewModel>
+{
+	private readonly SelectVariantViewModel _selectVariantViewModel;
+
+	public SelectVariantRowViewModel ViewModel { get; }
+
+	public CheckBoxRowView(SelectVariantViewModel selectVariantViewModel, MatcherResult<SelectOption> item)
+	{
+		_selectVariantViewModel = selectVariantViewModel;
+		ViewModel = new SelectVariantRowViewModel(item);
+		UIElementExtensions.InitializeComponent(
+			component: this,
+			"Whim.CommandPalette",
+			"Variants/Select/CheckBoxRowView"
+		);
+	}
+
+	public void Initialize()
+	{
+		this.SetTitle(OptionTitle.Inlines);
+	}
+
+	public void Update(MatcherResult<SelectOption> matcherResult)
+	{
+		Logger.Debug("Updating with a new item");
+		ViewModel.Update(matcherResult);
+		this.SetTitle(OptionTitle.Inlines);
+	}
+
+	private void CheckBox_Click(object _, Microsoft.UI.Xaml.RoutedEventArgs e)
+	{
+		_selectVariantViewModel.VariantRow_OnClick(this);
+	}
+}

--- a/src/Whim.CommandPalette/Variants/Select/CheckBoxRowView.xaml.cs
+++ b/src/Whim.CommandPalette/Variants/Select/CheckBoxRowView.xaml.cs
@@ -5,9 +5,7 @@ namespace Whim.CommandPalette;
 /// <summary>
 /// A palette row is a single command title, and an optional associated keybind.
 /// </summary>
-internal sealed partial class CheckBoxRowView
-	: UserControl,
-		IVariantRowView<SelectOption, SelectVariantRowViewModel>
+internal sealed partial class CheckBoxRowView : UserControl, IVariantRowView<SelectOption, SelectVariantRowViewModel>
 {
 	private readonly SelectVariantViewModel _selectVariantViewModel;
 

--- a/src/Whim.CommandPalette/Variants/Select/SelectVariantControl.cs
+++ b/src/Whim.CommandPalette/Variants/Select/SelectVariantControl.cs
@@ -12,7 +12,7 @@ internal class SelectVariantControl : IVariantControl
 
 	public SelectVariantControl(ICommandPaletteWindowViewModel windowViewModel)
 	{
-		_viewModel = new(windowViewModel, SelectRowFactory) { RowHeight = 24 };
+		_viewModel = new(windowViewModel, SelectRowFactory) { RowHeight = 36 };
 		_control = new SelectVariantView(_viewModel);
 	}
 

--- a/src/Whim.CommandPalette/Variants/Select/SelectVariantControl.cs
+++ b/src/Whim.CommandPalette/Variants/Select/SelectVariantControl.cs
@@ -21,6 +21,10 @@ internal class SelectVariantControl : IVariantControl
 		SelectVariantConfig config
 	)
 	{
+		if (config.AllowMultiSelect)
+		{
+			return new CheckBoxRowView(_viewModel, item);
+		}
 		return new RadioButtonRowView(_viewModel, item);
 	}
 

--- a/src/Whim.CommandPalette/Variants/Select/SelectVariantViewModel.cs
+++ b/src/Whim.CommandPalette/Variants/Select/SelectVariantViewModel.cs
@@ -204,12 +204,11 @@ internal class SelectVariantViewModel : IVariantViewModel
 			return;
 		}
 
-		IVariantRowModel<SelectOption> selectedItem = SelectRows[SelectedIndex].ViewModel.Model;
-		SelectOption selectedData = selectedItem.Data;
+		SelectVariantRowViewModel selectedItem = SelectRows[SelectedIndex].ViewModel;
 
 		if (_allowMultiSelect)
 		{
-			selectedData.IsSelected = !selectedData.IsSelected;
+			selectedItem.IsSelected = !selectedItem.IsSelected;
 		}
 		else
 		{
@@ -218,10 +217,10 @@ internal class SelectVariantViewModel : IVariantViewModel
 				variantItem.Data.IsSelected = false;
 			}
 
-			selectedData.IsSelected = true;
+			selectedItem.IsSelected = true;
 		}
 
-		_activationConfig.Matcher.OnMatchExecuted(selectedItem);
+		_activationConfig.Matcher.OnMatchExecuted(selectedItem.Model);
 		_commandPaletteWindowViewModel.RequestFocusTextBox();
 	}
 

--- a/src/Whim.CommandPalette/Whim.CommandPalette.csproj
+++ b/src/Whim.CommandPalette/Whim.CommandPalette.csproj
@@ -14,6 +14,7 @@
 		<AnalysisModeStyle>All</AnalysisModeStyle>
 		<AnalysisModeUsage>All</AnalysisModeUsage>
 		<BuildInParallel>true</BuildInParallel>
+		<Description>An extensible window manager for Windows.</Description>
 		<EnablePreviewMsixTooling>true</EnablePreviewMsixTooling>
 		<EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
 		<GenerateLibraryLayout>true</GenerateLibraryLayout>
@@ -21,6 +22,7 @@
 		<Platforms>x64;arm64;Any CPU</Platforms>
 		<RuntimeIdentifiers>win10-x64;win10-arm64</RuntimeIdentifiers>
 		<TargetFramework>net7.0-windows10.0.19041.0</TargetFramework>
+		<TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
 		<UseWinUI>true</UseWinUI>
 		<Version>0.1.0</Version>
 	</PropertyGroup>

--- a/src/Whim.CommandPalette/Whim.CommandPalette.csproj
+++ b/src/Whim.CommandPalette/Whim.CommandPalette.csproj
@@ -30,6 +30,7 @@
 		<None Remove="CommandPaletteWindow.xaml" />
 		<None Remove="PaletteItems\PaletteKeybindItem.xaml" />
 		<None Remove="Variants\FreeText\FreeTextVariantView.xaml" />
+		<None Remove="Variants\Select\CheckBoxVariantRowView.xaml" />
 		<None Remove="Variants\Select\SelectVariantView.xaml" />
 	</ItemGroup>
 
@@ -57,6 +58,18 @@
 	<ItemGroup>
 		<InternalsVisibleTo Include="Whim.CommandPalette.Tests" />
 		<InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<Page Update="Variants\Select\CheckBoxRowView.xaml">
+			<Generator>MSBuild:Compile</Generator>
+		</Page>
+	</ItemGroup>
+
+	<ItemGroup>
+		<Page Update="Variants\Select\RadioButtonRowView.xaml">
+			<Generator>MSBuild:Compile</Generator>
+		</Page>
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Whim.Tests/Workspace/WorkspaceManagerTests.cs
+++ b/src/Whim.Tests/Workspace/WorkspaceManagerTests.cs
@@ -1,6 +1,7 @@
 using Moq;
 using System;
 using System.Linq;
+using Windows.Web.AtomPub;
 using Xunit;
 
 namespace Whim.Tests;
@@ -438,23 +439,28 @@ public class WorkspaceManagerTests
 	}
 
 	[Fact]
-	public void MoveWindowToWorkspace_AlreadyInWorkspace()
+	public void MoveWindowToWorkspace_CannotFindWindow()
 	{
+		// Given
 		(var configContext, _, var monitors, _) = CreateMocks();
 
+		// Workspaces
 		Mock<IWorkspace> workspace = new();
 		Mock<IWorkspace> workspace2 = new();
-		using WorkspaceManager workspaceManager = new(configContext.Object) { workspace.Object, workspace2.Object };
-		workspaceManager.Activate(workspace.Object, monitors[0].Object);
-		workspaceManager.Activate(workspace2.Object, monitors[1].Object);
+		Mock<IWorkspace> workspace3 = new();
+		using WorkspaceManager workspaceManager =
+			new(configContext.Object) { workspace.Object, workspace2.Object, workspace3.Object };
 
+		// Windows
 		Mock<IWindow> window = new();
-		workspaceManager.WindowAdded(window.Object);
 		workspace.Reset();
 		workspace2.Reset();
+		workspace3.Reset();
 
+		// When
 		workspaceManager.MoveWindowToWorkspace(workspace.Object, window.Object);
 
+		// Then
 		workspace.Verify(w => w.RemoveWindow(window.Object), Times.Never());
 		workspace2.Verify(w => w.AddWindow(window.Object), Times.Never());
 	}
@@ -462,21 +468,30 @@ public class WorkspaceManagerTests
 	[Fact]
 	public void MoveWindowToWorkspace_Success()
 	{
+		// Given
 		(var configContext, _, var monitors, _) = CreateMocks();
 
+		// Workspaces
 		Mock<IWorkspace> workspace = new();
 		Mock<IWorkspace> workspace2 = new();
+		Mock<IWorkspace> workspace3 = new();
+
+		// Workspace manager
 		using WorkspaceManager workspaceManager = new(configContext.Object) { workspace.Object, workspace2.Object };
 		workspaceManager.Activate(workspace.Object, monitors[0].Object);
 		workspaceManager.Activate(workspace2.Object, monitors[1].Object);
 
+		// Windows
 		Mock<IWindow> window = new();
 		workspaceManager.WindowAdded(window.Object);
 		workspace.Reset();
 		workspace2.Reset();
+		workspace3.Reset();
 
+		// When
 		workspaceManager.MoveWindowToWorkspace(workspace2.Object, window.Object);
 
+		// Then
 		workspace.Verify(w => w.RemoveWindow(window.Object), Times.Once());
 		workspace2.Verify(w => w.AddWindow(window.Object), Times.Once());
 

--- a/src/Whim/Workspace/WorkspaceManager.cs
+++ b/src/Whim/Workspace/WorkspaceManager.cs
@@ -432,11 +432,6 @@ internal class WorkspaceManager : IWorkspaceManager
 
 		Logger.Debug($"Moving window {window} to workspace {workspace}");
 
-		if (ActiveWorkspace == workspace)
-		{
-			return;
-		}
-
 		_windowWorkspaceMap[window] = workspace;
 		ActiveWorkspace.RemoveWindow(window);
 		workspace.AddWindow(window);

--- a/src/Whim/Workspace/WorkspaceManager.cs
+++ b/src/Whim/Workspace/WorkspaceManager.cs
@@ -432,8 +432,15 @@ internal class WorkspaceManager : IWorkspaceManager
 
 		Logger.Debug($"Moving window {window} to workspace {workspace}");
 
+		// Find the current workspace for the window.
+		if (!_windowWorkspaceMap.TryGetValue(window, out IWorkspace? currentWorkspace))
+		{
+			Logger.Error($"Window {window} was not found in any workspace");
+			return;
+		}
+
 		_windowWorkspaceMap[window] = workspace;
-		ActiveWorkspace.RemoveWindow(window);
+		currentWorkspace.RemoveWindow(window);
 		workspace.AddWindow(window);
 
 		// Hide the window from the current layout. If the new workspace is active, then the


### PR DESCRIPTION
This completes the `SelectVariant` of the command palette by adding multi-select support, with checkboxes. The associated command to demonstrate this was moving multiple windows to a given workspace.

This PR also fixed bugs where:

- the `SelectVariant` and `MenuVariant` had incorrect heights for each row
- you could not move a window from a workspace if the workspace was not the active workspace
- interacting with each `SelectVariant` row via the keyboard or the clicking the row would not update the state of the row

