### PR TITLE
Handle workspaces with the same name, in WorkspaceWidget

### DIFF
--- a/Whim.sln
+++ b/Whim.sln
@@ -53,6 +53,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Whim.TreeLayout.CommandPale
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Whim.TestUtils", "src\Whim.TestUtils\Whim.TestUtils.csproj", "{2A977CC1-E11B-4A23-A0AB-CCEB8F42AD9A}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Whim.Bar.Tests", "src\Whim.Bar.Tests\Whim.Bar.Tests.csproj", "{6339FE1D-E9CF-4C71-868A-931CB51D6486}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -283,6 +285,18 @@ Global
 		{2A977CC1-E11B-4A23-A0AB-CCEB8F42AD9A}.Release|arm64.Build.0 = Release|arm64
 		{2A977CC1-E11B-4A23-A0AB-CCEB8F42AD9A}.Release|x64.ActiveCfg = Release|x64
 		{2A977CC1-E11B-4A23-A0AB-CCEB8F42AD9A}.Release|x64.Build.0 = Release|x64
+		{6339FE1D-E9CF-4C71-868A-931CB51D6486}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6339FE1D-E9CF-4C71-868A-931CB51D6486}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6339FE1D-E9CF-4C71-868A-931CB51D6486}.Debug|arm64.ActiveCfg = Debug|arm64
+		{6339FE1D-E9CF-4C71-868A-931CB51D6486}.Debug|arm64.Build.0 = Debug|arm64
+		{6339FE1D-E9CF-4C71-868A-931CB51D6486}.Debug|x64.ActiveCfg = Debug|x64
+		{6339FE1D-E9CF-4C71-868A-931CB51D6486}.Debug|x64.Build.0 = Debug|x64
+		{6339FE1D-E9CF-4C71-868A-931CB51D6486}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6339FE1D-E9CF-4C71-868A-931CB51D6486}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6339FE1D-E9CF-4C71-868A-931CB51D6486}.Release|arm64.ActiveCfg = Release|Any CPU
+		{6339FE1D-E9CF-4C71-868A-931CB51D6486}.Release|arm64.Build.0 = Release|Any CPU
+		{6339FE1D-E9CF-4C71-868A-931CB51D6486}.Release|x64.ActiveCfg = Release|Any CPU
+		{6339FE1D-E9CF-4C71-868A-931CB51D6486}.Release|x64.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Whim.Bar.Tests/ActiveLayout/ActiveLayoutWidgetViewModelTests.cs
+++ b/src/Whim.Bar.Tests/ActiveLayout/ActiveLayoutWidgetViewModelTests.cs
@@ -1,0 +1,91 @@
+using Moq;
+using Xunit;
+
+namespace Whim.Bar.Tests;
+
+[System.Diagnostics.CodeAnalysis.SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope")]
+public class ActiveLayoutWidgetViewModelTests
+{
+	private class Wrapper
+	{
+		public Mock<IContext> Context { get; } = new();
+		public Mock<IWorkspaceManager> WorkspaceManager { get; } = new();
+		public Mock<IWorkspace> Workspace { get; } = new();
+		public Mock<IMonitor> Monitor { get; } = new();
+
+		public Wrapper()
+		{
+			Context.SetupGet(c => c.WorkspaceManager).Returns(WorkspaceManager.Object);
+		}
+	}
+
+	[Fact]
+	public void WorkspaceManager_ActiveLayoutEngineChanged()
+	{
+		// Given
+		Wrapper wrapper = new();
+		ActiveLayoutWidgetViewModel viewModel = new(wrapper.Context.Object, wrapper.Monitor.Object);
+
+		// When
+		// Then
+		Assert.PropertyChanged(
+			viewModel,
+			nameof(viewModel.ActiveLayoutEngine),
+			() =>
+				wrapper.WorkspaceManager.Raise(
+					wm => wm.ActiveLayoutEngineChanged += null,
+					new ActiveLayoutEngineChangedEventArgs()
+					{
+						Workspace = wrapper.Workspace.Object,
+						PreviousLayoutEngine = wrapper.Workspace.Object.ActiveLayoutEngine,
+						CurrentLayoutEngine = wrapper.Workspace.Object.ActiveLayoutEngine
+					}
+				)
+		);
+	}
+
+	[Fact]
+	public void WorkspaceManager_MonitorWorkspaceChanged()
+	{
+		// Given
+		Wrapper wrapper = new();
+		ActiveLayoutWidgetViewModel viewModel = new(wrapper.Context.Object, wrapper.Monitor.Object);
+
+		// When
+		// Then
+		Assert.PropertyChanged(
+			viewModel,
+			nameof(viewModel.ActiveLayoutEngine),
+			() =>
+				wrapper.WorkspaceManager.Raise(
+					wm => wm.MonitorWorkspaceChanged += null,
+					new MonitorWorkspaceChangedEventArgs()
+					{
+						Monitor = wrapper.Monitor.Object,
+						NewWorkspace = wrapper.Workspace.Object
+					}
+				)
+		);
+	}
+
+	[Fact]
+	public void Dispose()
+	{
+		// Given
+		Wrapper wrapper = new();
+		ActiveLayoutWidgetViewModel viewModel = new(wrapper.Context.Object, wrapper.Monitor.Object);
+
+		// When
+		viewModel.Dispose();
+
+		// Then
+		wrapper.WorkspaceManager.VerifyRemove(
+			wm => wm.ActiveLayoutEngineChanged -= It.IsAny<EventHandler<ActiveLayoutEngineChangedEventArgs>>(),
+			Times.Once
+		);
+		wrapper.WorkspaceManager.VerifyRemove(
+			wm => wm.MonitorWorkspaceChanged -= It.IsAny<EventHandler<MonitorWorkspaceChangedEventArgs>>(),
+			Times.Once
+		);
+	}
+}

--- a/src/Whim.Bar.Tests/ActiveLayout/NextLayoutEngineCommandTests.cs
+++ b/src/Whim.Bar.Tests/ActiveLayout/NextLayoutEngineCommandTests.cs
@@ -1,0 +1,53 @@
+using Moq;
+using Xunit;
+
+namespace Whim.Bar.Tests;
+
+[System.Diagnostics.CodeAnalysis.SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope")]
+public class NextLayoutEngineCommandTests
+{
+	private class Wrapper
+	{
+		public Mock<IContext> Context { get; } = new();
+		public Mock<IWorkspaceManager> WorkspaceManager { get; } = new();
+		public Mock<IWorkspace> Workspace { get; } = new();
+		public Mock<IMonitor> Monitor { get; } = new();
+
+		public Wrapper()
+		{
+			Context.SetupGet(c => c.WorkspaceManager).Returns(WorkspaceManager.Object);
+			WorkspaceManager.Setup(wm => wm.GetWorkspaceForMonitor(It.IsAny<IMonitor>())).Returns(Workspace.Object);
+		}
+	}
+
+	[Fact]
+	public void Execute()
+	{
+		// Given
+		Wrapper wrapper = new();
+		ActiveLayoutWidgetViewModel viewModel = new(wrapper.Context.Object, wrapper.Monitor.Object);
+		NextLayoutEngineCommand command = new(wrapper.Context.Object, viewModel);
+
+		// When
+		command.Execute(null);
+
+		// Then
+		wrapper.WorkspaceManager.Verify(wm => wm.GetWorkspaceForMonitor(It.IsAny<IMonitor>()), Times.Once);
+		wrapper.Workspace.Verify(w => w.NextLayoutEngine(), Times.Once);
+	}
+
+	[Fact]
+	public void CanExecute()
+	{
+		// Given
+		Wrapper wrapper = new();
+		ActiveLayoutWidgetViewModel viewModel = new(wrapper.Context.Object, wrapper.Monitor.Object);
+		NextLayoutEngineCommand command = new(wrapper.Context.Object, viewModel);
+
+		// When
+		bool canExecute = command.CanExecute(null);
+
+		// Then
+		Assert.True(canExecute);
+	}
+}

--- a/src/Whim.Bar.Tests/BarConfigTests.cs
+++ b/src/Whim.Bar.Tests/BarConfigTests.cs
@@ -1,0 +1,23 @@
+using Xunit;
+
+namespace Whim.Bar.Tests;
+
+public class BarConfigTests
+{
+	[Fact]
+	public void Height_PropertyChanged()
+	{
+		// Given
+		BarConfig config =
+			new(
+				leftComponents: new List<BarComponent>(),
+				centerComponents: new List<BarComponent>(),
+				rightComponents: new List<BarComponent>()
+			);
+
+		// When
+		// Then
+		Assert.PropertyChanged(config, nameof(config.Height), () => config.Height = 1);
+		Assert.Equal(1, config.Height);
+	}
+}

--- a/src/Whim.Bar.Tests/BarLayoutEngineTests.cs
+++ b/src/Whim.Bar.Tests/BarLayoutEngineTests.cs
@@ -1,0 +1,49 @@
+using Moq;
+using Xunit;
+
+namespace Whim.Bar.Tests;
+
+public class BarLayoutEngineTests
+{
+	[Fact]
+	public void GetLayout()
+	{
+		// Given
+		BarConfig config =
+			new(
+				leftComponents: new List<BarComponent>(),
+				centerComponents: new List<BarComponent>(),
+				rightComponents: new List<BarComponent>()
+			)
+			{
+				Height = 30
+			};
+
+		Mock<ILayoutEngine> layoutEngine = new();
+		Mock<IMonitor> monitor = new();
+		monitor.SetupGet(m => m.ScaleFactor).Returns(100);
+
+		ILocation<int> location = new Location<int>()
+		{
+			X = 0,
+			Y = 0,
+			Width = 1920,
+			Height = 1080
+		};
+
+		BarLayoutEngine engine = new(config, layoutEngine.Object);
+
+		// When
+		IEnumerable<IWindowState> layout = engine.DoLayout(location, monitor.Object);
+
+		// Then
+		ILocation<int> expectedLocation = new Location<int>()
+		{
+			X = 0,
+			Y = 30,
+			Width = 1920,
+			Height = 1050
+		};
+		layoutEngine.Verify(m => m.DoLayout(expectedLocation, monitor.Object), Times.Once);
+	}
+}

--- a/src/Whim.Bar.Tests/Directory.Build.props
+++ b/src/Whim.Bar.Tests/Directory.Build.props
@@ -1,0 +1,5 @@
+<Project>
+	<PropertyGroup>
+		<GenerateDocumentationFile>false</GenerateDocumentationFile>
+	</PropertyGroup>
+</Project>

--- a/src/Whim.Bar.Tests/FocusedWindowWidgetViewModelTests.cs
+++ b/src/Whim.Bar.Tests/FocusedWindowWidgetViewModelTests.cs
@@ -1,0 +1,63 @@
+using Moq;
+using Xunit;
+
+namespace Whim.Bar.Tests;
+
+public class FocusedWindowWidgetViewModelTests
+{
+	private class Wrapper
+	{
+		public Mock<IContext> Context { get; } = new();
+		public Mock<IWorkspaceManager> WorkspaceManager { get; } = new();
+		public Mock<IWindowManager> WindowManager { get; } = new();
+		public Mock<IWorkspace> Workspace { get; } = new();
+		public Mock<IMonitor> Monitor { get; } = new();
+		public FocusedWindowWidgetViewModel ViewModel { get; }
+
+		public Wrapper()
+		{
+			Context.SetupGet(c => c.WorkspaceManager).Returns(WorkspaceManager.Object);
+			Context.SetupGet(c => c.WindowManager).Returns(WindowManager.Object);
+			WorkspaceManager
+				.Setup(wm => wm.GetEnumerator())
+				.Returns(new List<IWorkspace> { Workspace.Object }.GetEnumerator());
+			ViewModel = new FocusedWindowWidgetViewModel(Context.Object);
+		}
+	}
+
+	[Fact]
+	public void Value_PropertyChanged()
+	{
+		// Given
+		Wrapper wrapper = new();
+		FocusedWindowWidgetViewModel viewModel = wrapper.ViewModel;
+
+		// When
+		// Then
+		Assert.PropertyChanged(
+			viewModel,
+			nameof(viewModel.Value),
+			() =>
+			{
+				wrapper.WindowManager.Raise(
+					wm => wm.WindowFocused += null,
+					new WindowEventArgs() { Window = new Mock<IWindow>().Object }
+				);
+			}
+		);
+	}
+
+	[Fact]
+	public void Dispose()
+	{
+		// Given
+		Wrapper wrapper = new();
+		FocusedWindowWidgetViewModel viewModel = wrapper.ViewModel;
+
+		// When
+		viewModel.Dispose();
+
+		// Then
+		wrapper.WindowManager.VerifyRemove(wm => wm.WindowFocused -= It.IsAny<EventHandler<WindowEventArgs>>());
+	}
+}

--- a/src/Whim.Bar.Tests/GlobalSuppressions.cs
+++ b/src/Whim.Bar.Tests/GlobalSuppressions.cs
@@ -1,0 +1,16 @@
+// This file is used by Code Analysis to maintain SuppressMessage
+// attributes that are applied to this project.
+// Project-level suppressions either have no target or are given
+// a specific target and scoped to a namespace, type, member, etc.
+
+using System.Diagnostics.CodeAnalysis;
+
+// The general justification for these suppression messages is that this project contains tests, and it's
+// a bit excessive to have these particular rules for tests.
+[assembly: SuppressMessage("Design", "CA1014:Mark assemblies with CLSCompliantAttribute")]
+[assembly: SuppressMessage("Design", "CA1062:Validate arguments of public methods")]
+[assembly: SuppressMessage("Naming", "CA1707:Identifiers should not contain underscores")]
+[assembly: SuppressMessage("Style", "IDE0008:Use explicit type")]
+[assembly: SuppressMessage("Style", "IDE0042:Variable declaration can be deconstructed")]
+[assembly: SuppressMessage("Style", "IDE0058:Expression value is never used")]
+[assembly: SuppressMessage("Style", "IDE0022:Use expression body for methods")]

--- a/src/Whim.Bar.Tests/Text/TextWidgetViewModelTests.cs
+++ b/src/Whim.Bar.Tests/Text/TextWidgetViewModelTests.cs
@@ -1,0 +1,28 @@
+using Xunit;
+
+namespace Whim.Bar.Tests;
+
+public class TextWidgetViewModelTests
+{
+	[Fact]
+	public void Value_PropertyChanged_Null()
+	{
+		// Given
+		TextWidgetViewModel viewModel = new(null);
+
+		// When
+		// Then
+		Assert.PropertyChanged(viewModel, nameof(viewModel.Value), () => viewModel.Value = "test");
+	}
+
+	[Fact]
+	public void Value_PropertyChanged()
+	{
+		// Given
+		TextWidgetViewModel viewModel = new("test");
+
+		// When
+		// Then
+		Assert.PropertyChanged(viewModel, nameof(viewModel.Value), () => viewModel.Value = "test2");
+	}
+}

--- a/src/Whim.Bar.Tests/Text/TextWidgetViewModelTests.cs
+++ b/src/Whim.Bar.Tests/Text/TextWidgetViewModelTests.cs
@@ -13,6 +13,7 @@ public class TextWidgetViewModelTests
 		// When
 		// Then
 		Assert.PropertyChanged(viewModel, nameof(viewModel.Value), () => viewModel.Value = "test");
+		Assert.Equal("test", viewModel.Value);
 	}
 
 	[Fact]
@@ -24,5 +25,6 @@ public class TextWidgetViewModelTests
 		// When
 		// Then
 		Assert.PropertyChanged(viewModel, nameof(viewModel.Value), () => viewModel.Value = "test2");
+		Assert.Equal("test2", viewModel.Value);
 	}
 }

