### PR TITLE
Remove duplicate DoLayout commands

### DIFF
--- a/src/Whim.Tests/Workspace/WorkspaceManagerTests.cs
+++ b/src/Whim.Tests/Workspace/WorkspaceManagerTests.cs
@@ -266,8 +266,10 @@ public class WorkspaceManagerTests
 		Mock<IWorkspace> workspace2 = new();
 		MocksBuilder mocks = new(new[] { workspace, workspace2 });
 		IMonitor monitor = mocks.Monitors[0].Object;
+		IMonitor monitor2 = mocks.Monitors[1].Object;
 
 		mocks.WorkspaceManager.Activate(workspace.Object, monitor);
+		mocks.WorkspaceManager.Activate(workspace2.Object, monitor2);
 
 		// When a workspace is activated on a monitor which already has a workspace activated, then
 		// an event is raised
@@ -277,9 +279,9 @@ public class WorkspaceManagerTests
 			() => mocks.WorkspaceManager.Activate(workspace2.Object, monitor)
 		);
 
+		Assert.Equal(monitor, result.Arguments.Monitor);
 		Assert.Equal(workspace2.Object, result.Arguments.NewWorkspace);
 		Assert.Equal(workspace.Object, result.Arguments.OldWorkspace);
-		Assert.Equal(monitor, result.Arguments.Monitor);
 	}
 
 	[Fact]

--- a/src/Whim.Tests/Workspace/WorkspaceManagerTests.cs
+++ b/src/Whim.Tests/Workspace/WorkspaceManagerTests.cs
@@ -493,12 +493,6 @@ public class WorkspaceManagerTests
 		// Then
 		workspace.Verify(w => w.RemoveWindow(window.Object), Times.Once());
 		workspace2.Verify(w => w.AddWindow(window.Object), Times.Once());
-
-		// Verify that the window was hidden.
-		window.Verify(w => w.Hide(), Times.Once());
-
-		// Verify that DoLayout was called.
-		workspace2.Verify(w => w.DoLayout(), Times.Once());
 	}
 
 	[Fact]
@@ -753,9 +747,6 @@ public class WorkspaceManagerTests
 
 		workspace.Verify(w => w.RemoveWindow(window.Object), Times.Once());
 		workspace.Verify(w => w.MoveWindowToPoint(window.Object, It.IsAny<Point<double>>(), false), Times.Never());
-
-		workspace.Verify(w => w.DoLayout(), Times.Once());
-		workspace2.Verify(w => w.DoLayout(), Times.Once());
 
 		window.Verify(w => w.Focus(), Times.Once());
 	}

--- a/src/Whim.Tests/Workspace/WorkspaceManagerTests.cs
+++ b/src/Whim.Tests/Workspace/WorkspaceManagerTests.cs
@@ -807,6 +807,7 @@ public class WorkspaceManagerTests
 		MocksBuilder mocks = new(new[] { workspace, workspace2 });
 
 		mocks.WorkspaceManager.Activate(workspace.Object, mocks.Monitors[0].Object);
+		mocks.WorkspaceManager.Activate(workspace2.Object, mocks.Monitors[1].Object);
 
 		Mock<IWindow> window = new();
 		mocks.WorkspaceManager.AddPhantomWindow(workspace.Object, window.Object);
@@ -832,6 +833,7 @@ public class WorkspaceManagerTests
 		MocksBuilder mocks = new(new[] { workspace, workspace2 });
 
 		mocks.WorkspaceManager.Activate(workspace.Object, mocks.Monitors[0].Object);
+		mocks.WorkspaceManager.Activate(workspace2.Object, mocks.Monitors[1].Object);
 
 		Mock<IWindow> window = new();
 		mocks.WorkspaceManager.WindowAdded(window.Object);
@@ -844,7 +846,7 @@ public class WorkspaceManagerTests
 		mocks.WorkspaceManager.MoveWindowToPoint(window.Object, new Point<int>() { X = 0, Y = 0 });
 
 		// Then nothing happens
-		workspace.Verify(w => w.RemoveWindow(window.Object), Times.Never());
+		workspace.Verify(w => w.RemoveWindow(window.Object), Times.Once());
 		workspace.Verify(w => w.MoveWindowToPoint(window.Object, It.IsAny<Point<double>>(), false), Times.Never());
 	}
 

--- a/src/Whim.Tests/Workspace/WorkspaceManagerTests.cs
+++ b/src/Whim.Tests/Workspace/WorkspaceManagerTests.cs
@@ -203,6 +203,42 @@ public class WorkspaceManagerTests
 	}
 
 	[Fact]
+	public void SquareBracket_Get()
+	{
+		// Given
+		Mock<IWorkspace> workspace = new();
+		workspace.Setup(w => w.Name).Returns("workspace");
+		MocksBuilder mocks = new(new[] { workspace });
+
+		// When getting a workspace which does exist, then the workspace is returned
+		Assert.Equal(workspace.Object, mocks.WorkspaceManager["workspace"]);
+	}
+
+	[Fact]
+	public void GetEnumerator()
+	{
+		// Given
+		Mock<IWorkspace> workspace = new();
+		Mock<IWorkspace> workspace2 = new();
+		MocksBuilder mocks = new(new[] { workspace, workspace2 });
+
+		// When enumerating the workspaces, then the workspaces are returned
+		Assert.Equal(new[] { workspace.Object, workspace2.Object }, mocks.WorkspaceManager);
+	}
+
+	[Fact]
+	public void IEnumerable_GetEnumerator()
+	{
+		// Given
+		Mock<IWorkspace> workspace = new();
+		Mock<IWorkspace> workspace2 = new();
+		MocksBuilder mocks = new(new[] { workspace, workspace2 });
+
+		// When enumerating the workspaces, then the workspaces are returned
+		Assert.Equal(new[] { workspace.Object, workspace2.Object }, mocks.WorkspaceManager);
+	}
+
+	[Fact]
 	public void Activate_NoOldWorkspace()
 	{
 		// Given
@@ -1113,5 +1149,54 @@ public class WorkspaceManagerTests
 			h => mocks.WorkspaceManager.WorkspaceRenamed -= h,
 			() => mocks.WorkspaceManager.TriggerWorkspaceRenamed(eventArgs)
 		);
+	}
+
+	[Fact]
+	public void AddPhantomWindow()
+	{
+		// Given
+		Mock<IWorkspace> workspace = new();
+		Mock<IWindow> window = new();
+		MocksBuilder mocks = new(new[] { workspace });
+
+		// When a phantom window is added
+		mocks.WorkspaceManager.AddPhantomWindow(workspace.Object, window.Object);
+
+		// Then the phantom window is added to the list
+		Assert.Contains(window.Object, mocks.WorkspaceManager.PhantomWindows);
+	}
+
+	[Fact]
+	public void RemovePhantomWindow()
+	{
+		// Given
+		Mock<IWorkspace> workspace = new();
+		Mock<IWindow> window = new();
+		MocksBuilder mocks = new(new[] { workspace });
+
+		mocks.WorkspaceManager.AddPhantomWindow(workspace.Object, window.Object);
+
+		// When a phantom window is removed
+		mocks.WorkspaceManager.RemovePhantomWindow(window.Object);
+
+		// Then the phantom window is removed from the list
+		Assert.DoesNotContain(window.Object, mocks.WorkspaceManager.PhantomWindows);
+		Assert.Null(mocks.WorkspaceManager.GetMonitorForWindow(window.Object));
+	}
+
+	[Fact]
+	public void DoesDispose()
+	{
+		// Given
+		Mock<IWorkspace> workspace = new();
+		Mock<IWorkspace> workspace2 = new();
+		MocksBuilder mocks = new(new[] { workspace, workspace2 });
+
+		// When the workspace manager is disposed
+		mocks.WorkspaceManager.Dispose();
+
+		// Then the workspaces are disposed
+		workspace.Verify(w => w.Dispose(), Times.Once());
+		workspace2.Verify(w => w.Dispose(), Times.Once());
 	}
 }

--- a/src/Whim.Tests/Workspace/WorkspaceManagerTests.cs
+++ b/src/Whim.Tests/Workspace/WorkspaceManagerTests.cs
@@ -1056,4 +1056,60 @@ public class WorkspaceManagerTests
 		workspace2.Verify(w => w.DoLayout(), Times.Once());
 		workspace3.Verify(w => w.DoLayout(), Times.Exactly(2));
 	}
