### PR TITLE
Switching workspaces should always activate windows

### DIFF
--- a/src/Whim.Tests/Workspace/WorkspaceManagerTests.cs
+++ b/src/Whim.Tests/Workspace/WorkspaceManagerTests.cs
@@ -319,6 +319,7 @@ public class WorkspaceManagerTests
 		// The old workspace is deactivated, the new workspace is laid out, and the first window is
 		// focused.
 		oldWorkspace.Verify(w => w.Deactivate(), Times.Once);
+		oldWorkspace.Verify(w => w.DoLayout(), Times.Never);
 		newWorkspace.Verify(w => w.DoLayout(), Times.Once);
 		newWorkspace.Verify(w => w.FocusFirstWindow(), Times.Once);
 	}
@@ -347,6 +348,14 @@ public class WorkspaceManagerTests
 		Assert.Equal(monitor, result.Arguments.Monitor);
 		Assert.Equal(workspace2.Object, result.Arguments.NewWorkspace);
 		Assert.Equal(workspace.Object, result.Arguments.OldWorkspace);
+
+		workspace.Verify(w => w.Deactivate(), Times.Never);
+		workspace.Verify(w => w.DoLayout(), Times.Once);
+		workspace.Verify(w => w.FocusFirstWindow(), Times.Once);
+
+		workspace2.Verify(w => w.Deactivate(), Times.Never);
+		workspace2.Verify(w => w.DoLayout(), Times.Once);
+		workspace2.Verify(w => w.FocusFirstWindow(), Times.Once);
 	}
 
 	[Fact]

--- a/src/Whim.Tests/Workspace/WorkspaceManagerTests.cs
+++ b/src/Whim.Tests/Workspace/WorkspaceManagerTests.cs
@@ -306,6 +306,10 @@ public class WorkspaceManagerTests
 
 		mocks.WorkspaceManager.Activate(oldWorkspace.Object);
 
+		// Reset mocks
+		oldWorkspace.Reset();
+		newWorkspace.Reset();
+
 		// When a workspace is activated when there is another workspace activated, then the old
 		// workspace is deactivated, the new workspace is activated, and an event is raised
 		var result = Assert.Raises<MonitorWorkspaceChangedEventArgs>(
@@ -337,6 +341,10 @@ public class WorkspaceManagerTests
 		mocks.WorkspaceManager.Activate(workspace.Object, monitor);
 		mocks.WorkspaceManager.Activate(workspace2.Object, monitor2);
 
+		// Reset mocks
+		workspace.Reset();
+		workspace2.Reset();
+
 		// When a workspace is activated on a monitor which already has a workspace activated, then
 		// an event is raised
 		var result = Assert.Raises<MonitorWorkspaceChangedEventArgs>(
@@ -351,7 +359,7 @@ public class WorkspaceManagerTests
 
 		workspace.Verify(w => w.Deactivate(), Times.Never);
 		workspace.Verify(w => w.DoLayout(), Times.Once);
-		workspace.Verify(w => w.FocusFirstWindow(), Times.Once);
+		workspace.Verify(w => w.FocusFirstWindow(), Times.Never);
 
 		workspace2.Verify(w => w.Deactivate(), Times.Never);
 		workspace2.Verify(w => w.DoLayout(), Times.Once);

--- a/src/Whim.Tests/Workspace/WorkspaceTests.cs
+++ b/src/Whim.Tests/Workspace/WorkspaceTests.cs
@@ -763,7 +763,7 @@ public class WorkspaceTests
 		workspace.Deactivate();
 
 		// Then the windows are hidden and DoLayout is called
-		mocks.WorkspaceManager.Verify(wm => wm.GetMonitorForWorkspace(workspace), Times.Once);
+		mocks.WorkspaceManager.Verify(wm => wm.GetMonitorForWorkspace(workspace), Times.Never);
 		window.Verify(w => w.Hide(), Times.Once);
 		window2.Verify(w => w.Hide(), Times.Once);
 		phantomWindow.Verify(w => w.Hide(), Times.Once);

--- a/src/Whim/Workspace/Workspace.cs
+++ b/src/Whim/Workspace/Workspace.cs
@@ -338,7 +338,6 @@ internal class Workspace : IWorkspace
 		}
 
 		_windowLocations.Clear();
-		DoLayout();
 	}
 
 	public IWindowState? TryGetWindowLocation(IWindow window)

--- a/src/Whim/Workspace/WorkspaceManager.cs
+++ b/src/Whim/Workspace/WorkspaceManager.cs
@@ -199,13 +199,11 @@ internal class WorkspaceManager : IWorkspaceManager
 		// visible workspace when it receives the EVENT_OBJECT_HIDE event.
 		_monitorWorkspaceMap[focusedMonitor] = workspace;
 
-		// Hide all the windows from the old workspace.
-		oldWorkspace?.Deactivate();
-
 		// Send out an event about the losing monitor.
 		if (loserMonitor != null && oldWorkspace != null)
 		{
 			_monitorWorkspaceMap[loserMonitor] = oldWorkspace;
+			oldWorkspace.DoLayout();
 			MonitorWorkspaceChanged?.Invoke(
 				this,
 				new MonitorWorkspaceChangedEventArgs()
@@ -215,6 +213,11 @@ internal class WorkspaceManager : IWorkspaceManager
 					NewWorkspace = oldWorkspace
 				}
 			);
+		}
+		else
+		{
+			// Hide all the windows from the old workspace.
+			oldWorkspace?.Deactivate();
 		}
 
 		// Layout the new workspace.


### PR DESCRIPTION
Previously, `WorkspaceManager.Activate()` would call `oldWorkspace.Deactivate()` and `workspace.DoLayout`. `Deactivate()` would call `DoLayout` internally. There are a few issues with this:

- `Deactivate` hides windows. Thus, `DoLayout` is unnecessary.
- If the workspace is moving between monitors, it isn't necessary to call `Deactivate` at all.

I think there may have been a race condition in between `Deactivate`'s `window.Hide()` and usage `WindowDeferPosHandle` which resulted in windows being hidden by Windows _after_ having their location set by Windows.