### PR TITLE
Add the ability to close TreeLayout phantom windows

### DIFF
--- a/src/Whim.TreeLayout/PhantomNode.cs
+++ b/src/Whim.TreeLayout/PhantomNode.cs
@@ -38,7 +38,7 @@ public class PhantomNode : LeafNode
 	/// <returns></returns>
 	public static PhantomNode? CreatePhantomNode(IConfigContext configContext, SplitNode? parent = null)
 	{
-		PhantomWindow phantomWindow = new();
+		PhantomWindow phantomWindow = new(configContext);
 
 		IWindow? windowModel = configContext.WindowManager.CreateWindow(phantomWindow.GetHandle());
 

--- a/src/Whim.TreeLayout/PhantomWindow.xaml
+++ b/src/Whim.TreeLayout/PhantomWindow.xaml
@@ -6,9 +6,30 @@
 	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 	mc:Ignorable="d">
 
-	<Grid Background="{ThemeResource AcrylicBackgroundFillColorDefaultBrush}">
-		<StackPanel HorizontalAlignment="Center" VerticalAlignment="Center">
-			<TextBlock>Whim TreeLayout Phantom Window</TextBlock>
+	<StackPanel
+		Width="360"
+		HorizontalAlignment="Center"
+		VerticalAlignment="Center"
+		Orientation="Vertical"
+		Spacing="8">
+
+		<StackPanel Orientation="Horizontal" Spacing="8">
+			<FontIcon FontSize="50" Glyph="&#xE7C4;" />
+
+			<TextBlock FontSize="36">
+				Phantom Window
+			</TextBlock>
 		</StackPanel>
-	</Grid>
+
+		<TextBlock TextWrapping="WrapWholeWords">
+			This is a phantom window for the TreeLayout engine. It represents a space where a
+			new window can be opened in, or an existing window can be moved to.
+		</TextBlock>
+
+		<StackPanel HorizontalAlignment="Right" Orientation="Horizontal">
+			<Button Click="Button_Click" Content="Close" />
+		</StackPanel>
+
+	</StackPanel>
+
 </Window>

--- a/src/Whim.TreeLayout/PhantomWindow.xaml.cs
+++ b/src/Whim.TreeLayout/PhantomWindow.xaml.cs
@@ -2,10 +2,10 @@
 
 internal sealed partial class PhantomWindow : Microsoft.UI.Xaml.Window
 {
-	public PhantomWindow()
+	public PhantomWindow(IConfigContext configContext)
 	{
 		Title = "Whim TreeLayout Phantom Window";
-		ExtendsContentIntoTitleBar = true;
-		UIElementExtensions.InitializeComponent(this, "Whim.TreeLayout", "PhantomWindow");
+		this.InitializeBorderlessWindow(configContext, "Whim.TreeLayout", "PhantomWindow");
+		this.SetIsShownInSwitchers(false);
 	}
 }

--- a/src/Whim.TreeLayout/PhantomWindow.xaml.cs
+++ b/src/Whim.TreeLayout/PhantomWindow.xaml.cs
@@ -8,4 +8,9 @@ internal sealed partial class PhantomWindow : Microsoft.UI.Xaml.Window
 		this.InitializeBorderlessWindow(configContext, "Whim.TreeLayout", "PhantomWindow");
 		this.SetIsShownInSwitchers(false);
 	}
+
+	private void Button_Click(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)
+	{
+		this.Close();
+	}
 }

--- a/src/Whim.TreeLayout/TreeLayoutEngine.cs
+++ b/src/Whim.TreeLayout/TreeLayoutEngine.cs
@@ -600,7 +600,6 @@ public partial class TreeLayoutEngine : ITreeLayoutEngine
 
 		_phantomWindows.Add(phantomNode.Window);
 		_configContext.WorkspaceManager.ActiveWorkspace.AddPhantomWindow(this, phantomNode.Window);
-		_configContext.WorkspaceManager.ActiveWorkspace.DoLayout();
 		phantomNode.Focus();
 	}
 


### PR DESCRIPTION
The `PhantomWindow`'s XAML was updated to be more descriptive and add a `Close` button. Additionally, `PhantomWindow`s are now hidden from the taskbar, have had window controls removed.