+
+	[Fact]
+	public void AddProxyLayoutEngine()
+	{
+		// Given
+		MocksBuilder mocks = new();
+		Mock<ProxyLayoutEngine> proxyLayoutEngine = new();
+
+		// When a proxy layout engine is added
+		mocks.WorkspaceManager.AddProxyLayoutEngine(proxyLayoutEngine.Object);
+
+		// Then the proxy layout engine is added to the list
+		Assert.Contains(proxyLayoutEngine.Object, mocks.WorkspaceManager.ProxyLayoutEngines);
+	}
+
+	[Fact]
+	public void TriggerActiveLayoutEngineChanged()
+	{
+		// Given
+		MocksBuilder mocks = new();
+		ActiveLayoutEngineChangedEventArgs eventArgs =
+			new()
+			{
+				Workspace = new Mock<IWorkspace>().Object,
+				PreviousLayoutEngine = new Mock<ILayoutEngine>().Object,
+				CurrentLayoutEngine = new Mock<ILayoutEngine>().Object
+			};
+
+		// When the active layout engine is changed, then the event is triggered
+		Assert.Raises<ActiveLayoutEngineChangedEventArgs>(
+			h => mocks.WorkspaceManager.ActiveLayoutEngineChanged += h,
+			h => mocks.WorkspaceManager.ActiveLayoutEngineChanged -= h,
+			() => mocks.WorkspaceManager.TriggerActiveLayoutEngineChanged(eventArgs)
+		);
+	}
+
+	[Fact]
+	public void TriggerWorkspaceRenamed()
+	{
+		// Given
+		MocksBuilder mocks = new();
+		WorkspaceRenamedEventArgs eventArgs =
+			new()
+			{
+				Workspace = new Mock<IWorkspace>().Object,
+				PreviousName = "Previous",
+				CurrentName = "Current"
+			};
+
+		// When the workspace is renamed, then the event is triggered
+		Assert.Raises<WorkspaceRenamedEventArgs>(
+			h => mocks.WorkspaceManager.WorkspaceRenamed += h,
+			h => mocks.WorkspaceManager.WorkspaceRenamed -= h,
+			() => mocks.WorkspaceManager.TriggerWorkspaceRenamed(eventArgs)
+		);
+	}
 }

--- a/src/Whim.Tests/Workspace/WorkspaceManagerTests.cs
+++ b/src/Whim.Tests/Workspace/WorkspaceManagerTests.cs
@@ -5,11 +5,6 @@ using Xunit;
 
 namespace Whim.Tests;
 
-[System.Diagnostics.CodeAnalysis.SuppressMessage(
-	"Reliability",
-	"CA2000:Dispose objects before losing scope",
-	Justification = "Unnecessary for tests"
-)]
 public class WorkspaceManagerTests
 {
 	private class MocksBuilder
@@ -349,6 +344,32 @@ public class WorkspaceManagerTests
 		Mock<IWorkspace> workspace = new();
 		Mock<IWorkspace> workspace2 = new();
 		MocksBuilder mocks = new(new[] { workspace, workspace2 });
+
+		mocks.WorkspaceManager.Activate(workspace.Object, mocks.Monitors[0].Object);
+		mocks.WorkspaceManager.Activate(workspace2.Object, mocks.Monitors[1].Object);
+
+		// Reset the mocks
+		workspace.Reset();
+		workspace2.Reset();
+
+		// When a window is added
+		Mock<IWindow> window = new();
+		mocks.WorkspaceManager.WindowAdded(window.Object);
+
+		// Then the window is added to the active workspace
+		workspace.Verify(w => w.AddWindow(window.Object), Times.Once());
+		workspace2.Verify(w => w.AddWindow(window.Object), Times.Never());
+	}
+
+	[Fact]
+	public void WindowAdded_NoRouter_GetMonitorAtWindowCenter()
+	{
+		// Given
+		Mock<IWorkspace> workspace = new();
+		Mock<IWorkspace> workspace2 = new();
+		MocksBuilder mocks = new(new[] { workspace, workspace2 });
+
+		mocks.MonitorManager.Setup(m => m.GetMonitorAtPoint(It.IsAny<IPoint<int>>())).Returns(mocks.Monitors[0].Object);
 
 		mocks.WorkspaceManager.Activate(workspace.Object, mocks.Monitors[0].Object);
 		mocks.WorkspaceManager.Activate(workspace2.Object, mocks.Monitors[1].Object);

--- a/src/Whim.Tests/Workspace/WorkspaceManagerTests.cs
+++ b/src/Whim.Tests/Workspace/WorkspaceManagerTests.cs
@@ -246,6 +246,30 @@ public class WorkspaceManagerTests
 	}
 
 	[Fact]