--- a/src/Whim.Bar.Tests/Whim.Bar.Tests.csproj
+++ b/src/Whim.Bar.Tests/Whim.Bar.Tests.csproj
@@ -1,4 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
+
 	<PropertyGroup>
 		<AnalysisModeDesign>All</AnalysisModeDesign>
 		<AnalysisModeDocumentation>All</AnalysisModeDocumentation>
@@ -18,35 +19,34 @@
 		<EnablePreviewMsixTooling>true</EnablePreviewMsixTooling>
 		<EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
 		<GenerateLibraryLayout>true</GenerateLibraryLayout>
+		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<Platforms>x64;arm64;Any CPU</Platforms>
-		<RootNamespace>Whim.Bar</RootNamespace>
-		<RuntimeIdentifiers>win10-x64;win10-arm64</RuntimeIdentifiers>
 		<TargetFramework>net7.0-windows10.0.19041.0</TargetFramework>
-		<TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
-		<UseWinUI>true</UseWinUI>
 		<Version>0.1.0</Version>
 	</PropertyGroup>
+
 	<ItemGroup>
-		<None Remove="BarWindow.xaml" />
+		<PackageReference Include="coverlet.msbuild" Version="6.0.0">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+		<PackageReference Include="coverlet.collector" Version="6.0.0">
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
+		<PackageReference Include="FluentAssertions" Version="6.11.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
+		<PackageReference Include="Moq" Version="4.18.4" />
+		<PackageReference Include="xunit" Version="2.4.2" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.WindowsAppSDK" Version="1.3.230502000" />
-		<PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.756" />
-	</ItemGroup>
-	<ItemGroup>
-		<ProjectReference Include="..\Whim\Whim.csproj" />
+		<ProjectReference Include="..\Whim.Bar\Whim.Bar.csproj" />
 	</ItemGroup>
 
