### PR TITLE
Refactor Workspace to remove accidental overloading

### DIFF
--- a/src/Whim.FloatingLayout/FloatingLayoutEngine.cs
+++ b/src/Whim.FloatingLayout/FloatingLayoutEngine.cs
@@ -52,9 +52,9 @@ public class FloatingLayoutEngine : BaseProxyLayoutEngine
 	/// <summary>
 	/// This method is called when a window is moved.
 	/// </summary>
-	public override void AddWindowAtPoint(IWindow window, IPoint<double> point, bool isPhantom = false)
+	public override void AddWindowAtPoint(IWindow window, IPoint<double> point)
 	{
-		Logger.Debug($"Adding window {window} at point {point}. isPhantom={isPhantom}");
+		Logger.Debug($"Adding window {window} at point {point}");
 		if (_floatingLayoutConfig.IsWindowFloating(window))
 		{
 			UpdateFloatingWindow(window);

--- a/src/Whim.Tests/Workspace/WorkspaceManagerTests.cs
+++ b/src/Whim.Tests/Workspace/WorkspaceManagerTests.cs
@@ -831,7 +831,7 @@ public class WorkspaceManagerTests
 
 		// Then the window is not removed from the old workspace and not added to the new workspace
 		workspace.Verify(w => w.RemoveWindow(window.Object), Times.Never());
-		workspace.Verify(w => w.MoveWindowToPoint(window.Object, It.IsAny<Point<double>>(), false), Times.Never());
+		workspace.Verify(w => w.MoveWindowToPoint(window.Object, It.IsAny<Point<double>>()), Times.Never());
 	}
 
 	[Fact]
@@ -857,7 +857,7 @@ public class WorkspaceManagerTests
 
 		// Then nothing happens
 		workspace.Verify(w => w.RemoveWindow(window.Object), Times.Never());
-		workspace.Verify(w => w.MoveWindowToPoint(window.Object, It.IsAny<Point<double>>(), false), Times.Never());
+		workspace.Verify(w => w.MoveWindowToPoint(window.Object, It.IsAny<Point<double>>()), Times.Never());
 	}
 
 	[Fact]
@@ -883,7 +883,7 @@ public class WorkspaceManagerTests
 
 		// Then nothing happens
 		workspace.Verify(w => w.RemoveWindow(window.Object), Times.Once());
-		workspace.Verify(w => w.MoveWindowToPoint(window.Object, It.IsAny<Point<double>>(), false), Times.Never());
+		workspace.Verify(w => w.MoveWindowToPoint(window.Object, It.IsAny<Point<double>>()), Times.Never());
 	}
 
 	[Fact]
@@ -911,7 +911,7 @@ public class WorkspaceManagerTests
 
 		// Then the window is removed from the old workspace and added to the new workspace
 		workspace.Verify(w => w.RemoveWindow(window.Object), Times.Once());
-		workspace.Verify(w => w.MoveWindowToPoint(window.Object, It.IsAny<Point<double>>(), false), Times.Never());
+		workspace.Verify(w => w.MoveWindowToPoint(window.Object, It.IsAny<Point<double>>()), Times.Never());
 
 		window.Verify(w => w.Focus(), Times.Once());
 	}

--- a/src/Whim.Tests/Workspace/WorkspaceTests.cs
+++ b/src/Whim.Tests/Workspace/WorkspaceTests.cs
@@ -692,4 +692,38 @@ public class WorkspaceTests
 		// Then the layout engine is told to move the window
 		mocks.LayoutEngine.Verify(l => l.MoveWindowEdgeInDirection(Direction.Up, delta, window.Object), Times.Once);
 	}
+
+	[Fact]
+	public void MoveWindowToPoint_Success_PhantomWindow()
+	{
+		// Given
+		MocksBuilder mocks = new();
+		Mock<IWindow> window = new();
+		Workspace workspace = new(mocks.ConfigContext.Object, "Workspace", mocks.LayoutEngine.Object);
+		workspace.AddWindow(window.Object);
+		IPoint<double> point = new Point<double>() { X = 0.3, Y = 0.3 };
+
+		// When MoveWindowToPoint is called
+		workspace.MoveWindowToPoint(window.Object, point);
+
+		// Then the layout engine is told to move the window
+		mocks.LayoutEngine.Verify(l => l.AddWindowAtPoint(window.Object, point), Times.Once);
+	}
+
+	[Fact]
+	public void MoveWindowToPoint_Success()
+	{
+		// Given
+		MocksBuilder mocks = new();
+		Mock<IWindow> window = new();
+		Workspace workspace = new(mocks.ConfigContext.Object, "Workspace", mocks.LayoutEngine.Object);
+		workspace.AddWindow(window.Object);
+		IPoint<double> point = new Point<double>() { X = 0.3, Y = 0.3 };
+
+		// When MoveWindowToPoint is called
+		workspace.MoveWindowToPoint(window.Object, point);
+
+		// Then the layout engine is told to move the window
+		mocks.LayoutEngine.Verify(l => l.AddWindowAtPoint(window.Object, point), Times.Once);
+	}
 }