+	public void Activate_MultipleMonitors()
+	{
+		// Given there are two workspaces and monitors
+		Mock<IWorkspace> workspace = new();
+		Mock<IWorkspace> workspace2 = new();
+		MocksBuilder mocks = new(new[] { workspace, workspace2 });
+		IMonitor monitor = mocks.Monitors[0].Object;
+
+		mocks.WorkspaceManager.Activate(workspace.Object, monitor);
+
+		// When a workspace is activated on a monitor which already has a workspace activated, then
+		// an event is raised
+		var result = Assert.Raises<MonitorWorkspaceChangedEventArgs>(
+			h => mocks.WorkspaceManager.MonitorWorkspaceChanged += h,
+			h => mocks.WorkspaceManager.MonitorWorkspaceChanged -= h,
+			() => mocks.WorkspaceManager.Activate(workspace2.Object, monitor)
+		);
+
+		Assert.Equal(workspace2.Object, result.Arguments.NewWorkspace);
+		Assert.Equal(workspace.Object, result.Arguments.OldWorkspace);
+		Assert.Equal(monitor, result.Arguments.Monitor);
+	}
+
+	[Fact]
 	public void GetMonitorForWorkspace_NoWorkspace()
 	{
 		// Given

--- a/src/Whim.Tests/Workspace/WorkspaceManagerTests.cs
+++ b/src/Whim.Tests/Workspace/WorkspaceManagerTests.cs
@@ -46,21 +46,26 @@ public class WorkspaceManagerTests
 	[Fact]
 	public void Initialize_RequireAtLeastNWorkspace()
 	{
+		// Given
 		MocksBuilder mocks = new();
 
+		// When
 		using WorkspaceManager workspaceManager = new(mocks.ConfigContext.Object);
+
+		// Then
 		Assert.Throws<InvalidOperationException>(workspaceManager.Initialize);
 	}
 
 	[Fact]
 	public void Initialize_Success()
 	{
+		// Given
 		MocksBuilder mocks = new();
 
 		Mock<IWorkspace> workspace = new();
 		Mock<IWorkspace> workspace2 = new();
 
-		// Given the workspace manager has two workspaces
+		// the workspace manager has two workspaces
 		using WorkspaceManager workspaceManager =
 			new(mocks.ConfigContext.Object) { workspace.Object, workspace2.Object };
 
@@ -79,6 +84,7 @@ public class WorkspaceManagerTests
 	[Fact]
 	public void Add()
 	{
+		// Given
 		MocksBuilder mocks = new();
 
 		Mock<IWorkspace> workspace = new();
@@ -95,6 +101,7 @@ public class WorkspaceManagerTests
 	[Fact]
 	public void Remove_Workspace_RequireAtLeastNWorkspace()
 	{
+		// Given
 		MocksBuilder mocks = new();
 
 		Mock<IWorkspace> workspace = new();
@@ -110,6 +117,7 @@ public class WorkspaceManagerTests
 	[Fact]
 	public void Remove_Workspace_NotFound()
 	{
+		// Given
 		MocksBuilder mocks = new();
 
 		Mock<IWorkspace> workspace = new();
@@ -125,6 +133,7 @@ public class WorkspaceManagerTests
 	public void Remove_Workspace_Success()
 	{
 		Mock<IMonitor>[] monitorMocks = new[] { new Mock<IMonitor>() };
+		// Given
 		MocksBuilder mocks = new(monitorMocks);
 
 		Mock<IWorkspace> workspace = new();
@@ -143,6 +152,7 @@ public class WorkspaceManagerTests
 	[Fact]
 	public void Remove_String_NotFound()
 	{
+		// Given
 		MocksBuilder mocks = new();
 
 		Mock<IWorkspace> workspace = new();
@@ -157,8 +167,8 @@ public class WorkspaceManagerTests
 	[Fact]
 	public void Remove_String_Success()
 	{
-		Mock<IMonitor>[] monitorMocks = new[] { new Mock<IMonitor>() };
-		MocksBuilder mocks = new(monitorMocks);
+		// Given
+		MocksBuilder mocks = new(new[] { new Mock<IMonitor>() });
 
 		Mock<IWorkspace> workspace = new();
 		workspace.Setup(w => w.Name).Returns("workspace");
@@ -177,34 +187,40 @@ public class WorkspaceManagerTests
 	[Fact]
 	public void TryGet_Null()
 	{
+		// Given
 		MocksBuilder mocks = new();
-
 		using WorkspaceManager workspaceManager = new(mocks.ConfigContext.Object);
+
+		// When getting a workspace which does not exist, then null is returned
 		Assert.Null(workspaceManager.TryGet("not found"));
 	}
 
 	[Fact]
 	public void TryGet_Success()
 	{
+		// Given
 		MocksBuilder mocks = new();
 
 		Mock<IWorkspace> workspace = new();
 		workspace.Setup(w => w.Name).Returns("workspace");
 		using WorkspaceManager workspaceManager = new(mocks.ConfigContext.Object) { workspace.Object };
 
+		// When getting a workspace which does exist, then the workspace is returned
 		Assert.Equal(workspace.Object, workspaceManager.TryGet("workspace"));
 	}
 
 	[Fact]
 	public void Activate_NoOldWorkspace()
 	{
+		// Given
 		Mock<IMonitor>[] monitorMocks = new[] { new Mock<IMonitor>() };
 		MocksBuilder mocks = new(monitorMocks);
 
 		Mock<IWorkspace> workspace = new();
 		using WorkspaceManager workspaceManager = new(mocks.ConfigContext.Object) { workspace.Object };
 
-		// When a workspace is activated, it is focused on the focused monitor
+		// When a workspace is activated when there are no other workspaces activated, then it is
+		// focused on the focused monitor and raises an event,
 		var result = Assert.Raises<MonitorWorkspaceChangedEventArgs>(
 			h => workspaceManager.MonitorWorkspaceChanged += h,
 			h => workspaceManager.MonitorWorkspaceChanged -= h,
@@ -213,6 +229,7 @@ public class WorkspaceManagerTests
 		Assert.Equal(workspace.Object, result.Arguments.NewWorkspace);
 		Assert.Null(result.Arguments.OldWorkspace);
 
+		// Layout is done, and the first window is focused.
 		workspace.Verify(w => w.DoLayout(), Times.Once);
 		workspace.Verify(w => w.FocusFirstWindow(), Times.Once);
 	}
@@ -220,6 +237,7 @@ public class WorkspaceManagerTests
 	[Fact]
 	public void Activate_WithOldWorkspace()
 	{
+		// Given
 		Mock<IMonitor>[] monitorMocks = new[] { new Mock<IMonitor>() };
 		MocksBuilder mocks = new(monitorMocks);
 
@@ -230,7 +248,8 @@ public class WorkspaceManagerTests
 
 		workspaceManager.Activate(oldWorkspace.Object);
 
-		// When a workspace is activated, it is focused on the focused monitor
+		// When a workspace is activated when there is another workspace activated, then the old
+		// workspace is deactivated, the new workspace is activated, and an event is raised
 		var result = Assert.Raises<MonitorWorkspaceChangedEventArgs>(
 			h => workspaceManager.MonitorWorkspaceChanged += h,
 			h => workspaceManager.MonitorWorkspaceChanged -= h,
@@ -239,6 +258,8 @@ public class WorkspaceManagerTests
 		Assert.Equal(newWorkspace.Object, result.Arguments.NewWorkspace);
 		Assert.Equal(oldWorkspace.Object, result.Arguments.OldWorkspace);
 
+		// The old workspace is deactivated, the new workspace is laid out, and the first window is
+		// focused.
 		oldWorkspace.Verify(w => w.Deactivate(), Times.Once);
 		newWorkspace.Verify(w => w.DoLayout(), Times.Once);
 		newWorkspace.Verify(w => w.FocusFirstWindow(), Times.Once);
@@ -247,6 +268,7 @@ public class WorkspaceManagerTests
 	[Fact]
 	public void GetMonitorForWorkspace_NoWorkspace()
 	{
+		// Given
 		Mock<IMonitor>[] monitorMocks = new[] { new Mock<IMonitor>() };
 		MocksBuilder mocks = new(monitorMocks);
 
@@ -254,42 +276,56 @@ public class WorkspaceManagerTests
 		using WorkspaceManager workspaceManager = new(mocks.ConfigContext.Object) { workspace.Object, };
 		workspaceManager.Activate(workspace.Object);
 
-		// Get the monitor for a workspace which isn't in the workspace manager
-		Assert.Null(workspaceManager.GetMonitorForWorkspace(new Mock<IWorkspace>().Object));
+		// When we get the monitor for a workspace which isn't in the workspace manager
+		IMonitor? monitor = workspaceManager.GetMonitorForWorkspace(new Mock<IWorkspace>().Object);
+
+		// Then null is returned
+		Assert.Null(monitor);
 	}
 
 	[Fact]
 	public void GetMonitorForWorkspace_Success()
 	{
+		// Given
 		MocksBuilder mocks = new();
 
 		Mock<IWorkspace> workspace = new();
 		Mock<IWorkspace> workspace2 = new();
+
 		using WorkspaceManager workspaceManager =
 			new(mocks.ConfigContext.Object) { workspace.Object, workspace2.Object };
 		workspaceManager.Activate(workspace.Object);
 		workspaceManager.Activate(workspace2.Object, mocks.Monitors[1].Object);
 
-		// Get the monitor for a workspace which is in the workspace manager
-		Assert.Equal(mocks.Monitors[0].Object, workspaceManager.GetMonitorForWorkspace(workspace.Object));
+		// When we get the monitor for a workspace which is in the workspace manager
+		IMonitor? monitor = workspaceManager.GetMonitorForWorkspace(workspace.Object);
+
+		// Then the monitor is returned
+		Assert.Equal(mocks.Monitors[0].Object, monitor);
 	}
 
 	[Fact]
 	public void LayoutAllActiveWorkspaces()
 	{
+		// Given
 		MocksBuilder mocks = new();
 
 		Mock<IWorkspace> workspace = new();
 		Mock<IWorkspace> workspace2 = new();
+
 		using WorkspaceManager workspaceManager =
 			new(mocks.ConfigContext.Object) { workspace.Object, workspace2.Object };
 		workspaceManager.Activate(workspace.Object, mocks.Monitors[0].Object);
 		workspaceManager.Activate(workspace2.Object, mocks.Monitors[1].Object);
+
+		// Reset the mocks
 		workspace.Reset();
 		workspace2.Reset();
 
+		// When we layout all active workspaces
 		workspaceManager.LayoutAllActiveWorkspaces();
 
+		// Then all active workspaces are laid out
 		workspace.Verify(w => w.DoLayout(), Times.Once());
 		workspace2.Verify(w => w.DoLayout(), Times.Once());
 	}
@@ -297,20 +333,27 @@ public class WorkspaceManagerTests
 	[Fact]
 	public void WindowAdded_NoRouter()
 	{
+		// Given
 		MocksBuilder mocks = new();
 
 		Mock<IWorkspace> workspace = new();
 		Mock<IWorkspace> workspace2 = new();
+
 		using WorkspaceManager workspaceManager =
 			new(mocks.ConfigContext.Object) { workspace.Object, workspace2.Object };
+
 		workspaceManager.Activate(workspace.Object, mocks.Monitors[0].Object);
 		workspaceManager.Activate(workspace2.Object, mocks.Monitors[1].Object);
+
+		// Reset the mocks
 		workspace.Reset();
 		workspace2.Reset();
 
+		// When a window is added
 		Mock<IWindow> window = new();
 		workspaceManager.WindowAdded(window.Object);
 
+		// Then the window is added to the active workspace
 		workspace.Verify(w => w.AddWindow(window.Object), Times.Once());
 		workspace2.Verify(w => w.AddWindow(window.Object), Times.Never());
 	}
@@ -318,22 +361,30 @@ public class WorkspaceManagerTests
 	[Fact]
 	public void WindowAdded_Router()
 	{
+		// Given
 		MocksBuilder mocks = new();
 
 		Mock<IWorkspace> workspace = new();
 		Mock<IWorkspace> workspace2 = new();
+
 		using WorkspaceManager workspaceManager =
 			new(mocks.ConfigContext.Object) { workspace.Object, workspace2.Object };
+
 		workspaceManager.Activate(workspace.Object, mocks.Monitors[0].Object);
 		workspaceManager.Activate(workspace2.Object, mocks.Monitors[1].Object);
+
+		// Reset the mocks
 		workspace.Reset();
 		workspace2.Reset();
 
+		// There is a router which routes the window to a different workspace
 		Mock<IWindow> window = new();
 		mocks.RouterManager.Setup(r => r.RouteWindow(window.Object)).Returns(workspace2.Object);
 
+		// When a window is added
 		workspaceManager.WindowAdded(window.Object);
 
+		// Then the window is added to the workspace returned by the router
 		workspace.Verify(w => w.AddWindow(window.Object), Times.Never());
 		workspace2.Verify(w => w.AddWindow(window.Object), Times.Once());
 	}
@@ -341,23 +392,31 @@ public class WorkspaceManagerTests
 	[Fact]
 	public void WindowAdded_RouterToActive()
 	{
+		// Given
 		MocksBuilder mocks = new();
 
 		Mock<IWorkspace> workspace = new();
 		Mock<IWorkspace> workspace2 = new();
+
 		using WorkspaceManager workspaceManager =
 			new(mocks.ConfigContext.Object) { workspace.Object, workspace2.Object };
+
 		workspaceManager.Activate(workspace.Object, mocks.Monitors[0].Object);
 		workspaceManager.Activate(workspace2.Object, mocks.Monitors[1].Object);
+
+		// Reset the mocks
 		workspace.Reset();
 		workspace2.Reset();
 
+		// There is a router which routes the window to the active workspace
 		Mock<IWindow> window = new();
 		mocks.RouterManager.Setup(r => r.RouteWindow(window.Object)).Returns<IWorkspace?>(null);
 		mocks.RouterManager.Setup(r => r.RouteToActiveWorkspace).Returns(true);
 
+		// When a window is added
 		workspaceManager.WindowAdded(window.Object);
 
+		// Then the window is added to the active workspace
 		workspace.Verify(w => w.AddWindow(window.Object), Times.Once());
 		workspace2.Verify(w => w.AddWindow(window.Object), Times.Never());
 	}
@@ -365,20 +424,27 @@ public class WorkspaceManagerTests
 	[Fact]
 	public void WindowRemoved_NotFound()
 	{
+		// Given
 		MocksBuilder mocks = new();
 
 		Mock<IWorkspace> workspace = new();
 		Mock<IWorkspace> workspace2 = new();
+
 		using WorkspaceManager workspaceManager =
 			new(mocks.ConfigContext.Object) { workspace.Object, workspace2.Object };
+
 		workspaceManager.Activate(workspace.Object, mocks.Monitors[0].Object);
 		workspaceManager.Activate(workspace2.Object, mocks.Monitors[1].Object);
+
+		// Reset the mocks
 		workspace.Reset();
 		workspace2.Reset();
 
+		// When a window is removed
 		Mock<IWindow> window = new();
 		workspaceManager.WindowRemoved(window.Object);
 
+		// Then the window is removed from all workspaces
 		workspace.Verify(w => w.RemoveWindow(window.Object), Times.Never());
 		workspace2.Verify(w => w.RemoveWindow(window.Object), Times.Never());
 	}
@@ -386,22 +452,28 @@ public class WorkspaceManagerTests
 	[Fact]
 	public void WindowRemoved_Found()
 	{
+		// Given
 		MocksBuilder mocks = new();
 
 		Mock<IWorkspace> workspace = new();
 		Mock<IWorkspace> workspace2 = new();
+
 		using WorkspaceManager workspaceManager =
 			new(mocks.ConfigContext.Object) { workspace.Object, workspace2.Object };
+
 		workspaceManager.Activate(workspace.Object, mocks.Monitors[0].Object);
 		workspaceManager.Activate(workspace2.Object, mocks.Monitors[1].Object);
 
 		Mock<IWindow> window = new();
 		workspaceManager.WindowAdded(window.Object);
+		// Reset the mocks
 		workspace.Reset();
 		workspace2.Reset();
 
+		// When a window which is in a workspace is removed
 		workspaceManager.WindowRemoved(window.Object);
 
+		// Then the window is removed from the workspace
 		workspace.Verify(w => w.RemoveWindow(window.Object), Times.Once());
 		workspace2.Verify(w => w.RemoveWindow(window.Object), Times.Never());
 	}
@@ -409,19 +481,26 @@ public class WorkspaceManagerTests
 	[Fact]
 	public void MoveWindowToWorkspace_NoWindow()
 	{
+		// Given
 		MocksBuilder mocks = new();
 
 		Mock<IWorkspace> workspace = new();
 		Mock<IWorkspace> workspace2 = new();
+
 		using WorkspaceManager workspaceManager =
 			new(mocks.ConfigContext.Object) { workspace.Object, workspace2.Object };
+
 		workspaceManager.Activate(workspace.Object, mocks.Monitors[0].Object);
 		workspaceManager.Activate(workspace2.Object, mocks.Monitors[1].Object);
+
+		// Reset the mocks
 		workspace.Reset();
 		workspace2.Reset();
 
+		// When a window which is not in a workspace is moved to a workspace
 		workspaceManager.MoveWindowToWorkspace(workspace.Object);
 
+		// Then the window is not added to the workspace
 		workspace.Verify(w => w.RemoveWindow(It.IsAny<IWindow>()), Times.Never());
 		workspace2.Verify(w => w.AddWindow(It.IsAny<IWindow>()), Times.Never());
 	}
@@ -429,6 +508,7 @@ public class WorkspaceManagerTests
 	[Fact]
 	public void MoveWindowToWorkspace_PhantomWindow()
 	{
+		// Given
 		MocksBuilder mocks = new();
 
 		Mock<IWorkspace> workspace = new();
@@ -439,12 +519,15 @@ public class WorkspaceManagerTests
 		workspaceManager.Activate(workspace2.Object, mocks.Monitors[1].Object);
 
 		Mock<IWindow> window = new();
+		// When a phantom window is added
 		workspaceManager.AddPhantomWindow(workspace.Object, window.Object);
 		workspace.Reset();
 		workspace2.Reset();
 
+		// and moved to a workspace
 		workspaceManager.MoveWindowToWorkspace(workspace.Object, window.Object);
 
+		// Then the window is not removed or added to any workspace
 		workspace.Verify(w => w.RemoveWindow(window.Object), Times.Never());
 		workspace2.Verify(w => w.AddWindow(window.Object), Times.Never());
 	}
@@ -454,24 +537,24 @@ public class WorkspaceManagerTests
 	{
 		// Given
 		MocksBuilder mocks = new();
+		Mock<IWindow> window = new();
 
-		// Workspaces
+		// there are 3 workspaces
 		Mock<IWorkspace> workspace = new();
 		Mock<IWorkspace> workspace2 = new();
 		Mock<IWorkspace> workspace3 = new();
 		using WorkspaceManager workspaceManager =
 			new(mocks.ConfigContext.Object) { workspace.Object, workspace2.Object, workspace3.Object };
 
-		// Windows
-		Mock<IWindow> window = new();
+		// and 3 workspaces
 		workspace.Reset();
 		workspace2.Reset();
 		workspace3.Reset();
 
-		// When
+		// When a window not in any workspace is moved to a workspace
 		workspaceManager.MoveWindowToWorkspace(workspace.Object, window.Object);
 
-		// Then
+		// Then the window is not removed or added to any workspace
 		workspace.Verify(w => w.RemoveWindow(window.Object), Times.Never());
 		workspace2.Verify(w => w.AddWindow(window.Object), Times.Never());
 	}
@@ -481,29 +564,28 @@ public class WorkspaceManagerTests
 	{
 		// Given
 		MocksBuilder mocks = new();
+		Mock<IWindow> window = new();
 
-		// Workspaces
+		// there are 3 workspaces
 		Mock<IWorkspace> workspace = new();
 		Mock<IWorkspace> workspace2 = new();
 		Mock<IWorkspace> workspace3 = new();
 
-		// Workspace manager
 		using WorkspaceManager workspaceManager =
 			new(mocks.ConfigContext.Object) { workspace.Object, workspace2.Object };
 		workspaceManager.Activate(workspace.Object, mocks.Monitors[0].Object);
 		workspaceManager.Activate(workspace2.Object, mocks.Monitors[1].Object);
 
-		// Windows
-		Mock<IWindow> window = new();
+		// and the window is added
 		workspaceManager.WindowAdded(window.Object);
 		workspace.Reset();
 		workspace2.Reset();
 		workspace3.Reset();
 
-		// When
+		// When a window in a workspace is moved to another workspace
 		workspaceManager.MoveWindowToWorkspace(workspace2.Object, window.Object);
 
-		// Then
+		// Then the window is removed from the first workspace and added to the second
 		workspace.Verify(w => w.RemoveWindow(window.Object), Times.Once());
 		workspace2.Verify(w => w.AddWindow(window.Object), Times.Once());
 	}
@@ -511,19 +593,27 @@ public class WorkspaceManagerTests
 	[Fact]
 	public void MoveWindowToMonitor_NoWindow()
 	{
+		// Given
 		MocksBuilder mocks = new();
 
+		// there are 2 workspaces
 		Mock<IWorkspace> workspace = new();
 		Mock<IWorkspace> workspace2 = new();
+
 		using WorkspaceManager workspaceManager =
 			new(mocks.ConfigContext.Object) { workspace.Object, workspace2.Object };
+
 		workspaceManager.Activate(workspace.Object, mocks.Monitors[0].Object);
 		workspaceManager.Activate(workspace2.Object, mocks.Monitors[1].Object);
+
+		// Reset the mocks
 		workspace.Reset();
 		workspace2.Reset();
 
+		// When there is no focused window
 		workspaceManager.MoveWindowToMonitor(mocks.Monitors[0].Object);
 
+		// Then the window is not added to the workspace
 		workspace.Verify(w => w.RemoveWindow(It.IsAny<IWindow>()), Times.Never());
 		workspace2.Verify(w => w.AddWindow(It.IsAny<IWindow>()), Times.Never());
 	}
@@ -531,20 +621,28 @@ public class WorkspaceManagerTests
 	[Fact]
 	public void MoveWindowToMonitor_NoOldMonitor()
 	{
+		// Given
 		MocksBuilder mocks = new();
 
+		// there are 2 workspaces
 		Mock<IWorkspace> workspace = new();
 		Mock<IWorkspace> workspace2 = new();
 		using WorkspaceManager workspaceManager =
 			new(mocks.ConfigContext.Object) { workspace.Object, workspace2.Object };
+
 		workspaceManager.Activate(workspace.Object, mocks.Monitors[0].Object);
 		workspaceManager.Activate(workspace2.Object, mocks.Monitors[1].Object);
+
+		// Reset the mocks
 		workspace.Reset();
 		workspace2.Reset();
 
 		Mock<IWindow> window = new();
+
+		// When a window which is not in a workspace is moved to a monitor
 		workspaceManager.MoveWindowToMonitor(mocks.Monitors[0].Object, window.Object);
 
+		// Then the window is not added to the workspace
 		workspace.Verify(w => w.RemoveWindow(window.Object), Times.Never());
 		workspace2.Verify(w => w.AddWindow(window.Object), Times.Never());
 	}
@@ -552,8 +650,10 @@ public class WorkspaceManagerTests
 	[Fact]
 	public void MoveWindowToMonitor_OldMonitorIsNewMonitor()
 	{
+		// Given
 		MocksBuilder mocks = new();
 
+		// there are 2 workspaces
 		Mock<IWorkspace> workspace = new();
 		Mock<IWorkspace> workspace2 = new();
 		using WorkspaceManager workspaceManager =
@@ -566,8 +666,10 @@ public class WorkspaceManagerTests
 		workspace.Reset();
 		workspace2.Reset();
 
+		// When a window which is in a workspace is moved to the same monitor
 		workspaceManager.MoveWindowToMonitor(mocks.Monitors[0].Object, window.Object);
 
+		// Then the window is not added to the workspace
 		workspace.Verify(w => w.RemoveWindow(window.Object), Times.Never());
 		workspace2.Verify(w => w.AddWindow(window.Object), Times.Never());
 	}
@@ -575,8 +677,10 @@ public class WorkspaceManagerTests
 	[Fact]
 	public void MoveWindowToMonitor_WorkspaceForMonitorNotFound()
 	{
+		// Given
 		MocksBuilder mocks = new();
 
+		// there are 2 workspaces
 		Mock<IWorkspace> workspace = new();
 		Mock<IWorkspace> workspace2 = new();
 		using WorkspaceManager workspaceManager =
@@ -589,8 +693,10 @@ public class WorkspaceManagerTests
 		workspace.Reset();
 		workspace2.Reset();
 
+		// When a window which is in a workspace is moved to a monitor which isn't registered
 		workspaceManager.MoveWindowToMonitor(new Mock<IMonitor>().Object, window.Object);
 
+		// Then the window is not added to the workspace
 		workspace.Verify(w => w.RemoveWindow(window.Object), Times.Never());
 		workspace2.Verify(w => w.AddWindow(window.Object), Times.Never());
 	}
@@ -598,6 +704,7 @@ public class WorkspaceManagerTests
 	[Fact]
 	public void MoveWindowToMonitor_Success()
 	{
+		// Given
 		MocksBuilder mocks = new();
 
 		Mock<IWorkspace> workspace = new();
@@ -612,8 +719,10 @@ public class WorkspaceManagerTests
 		workspace.Reset();
 		workspace2.Reset();
 
+		// When a window which is in a workspace is moved to a monitor
 		workspaceManager.MoveWindowToMonitor(mocks.Monitors[1].Object, window.Object);
 
+		// Then the window is removed from the old workspace and added to the new workspace
 		workspace.Verify(w => w.RemoveWindow(window.Object), Times.Once());
 		workspace2.Verify(w => w.AddWindow(window.Object), Times.Once());
 	}
@@ -621,9 +730,12 @@ public class WorkspaceManagerTests
 	[Fact]
 	public void MoveWindowToPreviousMonitor_Success()
 	{
+		// Given
 		MocksBuilder mocks = new();
 
-		mocks.MonitorManager.Setup(m => m.GetPreviousMonitor(mocks.Monitors[0].Object)).Returns(mocks.Monitors[1].Object);
+		mocks.MonitorManager
+			.Setup(m => m.GetPreviousMonitor(mocks.Monitors[0].Object))
+			.Returns(mocks.Monitors[1].Object);
 
 		Mock<IWorkspace> workspace = new();
 		Mock<IWorkspace> workspace2 = new();
@@ -637,8 +749,10 @@ public class WorkspaceManagerTests
 		workspace.Reset();
 		workspace2.Reset();
 
+		// When a window which is in a workspace is moved to the previous monitor
 		workspaceManager.MoveWindowToPreviousMonitor(window.Object);
 
+		// Then the window is removed from the old workspace and added to the new workspace
 		workspace.Verify(w => w.RemoveWindow(window.Object), Times.Once());
 		workspace2.Verify(w => w.AddWindow(window.Object), Times.Once());
 	}
@@ -646,6 +760,7 @@ public class WorkspaceManagerTests
 	[Fact]
 	public void MoveWindowToNextMonitor_Success()
 	{
+		// Given
 		MocksBuilder mocks = new();
 
 		mocks.MonitorManager.Setup(m => m.GetNextMonitor(mocks.Monitors[0].Object)).Returns(mocks.Monitors[1].Object);
@@ -662,8 +777,10 @@ public class WorkspaceManagerTests
 		workspace.Reset();
 		workspace2.Reset();
 
+		// When a window which is in a workspace is moved to the next monitor
 		workspaceManager.MoveWindowToNextMonitor(window.Object);
 
+		// Then the window is removed from the old workspace and added to the new workspace
 		workspace.Verify(w => w.RemoveWindow(window.Object), Times.Once());
 		workspace2.Verify(w => w.AddWindow(window.Object), Times.Once());
 	}
@@ -671,6 +788,7 @@ public class WorkspaceManagerTests
 	[Fact]
 	public void MoveWindowToPoint_TargetWorkspaceNotFound()
 	{
+		// Given
 		MocksBuilder mocks = new();
 
 		Mock<IWorkspace> workspace = new();
@@ -681,19 +799,22 @@ public class WorkspaceManagerTests
 		workspaceManager.WindowAdded(window.Object);
 		workspace.Reset();
 
-		mocks.MonitorManager.Setup(m => m.GetMonitorAtPoint(It.IsAny<IPoint<int>>())).Returns(new Mock<IMonitor>().Object);
+		mocks.MonitorManager
+			.Setup(m => m.GetMonitorAtPoint(It.IsAny<IPoint<int>>()))
+			.Returns(new Mock<IMonitor>().Object);
 
+		// When a window which is in a workspace is moved to a point which doesn't correspond to any workspaces
 		workspaceManager.MoveWindowToPoint(window.Object, new Point<int>() { X = 0, Y = 0 });
 
+		// Then the window is not removed from the old workspace and not added to the new workspace
 		workspace.Verify(w => w.RemoveWindow(window.Object), Times.Never());
 		workspace.Verify(w => w.MoveWindowToPoint(window.Object, It.IsAny<Point<double>>(), false), Times.Never());
-
-		workspace.Verify(w => w.DoLayout(), Times.Never());
 	}
 
 	[Fact]
 	public void MoveWindowToPoint_PhantomWindow()
 	{
+		// Given
 		MocksBuilder mocks = new();
 
 		Mock<IWorkspace> workspace = new();
@@ -709,18 +830,18 @@ public class WorkspaceManagerTests
 
 		mocks.MonitorManager.Setup(m => m.GetMonitorAtPoint(It.IsAny<IPoint<int>>())).Returns(mocks.Monitors[1].Object);
 
+		// When a phantom is moved
 		workspaceManager.MoveWindowToPoint(window.Object, new Point<int>() { X = 0, Y = 0 });
 
+		// Then nothing happens
 		workspace.Verify(w => w.RemoveWindow(window.Object), Times.Never());
 		workspace.Verify(w => w.MoveWindowToPoint(window.Object, It.IsAny<Point<double>>(), false), Times.Never());
-
-		workspace.Verify(w => w.DoLayout(), Times.Never());
-		workspace2.Verify(w => w.DoLayout(), Times.Never());
 	}
 
 	[Fact]
 	public void MoveWindowToPoint_CannotRemoveWindow()
 	{
+		// Given
 		MocksBuilder mocks = new();
 
 		Mock<IWorkspace> workspace = new();
@@ -736,18 +857,18 @@ public class WorkspaceManagerTests
 		mocks.MonitorManager.Setup(m => m.GetMonitorAtPoint(It.IsAny<IPoint<int>>())).Returns(mocks.Monitors[1].Object);
 		workspace.Setup(w => w.RemoveWindow(window.Object)).Returns(false);
 
+		// When a window is moved to a point, but the window cannot be removed from the old workspace
 		workspaceManager.MoveWindowToPoint(window.Object, new Point<int>() { X = 0, Y = 0 });
 
+		// Then nothing happens
 		workspace.Verify(w => w.RemoveWindow(window.Object), Times.Never());
 		workspace.Verify(w => w.MoveWindowToPoint(window.Object, It.IsAny<Point<double>>(), false), Times.Never());
-
-		workspace.Verify(w => w.DoLayout(), Times.Never());
-		workspace2.Verify(w => w.DoLayout(), Times.Never());
 	}
 
 	[Fact]
 	public void MoveWindowToPoint_Success()
 	{
+		// Given
 		MocksBuilder mocks = new();
 
 		Mock<IWorkspace> workspace = new();
@@ -766,8 +887,10 @@ public class WorkspaceManagerTests
 		mocks.Monitors[1].Setup(m => m.WorkingArea).Returns(new Location<int>());
 		workspace.Setup(w => w.RemoveWindow(window.Object)).Returns(true);
 
+		// When a window is moved to a point
 		workspaceManager.MoveWindowToPoint(window.Object, new Point<int>() { X = 0, Y = 0 });
 
+		// Then the window is removed from the old workspace and added to the new workspace
 		workspace.Verify(w => w.RemoveWindow(window.Object), Times.Once());
 		workspace.Verify(w => w.MoveWindowToPoint(window.Object, It.IsAny<Point<double>>(), false), Times.Never());
 
@@ -788,10 +911,10 @@ public class WorkspaceManagerTests
 
 		Mock<IWindow> window = new();
 
-		// When
+		// When a window is focused
 		workspaceManager.WindowFocused(window.Object);
 
-		// Then
+		// Then the window is focused in all workspaces
 		workspace.Verify(w => w.WindowFocused(window.Object), Times.Once());
 		workspace2.Verify(w => w.WindowFocused(window.Object), Times.Once());
 	}
@@ -807,10 +930,10 @@ public class WorkspaceManagerTests
 
 		Mock<IWindow> window = new();
 
-		// When
+		// When a window is minimized, but the window is not found in any workspace
 		workspaceManager.WindowMinimizeStart(window.Object);
 
-		// Then
+		// Then nothing happens
 		workspace.Verify(w => w.RemoveWindow(window.Object), Times.Never());
 	}
 
@@ -831,10 +954,10 @@ public class WorkspaceManagerTests
 		Mock<IWindow> window = new();
 		workspaceManager.WindowAdded(window.Object);
 
-		// When
+		// When a window is minimized
 		workspaceManager.WindowMinimizeStart(window.Object);
 
-		// Then
+		// Then the window is removed from the workspace
 		workspace.Verify(w => w.RemoveWindow(window.Object), Times.Once());
 	}
 
@@ -854,10 +977,10 @@ public class WorkspaceManagerTests
 
 		Mock<IWindow> window = new();
 
-		// When
+		// When a window is restored
 		workspaceManager.WindowMinimizeEnd(window.Object);
 
-		// Then
+		// Then the window is routed to the workspace
 		routerManager.Verify(r => r.RouteWindow(window.Object), Times.Once());
 	}
 }

--- a/src/Whim.Tests/Workspace/WorkspaceTests.cs
+++ b/src/Whim.Tests/Workspace/WorkspaceTests.cs
@@ -278,4 +278,209 @@ public class WorkspaceTests
 		// Then the LayoutEngine's GetFirstWindow method is called
 		mocks.LayoutEngine.Verify(l => l.GetFirstWindow(), Times.Once);
 	}
+
+	[Fact]
+	public void NextLayoutEngine()
+	{
+		// Given
+		MocksBuilder mocks = new();
+		Mock<ILayoutEngine> layoutEngine = new();
+		Workspace workspace =
+			new(mocks.ConfigContext.Object, "Workspace", mocks.LayoutEngine.Object, layoutEngine.Object);
+
+		// When NextLayoutEngine is called
+		workspace.NextLayoutEngine();
+
+		// Then the active layout engine is set to the next one
+		Assert.True(Object.ReferenceEquals(layoutEngine.Object, workspace.ActiveLayoutEngine));
+		mocks.LayoutEngine.Verify(l => l.HidePhantomWindows(), Times.Once);
+	}
+
+	[Fact]
+	public void NextLayoutEngine_LastEngine()
+	{
+		// Given
+		MocksBuilder mocks = new();
+		Mock<ILayoutEngine> layoutEngine = new();
+		Workspace workspace =
+			new(mocks.ConfigContext.Object, "Workspace", mocks.LayoutEngine.Object, layoutEngine.Object);
+
+		// When NextLayoutEngine is called
+		workspace.NextLayoutEngine();
+		workspace.NextLayoutEngine();
+
+		// Then the active layout engine is set to the first one
+		Assert.True(Object.ReferenceEquals(mocks.LayoutEngine.Object, workspace.ActiveLayoutEngine));
+		mocks.LayoutEngine.Verify(l => l.HidePhantomWindows(), Times.Once);
+	}
+
+	[Fact]
+	public void NextLayoutEngine_PhantomWindow()
+	{
+		// Given the last focused window is a phantom window
+		MocksBuilder mocks = new();
+		Mock<ILayoutEngine> layoutEngine = new();
+		Workspace workspace =
+			new(mocks.ConfigContext.Object, "Workspace", mocks.LayoutEngine.Object, layoutEngine.Object);
+		workspace.AddPhantomWindow(mocks.LayoutEngine.Object, new Mock<IWindow>().Object);
+
+		// When NextLayoutEngine is called
+		workspace.NextLayoutEngine();
+
+		// Then the active layout engine is set to the next one
+		Assert.True(Object.ReferenceEquals(layoutEngine.Object, workspace.ActiveLayoutEngine));
+		mocks.LayoutEngine.Verify(l => l.HidePhantomWindows(), Times.Once);
+	}
+
+	[Fact]
+	public void PreviousLayoutEngine()
+	{
+		// Given
+		MocksBuilder mocks = new();
+		Mock<ILayoutEngine> layoutEngine = new();
+		Workspace workspace =
+			new(mocks.ConfigContext.Object, "Workspace", mocks.LayoutEngine.Object, layoutEngine.Object);
+
+		// When PreviousLayoutEngine is called
+		workspace.PreviousLayoutEngine();
+
+		// Then the active layout engine is set to the previous one
+		Assert.True(Object.ReferenceEquals(layoutEngine.Object, workspace.ActiveLayoutEngine));
+		mocks.LayoutEngine.Verify(l => l.HidePhantomWindows(), Times.Once);
+	}
+
+	[Fact]
+	public void PreviousLayoutEngine_FirstEngine()
+	{
+		// Given
+		MocksBuilder mocks = new();
+		Mock<ILayoutEngine> layoutEngine = new();
+		Workspace workspace =
+			new(mocks.ConfigContext.Object, "Workspace", mocks.LayoutEngine.Object, layoutEngine.Object);
+
+		// When PreviousLayoutEngine is called
+		workspace.PreviousLayoutEngine();
+		workspace.PreviousLayoutEngine();
+
+		// Then the active layout engine is set to the last one
+		Assert.True(Object.ReferenceEquals(mocks.LayoutEngine.Object, workspace.ActiveLayoutEngine));
+		layoutEngine.Verify(l => l.HidePhantomWindows(), Times.Once);
+	}
+
+	[Fact]
+	public void PreviousLayoutEngine_PhantomWindow()
+	{
+		// Given the last focused window is a phantom window
+		MocksBuilder mocks = new();
+		Mock<ILayoutEngine> layoutEngine = new();
+		Workspace workspace =
+			new(mocks.ConfigContext.Object, "Workspace", mocks.LayoutEngine.Object, layoutEngine.Object);
+		workspace.AddPhantomWindow(mocks.LayoutEngine.Object, new Mock<IWindow>().Object);
+
+		// When PreviousLayoutEngine is called
+		workspace.PreviousLayoutEngine();
+
+		// Then the active layout engine is set to the previous one
+		Assert.True(Object.ReferenceEquals(layoutEngine.Object, workspace.ActiveLayoutEngine));
+		mocks.LayoutEngine.Verify(l => l.HidePhantomWindows(), Times.Once);
+	}
+
+	[Fact]
+	public void AddWindow_Fails_AlreadyIncludesPhantomWindow()
+	{
+		// Given
+		MocksBuilder mocks = new();
+		Mock<IWindow> window = new();
+		Workspace workspace = new(mocks.ConfigContext.Object, "Workspace", mocks.LayoutEngine.Object);
+
+		// When AddWindow is called
+		workspace.AddPhantomWindow(mocks.LayoutEngine.Object, window.Object);
+		workspace.AddWindow(window.Object);
+
+		// Then the window is added to the layout engine
+		mocks.LayoutEngine.Verify(l => l.Add(window.Object), Times.Never);
+		mocks.LayoutEngine.Verify(l => l.DoLayout(It.IsAny<ILocation<int>>(), It.IsAny<IMonitor>()), Times.Never);
+	}
+
+	[Fact]
+	public void AddWindow_Fails_AlreadyIncludesWindow()
+	{
+		// Given
+		MocksBuilder mocks = new();
+		Mock<IWindow> window = new();
+		Workspace workspace = new(mocks.ConfigContext.Object, "Workspace", mocks.LayoutEngine.Object);
+
+		// When AddWindow is called
+		workspace.AddWindow(window.Object);
+		workspace.AddWindow(window.Object);
+
+		// Then the window is added to the layout engine
+		mocks.LayoutEngine.Verify(l => l.Add(window.Object), Times.Once);
+		mocks.WorkspaceManager.Verify(wm => wm.GetMonitorForWorkspace(workspace), Times.Once);
+	}
+
+	[Fact]
+	public void AddWindow_Success()
+	{
+		// Given
+		MocksBuilder mocks = new();
+		Mock<IWindow> window = new();
+		Workspace workspace = new(mocks.ConfigContext.Object, "Workspace", mocks.LayoutEngine.Object);
+
+		// When AddWindow is called
+		workspace.AddWindow(window.Object);
+
+		// Then the window is added to the layout engine
+		mocks.LayoutEngine.Verify(l => l.Add(window.Object), Times.Once);
+		mocks.WorkspaceManager.Verify(wm => wm.GetMonitorForWorkspace(workspace), Times.Once);
+	}
+
+	[Fact]
+	public void RemoveWindow_Fails_AlreadyRemoved()
+	{
+		// Given
+		MocksBuilder mocks = new();
+		Mock<IWindow> window = new();
+		Workspace workspace = new(mocks.ConfigContext.Object, "Workspace", mocks.LayoutEngine.Object);
+
+		// When RemoveWindow is called
+		workspace.RemoveWindow(window.Object);
+		workspace.RemoveWindow(window.Object);
+
+		// Then the window is removed from the layout engine
+		mocks.LayoutEngine.Verify(l => l.Remove(window.Object), Times.Never);
+		mocks.LayoutEngine.Verify(l => l.DoLayout(It.IsAny<ILocation<int>>(), It.IsAny<IMonitor>()), Times.Never);
+	}
+
+	[Fact]
+	public void RemoveWindow_Fails_CannotFindPhantomLayoutEngine()
+	{
+		// Given
+		MocksBuilder mocks = new();
+		Mock<IWindow> window = new();
+		Workspace workspace = new(mocks.ConfigContext.Object, "Workspace", mocks.LayoutEngine.Object);
+
+		// When RemoveWindow is called
+		workspace.RemoveWindow(window.Object);
+
+		// Then the window is removed from the layout engine
+		mocks.LayoutEngine.Verify(l => l.Remove(window.Object), Times.Never);
+		mocks.LayoutEngine.Verify(l => l.DoLayout(It.IsAny<ILocation<int>>(), It.IsAny<IMonitor>()), Times.Never);
+	}
+
+	[Fact]
+	public void RemoveWindow_Fail_DidNotRemoveFromLayoutEngine()
+	{
+		// Given
+		MocksBuilder mocks = new();
+		Mock<IWindow> window = new();
+		Workspace workspace = new(mocks.ConfigContext.Object, "Workspace", mocks.LayoutEngine.Object);
+
+		// When RemoveWindow is called
+		workspace.RemoveWindow(window.Object);
+
+		// Then the window is removed from the layout engine
+		mocks.LayoutEngine.Verify(l => l.Remove(window.Object), Times.Never);
+		mocks.LayoutEngine.Verify(l => l.DoLayout(It.IsAny<ILocation<int>>(), It.IsAny<IMonitor>()), Times.Never);
+	}
 }

--- a/src/Whim.Tests/Workspace/WorkspaceTests.cs
+++ b/src/Whim.Tests/Workspace/WorkspaceTests.cs
@@ -263,4 +263,19 @@ public class WorkspaceTests
 		// Then
 		Assert.Equal(window.Object, workspace.LastFocusedWindow);
 	}
+
+	[Fact]
+	public void FocusFirstWindow()
+	{
+		// Given
+		MocksBuilder mocks = new();
+		mocks.LayoutEngine.Setup(l => l.GetFirstWindow()).Returns(new Mock<IWindow>().Object);
+		Workspace workspace = new(mocks.ConfigContext.Object, "Workspace", mocks.LayoutEngine.Object);
+
+		// When FocusFirstWindow is called
+		workspace.FocusFirstWindow();
+
+		// Then the LayoutEngine's GetFirstWindow method is called
+		mocks.LayoutEngine.Verify(l => l.GetFirstWindow(), Times.Once);
+	}
 }

--- a/src/Whim/Workspace/Workspace.cs
+++ b/src/Whim/Workspace/Workspace.cs
@@ -20,8 +20,8 @@ internal class Workspace : IWorkspace
 				new WorkspaceRenamedEventArgs()
 				{
 					Workspace = this,
-					OldName = oldName,
-					NewName = _name
+					PreviousName = oldName,
+					CurrentName = _name
 				}
 			);
 		}

--- a/src/Whim/Workspace/Workspace.cs
+++ b/src/Whim/Workspace/Workspace.cs
@@ -343,6 +343,8 @@ internal class Workspace : IWorkspace
 		{
 			layoutEngine.AddWindowAtPoint(window, point, isPhantom);
 		}
+
+		DoLayout();
 	}
 
 	public override string ToString() => Name;

