### PR TITLE
Fix palette height

### DIFF
--- a/src/Whim.CommandPalette/CommandPaletteWindow.xaml.cs
+++ b/src/Whim.CommandPalette/CommandPaletteWindow.xaml.cs
@@ -50,7 +50,7 @@ internal sealed partial class CommandPaletteWindow : Microsoft.UI.Xaml.Window
 		if (e.WindowActivationState == WindowActivationState.Deactivated)
 		{
 			// Hide the window when it loses focus.
-			// ViewModel.RequestHide();
+			ViewModel.RequestHide();
 		}
 	}
 

--- a/src/Whim.CommandPalette/CommandPaletteWindow.xaml.cs
+++ b/src/Whim.CommandPalette/CommandPaletteWindow.xaml.cs
@@ -6,7 +6,7 @@ namespace Whim.CommandPalette;
 
 internal sealed partial class CommandPaletteWindow : Microsoft.UI.Xaml.Window
 {
-	public static double TextEntryHeight => 48;
+	public static double TextEntryHeight => 32;
 
 	private readonly IConfigContext _configContext;
 	private readonly IWindow _window;
@@ -50,7 +50,7 @@ internal sealed partial class CommandPaletteWindow : Microsoft.UI.Xaml.Window
 		if (e.WindowActivationState == WindowActivationState.Deactivated)
 		{
 			// Hide the window when it loses focus.
-			ViewModel.RequestHide();
+			// ViewModel.RequestHide();
 		}
 	}
 

--- a/src/Whim.CommandPalette/Variants/FreeText/FreeTextVariantView.xaml
+++ b/src/Whim.CommandPalette/Variants/FreeText/FreeTextVariantView.xaml
@@ -10,7 +10,7 @@
 	<TextBlock
 		x:Name="Prompt"
 		Height="{x:Bind local:FreeTextVariantView.ViewHeight}"
-		Padding="12,2,0,0"
+		Padding="12,11,0,0"
 		FontStyle="Italic"
 		Text="{x:Bind Path=ViewModel.Prompt}" />
 </UserControl>

