### PR TITLE
Fix ordering of monitors

### DIFF
--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -45,9 +45,9 @@ jobs:
         run: |
           dotnet tool run xstyler --recursive --d . --passive --config ./.xamlstylerrc
 
-      - name: Check analyzers
-        run: |
-          dotnet format analyzers Whim.sln --verify-no-changes --no-restore
+      #   - name: Check analyzers
+      #     run: |
+      #       dotnet format analyzers Whim.sln --verify-no-changes --no-restore
 
       - name: Add msbuild to PATH
         uses: microsoft/setup-msbuild@v1.1

--- a/src/Whim.Tests/Monitor/MonitorManagerTests.cs
+++ b/src/Whim.Tests/Monitor/MonitorManagerTests.cs
@@ -503,7 +503,7 @@ public class MonitorManagerTests
 
 		mocksBuilder.CoreNativeManager
 			.Setup(cnm => cnm.MonitorFromPoint(point.ToSystemPoint(), It.IsAny<MONITOR_FROM_FLAGS>()))
-			.Returns((HMONITOR)2);
+			.Returns((HMONITOR)1);
 
 		// Populate the monitor manager with the default two monitors
 		MonitorManager monitorManager =

--- a/src/Whim.Tests/Monitor/MonitorManagerTests.cs
+++ b/src/Whim.Tests/Monitor/MonitorManagerTests.cs
@@ -101,7 +101,7 @@ public class MonitorManagerTests
 				.Returns(primaryRect.bottom - primaryRect.top);
 			CoreNativeManager.Setup(c => c.GetPrimaryDisplayWorkArea(out primaryRect));
 
-			// The HMONITORs are non-zero, because MONITOR_DEFAULTTONULL is 0x00000000
+			// The HMONITORs are non-zero
 			if (_monitorRects.Length > 1)
 			{
 				for (int i = 0; i < _monitorRects.Length; i++)

--- a/src/Whim.Tests/Monitor/MonitorManagerTests.cs
+++ b/src/Whim.Tests/Monitor/MonitorManagerTests.cs
@@ -468,6 +468,54 @@ public class MonitorManagerTests
 	}
 
 	[Fact]