--- a/src/Whim/Workspace/Workspace.cs
+++ b/src/Whim/Workspace/Workspace.cs
@@ -447,6 +447,7 @@ internal class Workspace : IWorkspace
 	{
 		Logger.Debug($"Removing phantom window {window} in workspace {Name}");
 
+		// TODO: Shouldn't this be the other way around?
 		if (engine.ContainsEqual(ActiveLayoutEngine))
 		{
 			Logger.Error($"Layout engine {engine} is not active in workspace {Name}");

--- a/src/Whim/Workspace/Workspace.cs
+++ b/src/Whim/Workspace/Workspace.cs
@@ -359,6 +359,7 @@ internal class Workspace : IWorkspace
 		}
 
 		_windowLocations.Clear();
+		DoLayout();
 	}
 
 	public IWindowState? TryGetWindowLocation(IWindow window)

--- a/src/Whim/Workspace/WorkspaceManager.cs
+++ b/src/Whim/Workspace/WorkspaceManager.cs
@@ -258,12 +258,6 @@ internal class WorkspaceManager : IWorkspaceManager
 		}
 		workspace ??= ActiveWorkspace;
 
-		if (workspace == null)
-		{
-			Logger.Error($"No active workspace found.");
-			return;
-		}
-
 		_windowWorkspaceMap[window] = workspace;
 		workspace.AddWindow(window);
 		WindowRouted?.Invoke(this, RouteEventArgs.WindowAdded(window, workspace));