--- a/src/Whim.Tests/Workspace/WorkspaceTests.cs
+++ b/src/Whim.Tests/Workspace/WorkspaceTests.cs
@@ -565,4 +565,35 @@ public class WorkspaceTests
 		mocks.LayoutEngine.Verify(l => l.Remove(window.Object), Times.Once);
 		mocks.WorkspaceManager.Verify(wm => wm.GetMonitorForWorkspace(workspace), Times.Once);
 	}
+
+	[Fact]
+	public void FocusWindowInDirection_Fails_DoesNotContainWindow()
+	{
+		// Given
+		MocksBuilder mocks = new();
+		Mock<IWindow> window = new();
+		Workspace workspace = new(mocks.ConfigContext.Object, "Workspace", mocks.LayoutEngine.Object);
+
+		// When FocusWindowInDirection is called
+		workspace.FocusWindowInDirection(Direction.Up, window.Object);
+
+		// Then the layout engine is not told to focus the window
+		mocks.LayoutEngine.Verify(l => l.FocusWindowInDirection(Direction.Up, window.Object), Times.Never);
+	}
+
+	[Fact]
+	public void FocusWindowInDirection_Success()
+	{
+		// Given
+		MocksBuilder mocks = new();
+		Mock<IWindow> window = new();
+		Workspace workspace = new(mocks.ConfigContext.Object, "Workspace", mocks.LayoutEngine.Object);
+		workspace.AddWindow(window.Object);
+
+		// When FocusWindowInDirection is called
+		workspace.FocusWindowInDirection(Direction.Up, window.Object);
+
+		// Then the layout engine is told to focus the window
+		mocks.LayoutEngine.Verify(l => l.FocusWindowInDirection(Direction.Up, window.Object), Times.Once);
+	}
 }

--- a/src/Whim.Tests/Workspace/WorkspaceTests.cs
+++ b/src/Whim.Tests/Workspace/WorkspaceTests.cs
@@ -323,12 +323,16 @@ public class WorkspaceTests
 		Mock<ILayoutEngine> layoutEngine = new();
 		Workspace workspace =
 			new(mocks.ConfigContext.Object, "Workspace", mocks.LayoutEngine.Object, layoutEngine.Object);
-		workspace.AddPhantomWindow(mocks.LayoutEngine.Object, new Mock<IWindow>().Object);
+
+		Mock<IWindow> phantomWindow = new();
+		workspace.AddPhantomWindow(mocks.LayoutEngine.Object, phantomWindow.Object);
+		workspace.WindowFocused(phantomWindow.Object);
 
 		// When NextLayoutEngine is called
 		workspace.NextLayoutEngine();
 
 		// Then the active layout engine is set to the next one
+		Assert.Null(workspace.LastFocusedWindow);
 		Assert.True(Object.ReferenceEquals(layoutEngine.Object, workspace.ActiveLayoutEngine));
 		mocks.LayoutEngine.Verify(l => l.HidePhantomWindows(), Times.Once);
 	}
@@ -377,6 +381,10 @@ public class WorkspaceTests
 		Workspace workspace =
 			new(mocks.ConfigContext.Object, "Workspace", mocks.LayoutEngine.Object, layoutEngine.Object);
 		workspace.AddPhantomWindow(mocks.LayoutEngine.Object, new Mock<IWindow>().Object);
+
+		Mock<IWindow> phantomWindow = new();
+		workspace.AddPhantomWindow(mocks.LayoutEngine.Object, phantomWindow.Object);
+		workspace.WindowFocused(phantomWindow.Object);
 
 		// When PreviousLayoutEngine is called
 		workspace.PreviousLayoutEngine();

--- a/src/Whim.Tests/Workspace/WorkspaceTests.cs
+++ b/src/Whim.Tests/Workspace/WorkspaceTests.cs
@@ -596,4 +596,49 @@ public class WorkspaceTests
 		// Then the layout engine is told to focus the window
 		mocks.LayoutEngine.Verify(l => l.FocusWindowInDirection(Direction.Up, window.Object), Times.Once);
 	}