-	<ItemGroup>
-		<Page Update="BarWindow.xaml">
-			<Generator>MSBuild:Compile</Generator>
-		</Page>
-	</ItemGroup>
-
-	<ItemGroup>
-		<InternalsVisibleTo Include="Whim.Bar.Tests" />
-		<InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
-	</ItemGroup>
 </Project>

--- a/src/Whim.Bar.Tests/Workspace/SwitchWorkspaceCommandTests.cs
+++ b/src/Whim.Bar.Tests/Workspace/SwitchWorkspaceCommandTests.cs
@@ -1,0 +1,13 @@
+using Moq;
+using Xunit;
+
+namespace Whim.Bar.Tests;
+
+public class SwitchWorkspaceCommandTests
+{
+	[Fact]
+	public void Placeholder()
+	{
+		throw new NotImplementedException();
+	}
+}

--- a/src/Whim.Bar.Tests/Workspace/SwitchWorkspaceCommandTests.cs
+++ b/src/Whim.Bar.Tests/Workspace/SwitchWorkspaceCommandTests.cs
@@ -3,11 +3,93 @@ using Xunit;
 
 namespace Whim.Bar.Tests;
 
+[System.Diagnostics.CodeAnalysis.SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope")]
 public class SwitchWorkspaceCommandTests
 {
-	[Fact]
-	public void Placeholder()
+	private class Wrapper
 	{
-		throw new NotImplementedException();
+		public Mock<IContext> Context { get; } = new();
+		public Mock<IWorkspaceManager> WorkspaceManager { get; } = new();
+		public Mock<IWorkspace> Workspace { get; } = new();
+		public Mock<IMonitor> Monitor { get; } = new();
+		public WorkspaceWidgetViewModel ViewModel { get; }
+		public WorkspaceModel Model { get; }
+
+		public Wrapper()
+		{
+			Context.SetupGet(c => c.WorkspaceManager).Returns(WorkspaceManager.Object);
+			WorkspaceManager
+				.Setup(wm => wm.GetEnumerator())
+				.Returns(new List<IWorkspace> { Workspace.Object }.GetEnumerator());
+			ViewModel = new WorkspaceWidgetViewModel(Context.Object, Monitor.Object);
+			Model = new WorkspaceModel(Context.Object, ViewModel, Workspace.Object, true);
+		}
+	}
+
+	[Fact]
+	public void Workspace_PropertyChanged()
+	{
+		// Given
+		Wrapper wrapper = new();
+		SwitchWorkspaceCommand command = new(wrapper.Context.Object, wrapper.ViewModel, wrapper.Model);
+
+		// When
+		// Then
+		Assert.Raises<EventArgs>(
+			h => command.CanExecuteChanged += new EventHandler(h),
+			h => command.CanExecuteChanged -= new EventHandler(h),
+			() => wrapper.Model.ActiveOnMonitor = true
+		);
+	}
+
+	[Fact]
+	public void Execute_InvalidObject()
+	{
+		// Given
+		Wrapper wrapper = new();
+		SwitchWorkspaceCommand command = new(wrapper.Context.Object, wrapper.ViewModel, wrapper.Model);
+
+		// When
+		command.Execute(null);
+
+		// Then
+		wrapper.WorkspaceManager.Verify(
+			wm => wm.Activate(wrapper.Workspace.Object, wrapper.ViewModel.Monitor),
+			Times.Never
+		);
+	}
+
+	[Fact]
+	public void Execute_ValidObject()
+	{
+		// Given
+		Wrapper wrapper = new();
+		SwitchWorkspaceCommand command = new(wrapper.Context.Object, wrapper.ViewModel, wrapper.Model);
+
+		// When
+		command.Execute(wrapper.Model);
+
+		// Then
+		wrapper.WorkspaceManager.Verify(
+			wm => wm.Activate(wrapper.Workspace.Object, wrapper.ViewModel.Monitor),
+			Times.Once
+		);
+	}
+
+	[Fact]
+	public void Dispose()
+	{
+		// Given
+		Wrapper wrapper = new();
+		SwitchWorkspaceCommand command = new(wrapper.Context.Object, wrapper.ViewModel, wrapper.Model);
+
+		// When
+		command.Dispose();
+
+		// Then
+		wrapper.WorkspaceManager.Verify(
+			wm => wm.Activate(wrapper.Workspace.Object, wrapper.ViewModel.Monitor),
+			Times.Never
+		);
 	}
 }

--- a/src/Whim.Bar.Tests/Workspace/WorkspaceModelTests.cs
+++ b/src/Whim.Bar.Tests/Workspace/WorkspaceModelTests.cs
@@ -19,6 +19,7 @@ public class WorkspaceModelTests
 				.Setup(wm => wm.GetEnumerator())
 				.Returns(new List<IWorkspace> { Workspace.Object }.GetEnumerator());
 			ViewModel = new WorkspaceWidgetViewModel(Context.Object, new Mock<IMonitor>().Object);
+			Workspace.SetupGet(w => w.Name).Returns("name");
 		}
 	}
 