--- a/src/Whim/Workspace/WorkspaceManager.cs
+++ b/src/Whim/Workspace/WorkspaceManager.cs
@@ -254,7 +254,11 @@ internal class WorkspaceManager : IWorkspaceManager
 
 		if (!_configContext.RouterManager.RouteToActiveWorkspace && workspace == null)
 		{
-			workspace = GetWorkspaceForWindowLocation(window);
+			IMonitor? monitor = _configContext.MonitorManager.GetMonitorAtPoint(window.Center);
+			if (monitor is not null)
+			{
+				workspace = GetWorkspaceForMonitor(monitor);
+			}
 		}
 		workspace ??= ActiveWorkspace;
 
@@ -262,17 +266,6 @@ internal class WorkspaceManager : IWorkspaceManager
 		workspace.AddWindow(window);
 		WindowRouted?.Invoke(this, RouteEventArgs.WindowAdded(window, workspace));
 		Logger.Debug($"Window {window} added to workspace {workspace.Name}");
-	}
-
-	private IWorkspace? GetWorkspaceForWindowLocation(IWindow window)
-	{
-		IMonitor? monitor = _configContext.MonitorManager.GetMonitorAtPoint(window.Center);
-		if (monitor is null)
-		{
-			return null;
-		}
-
-		return GetWorkspaceForMonitor(monitor);
 	}
 
 	/// <summary>