+
+	[Fact]
+	public void SwapWindowInDirection_Fails_WindowIsNull()
+	{
+		// Given
+		MocksBuilder mocks = new();
+		Workspace workspace = new(mocks.ConfigContext.Object, "Workspace", mocks.LayoutEngine.Object);
+
+		// When SwapWindowInDirection is called
+		workspace.SwapWindowInDirection(Direction.Up, null);
+
+		// Then the layout engine is not told to swap the window
+		mocks.LayoutEngine.Verify(l => l.SwapWindowInDirection(Direction.Up, It.IsAny<IWindow>()), Times.Never);
+	}
+
+	[Fact]
+	public void SwapWindowInDirection_Fails_DoesNotContainWindow()
+	{
+		// Given
+		MocksBuilder mocks = new();
+		Mock<IWindow> window = new();
+		Workspace workspace = new(mocks.ConfigContext.Object, "Workspace", mocks.LayoutEngine.Object);
+
+		// When SwapWindowInDirection is called
+		workspace.SwapWindowInDirection(Direction.Up, window.Object);
+
+		// Then the layout engine is not told to swap the window
+		mocks.LayoutEngine.Verify(l => l.SwapWindowInDirection(Direction.Up, window.Object), Times.Never);
+	}
+
+	[Fact]
+	public void SwapWindowInDirection_Success()
+	{
+		// Given
+		MocksBuilder mocks = new();
+		Mock<IWindow> window = new();
+		Workspace workspace = new(mocks.ConfigContext.Object, "Workspace", mocks.LayoutEngine.Object);
+		workspace.AddWindow(window.Object);
+
+		// When SwapWindowInDirection is called
+		workspace.SwapWindowInDirection(Direction.Up, window.Object);
+
+		// Then the layout engine is told to swap the window
+		mocks.LayoutEngine.Verify(l => l.SwapWindowInDirection(Direction.Up, window.Object), Times.Once);
+	}
 }

--- a/src/Whim.Tests/Workspace/WorkspaceTests.cs
+++ b/src/Whim.Tests/Workspace/WorkspaceTests.cs
@@ -22,6 +22,7 @@ public class WorkspaceTests
 		public MocksBuilder()
 		{
 			ConfigContext.Setup(c => c.WorkspaceManager).Returns(WorkspaceManager.Object);
+			LayoutEngine.Setup(l => l.ContainsEqual(LayoutEngine.Object)).Returns(true);
 		}
 	}
 
@@ -393,8 +394,12 @@ public class WorkspaceTests
 		Mock<IWindow> window = new();
 		Workspace workspace = new(mocks.ConfigContext.Object, "Workspace", mocks.LayoutEngine.Object);
 
-		// When AddWindow is called
 		workspace.AddPhantomWindow(mocks.LayoutEngine.Object, window.Object);
+
+		// Reset mocks
+		window.Reset();
+
+		// When AddWindow is called
 		workspace.AddWindow(window.Object);
 
 		// Then the window is added to the layout engine

--- a/src/Whim.Tests/Workspace/WorkspaceTests.cs
+++ b/src/Whim.Tests/Workspace/WorkspaceTests.cs
@@ -641,4 +641,55 @@ public class WorkspaceTests
 		// Then the layout engine is told to swap the window
 		mocks.LayoutEngine.Verify(l => l.SwapWindowInDirection(Direction.Up, window.Object), Times.Once);
 	}
+
+	[Fact]
+	public void MoveWindowEdgeInDirection_Fails_WindowIsNull()
+	{
+		// Given
+		MocksBuilder mocks = new();
+		Workspace workspace = new(mocks.ConfigContext.Object, "Workspace", mocks.LayoutEngine.Object);
+		double delta = 0.3;
+
+		// When MoveWindowEdgeInDirection is called
+		workspace.MoveWindowEdgeInDirection(Direction.Up, delta, null);
+
+		// Then the layout engine is not told to move the window
+		mocks.LayoutEngine.Verify(
+			l => l.MoveWindowEdgeInDirection(Direction.Up, delta, It.IsAny<IWindow>()),
+			Times.Never
+		);
+	}
+
+	[Fact]
+	public void MoveWindowEdgeInDirection_Fails_DoesNotContainWindow()
+	{
+		// Given
+		MocksBuilder mocks = new();
+		Mock<IWindow> window = new();
+		Workspace workspace = new(mocks.ConfigContext.Object, "Workspace", mocks.LayoutEngine.Object);
+		double delta = 0.3;
+
+		// When MoveWindowEdgeInDirection is called
+		workspace.MoveWindowEdgeInDirection(Direction.Up, delta, window.Object);
+
+		// Then the layout engine is not told to move the window
+		mocks.LayoutEngine.Verify(l => l.MoveWindowEdgeInDirection(Direction.Up, delta, window.Object), Times.Never);
+	}
+
+	[Fact]
+	public void MoveWindowEdgeInDirection_Success()
+	{
+		// Given
+		MocksBuilder mocks = new();
+		Mock<IWindow> window = new();
+		Workspace workspace = new(mocks.ConfigContext.Object, "Workspace", mocks.LayoutEngine.Object);
+		workspace.AddWindow(window.Object);
+		double delta = 0.3;
+
+		// When MoveWindowEdgeInDirection is called
+		workspace.MoveWindowEdgeInDirection(Direction.Up, delta, window.Object);
+
+		// Then the layout engine is told to move the window
+		mocks.LayoutEngine.Verify(l => l.MoveWindowEdgeInDirection(Direction.Up, delta, window.Object), Times.Once);
+	}
 }