--- a/src/Whim.CommandPalette/Variants/FreeText/FreeTextVariantView.xaml.cs
+++ b/src/Whim.CommandPalette/Variants/FreeText/FreeTextVariantView.xaml.cs
@@ -4,7 +4,7 @@ namespace Whim.CommandPalette;
 
 internal sealed partial class FreeTextVariantView : UserControl
 {
-	public static double ViewHeight => 36;
+	public static double ViewHeight => 40;
 
 	public FreeTextVariantViewModel ViewModel { get; }
 

--- a/src/Whim.CommandPalette/Variants/Menu/MenuVariantView.xaml
+++ b/src/Whim.CommandPalette/Variants/Menu/MenuVariantView.xaml
@@ -13,7 +13,7 @@
 			Padding="12,0,0,0"
 			RelativePanel.AlignLeftWithPanel="True"
 			RelativePanel.AlignVerticalCenterWithPanel="True"
-			Visibility="Collapsed">
+			Visibility="{x:Bind Path=ViewModel.NoMatchingCommandsTextBlockVisibility, Mode=OneWay}">
 			No matching commands
 		</TextBlock>
 
@@ -27,6 +27,7 @@
 			RelativePanel.AlignRightWithPanel="True"
 			RelativePanel.AlignTopWithPanel="True"
 			SelectedIndex="{x:Bind Path=ViewModel.SelectedIndex, Mode=TwoWay}"
-			SelectionMode="Single" />
+			SelectionMode="Single"
+			Visibility="{x:Bind Path=ViewModel.ListViewItemsVisibility, Mode=OneWay}" />
 	</RelativePanel>
 </UserControl>

--- a/src/Whim.CommandPalette/Variants/Menu/MenuVariantView.xaml.cs
+++ b/src/Whim.CommandPalette/Variants/Menu/MenuVariantView.xaml.cs
@@ -7,7 +7,7 @@ internal sealed partial class MenuVariantView : UserControl
 {
 	public MenuVariantViewModel ViewModel { get; }
 
-	public double NonIdealStateHeight => 36;
+	public static double NonIdealStateHeight => 36;
 
 	public MenuVariantView(MenuVariantViewModel viewModel)
 	{

--- a/src/Whim.CommandPalette/Variants/Menu/MenuVariantView.xaml.cs
+++ b/src/Whim.CommandPalette/Variants/Menu/MenuVariantView.xaml.cs
@@ -7,7 +7,10 @@ internal sealed partial class MenuVariantView : UserControl
 {
 	public MenuVariantViewModel ViewModel { get; }
 
-	public static double NonIdealStateHeight => 36;
+	/// <summary>
+	/// The height of a row, including the surrounding padding/margin.
+	/// </summary>
+	public static double RowHeight => MenuVariantRowView.MenuRowHeight + (2 * 2);
 
 	public MenuVariantView(MenuVariantViewModel viewModel)
 	{
@@ -28,19 +31,6 @@ internal sealed partial class MenuVariantView : UserControl
 		ViewModel.ExecuteCommand();
 	}
 
-	public double GetViewMaxHeight()
-	{
-		if (ViewModel.MenuRows.Count == 0)
-		{
-			return NonIdealStateHeight;
-		}
-
-		// On first render, there'll be no items, so return maximum possible height.
-		if (ListViewItems.ContainerFromIndex(0) is not ListViewItem listViewItem)
-		{
-			return double.PositiveInfinity;
-		}
-
-		return listViewItem.ActualHeight * ListViewItems.Items.Count;
-	}
+	public double GetViewMaxHeight() =>
+		ViewModel.MenuRows.Count == 0 ? RowHeight : RowHeight * ViewModel.MenuRows.Count;
 }

--- a/src/Whim.CommandPalette/Variants/Menu/MenuVariantView.xaml.cs
+++ b/src/Whim.CommandPalette/Variants/Menu/MenuVariantView.xaml.cs
@@ -7,6 +7,8 @@ internal sealed partial class MenuVariantView : UserControl
 {
 	public MenuVariantViewModel ViewModel { get; }
 
+	public double NonIdealStateHeight => 36;
+
 	public MenuVariantView(MenuVariantViewModel viewModel)
 	{
 		ViewModel = viewModel;
@@ -28,6 +30,17 @@ internal sealed partial class MenuVariantView : UserControl
 
 	public double GetViewMaxHeight()
 	{
-		return ViewModel.MenuRows.Count * MenuVariantRowView.MenuRowHeight;
+		if (ViewModel.MenuRows.Count == 0)
+		{
+			return NonIdealStateHeight;
+		}
+
+		// On first render, there'll be no items, so return maximum possible height.
+		if (ListViewItems.ContainerFromIndex(0) is not ListViewItem listViewItem)
+		{
+			return double.PositiveInfinity;
+		}
+
+		return listViewItem.ActualHeight * ListViewItems.Items.Count;
 	}
 }

--- a/src/Whim.CommandPalette/Variants/Menu/MenuVariantViewModel.cs
+++ b/src/Whim.CommandPalette/Variants/Menu/MenuVariantViewModel.cs
@@ -37,20 +37,6 @@ internal class MenuVariantViewModel : IVariantViewModel
 
 	public bool ShowSaveButton => false;
 
-	private Visibility _listViewItemsWrapperVisibility = Visibility.Visible;
-	public Visibility ListViewItemsWrapperVisibility
-	{
-		get => _listViewItemsWrapperVisibility;
-		set
-		{
-			if (ListViewItemsWrapperVisibility != value)
-			{
-				_listViewItemsWrapperVisibility = value;
-				OnPropertyChanged(nameof(ListViewItemsWrapperVisibility));
-			}
-		}
-	}
-
 	private Visibility _listViewItemsVisibility = Visibility.Visible;
 	public Visibility ListViewItemsVisibility
 	{
@@ -134,7 +120,6 @@ internal class MenuVariantViewModel : IVariantViewModel
 
 		int matchesCount = LoadMenuMatches(_commandPaletteWindowViewModel.Text, _activationConfig);
 
-		ListViewItemsWrapperVisibility = Visibility.Visible;
 		if (matchesCount == 0)
 		{
 			NoMatchingCommandsTextBlockVisibility = Visibility.Visible;
@@ -301,7 +286,6 @@ internal class MenuVariantViewModel : IVariantViewModel
 	public void Hide()
 	{
 		NoMatchingCommandsTextBlockVisibility = Visibility.Collapsed;
-		ListViewItemsWrapperVisibility = Visibility.Collapsed;
 	}
 
 	public void Save() { }

--- a/src/Whim.CommandPalette/Variants/Select/SelectVariantControl.cs
+++ b/src/Whim.CommandPalette/Variants/Select/SelectVariantControl.cs
@@ -12,7 +12,7 @@ internal class SelectVariantControl : IVariantControl
 
 	public SelectVariantControl(ICommandPaletteWindowViewModel windowViewModel)
 	{
-		_viewModel = new(windowViewModel, SelectRowFactory) { RowHeight = 36 };
+		_viewModel = new(windowViewModel, SelectRowFactory);
 		_control = new SelectVariantView(_viewModel);
 	}
 
@@ -28,5 +28,5 @@ internal class SelectVariantControl : IVariantControl
 		return new RadioButtonRowView(_viewModel, item);
 	}
 
-	public double GetViewMaxHeight() => _viewModel.GetViewMaxHeight();
+	public double GetViewMaxHeight() => _control.GetViewMaxHeight();
 }

--- a/src/Whim.CommandPalette/Variants/Select/SelectVariantView.xaml
+++ b/src/Whim.CommandPalette/Variants/Select/SelectVariantView.xaml
@@ -30,7 +30,6 @@
 			SelectionMode="Single">
 			<ListView.ItemContainerStyle>
 				<Style TargetType="ListViewItem">
-					<Setter Property="Height" Value="{x:Bind ViewModel.RowHeight}" />
 					<Setter Property="HorizontalContentAlignment" Value="Stretch" />
 					<Setter Property="VerticalContentAlignment" Value="Stretch" />
 				</Style>

--- a/src/Whim.CommandPalette/Variants/Select/SelectVariantView.xaml
+++ b/src/Whim.CommandPalette/Variants/Select/SelectVariantView.xaml
@@ -13,7 +13,7 @@
 			Padding="12,0,0,0"
 			RelativePanel.AlignLeftWithPanel="True"
 			RelativePanel.AlignVerticalCenterWithPanel="True"
-			Visibility="Collapsed">
+			Visibility="{x:Bind Path=ViewModel.NoMatchingOptionsTextBlockVisibility, Mode=OneWay}">
 			No matching options
 		</TextBlock>
 
@@ -27,7 +27,8 @@
 			RelativePanel.AlignRightWithPanel="True"
 			RelativePanel.AlignTopWithPanel="True"
 			SelectedIndex="{x:Bind Path=ViewModel.SelectedIndex, Mode=TwoWay}"
-			SelectionMode="Single">
+			SelectionMode="Single"
+			Visibility="{x:Bind Path=ViewModel.SelectRowsItemsVisibility, Mode=OneWay}">
 			<ListView.ItemContainerStyle>
 				<Style TargetType="ListViewItem">
 					<Setter Property="HorizontalContentAlignment" Value="Stretch" />

--- a/src/Whim.CommandPalette/Variants/Select/SelectVariantView.xaml.cs
+++ b/src/Whim.CommandPalette/Variants/Select/SelectVariantView.xaml.cs
@@ -7,7 +7,10 @@ internal sealed partial class SelectVariantView : UserControl
 {
 	public SelectVariantViewModel ViewModel { get; }
 
-	public static double NonIdealStateHeight => 36;
+	/// <summary>
+	/// The height of a row, including the surrounding padding/margin.
+	/// </summary>
+	public static double RowHeight => 40;
 
 	public SelectVariantView(SelectVariantViewModel viewModel)
 	{
@@ -33,19 +36,6 @@ internal sealed partial class SelectVariantView : UserControl
 		}
 	}
 
-	public double GetViewMaxHeight()
-	{
-		if (ViewModel.SelectRows.Count == 0)
-		{
-			return NonIdealStateHeight;
-		}
-
-		// On first render, there'll be no items, so return maximum possible height.
-		if (ListViewItems.ContainerFromIndex(0) is not ListViewItem listViewItem)
-		{
-			return double.PositiveInfinity;
-		}
-
-		return listViewItem.ActualHeight * ListViewItems.Items.Count;
-	}
+	public double GetViewMaxHeight() =>
+		ViewModel.SelectRows.Count == 0 ? RowHeight : RowHeight * ViewModel.SelectRows.Count;
 }

--- a/src/Whim.CommandPalette/Variants/Select/SelectVariantView.xaml.cs
+++ b/src/Whim.CommandPalette/Variants/Select/SelectVariantView.xaml.cs
@@ -7,6 +7,8 @@ internal sealed partial class SelectVariantView : UserControl
 {
 	public SelectVariantViewModel ViewModel { get; }
 
+	public static double NonIdealStateHeight => 36;
+
 	public SelectVariantView(SelectVariantViewModel viewModel)
 	{
 		ViewModel = viewModel;
@@ -29,5 +31,21 @@ internal sealed partial class SelectVariantView : UserControl
 			ViewModel.SelectedIndex = idx;
 			ViewModel.UpdateSelectedItem();
 		}
+	}
+
+	public double GetViewMaxHeight()
+	{
+		if (ViewModel.SelectRows.Count == 0)
+		{
+			return NonIdealStateHeight;
+		}
+
+		// On first render, there'll be no items, so return maximum possible height.
+		if (ListViewItems.ContainerFromIndex(0) is not ListViewItem listViewItem)
+		{
+			return double.PositiveInfinity;
+		}
+
+		return listViewItem.ActualHeight * ListViewItems.Items.Count;
 	}
 }

--- a/src/Whim.CommandPalette/Variants/Select/SelectVariantViewModel.cs
+++ b/src/Whim.CommandPalette/Variants/Select/SelectVariantViewModel.cs
@@ -41,20 +41,6 @@ internal class SelectVariantViewModel : IVariantViewModel
 
 	public bool ShowSaveButton => true;
 
-	private Visibility _selectRowsItemsWrapperVisibility = Visibility.Visible;
-	public Visibility SelectRowsItemsWrapperVisibility
-	{
-		get => _selectRowsItemsWrapperVisibility;
-		set
-		{
-			if (SelectRowsItemsWrapperVisibility != value)
-			{
-				_selectRowsItemsWrapperVisibility = value;
-				OnPropertyChanged(nameof(SelectRowsItemsWrapperVisibility));
-			}
-		}
-	}
-
 	private Visibility _selectRowsControlVisibility = Visibility.Visible;
 	public Visibility SelectRowsItemsVisibility
 	{
@@ -138,7 +124,6 @@ internal class SelectVariantViewModel : IVariantViewModel
 
 		int matchesCount = LoadSelectMatches(_commandPaletteWindowViewModel.Text, _activationConfig);
 
-		SelectRowsItemsWrapperVisibility = Visibility.Visible;
 		if (matchesCount == 0)
 		{
 			NoMatchingOptionsTextBlockVisibility = Visibility.Visible;

--- a/src/Whim.CommandPalette/Variants/Select/SelectVariantViewModel.cs
+++ b/src/Whim.CommandPalette/Variants/Select/SelectVariantViewModel.cs
@@ -39,11 +39,6 @@ internal class SelectVariantViewModel : IVariantViewModel
 
 	public readonly ObservableCollection<IVariantRowView<SelectOption, SelectVariantRowViewModel>> SelectRows = new();
 
-	/// <summary>
-	/// The height of the row.
-	/// </summary>
-	public required double RowHeight { get; init; }
-
 	public bool ShowSaveButton => true;
 
 	private Visibility _selectRowsItemsWrapperVisibility = Visibility.Visible;
@@ -332,8 +327,6 @@ internal class SelectVariantViewModel : IVariantViewModel
 	public void Hide() { }
 
 	public void Save() => _activationConfig?.Callback(_allItems.Select(x => x.Data));
-
-	public double GetViewMaxHeight() => SelectRows.Count * RowHeight;
 
 	protected virtual void OnPropertyChanged(string propertyName)
 	{


### PR DESCRIPTION
This ensures that as many palette list items can be shown as possible. It also fixes the  overall height of the palette so there is no spare space. The `MenuVariantView` and `SelectVariantView` now bind their visibilities correctly.