--- a/src/Whim/Workspace/WorkspaceManager.cs
+++ b/src/Whim/Workspace/WorkspaceManager.cs
@@ -442,11 +442,6 @@ internal class WorkspaceManager : IWorkspaceManager
 		_windowWorkspaceMap[window] = workspace;
 		currentWorkspace.RemoveWindow(window);
 		workspace.AddWindow(window);
-
-		// Hide the window from the current layout. If the new workspace is active, then the
-		// window will be shown as part of DoLayout().
-		window.Hide();
-		workspace.DoLayout();
 	}
 
 	public void MoveWindowToMonitor(IMonitor monitor, IWindow? window = null)

--- a/src/Whim/Workspace/WorkspaceManager.cs
+++ b/src/Whim/Workspace/WorkspaceManager.cs
@@ -183,11 +183,10 @@ internal class WorkspaceManager : IWorkspaceManager
 		// Hide all the windows from the old workspace.
 		oldWorkspace?.Deactivate();
 
-		// Layout the losing monitor.
+		// Send out an event about the losing monitor.
 		if (loserMonitor != null && oldWorkspace != null)
 		{
 			_monitorWorkspaceMap[loserMonitor] = oldWorkspace;
-			oldWorkspace.DoLayout();
 			MonitorWorkspaceChanged?.Invoke(
 				this,
 				new MonitorWorkspaceChangedEventArgs()

--- a/src/Whim/Workspace/WorkspaceManager.cs
+++ b/src/Whim/Workspace/WorkspaceManager.cs
@@ -27,6 +27,8 @@ internal class WorkspaceManager : IWorkspaceManager
 	/// </summary>
 	private readonly HashSet<IWindow> _phantomWindows = new();
 
+	internal IEnumerable<IWindow> PhantomWindows => _phantomWindows;
+
 	/// <summary>
 	/// Maps monitors to their active workspace.
 	/// </summary>
@@ -537,6 +539,7 @@ internal class WorkspaceManager : IWorkspaceManager
 		_phantomWindows.Remove(window);
 		_windowWorkspaceMap.Remove(window);
 	}
+	#endregion
 
 	protected virtual void Dispose(bool disposing)
 	{
@@ -565,5 +568,4 @@ internal class WorkspaceManager : IWorkspaceManager
 		Dispose(disposing: true);
 		GC.SuppressFinalize(this);
 	}
-	#endregion
 }