--- a/src/Whim.TreeLayout.Tests/TestAddWindowAtPoint.cs
+++ b/src/Whim.TreeLayout.Tests/TestAddWindowAtPoint.cs
@@ -11,7 +11,7 @@ public class TestAddWindowAtPoint
 		TestTreeEngineEmpty emptyEngine = new();
 		Mock<IWindow> window = new();
 
-		emptyEngine.Engine.AddWindowAtPoint(window.Object, new Point<double>() { X = 0, Y = 0 }, false);
+		emptyEngine.Engine.AddWindowAtPoint(window.Object, new Point<double>() { X = 0, Y = 0 });
 
 		Assert.True(emptyEngine.Engine.Root is WindowNode);
 	}
@@ -24,7 +24,7 @@ public class TestAddWindowAtPoint
 		emptyEngine.Engine.AddWindow(rootWindow.Object);
 
 		Mock<IWindow> pointWindow = new();
-		emptyEngine.Engine.AddWindowAtPoint(pointWindow.Object, new Point<double>() { X = -10, Y = -10 }, false);
+		emptyEngine.Engine.AddWindowAtPoint(pointWindow.Object, new Point<double>() { X = -10, Y = -10 });
 
 		Assert.Single(emptyEngine.Engine);
 	}
@@ -37,7 +37,7 @@ public class TestAddWindowAtPoint
 		emptyEngine.Engine.AddWindow(rootWindow.Object);
 
 		Mock<IWindow> pointWindow = new();
-		emptyEngine.Engine.AddWindowAtPoint(pointWindow.Object, new Point<double>() { X = 0.5, Y = 0.5 }, false);
+		emptyEngine.Engine.AddWindowAtPoint(pointWindow.Object, new Point<double>() { X = 0.5, Y = 0.5 });
 
 		Assert.True(emptyEngine.Engine.Root is SplitNode);
 		Assert.Equal(2, emptyEngine.Engine.Count);
@@ -51,11 +51,11 @@ public class TestAddWindowAtPoint
 		emptyEngine.Engine.AddWindow(rootWindow.Object);
 
 		Mock<IWindow> windowWithParent = new();
-		emptyEngine.Engine.AddWindowAtPoint(windowWithParent.Object, new Point<double>() { X = 0.5, Y = 0.5 }, false);
+		emptyEngine.Engine.AddWindowAtPoint(windowWithParent.Object, new Point<double>() { X = 0.5, Y = 0.5 });
 
 		emptyEngine.Engine.AddNodeDirection = Direction.Left;
 		Mock<IWindow> pointWindow = new();
-		emptyEngine.Engine.AddWindowAtPoint(pointWindow.Object, new Point<double>() { X = 0.75, Y = 0.75 }, false);
+		emptyEngine.Engine.AddWindowAtPoint(pointWindow.Object, new Point<double>() { X = 0.75, Y = 0.75 });
 
 		Assert.True(emptyEngine.Engine.Root is SplitNode);
 		Assert.Equal(3, emptyEngine.Engine.Count);
@@ -75,11 +75,11 @@ public class TestAddWindowAtPoint
 		emptyEngine.Engine.AddWindow(rootWindow.Object);
 
 		Mock<IWindow> windowWithParent = new();
-		emptyEngine.Engine.AddWindowAtPoint(windowWithParent.Object, new Point<double>() { X = 0.5, Y = 0.5 }, false);
+		emptyEngine.Engine.AddWindowAtPoint(windowWithParent.Object, new Point<double>() { X = 0.5, Y = 0.5 });
 
 		emptyEngine.Engine.AddNodeDirection = Direction.Right;
 		Mock<IWindow> pointWindow = new();
-		emptyEngine.Engine.AddWindowAtPoint(pointWindow.Object, new Point<double>() { X = 0.6, Y = 0.6 }, false);
+		emptyEngine.Engine.AddWindowAtPoint(pointWindow.Object, new Point<double>() { X = 0.6, Y = 0.6 });
 
 		Assert.True(emptyEngine.Engine.Root is SplitNode);
 		Assert.Equal(3, emptyEngine.Engine.Count);
@@ -100,10 +100,10 @@ public class TestAddWindowAtPoint
 		emptyEngine.Engine.AddWindow(rootWindow.Object);
 
 		Mock<IWindow> windowWithParent = new();
