### PR TITLE
Show tree bar widget on all relevant bars

### DIFF
--- a/Whim.sln
+++ b/Whim.sln
@@ -47,6 +47,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Whim.Gaps.Tests", "src\Whim
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Whim.TreeLayout.CommandPalette", "src\Whim.TreeLayout.CommandPalette\Whim.TreeLayout.CommandPalette.csproj", "{8CD01B7A-78BD-48BD-B274-B2FEE48CC8F4}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Whim.TreeLayout.Bar.Tests", "src\Whim.TreeLayout.Bar.Tests\Whim.TreeLayout.Bar.Tests.csproj", "{860D3B0C-E324-4E3D-84DE-20356E21DE3F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -241,6 +243,18 @@ Global
 		{8CD01B7A-78BD-48BD-B274-B2FEE48CC8F4}.Release|arm64.Build.0 = Release|arm64
 		{8CD01B7A-78BD-48BD-B274-B2FEE48CC8F4}.Release|x64.ActiveCfg = Release|x64
 		{8CD01B7A-78BD-48BD-B274-B2FEE48CC8F4}.Release|x64.Build.0 = Release|x64
+		{860D3B0C-E324-4E3D-84DE-20356E21DE3F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{860D3B0C-E324-4E3D-84DE-20356E21DE3F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{860D3B0C-E324-4E3D-84DE-20356E21DE3F}.Debug|arm64.ActiveCfg = Debug|arm64
+		{860D3B0C-E324-4E3D-84DE-20356E21DE3F}.Debug|arm64.Build.0 = Debug|arm64
+		{860D3B0C-E324-4E3D-84DE-20356E21DE3F}.Debug|x64.ActiveCfg = Debug|x64
+		{860D3B0C-E324-4E3D-84DE-20356E21DE3F}.Debug|x64.Build.0 = Debug|x64
+		{860D3B0C-E324-4E3D-84DE-20356E21DE3F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{860D3B0C-E324-4E3D-84DE-20356E21DE3F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{860D3B0C-E324-4E3D-84DE-20356E21DE3F}.Release|arm64.ActiveCfg = Release|arm64
+		{860D3B0C-E324-4E3D-84DE-20356E21DE3F}.Release|arm64.Build.0 = Release|arm64
+		{860D3B0C-E324-4E3D-84DE-20356E21DE3F}.Release|x64.ActiveCfg = Release|x64
+		{860D3B0C-E324-4E3D-84DE-20356E21DE3F}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Whim.TreeLayout.Bar.Tests/Directory.Build.props
+++ b/src/Whim.TreeLayout.Bar.Tests/Directory.Build.props
@@ -1,0 +1,5 @@
+<Project>
+	<PropertyGroup>
+		<GenerateDocumentationFile>false</GenerateDocumentationFile>
+	</PropertyGroup>
+</Project>

--- a/src/Whim.TreeLayout.Bar.Tests/GlobalSuppressions.cs
+++ b/src/Whim.TreeLayout.Bar.Tests/GlobalSuppressions.cs
@@ -1,0 +1,16 @@
+﻿// This file is used by Code Analysis to maintain SuppressMessage
+// attributes that are applied to this project.
+// Project-level suppressions either have no target or are given
+// a specific target and scoped to a namespace, type, member, etc.
+
+using System.Diagnostics.CodeAnalysis;
+
+// The general justification for these suppression messages is that this project contains tests, and it's
+// a bit excessive to have these particular rules for tests.
+[assembly: SuppressMessage("Design", "CA1014:Mark assemblies with CLSCompliantAttribute")]
+[assembly: SuppressMessage("Design", "CA1062:Validate arguments of public methods")]
+[assembly: SuppressMessage("Naming", "CA1707:Identifiers should not contain underscores")]
+[assembly: SuppressMessage("Style", "IDE0008:Use explicit type")]
+[assembly: SuppressMessage("Style", "IDE0042:Variable declaration can be deconstructed")]
+[assembly: SuppressMessage("Style", "IDE0058:Expression value is never used")]
+[assembly: SuppressMessage("Style", "IDE0022:Use expression body for methods")]

--- a/src/Whim.TreeLayout.Bar.Tests/ToggleDirectionCommandTests.cs
+++ b/src/Whim.TreeLayout.Bar.Tests/ToggleDirectionCommandTests.cs
@@ -1,0 +1,57 @@
+using Moq;
+using Xunit;
+
+namespace Whim.TreeLayout.Bar.Tests;
+
+public class ToggleDirectionCommandTests
+{
+	private class MocksBuilder
+	{
+		public Mock<IContext> Context { get; } = new();
+		public Mock<IMonitor> Monitor { get; } = new();
+		public Mock<IWorkspaceManager> WorkspaceManager { get; } = new();
+		public Mock<IWorkspace> Workspace { get; } = new();
+		public Mock<ITreeLayoutEngine> TreeLayoutEngine { get; } = new();
+		public TreeLayoutEngineWidgetViewModel ViewModel { get; }
+
+		public MocksBuilder()
+		{
+			Context.SetupGet(x => x.WorkspaceManager).Returns(WorkspaceManager.Object);
+			WorkspaceManager.Setup(x => x.GetWorkspaceForMonitor(Monitor.Object)).Returns(Workspace.Object);
+			Workspace.SetupGet(x => x.ActiveLayoutEngine).Returns(TreeLayoutEngine.Object);
+
+			TreeLayoutEngine.Setup(t => t.GetLayoutEngine<ITreeLayoutEngine>()).Returns(TreeLayoutEngine.Object);
+
+			ViewModel = new TreeLayoutEngineWidgetViewModel(Context.Object, Monitor.Object);
+		}
+	}
+
+	[Fact]
+	public void CanExecute_ShouldReturnTrue()
+	{
+		// Given
+		MocksBuilder mocks = new();
+		ToggleDirectionCommand command = new(mocks.ViewModel);
+
+		// When
+		bool actual = command.CanExecute(null);
+
+		// Then
+		Assert.True(actual);
+	}
+
+	[Fact]
+	public void Execute_ShouldToggleDirection()
+	{
+		// Given
+		MocksBuilder mocks = new();
+		mocks.ViewModel.DirectionValue = Direction.Up;
+		ToggleDirectionCommand command = new(mocks.ViewModel);
+
+		// When
+		command.Execute(null);
+
+		// Then
+		mocks.TreeLayoutEngine.VerifySet(t => t.AddNodeDirection = Direction.Right);
+	}
+}

--- a/src/Whim.TreeLayout.Bar.Tests/TreeLayoutEngineWidgetViewModelTests.cs
+++ b/src/Whim.TreeLayout.Bar.Tests/TreeLayoutEngineWidgetViewModelTests.cs
@@ -1,0 +1,129 @@
+using Microsoft.UI.Xaml;
+using Moq;
+using Xunit;
+
+namespace Whim.TreeLayout.Bar.Tests;
+
+[System.Diagnostics.CodeAnalysis.SuppressMessage(
+	"Reliability",
+	"CA2000:Dispose objects before losing scope",
+	Justification = "Unnecessary for tests"
+)]
+public class TreeLayoutEngineWidgetViewModelTests
+{
+	private class MocksBuilder
+	{
+		public Mock<IContext> Context { get; } = new();
+		public Mock<IMonitor> Monitor { get; } = new();
+		public Mock<IWorkspaceManager> WorkspaceManager { get; } = new();
+		public Mock<IWorkspace> Workspace { get; } = new();
+		public Mock<ITreeLayoutEngine> TreeLayoutEngine { get; } = new();
+
+		public MocksBuilder()
+		{
+			Context.SetupGet(x => x.WorkspaceManager).Returns(WorkspaceManager.Object);
+			WorkspaceManager.Setup(x => x.GetWorkspaceForMonitor(Monitor.Object)).Returns(Workspace.Object);
+			Workspace.SetupGet(x => x.ActiveLayoutEngine).Returns(TreeLayoutEngine.Object);
+
+			TreeLayoutEngine.Setup(t => t.GetLayoutEngine<ITreeLayoutEngine>()).Returns(TreeLayoutEngine.Object);
+		}
+	}
+
+	[Fact]
+	public void IsVisible_WhenDirectionValueIsNull_ReturnsCollapsed()
+	{
+		// Given
+		MocksBuilder mocks = new();
+		TreeLayoutEngineWidgetViewModel viewModel = new(mocks.Context.Object, mocks.Monitor.Object);
+
+		// When
+		Visibility actual = viewModel.IsVisible;
+
+		// Then
+		Assert.Equal(Visibility.Collapsed, actual);
+	}
+
+	[Fact]
+	public void IsVisible_WhenDirectionValueIsNotNull_ReturnsVisible()
+	{
+		// Given
+		MocksBuilder mocks = new();
+		TreeLayoutEngineWidgetViewModel viewModel =
+			new(mocks.Context.Object, mocks.Monitor.Object) { DirectionValue = Direction.Left };
+
+		// When
+		Visibility actual = viewModel.IsVisible;
+
+		// Then
+		Assert.Equal(Visibility.Visible, actual);
+	}
+
+	[Fact]
+	public void AddNodeDirection_WhenDirectionValueIsNull_ReturnsNull()
+	{
+		// Given
+		MocksBuilder mocks = new();
+		TreeLayoutEngineWidgetViewModel viewModel = new(mocks.Context.Object, mocks.Monitor.Object);
+
+		// When
+		string? actual = viewModel.AddNodeDirection;
+
+		// Then
+		Assert.Null(actual);
+	}
+
+	[InlineData(Direction.Left, "Left")]
+	[InlineData(Direction.Right, "Right")]
+	[InlineData(Direction.Up, "Up")]
+	[InlineData(Direction.Down, "Down")]
+	[Theory]
+	public void AddNodeDirection_WhenDirectionValueIsNotNull_ReturnsStringRepresentation(
+		Direction direction,
+		string expected
+	)
+	{
+		// Given
+		MocksBuilder mocks = new();
+		TreeLayoutEngineWidgetViewModel viewModel =
+			new(mocks.Context.Object, mocks.Monitor.Object) { DirectionValue = direction };
+
+		// When
+		string? actual = viewModel.AddNodeDirection;
+
+		// Then
+		Assert.Equal(expected, actual);
+	}
+
+	[Fact]
+	public void ToggleDirection_WhenDirectionValueIsNull_DoesNothing()
+	{
+		// Given
+		MocksBuilder mocks = new();
+		TreeLayoutEngineWidgetViewModel viewModel = new(mocks.Context.Object, mocks.Monitor.Object);
+
+		// When
+		viewModel.ToggleDirection();
+
+		// Then
+		Assert.Null(viewModel.DirectionValue);
+	}
+
+	[InlineData(Direction.Left, Direction.Up)]
+	[InlineData(Direction.Up, Direction.Right)]
+	[InlineData(Direction.Right, Direction.Down)]
+	[InlineData(Direction.Down, Direction.Left)]
+	[Theory]
+	public void ToggleDirection_WhenDirectionValueIsNotNull_TogglesDirection(Direction initial, Direction expected)
+	{
+		// Given
+		MocksBuilder mocks = new();
+		TreeLayoutEngineWidgetViewModel viewModel =
+			new(mocks.Context.Object, mocks.Monitor.Object) { DirectionValue = initial };
+
+		// When
+		viewModel.ToggleDirection();
+
+		// Then
+		mocks.TreeLayoutEngine.VerifySet(t => t.AddNodeDirection = expected, Times.Once);
+	}
+}

--- a/src/Whim.TreeLayout.Bar.Tests/TreeLayoutEngineWidgetViewModelTests.cs
+++ b/src/Whim.TreeLayout.Bar.Tests/TreeLayoutEngineWidgetViewModelTests.cs
@@ -227,4 +227,25 @@ public class TreeLayoutEngineWidgetViewModelTests
 		// Then
 		Assert.Equal(Direction.Down, viewModel.DirectionValue);
 	}
+
+	[Fact]
+	public void Dispose()
+	{
+		// Given
+		MocksBuilder mocks = new(true);
+		TreeLayoutEngineWidgetViewModel viewModel = new(mocks.Context.Object, mocks.Monitor.Object);
+
+		// When
+		viewModel.Dispose();
+
+		// Then
+		mocks.WorkspaceManager.VerifyRemove(
+			x => x.MonitorWorkspaceChanged -= It.IsAny<EventHandler<MonitorWorkspaceChangedEventArgs>>(),
+			Times.Once
+		);
+		mocks.WorkspaceManager.VerifyRemove(
+			x => x.ActiveLayoutEngineChanged -= It.IsAny<EventHandler<ActiveLayoutEngineChangedEventArgs>>(),
+			Times.Once
+		);
+	}
 }

--- a/src/Whim.TreeLayout.Bar.Tests/TreeLayoutEngineWidgetViewModelTests.cs
+++ b/src/Whim.TreeLayout.Bar.Tests/TreeLayoutEngineWidgetViewModelTests.cs
@@ -19,13 +19,16 @@ public class TreeLayoutEngineWidgetViewModelTests
 		public Mock<IWorkspace> Workspace { get; } = new();
 		public Mock<ITreeLayoutEngine> TreeLayoutEngine { get; } = new();
 
-		public MocksBuilder()
+		public MocksBuilder(bool canGetLayoutEngine)
 		{
 			Context.SetupGet(x => x.WorkspaceManager).Returns(WorkspaceManager.Object);
 			WorkspaceManager.Setup(x => x.GetWorkspaceForMonitor(Monitor.Object)).Returns(Workspace.Object);
 			Workspace.SetupGet(x => x.ActiveLayoutEngine).Returns(TreeLayoutEngine.Object);
 
-			TreeLayoutEngine.Setup(t => t.GetLayoutEngine<ITreeLayoutEngine>()).Returns(TreeLayoutEngine.Object);
+			if (canGetLayoutEngine)
+			{
+				TreeLayoutEngine.Setup(t => t.GetLayoutEngine<ITreeLayoutEngine>()).Returns(TreeLayoutEngine.Object);
+			}
 		}
 	}
 
@@ -33,7 +36,7 @@ public class TreeLayoutEngineWidgetViewModelTests
 	public void IsVisible_WhenDirectionValueIsNull_ReturnsCollapsed()
 	{
 		// Given
-		MocksBuilder mocks = new();
+		MocksBuilder mocks = new(false);
 		TreeLayoutEngineWidgetViewModel viewModel = new(mocks.Context.Object, mocks.Monitor.Object);
 
 		// When
@@ -47,7 +50,7 @@ public class TreeLayoutEngineWidgetViewModelTests
 	public void IsVisible_WhenDirectionValueIsNotNull_ReturnsVisible()
 	{
 		// Given
-		MocksBuilder mocks = new();
+		MocksBuilder mocks = new(false);
 		TreeLayoutEngineWidgetViewModel viewModel =
 			new(mocks.Context.Object, mocks.Monitor.Object) { DirectionValue = Direction.Left };
 
@@ -62,7 +65,7 @@ public class TreeLayoutEngineWidgetViewModelTests
 	public void AddNodeDirection_WhenDirectionValueIsNull_ReturnsNull()
 	{
 		// Given
-		MocksBuilder mocks = new();
+		MocksBuilder mocks = new(false);
 		TreeLayoutEngineWidgetViewModel viewModel = new(mocks.Context.Object, mocks.Monitor.Object);
 
 		// When
@@ -83,7 +86,7 @@ public class TreeLayoutEngineWidgetViewModelTests
 	)
 	{
 		// Given
-		MocksBuilder mocks = new();
+		MocksBuilder mocks = new(true);
 		TreeLayoutEngineWidgetViewModel viewModel =
 			new(mocks.Context.Object, mocks.Monitor.Object) { DirectionValue = direction };
 
@@ -98,7 +101,7 @@ public class TreeLayoutEngineWidgetViewModelTests
 	public void ToggleDirection_WhenDirectionValueIsNull_DoesNothing()
 	{
 		// Given
-		MocksBuilder mocks = new();
+		MocksBuilder mocks = new(false);
 		TreeLayoutEngineWidgetViewModel viewModel = new(mocks.Context.Object, mocks.Monitor.Object);
 
 		// When
@@ -116,7 +119,7 @@ public class TreeLayoutEngineWidgetViewModelTests
 	public void ToggleDirection_WhenDirectionValueIsNotNull_TogglesDirection(Direction initial, Direction expected)
 	{
 		// Given
-		MocksBuilder mocks = new();
+		MocksBuilder mocks = new(true);
 		TreeLayoutEngineWidgetViewModel viewModel =
 			new(mocks.Context.Object, mocks.Monitor.Object) { DirectionValue = initial };
 

--- a/src/Whim.TreeLayout.Bar.Tests/TreeLayoutEngineWidgetViewModelTests.cs
+++ b/src/Whim.TreeLayout.Bar.Tests/TreeLayoutEngineWidgetViewModelTests.cs
@@ -207,7 +207,6 @@ public class TreeLayoutEngineWidgetViewModelTests
 		TreeLayoutEngineWidgetViewModel viewModel = new(mocks.Context.Object, mocks.Monitor.Object);
 
 		// When
-		mocks.WorkspaceManager.Reset();
 		mocks.WorkspaceManager.Raise(
 			x => x.MonitorWorkspaceChanged += null,
 			new MonitorWorkspaceChangedEventArgs()
@@ -219,7 +218,7 @@ public class TreeLayoutEngineWidgetViewModelTests
 		);
 
 		// Then should not have called anything
-		mocks.WorkspaceManager.Verify(x => x.GetWorkspaceForMonitor(It.IsAny<IMonitor>()), Times.Never);
+		mocks.WorkspaceManager.Verify(x => x.GetWorkspaceForMonitor(It.IsAny<IMonitor>()), Times.Once);
 	}
 
 	[Fact]

--- a/src/Whim.TreeLayout.Bar.Tests/TreeLayoutEngineWidgetViewModelTests.cs
+++ b/src/Whim.TreeLayout.Bar.Tests/TreeLayoutEngineWidgetViewModelTests.cs
@@ -148,13 +148,15 @@ public class TreeLayoutEngineWidgetViewModelTests
 		// Given
 		MocksBuilder mocks = new(true);
 		mocks.TreeLayoutEngine.Setup(t => t.GetLayoutEngine<ITreeLayoutEngine>()).Returns((ITreeLayoutEngine?)null);
-		TreeLayoutEngineWidgetViewModel viewModel = new(mocks.Context.Object, mocks.Monitor.Object);
+		TreeLayoutEngineWidgetViewModel viewModel =
+			new(mocks.Context.Object, mocks.Monitor.Object) { DirectionValue = Direction.Left };
 
 		// When
 		viewModel.ToggleDirection();
 
 		// Then
 		mocks.TreeLayoutEngine.VerifySet(t => t.AddNodeDirection = It.IsAny<Direction>(), Times.Never);
+		Assert.Null(viewModel.DirectionValue);
 	}
 
 	[Fact]

--- a/src/Whim.TreeLayout.Bar.Tests/TreeLayoutEngineWidgetViewModelTests.cs
+++ b/src/Whim.TreeLayout.Bar.Tests/TreeLayoutEngineWidgetViewModelTests.cs
@@ -158,6 +158,21 @@ public class TreeLayoutEngineWidgetViewModelTests
 	}
 
 	[Fact]
+	public void ToggleDirection_InvalidDirection()
+	{
+		// Given
+		MocksBuilder mocks = new(true);
+		mocks.TreeLayoutEngine.SetupGet(t => t.AddNodeDirection).Returns((Direction)42);
+		TreeLayoutEngineWidgetViewModel viewModel = new(mocks.Context.Object, mocks.Monitor.Object);
+
+		// When
+		viewModel.ToggleDirection();
+
+		// Then
+		mocks.TreeLayoutEngine.VerifySet(t => t.AddNodeDirection = It.IsAny<Direction>(), Times.Never);
+	}
+
+	[Fact]
 	public void WorkspaceManager_MonitorWorkspaceChanged_Success()
 	{
 		// Given

--- a/src/Whim.TreeLayout.Bar.Tests/TreeLayoutEngineWidgetViewModelTests.cs
+++ b/src/Whim.TreeLayout.Bar.Tests/TreeLayoutEngineWidgetViewModelTests.cs
@@ -248,4 +248,18 @@ public class TreeLayoutEngineWidgetViewModelTests
 			Times.Once
 		);
 	}
+
+	[Fact]
+	public void ToggleDirectionCommand()
+	{
+		// Given
+		MocksBuilder mocks = new(true);
+		TreeLayoutEngineWidgetViewModel viewModel = new(mocks.Context.Object, mocks.Monitor.Object);
+
+		// When
+		viewModel.ToggleDirectionCommand.Execute(null);
+
+		// Then
+		mocks.TreeLayoutEngine.VerifySet(t => t.AddNodeDirection = It.IsAny<Direction>(), Times.Once);
+	}
 }

--- a/src/Whim.TreeLayout.Bar.Tests/Whim.TreeLayout.Bar.Tests.csproj
+++ b/src/Whim.TreeLayout.Bar.Tests/Whim.TreeLayout.Bar.Tests.csproj
@@ -1,4 +1,5 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
+
 	<PropertyGroup>
 		<AnalysisModeDesign>All</AnalysisModeDesign>
 		<AnalysisModeDocumentation>All</AnalysisModeDocumentation>
@@ -18,38 +19,34 @@
 		<EnablePreviewMsixTooling>true</EnablePreviewMsixTooling>
 		<EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
 		<GenerateLibraryLayout>true</GenerateLibraryLayout>
+		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<Platforms>x64;arm64;Any CPU</Platforms>
-		<RootNamespace>Whim.TreeLayout.Bar</RootNamespace>
-		<RuntimeIdentifiers>win10-x64;win10-arm64</RuntimeIdentifiers>
 		<TargetFramework>net7.0-windows10.0.19041.0</TargetFramework>
-		<TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
-		<UseWinUI>true</UseWinUI>
 		<Version>0.1.0</Version>
 	</PropertyGroup>
+
 	<ItemGroup>
-		<None Remove="TreeLayoutEngineWidget.xaml" />
+		<PackageReference Include="coverlet.msbuild" Version="3.2.0">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+		<PackageReference Include="coverlet.collector" Version="3.2.0">
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
+		<PackageReference Include="FluentAssertions" Version="6.10.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+		<PackageReference Include="Moq" Version="4.18.4" />
+		<PackageReference Include="xunit" Version="2.4.2" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.WindowsAppSDK" Version="1.2.230313.1" />
-		<PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.756" />
+		<ProjectReference Include="..\Whim.TreeLayout.Bar\Whim.TreeLayout.Bar.csproj" />
 	</ItemGroup>
 
-	<ItemGroup>
-		<ProjectReference Include="..\Whim\Whim.csproj" />
-		<ProjectReference Include="..\Whim.Bar\Whim.Bar.csproj" />
-		<ProjectReference Include="..\Whim.TreeLayout\Whim.TreeLayout.csproj" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<InternalsVisibleTo Include="Whim.TreeLayout.Bar.Tests" />
-		<InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<Page Update="TreeLayoutEngineWidget.xaml">
-			<Generator>MSBuild:Compile</Generator>
-		</Page>
-	</ItemGroup>
 </Project>

--- a/src/Whim.TreeLayout.Bar/TreeLayoutEngineWidgetViewModel.cs
+++ b/src/Whim.TreeLayout.Bar/TreeLayoutEngineWidgetViewModel.cs
@@ -23,14 +23,14 @@ public class TreeLayoutEngineWidgetViewModel : INotifyPropertyChanged, IDisposab
 	/// <summary>
 	/// The string representation of <see cref="DirectionValue"/>.
 	/// </summary>
-	public string? AddNodeDirection => _directionValue.ToString();
+	public string? AddNodeDirection => _directionValue?.ToString();
 
 	/// <summary>
 	/// The direction in which windows will be added. If this is <see langword="null"/>, then the
 	/// monitor for this widget is not focused, or does not have a <see cref="ITreeLayoutEngine"/>
 	/// as the active layout engine.
 	/// </summary>
-	private Direction? DirectionValue
+	internal Direction? DirectionValue
 	{
 		get => _directionValue;
 		set
@@ -87,7 +87,7 @@ public class TreeLayoutEngineWidgetViewModel : INotifyPropertyChanged, IDisposab
 		}
 
 		IWorkspace? workspace = _context.WorkspaceManager.GetWorkspaceForMonitor(_monitor);
-		ITreeLayoutEngine? engine = workspace?.ActiveLayoutEngine.GetLayoutEngine<TreeLayoutEngine>();
+		ITreeLayoutEngine? engine = workspace?.ActiveLayoutEngine.GetLayoutEngine<ITreeLayoutEngine>();
 
 		if (engine is null)
 		{
@@ -109,7 +109,7 @@ public class TreeLayoutEngineWidgetViewModel : INotifyPropertyChanged, IDisposab
 		}
 
 		IWorkspace? workspace = _context.WorkspaceManager.GetWorkspaceForMonitor(_monitor);
-		ITreeLayoutEngine? engine = workspace?.ActiveLayoutEngine.GetLayoutEngine<TreeLayoutEngine>();
+		ITreeLayoutEngine? engine = workspace?.ActiveLayoutEngine.GetLayoutEngine<ITreeLayoutEngine>();
 
 		if (engine is null)
 		{

--- a/src/Whim.TreeLayout.Bar/TreeLayoutEngineWidgetViewModel.cs
+++ b/src/Whim.TreeLayout.Bar/TreeLayoutEngineWidgetViewModel.cs
@@ -63,7 +63,7 @@ public class TreeLayoutEngineWidgetViewModel : INotifyPropertyChanged, IDisposab
 		_context = context;
 		_monitor = monitor;
 		ToggleDirectionCommand = new ToggleDirectionCommand(this);
-		UpdateNodeDirection();
+		UpdateNodeDirection(monitor);
 
 		_context.WorkspaceManager.MonitorWorkspaceChanged += WorkspaceManager_MonitorWorkspaceChanged;
 		_context.WorkspaceManager.ActiveLayoutEngineChanged += WorkspaceManager_ActiveLayoutEngineChanged;
@@ -71,24 +71,23 @@ public class TreeLayoutEngineWidgetViewModel : INotifyPropertyChanged, IDisposab
 
 	private void WorkspaceManager_MonitorWorkspaceChanged(object? sender, MonitorWorkspaceChangedEventArgs e)
 	{
-		UpdateNodeDirection();
+		UpdateNodeDirection(e.Monitor);
 	}
 
 	private void WorkspaceManager_ActiveLayoutEngineChanged(object? sender, ActiveLayoutEngineChangedEventArgs e)
 	{
-		UpdateNodeDirection();
+		UpdateNodeDirection(_context.MonitorManager.FocusedMonitor);
 	}
 
-	private void UpdateNodeDirection()
+	private void UpdateNodeDirection(IMonitor updatedMonitor)
 	{
-		if (_monitor != _context.MonitorManager.FocusedMonitor)
+		if (_monitor != updatedMonitor)
 		{
-			DirectionValue = null;
 			return;
 		}
 
-		ILayoutEngine rootEngine = _context.WorkspaceManager.ActiveWorkspace.ActiveLayoutEngine;
-		ITreeLayoutEngine? engine = rootEngine.GetLayoutEngine<TreeLayoutEngine>();
+		IWorkspace? workspace = _context.WorkspaceManager.GetWorkspaceForMonitor(_monitor);
+		ITreeLayoutEngine? engine = workspace?.ActiveLayoutEngine.GetLayoutEngine<TreeLayoutEngine>();
 
 		if (engine is null)
 		{
@@ -109,8 +108,8 @@ public class TreeLayoutEngineWidgetViewModel : INotifyPropertyChanged, IDisposab
 			return;
 		}
 
-		ILayoutEngine rootEngine = _context.WorkspaceManager.ActiveWorkspace.ActiveLayoutEngine;
-		ITreeLayoutEngine? engine = rootEngine.GetLayoutEngine<TreeLayoutEngine>();
+		IWorkspace? workspace = _context.WorkspaceManager.GetWorkspaceForMonitor(_monitor);
+		ITreeLayoutEngine? engine = workspace?.ActiveLayoutEngine.GetLayoutEngine<TreeLayoutEngine>();
 
 		if (engine is null)
 		{


### PR DESCRIPTION
The `TreeLayoutEngineWidgetViewModel` now updates correctly when receiving events from `WorkspaceManager`. Previously it would only populate on first load if the bar was in the focused monitor. However, we want each bar to show the state for their monitor, not for the active workspace.

To fix this, we are now cognizant of the monitor when receiving updates.