--- a/src/Whim/Workspace/WorkspaceManager.cs
+++ b/src/Whim/Workspace/WorkspaceManager.cs
@@ -217,12 +217,12 @@ internal class WorkspaceManager : IWorkspaceManager
 		Logger.Debug($"Getting monitor for active workspace {workspace}");
 
 		// Linear search for the monitor that contains the workspace.
-		foreach (IMonitor monitor in _configContext.MonitorManager)
+		foreach ((IMonitor m, IWorkspace w) in _monitorWorkspaceMap)
 		{
-			if (_monitorWorkspaceMap[monitor] == workspace)
+			if (w == workspace)
 			{
-				Logger.Debug($"Found monitor {monitor} for workspace {workspace}");
-				return monitor;
+				Logger.Debug($"Found monitor {m} for workspace {workspace}");
+				return m;
 			}
 		}
 
@@ -356,11 +356,7 @@ internal class WorkspaceManager : IWorkspaceManager
 			// If there's no workspace, create one.
 			if (workspace is null)
 			{
-				workspace = _configContext.WorkspaceManager.WorkspaceFactory(
-					_configContext,
-					$"Workspace {_workspaces.Count + 1}"
-				);
-
+				workspace = WorkspaceFactory(_configContext, $"Workspace {_workspaces.Count + 1}");
 				workspace.Initialize();
 			}
 