@@ -49,6 +50,7 @@ public class WorkspaceModelTests
 
 		// When
 		// Then
+		Assert.Equal(model.Name, wrapper.Workspace.Object.Name);
 		Assert.PropertyChanged(
 			model,
 			nameof(model.Name),

--- a/src/Whim.Bar.Tests/Workspace/WorkspaceModelTests.cs
+++ b/src/Whim.Bar.Tests/Workspace/WorkspaceModelTests.cs
@@ -1,0 +1,67 @@
+using Moq;
+using Xunit;
+
+namespace Whim.Bar.Tests;
+
+public class WorkspaceModelTests
+{
+	private class Wrapper
+	{
+		public Mock<IContext> Context { get; } = new();
+		public Mock<IWorkspaceManager> WorkspaceManager { get; } = new();
+		public Mock<IWorkspace> Workspace { get; } = new();
+		public WorkspaceWidgetViewModel ViewModel { get; }
+
+		public Wrapper()
+		{
+			Context.SetupGet(c => c.WorkspaceManager).Returns(WorkspaceManager.Object);
+			WorkspaceManager
+				.Setup(wm => wm.GetEnumerator())
+				.Returns(new List<IWorkspace> { Workspace.Object }.GetEnumerator());
+			ViewModel = new WorkspaceWidgetViewModel(Context.Object, new Mock<IMonitor>().Object);
+		}
+	}
+
+	[InlineData(true)]
+	[InlineData(false)]
+	[Theory]
+	public void ActiveOnMonitor(bool activeOnMonitor)
+	{
+		// Given
+		Wrapper wrapper = new();
+		WorkspaceModel model =
+			new(wrapper.Context.Object, wrapper.ViewModel, wrapper.Workspace.Object, activeOnMonitor);
+
+		// When
+		Assert.PropertyChanged(model, nameof(model.ActiveOnMonitor), () => model.ActiveOnMonitor = !activeOnMonitor);
+
+		// Then
+		Assert.Equal(!activeOnMonitor, model.ActiveOnMonitor);
+	}
+
+	[Fact]
+	public void Workspace_Renamed()
+	{
+		// Given
+		Wrapper wrapper = new();
+		WorkspaceModel model = new(wrapper.Context.Object, wrapper.ViewModel, wrapper.Workspace.Object, true);
+		string newName = "new name";
+
+		// When
+		// Then
+		Assert.PropertyChanged(
+			model,
+			nameof(model.Name),
+			() =>
+				model.Workspace_Renamed(
+					wrapper.Workspace.Object,
+					new WorkspaceRenamedEventArgs()
+					{
+						PreviousName = wrapper.Workspace.Object.Name,
+						CurrentName = newName,
+						Workspace = wrapper.Workspace.Object
+					}
+				)
+		);
+	}
+}

--- a/src/Whim.Bar.Tests/Workspace/WorkspaceWidgetViewModelTests.cs
+++ b/src/Whim.Bar.Tests/Workspace/WorkspaceWidgetViewModelTests.cs
@@ -1,0 +1,186 @@
+using Moq;
+using Xunit;
+
+namespace Whim.Bar.Tests;
+
+[System.Diagnostics.CodeAnalysis.SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope")]
+public class WorkspaceWidgetViewModelTests
+{
+	private class Wrapper
+	{
+		public Mock<IContext> Context { get; } = new();
+		public Mock<IWorkspaceManager> WorkspaceManager { get; } = new();
+		public Mock<IWorkspace> Workspace { get; } = new();
+		public Mock<IMonitor> Monitor { get; } = new();
+
+		public Wrapper()
+		{
+			Context.SetupGet(c => c.WorkspaceManager).Returns(WorkspaceManager.Object);
+			WorkspaceManager
+				.Setup(wm => wm.GetEnumerator())
+				.Returns(new List<IWorkspace> { Workspace.Object }.GetEnumerator());
+			WorkspaceManager.Setup(wm => wm.GetMonitorForWorkspace(Workspace.Object)).Returns(Monitor.Object);
+		}
+	}
+
+	[Fact]
+	public void WorkspaceManager_WorkspaceAdded_AlreadyExists()
+	{
+		// Given
+		Wrapper wrapper = new();
+		WorkspaceWidgetViewModel viewModel = new(wrapper.Context.Object, wrapper.Monitor.Object);
+
+		// When
+		wrapper.WorkspaceManager.Raise(
+			wm => wm.WorkspaceAdded += null,
+			new WorkspaceEventArgs() { Workspace = wrapper.Workspace.Object }
+		);
+
+		// Then
+		Assert.Single(viewModel.Workspaces);
+		Assert.Equal(wrapper.Workspace.Object, viewModel.Workspaces[0].Workspace);
+		wrapper.WorkspaceManager.Verify(wm => wm.GetMonitorForWorkspace(wrapper.Workspace.Object), Times.Once);
+	}
+
+	[Fact]
+	public void WorkspaceManager_WorkspaceAdded()
+	{
+		// Given
+		Wrapper wrapper = new();
+		WorkspaceWidgetViewModel viewModel = new(wrapper.Context.Object, wrapper.Monitor.Object);
+		Mock<IWorkspace> addedWorkspace = new();
+
+		// When
+		wrapper.WorkspaceManager.Raise(
+			wm => wm.WorkspaceAdded += null,
+			new WorkspaceEventArgs() { Workspace = addedWorkspace.Object }
+		);
+
+		// Then
+		Assert.Equal(2, viewModel.Workspaces.Count);
+		wrapper.WorkspaceManager.Verify(wm => wm.GetMonitorForWorkspace(wrapper.Workspace.Object), Times.Once);
+		wrapper.WorkspaceManager.Verify(wm => wm.GetMonitorForWorkspace(addedWorkspace.Object), Times.Once);
+	}
+
+	[Fact]
+	public void WorkspaceManager_WorkspaceRemoved()
+	{
+		// Given
+		Wrapper wrapper = new();
+		WorkspaceWidgetViewModel viewModel = new(wrapper.Context.Object, wrapper.Monitor.Object);
+
+		// When
+		wrapper.WorkspaceManager.Raise(
+			wm => wm.WorkspaceRemoved += null,
+			new WorkspaceEventArgs() { Workspace = wrapper.Workspace.Object }
+		);
+
+		// Then
+		Assert.Empty(viewModel.Workspaces);
+	}
+
+	[Fact]
+	public void WorkspaceManager_WorkspaceRemoved_DoesNotExist()
+	{
+		// Given
+		Wrapper wrapper = new();
+		WorkspaceWidgetViewModel viewModel = new(wrapper.Context.Object, wrapper.Monitor.Object);
+		Mock<IWorkspace> removedWorkspace = new();
+
+		// When
+		wrapper.WorkspaceManager.Raise(
+			wm => wm.WorkspaceRemoved += null,
+			new WorkspaceEventArgs() { Workspace = removedWorkspace.Object }
+		);
+
+		// Then
+		Assert.Single(viewModel.Workspaces);
+		Assert.Equal(wrapper.Workspace.Object, viewModel.Workspaces[0].Workspace);
+	}
+
+	[Fact]
+	public void WorkspaceManager_MonitorWorkspaceChanged_Deactivate()
+	{
+		// Given
+		Wrapper wrapper = new();
+		WorkspaceWidgetViewModel viewModel = new(wrapper.Context.Object, wrapper.Monitor.Object);
+
+		// When
+		wrapper.WorkspaceManager.Raise(
+			wm => wm.MonitorWorkspaceChanged += null,
+			new MonitorWorkspaceChangedEventArgs()
+			{
+				Monitor = wrapper.Monitor.Object,
+				OldWorkspace = wrapper.Workspace.Object,
+				NewWorkspace = new Mock<IWorkspace>().Object
+			}
+		);
+
+		// Then
+		WorkspaceModel model = viewModel.Workspaces[0];
+		Assert.False(model.ActiveOnMonitor);
+	}
+
+	[Fact]
+	public void WorkspaceManager_MonitorWorkspaceChanged_Activate()
+	{
+		// Given
+		Wrapper wrapper = new();
+		WorkspaceWidgetViewModel viewModel = new(wrapper.Context.Object, wrapper.Monitor.Object);
+
+		// Add workspace
+		Mock<IWorkspace> addedWorkspace = new();
+		wrapper.WorkspaceManager.Raise(
+			wm => wm.WorkspaceAdded += null,
+			new WorkspaceEventArgs() { Workspace = addedWorkspace.Object }
+		);
+
+		// Verify that the correct workspace is active on the monitor
+		WorkspaceModel existingModel = viewModel.Workspaces[0];
+		WorkspaceModel addedWorkspaceModel = viewModel.Workspaces[1];
+		Assert.True(existingModel.ActiveOnMonitor);
+		Assert.False(addedWorkspaceModel.ActiveOnMonitor);
+
+		// When
+		wrapper.WorkspaceManager.Raise(
+			wm => wm.MonitorWorkspaceChanged += null,
+			new MonitorWorkspaceChangedEventArgs()
+			{
+				Monitor = wrapper.Monitor.Object,
+				OldWorkspace = existingModel.Workspace,
+				NewWorkspace = addedWorkspaceModel.Workspace
+			}
+		);
+
+		// Then
+		Assert.False(existingModel.ActiveOnMonitor);
+		Assert.True(addedWorkspaceModel.ActiveOnMonitor);
+	}
+
+	[Fact]
+	public void WorkspaceManager_WorkspaceRenamed_ExistingWorkspace()
+	{
+		// Given
+		Wrapper wrapper = new();
+		WorkspaceWidgetViewModel viewModel = new(wrapper.Context.Object, wrapper.Monitor.Object);
+
+		// When
+		// Then
+		Assert.PropertyChanged(
+			viewModel.Workspaces[0],
+			nameof(WorkspaceModel.Name),
+			() =>
+			{
+				wrapper.WorkspaceManager.Raise(
+					wm => wm.WorkspaceRenamed += null,
+					new WorkspaceRenamedEventArgs()
+					{
+						Workspace = wrapper.Workspace.Object,
+						PreviousName = "Old Name",
+						CurrentName = "New Name"
+					}
+				);
+			}
+		);
+	}
+}

--- a/src/Whim.Bar/FocusedWindow/FocusedWindowWidgetViewModel.cs
+++ b/src/Whim.Bar/FocusedWindow/FocusedWindowWidgetViewModel.cs
@@ -30,7 +30,7 @@ public class FocusedWindowWidgetViewModel : INotifyPropertyChanged, IDisposable
 	public event PropertyChangedEventHandler? PropertyChanged;
 
 	/// <inheritdoc/>
-	protected virtual void OnPropertyChanged(string propertyName)
+	protected virtual void OnPropertyChanged(string propertyName) =>
 	{
 		PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
 	}

--- a/src/Whim.Bar/FocusedWindow/FocusedWindowWidgetViewModel.cs
+++ b/src/Whim.Bar/FocusedWindow/FocusedWindowWidgetViewModel.cs
@@ -31,9 +31,7 @@ public class FocusedWindowWidgetViewModel : INotifyPropertyChanged, IDisposable
 
 	/// <inheritdoc/>
 	protected virtual void OnPropertyChanged(string propertyName) =>
-	{
 		PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
-	}
 
 	/// <inheritdoc/>
 	protected virtual void Dispose(bool disposing)

--- a/src/Whim.Bar/Text/TextWidgetViewModel.cs
+++ b/src/Whim.Bar/Text/TextWidgetViewModel.cs
@@ -25,15 +25,6 @@ public class TextWidgetViewModel : INotifyPropertyChanged
 		}
 	}
 