-		emptyEngine.Engine.AddWindowAtPoint(windowWithParent.Object, new Point<double>() { X = 0.5, Y = 0.5 }, false);
+		emptyEngine.Engine.AddWindowAtPoint(windowWithParent.Object, new Point<double>() { X = 0.5, Y = 0.5 });
 
 		Mock<IWindow> pointWindow = new();
-		emptyEngine.Engine.AddWindowAtPoint(pointWindow.Object, new Point<double>() { X = 0.6, Y = 0.6 }, false);
+		emptyEngine.Engine.AddWindowAtPoint(pointWindow.Object, new Point<double>() { X = 0.6, Y = 0.6 });
 
 		Assert.True(emptyEngine.Engine.Root is SplitNode);
 		Assert.Equal(3, emptyEngine.Engine.Count);
@@ -124,10 +124,10 @@ public class TestAddWindowAtPoint
 		emptyEngine.Engine.AddWindow(rootWindow.Object);
 
 		Mock<IWindow> windowWithParent = new();
-		emptyEngine.Engine.AddWindowAtPoint(windowWithParent.Object, new Point<double>() { X = 0.5, Y = 0.5 }, false);
+		emptyEngine.Engine.AddWindowAtPoint(windowWithParent.Object, new Point<double>() { X = 0.5, Y = 0.5 });
 
 		Mock<IWindow> pointWindow = new();
-		emptyEngine.Engine.AddWindowAtPoint(pointWindow.Object, new Point<double>() { X = 0.75, Y = 0.75 }, false);
+		emptyEngine.Engine.AddWindowAtPoint(pointWindow.Object, new Point<double>() { X = 0.75, Y = 0.75 });
 
 		Assert.True(emptyEngine.Engine.Root is SplitNode);
 		Assert.Equal(3, emptyEngine.Engine.Count);

--- a/src/Whim.TreeLayout/TreeLayoutEngine.cs
+++ b/src/Whim.TreeLayout/TreeLayoutEngine.cs
@@ -616,12 +616,12 @@ public partial class TreeLayoutEngine : ITreeLayoutEngine
 	}
 
 	/// <inheritdoc/>
-	public void AddWindowAtPoint(IWindow window, IPoint<double> point, bool isPhantom)
+	public void AddWindowAtPoint(IWindow window, IPoint<double> point)
 	{
 		if (Root == null)
 		{
 			// Add the window normally.
-			MoveWindowToPointAddWindow(window, isPhantom, null);
+			MoveWindowToPointAddWindow(window, null);
 			return;
 		}
 
@@ -656,7 +656,7 @@ public partial class TreeLayoutEngine : ITreeLayoutEngine
 			AddNodeDirection = point.Y < nodeLocation.Y + (nodeLocation.Height / 2) ? Direction.Up : Direction.Down;
 		}
 
-		MoveWindowToPointAddWindow(window, isPhantom, node.Window);
+		MoveWindowToPointAddWindow(window, node.Window);
 
 		// Restore the old direction.
 		AddNodeDirection = oldAddNodeDirection;
@@ -668,11 +668,10 @@ public partial class TreeLayoutEngine : ITreeLayoutEngine
 	/// Otherwise, it calls <see cref="AddWindow(IWindow, IWindow?)"/>.
 	/// </summary>
 	/// <param name="window">The window to add.</param>
-	/// <param name="isPhantom">Whether the window is a phantom window.</param>
 	/// <param name="focusedWindow">The focused window.</param>