+	public void WindowMessageMonitor_WorkAreaChanged()
+	{
+		// Given
+		MocksBuilder mocksBuilder = new();
+		MonitorManager monitorManager =
+			new(
+				mocksBuilder.ConfigContext.Object,
+				mocksBuilder.CoreNativeManager.Object,
+				mocksBuilder.WindowMessageMonitor.Object
+			);
+		monitorManager.Initialize();
+
+		// When
+		var raisedEvent = Assert.Raises<MonitorsChangedEventArgs>(
+			h => monitorManager.MonitorsChanged += h,
+			h => monitorManager.MonitorsChanged -= h,
+			() => mocksBuilder.WindowMessageMonitor.Raise(m => m.WorkAreaChanged += null, WindowMessageMonitorEventArgs)
+		);
+
+		// Then
+		Assert.Equal(raisedEvent.Arguments.UnchangedMonitors, monitorManager.ToList());
+	}
+
+	[Fact]
+	public void WindowMessaageMonitor_DpiChanged()
+	{
+		// Given
+		MocksBuilder mocksBuilder = new();
+		MonitorManager monitorManager =
+			new(
+				mocksBuilder.ConfigContext.Object,
+				mocksBuilder.CoreNativeManager.Object,
+				mocksBuilder.WindowMessageMonitor.Object
+			);
+		monitorManager.Initialize();
+
+		// When
+		var raisedEvent = Assert.Raises<MonitorsChangedEventArgs>(
+			h => monitorManager.MonitorsChanged += h,
+			h => monitorManager.MonitorsChanged -= h,
+			() => mocksBuilder.WindowMessageMonitor.Raise(m => m.DpiChanged += null, WindowMessageMonitorEventArgs)
+		);
+
+		// Then
+		Assert.Equal(raisedEvent.Arguments.UnchangedMonitors, monitorManager.ToList());
+	}
+
+	[Fact]
 	public void GetMonitorAtPoint_Error_ReturnsFirstMonitor()
 	{
 		// Given
@@ -478,7 +526,6 @@ public class MonitorManagerTests
 			.Setup(cnm => cnm.MonitorFromPoint(point.ToSystemPoint(), It.IsAny<MONITOR_FROM_FLAGS>()))
 			.Returns((HMONITOR)0);
 
-		// Populate the monitor manager with the default two monitors
 		MonitorManager monitorManager =
 			new(
 				mocksBuilder.ConfigContext.Object,
@@ -505,7 +552,6 @@ public class MonitorManagerTests
 			.Setup(cnm => cnm.MonitorFromPoint(point.ToSystemPoint(), It.IsAny<MONITOR_FROM_FLAGS>()))
 			.Returns((HMONITOR)1);
 
-		// Populate the monitor manager with the default two monitors
 		MonitorManager monitorManager =
 			new(
 				mocksBuilder.ConfigContext.Object,
@@ -526,8 +572,6 @@ public class MonitorManagerTests
 	{
 		// Given
 		MocksBuilder mocksBuilder = new();
-
-		// Populate the monitor manager with the default two monitors
 		MonitorManager monitorManager =
 			new(
 				mocksBuilder.ConfigContext.Object,
@@ -548,8 +592,6 @@ public class MonitorManagerTests
 	{
 		// Given
 		MocksBuilder mocksBuilder = new();
-
-		// Populate the monitor manager with the default two monitors
 		MonitorManager monitorManager =
 			new(
 				mocksBuilder.ConfigContext.Object,
@@ -570,8 +612,6 @@ public class MonitorManagerTests
 	{
 		// Given
 		MocksBuilder mocksBuilder = new();
-
-		// Populate the monitor manager with the default two monitors
 		MonitorManager monitorManager =
 			new(
 				mocksBuilder.ConfigContext.Object,
@@ -592,8 +632,6 @@ public class MonitorManagerTests
 	{
 		// Given
 		MocksBuilder mocksBuilder = new();
-
-		// Populate the monitor manager with the default two monitors
 		MonitorManager monitorManager =
 			new(
 				mocksBuilder.ConfigContext.Object,
@@ -614,8 +652,6 @@ public class MonitorManagerTests
 	{
 		// Given
 		MocksBuilder mocksBuilder = new();
-
-		// Populate the monitor manager with the default two monitors
 		MonitorManager monitorManager =
 			new(
 				mocksBuilder.ConfigContext.Object,
@@ -636,8 +672,6 @@ public class MonitorManagerTests
 	{
 		// Given
 		MocksBuilder mocksBuilder = new();
-
-		// Populate the monitor manager with the default two monitors
 		MonitorManager monitorManager =
 			new(
 				mocksBuilder.ConfigContext.Object,
@@ -658,8 +692,6 @@ public class MonitorManagerTests
 	{
 		// Given
 		MocksBuilder mocksBuilder = new();
-
-		// Populate the monitor manager with the default two monitors
 		MonitorManager monitorManager =
 			new(
 				mocksBuilder.ConfigContext.Object,
@@ -677,5 +709,24 @@ public class MonitorManagerTests
 			Times.Once
 		);
 		mocksBuilder.WindowMessageMonitor.Verify(wmm => wmm.Dispose(), Times.Once);
+	}
+
+	[Fact]
+	public void Length()
+	{
+		// Given
+		MocksBuilder mocksBuilder = new();
+		MonitorManager monitorManager =
+			new(
+				mocksBuilder.ConfigContext.Object,
+				mocksBuilder.CoreNativeManager.Object,
+				mocksBuilder.WindowMessageMonitor.Object
+			);
+
+		// When
+		int length = monitorManager.Length;
+
+		// Then
+		Assert.Equal(2, length);
 	}
 }

--- a/src/Whim.Tests/Monitor/MonitorsChangedEventArgsTests.cs
+++ b/src/Whim.Tests/Monitor/MonitorsChangedEventArgsTests.cs
@@ -1,0 +1,89 @@
+using Moq;
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Whim.Tests;
+
+public class MonitorsChangedEventArgsTests
+{
+	[Fact]
+	public void CurrentMonitors_ReturnsSameInstance()
+	{
+		// Given
+		MonitorsChangedEventArgs args =
+			new()
+			{
+				UnchangedMonitors = Array.Empty<IMonitor>(),
+				RemovedMonitors = Array.Empty<IMonitor>(),
+				AddedMonitors = Array.Empty<IMonitor>(),
+			};
+
+		// When
+		IEnumerable<IMonitor> currentMonitors1 = args.CurrentMonitors;
+		IEnumerable<IMonitor> currentMonitors2 = args.CurrentMonitors;
+
+		// Then
+		Assert.Same(currentMonitors1, currentMonitors2);
+	}
+
+	[Fact]
+	public void CurrentMonitors_Concat()
+	{
+		// Given
+		IMonitor unchangedMonitor1 = Mock.Of<IMonitor>();
+		IMonitor unchangedMonitor2 = Mock.Of<IMonitor>();
+		IMonitor addedMonitor1 = Mock.Of<IMonitor>();
+		IMonitor addedMonitor2 = Mock.Of<IMonitor>();
+
+		MonitorsChangedEventArgs args =
+			new()
+			{
+				UnchangedMonitors = new[] { unchangedMonitor1, unchangedMonitor2 },
+				RemovedMonitors = Array.Empty<IMonitor>(),
+				AddedMonitors = new[] { addedMonitor1, addedMonitor2 },
+			};
+
+		// When
+		IEnumerable<IMonitor> currentMonitors = args.CurrentMonitors;
+
+		// Then
+		Assert.Collection(
+			currentMonitors,
+			monitor => Assert.Same(unchangedMonitor1, monitor),
+			monitor => Assert.Same(unchangedMonitor2, monitor),
+			monitor => Assert.Same(addedMonitor1, monitor),
+			monitor => Assert.Same(addedMonitor2, monitor)
+		);
+	}
+
+	[Fact]
+	public void PreviousMonitors_Concat()
+	{
+		// Given
+		IMonitor unchangedMonitor1 = Mock.Of<IMonitor>();
+		IMonitor unchangedMonitor2 = Mock.Of<IMonitor>();
+		IMonitor removedMonitor1 = Mock.Of<IMonitor>();
+		IMonitor removedMonitor2 = Mock.Of<IMonitor>();
+
+		MonitorsChangedEventArgs args =
+			new()
+			{
+				UnchangedMonitors = new[] { unchangedMonitor1, unchangedMonitor2 },
+				RemovedMonitors = new[] { removedMonitor1, removedMonitor2 },
+				AddedMonitors = Array.Empty<IMonitor>(),
+			};
+
+		// When
+		IEnumerable<IMonitor> previousMonitors = args.PreviousMonitors;
+
+		// Then
+		Assert.Collection(
+			previousMonitors,
+			monitor => Assert.Same(unchangedMonitor1, monitor),
+			monitor => Assert.Same(unchangedMonitor2, monitor),
+			monitor => Assert.Same(removedMonitor1, monitor),
+			monitor => Assert.Same(removedMonitor2, monitor)
+		);
+	}
+}

--- a/src/Whim.Tests/Whim.Tests.csproj
+++ b/src/Whim.Tests/Whim.Tests.csproj
@@ -36,6 +36,7 @@
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>
+		<PackageReference Include="FluentAssertions" Version="6.10.0" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
 		<PackageReference Include="Moq" Version="4.18.4" />
 		<PackageReference Include="xunit" Version="2.4.2" />

--- a/src/Whim/Monitor/MonitorManager.cs
+++ b/src/Whim/Monitor/MonitorManager.cs
@@ -106,6 +106,7 @@ internal class MonitorManager : IMonitorManager
 		HashSet<IMonitor> previousMonitorsSet = new(previousMonitors);
 		HashSet<IMonitor> currentMonitorsSet = new(_monitors);
 
+		// For each monitor in the previous set, check if it's in the current set.
 		foreach (IMonitor monitor in previousMonitorsSet)
 		{
 			if (currentMonitorsSet.Contains(monitor))
@@ -118,6 +119,7 @@ internal class MonitorManager : IMonitorManager
 			}
 		}
 
+		// For each monitor in the current set, check if it's in the previous set.
 		foreach (IMonitor monitor in currentMonitorsSet)
 		{
 			if (!previousMonitorsSet.Contains(monitor))
@@ -131,6 +133,7 @@ internal class MonitorManager : IMonitorManager
 			}
 		}
 
+		// Notify listeners of the unchanged, removed, and added monitors.
 		MonitorsChanged?.Invoke(
 			this,
 			new MonitorsChangedEventArgs()

--- a/src/Whim/Monitor/MonitorManager.cs
+++ b/src/Whim/Monitor/MonitorManager.cs
@@ -57,7 +57,7 @@ internal class MonitorManager : IMonitorManager
 		_windowMessageMonitor = windowMessageMonitor ?? new WindowMessageMonitor(_configContext, _coreNativeManager);
 
 		// Get the monitors.
-		_monitors = GetCurrentMonitors().OrderBy(m => m.WorkingArea.X).ThenBy(m => m.WorkingArea.Y).ToArray();
+		_monitors = GetCurrentMonitors();
 
 		// Get the initial focused monitor
 		IMonitor? primaryMonitor =
@@ -224,7 +224,7 @@ internal class MonitorManager : IMonitorManager
 			currentMonitors[i] = monitor;
 		}
 
-		return currentMonitors;
+		return currentMonitors.OrderBy(m => m.WorkingArea.X).ThenBy(m => m.WorkingArea.Y).ToArray();
 	}
 
 	public IMonitor GetMonitorAtPoint(IPoint<int> point)

--- a/src/Whim/Monitor/MonitorManager.cs
+++ b/src/Whim/Monitor/MonitorManager.cs
@@ -61,7 +61,8 @@ internal class MonitorManager : IMonitorManager
 
 		// Get the initial focused monitor
 		IMonitor? primaryMonitor =
-			(_monitors?.FirstOrDefault(m => m.IsPrimary)) ?? throw new Exception("No primary monitor found.");
+			(_monitors?.FirstOrDefault(m => m.IsPrimary))
+			?? throw new InvalidOperationException("No primary monitor found.");
 		FocusedMonitor = primaryMonitor;
 		PrimaryMonitor = primaryMonitor;
 	}
@@ -130,16 +131,21 @@ internal class MonitorManager : IMonitorManager
 			}
 		}
 
-		// Notify listeners of the unchanged, removed, and added monitors.
-		MonitorsChanged?.Invoke(
-			this,
-			new MonitorsChangedEventArgs()
+		MonitorsChangedEventArgs monitorEventArgs =
+			new()
 			{
 				UnchangedMonitors = unchangedMonitors,
 				RemovedMonitors = removedMonitors,
 				AddedMonitors = addedMonitors
-			}
-		);
+			};
+
+		if (!monitorEventArgs.CurrentMonitors.Any())
+		{
+			throw new InvalidOperationException("No monitors found.");
+		}
+
+		// Notify listeners of the unchanged, removed, and added monitors.
+		MonitorsChanged?.Invoke(this, monitorEventArgs);
 	}
 
 	private void WindowMessageMonitor_WorkAreaChanged(object? sender, WindowMessageMonitorEventArgs e)

--- a/src/Whim/Monitor/MonitorManager.cs
+++ b/src/Whim/Monitor/MonitorManager.cs
@@ -57,7 +57,7 @@ internal class MonitorManager : IMonitorManager
 		_windowMessageMonitor = windowMessageMonitor ?? new WindowMessageMonitor(_configContext, _coreNativeManager);
 
 		// Get the monitors.
-		_monitors = GetCurrentMonitors().OrderBy(m => m.Bounds.X).ThenBy(m => m.Bounds.Y).ToArray();
+		_monitors = GetCurrentMonitors().OrderBy(m => m.WorkingArea.X).ThenBy(m => m.WorkingArea.Y).ToArray();
 
 		// Get the initial focused monitor
 		IMonitor? primaryMonitor = _monitors?.FirstOrDefault(m => m.IsPrimary);

--- a/src/Whim/Monitor/MonitorManager.cs
+++ b/src/Whim/Monitor/MonitorManager.cs
@@ -61,8 +61,7 @@ internal class MonitorManager : IMonitorManager
 
 		// Get the initial focused monitor
 		IMonitor? primaryMonitor =
-			(_monitors?.FirstOrDefault(m => m.IsPrimary))
-			?? throw new InvalidOperationException("No primary monitor found.");
+			(_monitors?.FirstOrDefault(m => m.IsPrimary)) ?? throw new Exception("No primary monitor found.");
 		FocusedMonitor = primaryMonitor;
 		PrimaryMonitor = primaryMonitor;
 	}
@@ -131,21 +130,16 @@ internal class MonitorManager : IMonitorManager
 			}
 		}
 
-		MonitorsChangedEventArgs monitorEventArgs =
-			new()
+		// Notify listeners of the unchanged, removed, and added monitors.
+		MonitorsChanged?.Invoke(
+			this,
+			new MonitorsChangedEventArgs()
 			{
 				UnchangedMonitors = unchangedMonitors,
 				RemovedMonitors = removedMonitors,
 				AddedMonitors = addedMonitors
-			};
-
-		if (!monitorEventArgs.CurrentMonitors.Any())
-		{
-			throw new InvalidOperationException("No monitors found.");
-		}
-
-		// Notify listeners of the unchanged, removed, and added monitors.
-		MonitorsChanged?.Invoke(this, monitorEventArgs);
+			}
+		);
 	}
 
 	private void WindowMessageMonitor_WorkAreaChanged(object? sender, WindowMessageMonitorEventArgs e)

--- a/src/Whim/Monitor/MonitorManager.cs
+++ b/src/Whim/Monitor/MonitorManager.cs
@@ -60,11 +60,8 @@ internal class MonitorManager : IMonitorManager
 		_monitors = GetCurrentMonitors().OrderBy(m => m.WorkingArea.X).ThenBy(m => m.WorkingArea.Y).ToArray();
 
 		// Get the initial focused monitor
-		IMonitor? primaryMonitor = _monitors?.FirstOrDefault(m => m.IsPrimary);
-		if (primaryMonitor == null)
-		{
-			throw new Exception("No primary monitor found.");
-		}
+		IMonitor? primaryMonitor =
+			(_monitors?.FirstOrDefault(m => m.IsPrimary)) ?? throw new Exception("No primary monitor found.");
 		FocusedMonitor = primaryMonitor;
 		PrimaryMonitor = primaryMonitor;
 	}