-	/// <inheritdoc/>
-	public event PropertyChangedEventHandler? PropertyChanged;
-
-	/// <inheritdoc/>
-	protected virtual void OnPropertyChanged(string propertyName)
-	{
-		PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
-	}
-
 	/// <summary>
 	/// Creates a new instance of <see cref="TextWidgetViewModel"/> with the given text.
 	/// </summary>
@@ -41,5 +32,14 @@ public class TextWidgetViewModel : INotifyPropertyChanged
 	public TextWidgetViewModel(string? value)
 	{
 		_value = value ?? string.Empty;
+	}
+
+	/// <inheritdoc/>
+	public event PropertyChangedEventHandler? PropertyChanged;
+
+	/// <inheritdoc/>
+	protected virtual void OnPropertyChanged(string propertyName)
+	{
+		PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
 	}
 }

--- a/src/Whim.Bar/Workspace/WorkspaceWidgetViewModel.cs
+++ b/src/Whim.Bar/Workspace/WorkspaceWidgetViewModel.cs
@@ -56,7 +56,7 @@ public class WorkspaceWidgetViewModel : INotifyPropertyChanged, IDisposable
 
 	private void WorkspaceManager_WorkspaceAdded(object? sender, WorkspaceEventArgs args)
 	{
-		if (Workspaces.Any(w => w.Name == args.Workspace.Name))
+		if (Workspaces.Any(model => model.Workspace == args.Workspace))
 		{
 			return;
 		}
@@ -67,13 +67,13 @@ public class WorkspaceWidgetViewModel : INotifyPropertyChanged, IDisposable
 
 	private void WorkspaceManager_WorkspaceRemoved(object? sender, WorkspaceEventArgs args)
 	{
-		WorkspaceModel? workspace = Workspaces.FirstOrDefault(w => w.Name == args.Workspace.Name);
-		if (workspace == null)
+		WorkspaceModel? workspaceModel = Workspaces.FirstOrDefault(model => model.Workspace == args.Workspace);
+		if (workspaceModel == null)
 		{
 			return;
 		}
 
-		Workspaces.Remove(workspace);
+		Workspaces.Remove(workspaceModel);
 	}
 
 	private void WorkspaceManager_MonitorWorkspaceChanged(object? sender, MonitorWorkspaceChangedEventArgs args)
@@ -83,19 +83,23 @@ public class WorkspaceWidgetViewModel : INotifyPropertyChanged, IDisposable
 			return;
 		}
 