-	private void MoveWindowToPointAddWindow(IWindow window, bool isPhantom, IWindow? focusedWindow)
+	private void MoveWindowToPointAddWindow(IWindow window, IWindow? focusedWindow)
 	{
-		if (isPhantom)
+		if (_phantomWindows.Contains(window))
 		{
 			// We don't actually care about this phantom window, as we'll spawn a new one.
 			window.Close();

--- a/src/Whim/Layout/BaseStackLayoutEngine.cs
+++ b/src/Whim/Layout/BaseStackLayoutEngine.cs
@@ -84,7 +84,7 @@ public abstract class BaseStackLayoutEngine : ILayoutEngine
 	public abstract void MoveWindowEdgeInDirection(Direction edge, double delta, IWindow window);
 
 	/// <inheritdoc/>
-	public abstract void AddWindowAtPoint(IWindow window, IPoint<double> point, bool isPhantom);
+	public abstract void AddWindowAtPoint(IWindow window, IPoint<double> point);
 
 	/// <inheritdoc/>
 	public void HidePhantomWindows() { }

--- a/src/Whim/Layout/ColumnLayoutEngine.cs
+++ b/src/Whim/Layout/ColumnLayoutEngine.cs
@@ -143,7 +143,7 @@ public class ColumnLayoutEngine : BaseStackLayoutEngine
 	}
 
 	/// <inheritdoc />
-	public override void AddWindowAtPoint(IWindow window, IPoint<double> point, bool _isPhantom)
+	public override void AddWindowAtPoint(IWindow window, IPoint<double> point)
 	{
 		Logger.Debug($"Adding window {window} to layout engine {Name} at point {point}");
 

--- a/src/Whim/Layout/ILayoutEngine.cs
+++ b/src/Whim/Layout/ILayoutEngine.cs
@@ -62,8 +62,7 @@ public interface ILayoutEngine : ICollection<IWindow>
 	/// </summary>
 	/// <param name="window">The window to move.</param>
 	/// <param name="point">The point to move the window to.</param>
-	/// <param name="isPhantom">Whether the window is a phantom window.</param>
-	public void AddWindowAtPoint(IWindow window, IPoint<double> point, bool isPhantom = false);
+	public void AddWindowAtPoint(IWindow window, IPoint<double> point);
 
 	/// <summary>
 	/// Checks to see if this <see cref="ILayoutEngine"/> or a child layout engine is type

--- a/src/Whim/Layout/ProxyLayoutEngine.cs
+++ b/src/Whim/Layout/ProxyLayoutEngine.cs
@@ -83,8 +83,8 @@ public abstract class BaseProxyLayoutEngine : ILayoutEngine
 	public virtual void HidePhantomWindows() => InnerLayoutEngine.HidePhantomWindows();
 
 	/// <inheritdoc/>
-	public virtual void AddWindowAtPoint(IWindow window, IPoint<double> point, bool isPhantom) =>
-		InnerLayoutEngine.AddWindowAtPoint(window, point, isPhantom);
+	public virtual void AddWindowAtPoint(IWindow window, IPoint<double> point) =>
+		InnerLayoutEngine.AddWindowAtPoint(window, point);
 
 	/// <summary>
 	/// Checks to see if this <cref name="ILayoutEngine"/>

--- a/src/Whim/Workspace/IWorkspace.cs
+++ b/src/Whim/Workspace/IWorkspace.cs
@@ -130,12 +130,11 @@ public interface IWorkspace : IDisposable
 	public void MoveWindowEdgeInDirection(Direction edge, double delta, IWindow? window = null);
 
 	/// <summary>
-	/// Moves the given <paramref name="window"/> to the given <paramref name="point"/>.
+	/// Moves or adds the given <paramref name="window"/> to the given <paramref name="point"/>.
 	/// </summary>
 	/// <param name="window">The window to move.</param>
 	/// <param name="point">The point to move the window to.</param>
-	/// <param name="isPhantom">Indicates whether the window being moved is a phantom window.</param>
-	public void MoveWindowToPoint(IWindow window, IPoint<double> point, bool isPhantom = false);
+	public void MoveWindowToPoint(IWindow window, IPoint<double> point);
 	#endregion
 
 	#region Phantom Windows

--- a/src/Whim/Workspace/IWorkspace.cs
+++ b/src/Whim/Workspace/IWorkspace.cs
@@ -142,6 +142,13 @@ public interface IWorkspace : IDisposable
 	/// <summary>
 	/// Add a phantom window. This can only be done by the active layout engine.
 	/// </summary>
+	/// <remarks>
+	/// Phantom windows are placeholder windows that represent a space in the
+	/// current layout engine.
+	///
+	/// They are designed to let a layout engine reserve a space, for a new window,
+	/// or for a window that is being moved around.
+	/// </remarks>
 	/// <param name="engine">The layout engine to add the phantom window to.</param>
 	/// <param name="window">The phantom window to add.</param>
 	public void AddPhantomWindow(ILayoutEngine engine, IWindow window);

--- a/src/Whim/Workspace/IWorkspace.cs
+++ b/src/Whim/Workspace/IWorkspace.cs
@@ -158,8 +158,7 @@ public interface IWorkspace : IDisposable
 	/// </summary>
 	/// <param name="engine">The layout engine to remove the phantom window from.</param>
 	/// <param name="window">The phantom window to remove.</param>
-	/// <param name="doLayout">Indicates whether to do a layout after removing the phantom window.</param>
-	public void RemovePhantomWindow(ILayoutEngine engine, IWindow window, bool doLayout = false);
+	public void RemovePhantomWindow(ILayoutEngine engine, IWindow window);
 	#endregion
 
 	/// <summary>

--- a/src/Whim/Workspace/IWorkspace.cs
+++ b/src/Whim/Workspace/IWorkspace.cs
@@ -106,7 +106,7 @@ public interface IWorkspace : IDisposable
 	/// <param name="window">
 	/// The origin window
 	/// </param>
-	public void FocusWindowInDirection(Direction direction, IWindow window);
+	public void FocusWindowInDirection(Direction direction, IWindow? window = null);
 
 	/// <summary>
 	/// Swaps the <paramref name="window"/> in the <paramref name="direction"/>.

--- a/src/Whim/Workspace/Workspace.cs
+++ b/src/Whim/Workspace/Workspace.cs
@@ -343,6 +343,11 @@ internal class Workspace : IWorkspace
 			window.Hide();
 		}
 
+		foreach (IWindow window in _phantomWindows.Keys)
+		{
+			window.Hide();
+		}
+
 		_windowLocations.Clear();
 		DoLayout();
 	}