--- a/src/Whim/Workspace/WorkspaceManager.cs
+++ b/src/Whim/Workspace/WorkspaceManager.cs
@@ -538,8 +538,6 @@ internal class WorkspaceManager : IWorkspaceManager
 		_windowWorkspaceMap[window] = targetWorkspace;
 
 		// Trigger layouts.
-		ActiveWorkspace.DoLayout();
-		targetWorkspace.DoLayout();
 		window.Focus();
 	}
 

--- a/src/Whim/Workspace/WorkspaceRenamedEvent.cs
+++ b/src/Whim/Workspace/WorkspaceRenamedEvent.cs
@@ -10,12 +10,12 @@ public class WorkspaceRenamedEventArgs : EventArgs
 	/// <summary>
 	/// The old name of the workspace.
 	/// </summary>
-	public required string OldName { get; init; }
+	public required string PreviousName { get; init; }
 
 	/// <summary>
 	/// The new name of the workspace.
 	/// </summary>
-	public required string NewName { get; init; }
+	public required string CurrentName { get; init; }
 
 	/// <summary>
 	/// The workspace that was renamed.


### PR DESCRIPTION
Previously, `WorkspaceManager` called `Workspace.DoLayout`. However, `WorkspaceManager` only calls core methods, so there's no need as `Workspace` already calls `DoLayout` where necessary. Also, coverage has increased.