+		// Set the old workspace's model to not be active on the monitor
 		if (args.OldWorkspace != null)
 		{
-			WorkspaceModel? oldWorkspace = Workspaces.FirstOrDefault(model => model.Workspace == args.OldWorkspace);
-			if (oldWorkspace != null)
+			WorkspaceModel? oldWorkspaceModel = Workspaces.FirstOrDefault(
+				model => model.Workspace == args.OldWorkspace
+			);
+			if (oldWorkspaceModel != null)
 			{
-				oldWorkspace.ActiveOnMonitor = false;
+				oldWorkspaceModel.ActiveOnMonitor = false;
 			}
 		}
 
-		WorkspaceModel? newWorkspace = Workspaces.FirstOrDefault(model => model.Workspace == args.NewWorkspace);
-		if (newWorkspace != null)
+		// Set the new workspace's model to be active on the monitor
+		WorkspaceModel? newWorkspaceModel = Workspaces.FirstOrDefault(model => model.Workspace == args.NewWorkspace);
+		if (newWorkspaceModel != null)
 		{
-			newWorkspace.ActiveOnMonitor = true;
+			newWorkspaceModel.ActiveOnMonitor = true;
 		}
 	}
 

--- a/src/Whim.Bar/Workspace/WorkspaceWidgetViewModel.cs
+++ b/src/Whim.Bar/Workspace/WorkspaceWidgetViewModel.cs
@@ -85,14 +85,14 @@ public class WorkspaceWidgetViewModel : INotifyPropertyChanged, IDisposable
 
 		if (args.OldWorkspace != null)
 		{
-			WorkspaceModel? oldWorkspace = Workspaces.FirstOrDefault(w => w.Name == args.OldWorkspace.Name);
+			WorkspaceModel? oldWorkspace = Workspaces.FirstOrDefault(model => model.Workspace == args.OldWorkspace);
 			if (oldWorkspace != null)
 			{
 				oldWorkspace.ActiveOnMonitor = false;
 			}
 		}
 
-		WorkspaceModel? newWorkspace = Workspaces.FirstOrDefault(w => w.Name == args.NewWorkspace.Name);
+		WorkspaceModel? newWorkspace = Workspaces.FirstOrDefault(model => model.Workspace == args.NewWorkspace);
 		if (newWorkspace != null)
 		{
 			newWorkspace.ActiveOnMonitor = true;


### PR DESCRIPTION
We now compare by workspace identity, not workspace name. Additionally, tests were added for `Whim.Bar`. As a result, some dead code was removed from `ActiveLayoutWidgetViewModel`.