--- a/src/Whim/Workspace/Workspace.cs
+++ b/src/Whim/Workspace/Workspace.cs
@@ -422,7 +422,7 @@ internal class Workspace : IWorkspace
 		DoLayout();
 	}
 
-	public void RemovePhantomWindow(ILayoutEngine engine, IWindow window, bool doLayout = false)
+	public void RemovePhantomWindow(ILayoutEngine engine, IWindow window)
 	{
 		Logger.Debug($"Removing phantom window {window} in workspace {Name}");
 
@@ -447,10 +447,7 @@ internal class Workspace : IWorkspace
 		_phantomWindows.Remove(window);
 		_configContext.WorkspaceManager.RemovePhantomWindow(window);
 
-		if (doLayout)
-		{
-			DoLayout();
-		}
+		DoLayout();
 	}
 	#endregion
 

--- a/src/Whim/Workspace/Workspace.cs
+++ b/src/Whim/Workspace/Workspace.cs
@@ -222,7 +222,11 @@ internal class Workspace : IWorkspace
 
 		if (_phantomWindows.TryGetValue(window, out ILayoutEngine? phantomLayoutEngine))
 		{
-			bool removePhantomSuccess = RemovePhantomWindow(phantomLayoutEngine, window);
+			bool removePhantomSuccess = phantomLayoutEngine.Remove(window);
+			if (removePhantomSuccess)
+			{
+				_phantomWindows.Remove(window);
+			}
 			DoLayout();
 			return removePhantomSuccess;
 		}
@@ -250,25 +254,6 @@ internal class Workspace : IWorkspace
 		}
 
 		return success;
-	}
-
-	private bool RemovePhantomWindow(ILayoutEngine phantomLayoutEngine, IWindow window)
-	{
-		Logger.Debug($"Removing phantom window {window} from workspace {Name}");
-
-		if (!ActiveLayoutEngine.ContainsEqual(phantomLayoutEngine))
-		{
-			Logger.Error($"Phantom window {window} is not in the active layout engine {ActiveLayoutEngine}");
-			return false;
-		}
-
-		if (!phantomLayoutEngine.Remove(window))
-		{
-			Logger.Error($"Phantom window {window} could not be removed from layout engine {phantomLayoutEngine}");
-			return false;
-		}
-
-		return true;
 	}
 
 	public void FocusWindowInDirection(Direction direction, IWindow window)