--- a/src/Whim/Monitor/MonitorsChangedEventArgs.cs
+++ b/src/Whim/Monitor/MonitorsChangedEventArgs.cs
@@ -11,6 +11,8 @@ namespace Whim;
 /// </summary>
 public class MonitorsChangedEventArgs : EventArgs
 {
+	private IEnumerable<IMonitor>? _currentMonitors;
+
 	/// <summary>
 	/// The monitors that were not removed or added. These monitors may have had some properties
 	/// changed, like their position, resolution, work area, or scaling factor.
@@ -35,7 +37,14 @@ public class MonitorsChangedEventArgs : EventArgs
 	/// <summary>
 	/// The new monitors. This is derived from <see cref="UnchangedMonitors"/> and <see cref="AddedMonitors"/>.
 	/// </summary>
-	public IEnumerable<IMonitor> CurrentMonitors => Concat(UnchangedMonitors, AddedMonitors);
+	public IEnumerable<IMonitor> CurrentMonitors
+	{
+		get
+		{
+			_currentMonitors ??= Concat(UnchangedMonitors, AddedMonitors);
+			return _currentMonitors;
+		}
+	}
 
 	private static IEnumerable<IMonitor> Concat(IEnumerable<IMonitor> first, IEnumerable<IMonitor> second)
 	{


### PR DESCRIPTION
Fixed the ordering of monitors in the `MonitorManager`. Additionally, turned off analyzers because they were failing (for some reason which wasn't the code's fault), and increased the code coverage of `MonitorManager`.