@@ -426,7 +411,7 @@ internal class Workspace : IWorkspace
 	{
 		Logger.Debug($"Adding phantom window {window} in workspace {Name}");
 
-		if (engine.ContainsEqual(ActiveLayoutEngine))
+		if (!ActiveLayoutEngine.ContainsEqual(engine))
 		{
 			Logger.Error($"Layout engine {engine} is not active in workspace {Name}");
 			return;
@@ -447,8 +432,7 @@ internal class Workspace : IWorkspace
 	{
 		Logger.Debug($"Removing phantom window {window} in workspace {Name}");
 
-		// TODO: Shouldn't this be the other way around?
-		if (engine.ContainsEqual(ActiveLayoutEngine))
+		if (!ActiveLayoutEngine.ContainsEqual(engine))
 		{
 			Logger.Error($"Layout engine {engine} is not active in workspace {Name}");
 			return;

--- a/src/Whim/Workspace/Workspace.cs
+++ b/src/Whim/Workspace/Workspace.cs
@@ -307,22 +307,15 @@ internal class Workspace : IWorkspace
 		}
 	}
 
-	public void MoveWindowToPoint(IWindow window, IPoint<double> point, bool isPhantom)
+	public void MoveWindowToPoint(IWindow window, IPoint<double> point)
 	{
 		Logger.Debug($"Moving window {window} to point {point} in workspace {Name}");
-
-		// Double check isPhantom.
-		if (_phantomWindows.ContainsKey(window) && !isPhantom)
-		{
-			Logger.Error($"Window {window} is a phantom window but is not being moved to a phantom point");
-			return;
-		}
 
 		_windows.Add(window);
 
 		foreach (ILayoutEngine layoutEngine in _layoutEngines)
 		{
-			layoutEngine.AddWindowAtPoint(window, point, isPhantom);
+			layoutEngine.AddWindowAtPoint(window, point);
 		}
 
 		DoLayout();

--- a/src/Whim/Workspace/Workspace.cs
+++ b/src/Whim/Workspace/Workspace.cs
@@ -226,8 +226,8 @@ internal class Workspace : IWorkspace
 			if (removePhantomSuccess)
 			{
 				_phantomWindows.Remove(window);
+				DoLayout();
 			}
-			DoLayout();
 			return removePhantomSuccess;
 		}
 

--- a/src/Whim/Workspace/Workspace.cs
+++ b/src/Whim/Workspace/Workspace.cs
@@ -256,59 +256,55 @@ internal class Workspace : IWorkspace
 		return success;
 	}
 
-	public void FocusWindowInDirection(Direction direction, IWindow window)
+	private IWindow? GetValidWindow(IWindow? window)
 	{
-		Logger.Debug($"Focusing window {window} in workspace {Name}");
+		window ??= LastFocusedWindow;
+
+		if (window == null)
+		{
+			Logger.Error($"Could not find a valid window in workspace {Name} to perform action");
+			return null;
+		}
 
 		if (!ContainsWindow(window))
 		{
 			Logger.Error($"Window {window} does not exist in workspace {Name}");
-			return;
+			return null;
 		}
 
-		ActiveLayoutEngine.FocusWindowInDirection(direction, window);
+		return window;
+	}
+
+	public void FocusWindowInDirection(Direction direction, IWindow? window = null)
+	{
+		Logger.Debug($"Focusing window {window} in workspace {Name}");
+
+		if (GetValidWindow(window) is IWindow validWindow)
+		{
+			ActiveLayoutEngine.FocusWindowInDirection(direction, validWindow);
+		}
 	}
 
 	public void SwapWindowInDirection(Direction direction, IWindow? window = null)
 	{
-		window ??= LastFocusedWindow;
-		if (window == null)
-		{
-			Logger.Error($"No window to swap in workspace {Name}");
-			return;
-		}
-
 		Logger.Debug($"Swapping window {window} in workspace {Name} in direction {direction}");
 
-		if (!ContainsWindow(window))
+		if (GetValidWindow(window) is IWindow validWindow)
 		{
-			Logger.Error($"Window {window} does not exist in workspace {Name}");
-			return;
+			ActiveLayoutEngine.SwapWindowInDirection(direction, validWindow);
+			DoLayout();
 		}
-
-		ActiveLayoutEngine.SwapWindowInDirection(direction, window);
-		DoLayout();
 	}
 
 	public void MoveWindowEdgeInDirection(Direction edge, double delta, IWindow? window = null)
 	{
-		window ??= LastFocusedWindow;
-		if (window == null)
-		{
-			Logger.Error($"No window to move in workspace {Name}");
-			return;
-		}
-
 		Logger.Debug($"Moving window {window} in workspace {Name} in direction {edge} by {delta}");
 
-		if (!ContainsWindow(window))
+		if (GetValidWindow(window) is IWindow validWindow)
 		{
-			Logger.Error($"Window {window} does not exist in workspace {Name}");
-			return;
+			ActiveLayoutEngine.MoveWindowEdgeInDirection(edge, delta, validWindow);
+			DoLayout();
 		}
-
-		ActiveLayoutEngine.MoveWindowEdgeInDirection(edge, delta, window);
-		DoLayout();
 	}
 
 	public void MoveWindowToPoint(IWindow window, IPoint<double> point, bool isPhantom)

--- a/src/Whim/Workspace/WorkspaceManager.cs
+++ b/src/Whim/Workspace/WorkspaceManager.cs
@@ -518,7 +518,7 @@ internal class WorkspaceManager : IWorkspaceManager
 		IPoint<double> normalized = targetMonitor.WorkingArea.ToUnitSquare(pointInMonitor);
 		Logger.Debug($"Normalized location: {normalized}");
 
-		targetWorkspace.MoveWindowToPoint(window, normalized, isPhantom);
+		targetWorkspace.MoveWindowToPoint(window, normalized);
 		_windowWorkspaceMap[window] = targetWorkspace;
 
 		// Trigger layouts.


### PR DESCRIPTION
Refactored `Workspace` to remove the duplicate `RemovePhantomWindow` overload and fold its logic into `RemoveWindow`. Additionally, the methods `<Operation>WindowInDirection` were refactored to move common functionality into a shared private method.

`IWorkspace.MoveWindowToPoint` and `ILayoutEngine.AddWindowAtPoint` no longer take in the parameter `isPhantom`. Instead, we assume that any window added via this method is not a phantom window - it's up to the caller to ensure correctness here.

Coverage for `Workspace` has been drastically increased.