### PR TITLE
User-defined commands use the protected `whim.custom` prefix

### DIFF
--- a/src/Whim.Tests/Commands/CommandManagerTests.cs
+++ b/src/Whim.Tests/Commands/CommandManagerTests.cs
@@ -9,93 +9,54 @@ namespace Whim.Tests;
 public class CommandManagerTests
 {
 	[Fact]
-	public void Add_Success()
+	public void AddPluginCommand_Success()
 	{
 		// Given
 		Mock<ICommand> command = new();
 		command.SetupGet(c => c.Id).Returns("command");
-		ICommandManager commandManager = new CommandManager();
+		CommandManager commandManager = new();
 
 		// When
-		commandManager.Add(command.Object);
+		commandManager.AddPluginCommand(command.Object);
 
 		// Then
-		Assert.True(commandManager.Contains(command.Object));
+		Assert.Contains(command.Object, commandManager);
 		Assert.Equal(command.Object, commandManager.TryGetCommand(command.Object.Id));
 		Assert.Single(commandManager);
 	}
 
 	[Fact]
-	public void Add_AlreadyContainsCommand()
+	public void AddPluginCommand_AlreadyContainsCommand()
 	{
 		// Given
 		Mock<ICommand> command = new();
 		command.SetupGet(c => c.Id).Returns("command");
-		ICommandManager commandManager = new CommandManager();
+		CommandManager commandManager = new();
 
 		// When
-		commandManager.Add(command.Object);
-		Assert.Throws<InvalidOperationException>(() => commandManager.Add(command.Object));
+		commandManager.AddPluginCommand(command.Object);
+		Assert.Throws<InvalidOperationException>(() => commandManager.AddPluginCommand(command.Object));
 
 		// Then
-		Assert.True(commandManager.Contains(command.Object));
+		Assert.Contains(command.Object, commandManager);
 		Assert.Equal(command.Object, commandManager.TryGetCommand(command.Object.Id));
 		Assert.Single(commandManager);
 	}
 
 	[Fact]
-	public void Clear()
+	public void Add()
 	{
 		// Given
-		Mock<ICommand> command = new();
-		command.SetupGet(c => c.Id).Returns("command");
-		ICommandManager commandManager = new CommandManager();
+		CommandManager commandManager = new();
 
 		// When
-		commandManager.Add(command.Object);
-		commandManager.Clear();
+		commandManager.Add("command", "title", () => { });
 
 		// Then
-		Assert.False(commandManager.Contains(command.Object));
-		Assert.Null(commandManager.TryGetCommand(command.Object.Id));
-		Assert.Empty(commandManager);
-	}
-
-	[Fact]
-	public void Contains()
-	{
-		// Given
-		Mock<ICommand> command = new();
-		command.SetupGet(c => c.Id).Returns("command");
-
-		Mock<ICommand> notAddedCommand = new();
-		notAddedCommand.SetupGet(c => c.Id).Returns("notAddedCommand");
-
-		ICommandManager commandManager = new CommandManager();
-
-		// When
-		commandManager.Add(command.Object);
-
-		// Then
-		Assert.True(commandManager.Contains(command.Object));
-		Assert.False(commandManager.Contains(notAddedCommand.Object));
-	}
-
-	[Fact]
-	public void CopyTo()
-	{
-		// Given
-		Mock<ICommand> command = new();
-		command.SetupGet(c => c.Id).Returns("command");
-		ICommandManager commandManager = new CommandManager();
-
-		// When
-		commandManager.Add(command.Object);
-		ICommand[] commands = new ICommand[1];
-		commandManager.CopyTo(commands, 0);
-
-		// Then
-		Assert.Equal(command.Object, commands[0]);
+		ICommand? command = commandManager.TryGetCommand("whim.custom.command");
+		Assert.NotNull(command);
+		Assert.Equal("whim.custom.command", command!.Id);
+		Assert.Equal("title", command.Title);
 	}
 
 	[Fact]
@@ -104,61 +65,14 @@ public class CommandManagerTests
 		// Given
 		Mock<ICommand> command = new();
 		command.SetupGet(c => c.Id).Returns("command");
-		ICommandManager commandManager = new CommandManager();
+		CommandManager commandManager = new();
 
 		// When
-		commandManager.Add(command.Object);
+		commandManager.AddPluginCommand(command.Object);
 
 		// Then
 		List<ICommand> allCommands = commandManager.ToList();
 		Assert.Single(allCommands);
 		Assert.Equal(command.Object, allCommands[0]);
-	}
-
-	[Fact]
-	public void Remove_DoesNotContainCommand()
-	{
-		// Given
-		Mock<ICommand> command = new();
-		command.SetupGet(c => c.Id).Returns("command");
-		ICommandManager commandManager = new CommandManager();
-
-		// When
-		bool result = commandManager.Remove(command.Object);
-
-		// Then
-		Assert.False(result);
-	}
-
-	[Fact]
-	public void Remove_ContainsCommand()
-	{
-		// Given
-		Mock<ICommand> command = new();
-		command.SetupGet(c => c.Id).Returns("command");
-		ICommandManager commandManager = new CommandManager();
-
-		// When
-		commandManager.Add(command.Object);
-		bool result = commandManager.Remove(command.Object);
-
-		// Then
-		Assert.True(result);
-		Assert.False(commandManager.Contains(command.Object));
-		Assert.Null(commandManager.TryGetCommand(command.Object.Id));
-		Assert.Empty(commandManager);
-	}
-
-	[Fact]
-	public void IsReadOnly()
-	{
-		// Given
-		ICommandManager commandManager = new CommandManager();
-
-		// When
-		bool result = commandManager.IsReadOnly;
-
-		// Then
-		Assert.False(result);
 	}
 }

--- a/src/Whim.Tests/Layout/BaseStackLayoutEngineTests.cs
+++ b/src/Whim.Tests/Layout/BaseStackLayoutEngineTests.cs
@@ -1,0 +1,135 @@
+using Moq;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Whim.Tests;
+
+public class BaseStackLayoutEngineTests
+{
+	private class TestLayoutEngine : BaseStackLayoutEngine
+	{
+		public override string Name => "Test";
+
+		public override void AddWindowAtPoint(IWindow window, IPoint<double> point) =>
+			throw new System.NotImplementedException();
+
+		public override IEnumerable<IWindowState> DoLayout(ILocation<int> location, IMonitor monitor) =>
+			throw new System.NotImplementedException();
+
+		public override void FocusWindowInDirection(Direction direction, IWindow window) =>
+			throw new System.NotImplementedException();
+
+		public override void MoveWindowEdgeInDirection(Direction edge, double delta, IWindow window) =>
+			throw new System.NotImplementedException();
+
+		public override void SwapWindowInDirection(Direction direction, IWindow window) =>
+			throw new System.NotImplementedException();
+	}
+
+	[Fact]
+	public void Add()
+	{
+		// Given
+		TestLayoutEngine engine = new();
+		Mock<IWindow> window = new();
+
+		// When
+		engine.Add(window.Object);
+
+		// Then
+		Assert.Single(engine);
+	}
+
+	[Fact]
+	public void Remove()
+	{
+		// Given
+		TestLayoutEngine engine = new();
+		Mock<IWindow> window = new();
+		engine.Add(window.Object);
+
+		// When
+		bool result = engine.Remove(window.Object);
+
+		// Then
+		Assert.True(result);
+		Assert.Empty(engine);
+	}
+
+	[Fact]
+	public void Clear()
+	{
+		// Given
+		TestLayoutEngine engine = new();
+		Mock<IWindow> window = new();
+		engine.Add(window.Object);
+
+		// When
+		engine.Clear();
+
+		// Then
+		Assert.Empty(engine);
+	}
+
+	[Fact]
+	public void Contains()
+	{
+		// Given
+		TestLayoutEngine engine = new();
+		Mock<IWindow> window = new();
+		engine.Add(window.Object);
+
+		// When
+		bool result = engine.Contains(window.Object);
+
+		// Then
+		Assert.True(result);
+	}
+
+	[Fact]
+	public void CopyTo()
+	{
+		// Given
+		TestLayoutEngine engine = new();
+		Mock<IWindow> window = new();
+		engine.Add(window.Object);
+		IWindow[] array = new IWindow[1];
+
+		// When
+		engine.CopyTo(array, 0);
+
+		// Then
+		Assert.Equal(window.Object, array[0]);
+	}
+
+	[Fact]
+	public void GetEnumerator()
+	{
+		// Given
+		TestLayoutEngine engine = new();
+		Mock<IWindow> window = new();
+		engine.Add(window.Object);
+
+		// When
+		IEnumerator<IWindow> enumerator = engine.GetEnumerator();
+
+		// Then
+		Assert.True(enumerator.MoveNext());
+		Assert.Equal(window.Object, enumerator.Current);
+	}
+
+	[Fact]
+	public void GetFirstWindow()
+	{
+		// Given
+		TestLayoutEngine engine = new();
+		Mock<IWindow> window = new();
+		engine.Add(window.Object);
+
+		// When
+		IWindow? result = engine.GetFirstWindow();
+
+		// Then
+		Assert.Equal(window.Object, result);
+	}
+}

--- a/src/Whim.Tests/Plugin/PluginManagerTests.cs
+++ b/src/Whim.Tests/Plugin/PluginManagerTests.cs
@@ -273,6 +273,23 @@ public class PluginManagerTests
 	}
 
 	[Fact]
+	public void AddPlugin_ReservedName()
+	{
+		// Given
+		MocksWrapper mocks = new();
+
+		mocks.Plugin2.Setup(p => p.Name).Returns("whim.custom");
+
+		PluginManager pluginManager = new(mocks.Context.Object, mocks.FileManager.Object, mocks.CommandManager);
+
+		// When
+		Assert.Throws<InvalidOperationException>(() => pluginManager.AddPlugin(mocks.Plugin2.Object));
+
+		// Then
+		Assert.Equal(0, pluginManager.LoadedPlugins.Count);
+	}
+
+	[Fact]
 	public void Contains()
 	{
 		// Given

--- a/src/Whim.Tests/Plugin/PluginManagerTests.cs
+++ b/src/Whim.Tests/Plugin/PluginManagerTests.cs
@@ -25,9 +25,9 @@ public class PluginManagerTests
 		public Mock<IPlugin> Plugin1 { get; } = new();
 		public Mock<IPlugin> Plugin2 { get; } = new();
 		public Mock<IPlugin> Plugin3 { get; } = new();
-		public PluginCommands PluginCommands1 { get; } = new("Plugin1");
-		public PluginCommands PluginCommands2 { get; } = new("Plugin2");
-		public PluginCommands PluginCommands3 { get; } = new("Plugin3");
+		public PluginCommands PluginCommands1 { get; } = new("whim.plugin1");
+		public PluginCommands PluginCommands2 { get; } = new("whim.plugin2");
+		public PluginCommands PluginCommands3 { get; } = new("whim.plugin3");
 		public string WrittenTextContents { get; private set; } = string.Empty;
 
 		public MocksWrapper()
@@ -41,9 +41,9 @@ public class PluginManagerTests
 				.Setup(fm => fm.WriteAllText(It.IsAny<string>(), It.IsAny<string>()))
 				.Callback<string, string>((filePath, contents) => WrittenTextContents = contents);
 
-			Plugin1.Setup(p => p.Name).Returns("Plugin1");
-			Plugin2.Setup(p => p.Name).Returns("Plugin2");
-			Plugin3.Setup(p => p.Name).Returns("Plugin3");
+			Plugin1.Setup(p => p.Name).Returns("whim.plugin1");
+			Plugin2.Setup(p => p.Name).Returns("whim.plugin2");
+			Plugin3.Setup(p => p.Name).Returns("whim.plugin3");
 
 			Plugin1.Setup(p => p.PluginCommands).Returns(PluginCommands1);
 			Plugin2.Setup(p => p.PluginCommands).Returns(PluginCommands2);
@@ -71,8 +71,8 @@ public class PluginManagerTests
 		private static MemoryStream CreateSavedStateStream()
 		{
 			PluginManagerSavedState savedState = new();
-			savedState.Plugins.Add("Plugin1", JsonSerializer.SerializeToElement(new Dictionary<string, object>()));
-			savedState.Plugins.Add("Plugin2", JsonSerializer.SerializeToElement(new Dictionary<string, object>()));
+			savedState.Plugins.Add("whim.plugin1", JsonSerializer.SerializeToElement(new Dictionary<string, object>()));
+			savedState.Plugins.Add("whim.plugin2", JsonSerializer.SerializeToElement(new Dictionary<string, object>()));
 
 			MemoryStream stream = new();
 			stream.Write(JsonSerializer.SerializeToUtf8Bytes(savedState));
@@ -238,55 +238,59 @@ public class PluginManagerTests
 		// I want to verify that the command passed into Add is equivalent to the one created in the mocks
 		Assert.Equal(4, mocks.CommandManager.Count);
 		List<ICommand> commands = mocks.CommandManager.ToList();
-		Assert.Equal("Plugin1.command1", commands[0].Id);
-		Assert.Equal("Plugin2.command2", commands[1].Id);
-		Assert.Equal("Plugin2.command22", commands[2].Id);
-		Assert.Equal("Plugin3.command3", commands[3].Id);
+		Assert.Equal("whim.plugin1.command1", commands[0].Id);
+		Assert.Equal("whim.plugin2.command2", commands[1].Id);
+		Assert.Equal("whim.plugin2.command22", commands[2].Id);
+		Assert.Equal("whim.plugin3.command3", commands[3].Id);
 
 		mocks.KeybindManager.Verify(km => km.Add(It.IsAny<string>(), It.IsAny<Keybind>()), Times.Exactly(2));
 		mocks.KeybindManager.Verify(
-			km => km.Add("Plugin2.command2", new Keybind(KeyModifiers.LControl, VIRTUAL_KEY.VK_A)),
+			km => km.Add("whim.plugin2.command2", new Keybind(KeyModifiers.LControl, VIRTUAL_KEY.VK_A)),
 			Times.Once
 		);
 		mocks.KeybindManager.Verify(
-			km => km.Add("Plugin3.command3", new Keybind(KeyModifiers.LShift, VIRTUAL_KEY.VK_B)),
+			km => km.Add("whim.plugin3.command3", new Keybind(KeyModifiers.LShift, VIRTUAL_KEY.VK_B)),
 			Times.Once
 		);
 	}
 
-	[Fact]
-	public void AddPlugin_DuplicateName()
+	[InlineData("whim.plugin1", "Plugin with name 'whim.plugin1' already exists.")]
+	[InlineData("whim.custom", "Name 'whim.custom' is reserved for user-defined commands.")]
+	[InlineData("whim", "Name 'whim' is reserved for internal use.")]
+	[InlineData("", "Plugin name cannot be empty.")]
+	[InlineData(
+		"Hello world",
+		"Plugin name must be in the format [first](.[second])*. For more, see the regex in PluginManager.cs."
+	)]
+	[InlineData(
+		"whim.name.",
+		"Plugin name must be in the format [first](.[second])*. For more, see the regex in PluginManager.cs."
+	)]
+	[InlineData(
+		"whim.name..",
+		"Plugin name must be in the format [first](.[second])*. For more, see the regex in PluginManager.cs."
+	)]
+	[InlineData(
+		"whim..name",
+		"Plugin name must be in the format [first](.[second])*. For more, see the regex in PluginManager.cs."
+	)]
+	[Theory]
+	public void AddPlugin_InvalidName(string name, string expectedMessage)
 	{
 		// Given
 		MocksWrapper mocks = new();
 
-		mocks.Plugin2.Setup(p => p.Name).Returns("Plugin1");
+		mocks.Plugin2.Setup(p => p.Name).Returns(name);
 
 		PluginManager pluginManager = new(mocks.Context.Object, mocks.FileManager.Object, mocks.CommandManager);
 
 		// When
 		pluginManager.AddPlugin(mocks.Plugin1.Object);
-		Assert.Throws<InvalidOperationException>(() => pluginManager.AddPlugin(mocks.Plugin2.Object));
+		Exception ex = Assert.Throws<InvalidOperationException>(() => pluginManager.AddPlugin(mocks.Plugin2.Object));
 
 		// Then
+		Assert.Equal(expectedMessage, ex.Message);
 		Assert.Equal(1, pluginManager.LoadedPlugins.Count);
-	}
-
-	[Fact]
-	public void AddPlugin_ReservedName()
-	{
-		// Given
-		MocksWrapper mocks = new();
-
-		mocks.Plugin2.Setup(p => p.Name).Returns("whim.custom");
-
-		PluginManager pluginManager = new(mocks.Context.Object, mocks.FileManager.Object, mocks.CommandManager);
-
-		// When
-		Assert.Throws<InvalidOperationException>(() => pluginManager.AddPlugin(mocks.Plugin2.Object));
-
-		// Then
-		Assert.Equal(0, pluginManager.LoadedPlugins.Count);
 	}
 
 	[Fact]
@@ -301,10 +305,10 @@ public class PluginManagerTests
 		pluginManager.AddPlugin(mocks.Plugin3.Object);
 
 		// When
-		bool contains1 = pluginManager.Contains("Plugin1");
-		bool contains2 = pluginManager.Contains("Plugin2");
-		bool contains3 = pluginManager.Contains("Plugin3");
-		bool contains4 = pluginManager.Contains("Plugin4");
+		bool contains1 = pluginManager.Contains("whim.plugin1");
+		bool contains2 = pluginManager.Contains("whim.plugin2");
+		bool contains3 = pluginManager.Contains("whim.plugin3");
+		bool contains4 = pluginManager.Contains("whim.plugin4");
 
 		// Then
 		Assert.True(contains1);
@@ -332,7 +336,7 @@ public class PluginManagerTests
 			fm => fm.WriteAllText($"{mocks.FileManager.Object.SavedStateDir}\\plugins.json", It.IsAny<string>()),
 			Times.Once
 		);
-		Assert.Equal("""{"Plugins":{"Plugin1":{},"Plugin2":{}}}""", mocks.WrittenTextContents);
+		Assert.Equal("""{"Plugins":{"whim.plugin1":{},"whim.plugin2":{}}}""", mocks.WrittenTextContents);
 
 		mocks.Plugin1.As<IDisposable>().Verify(p => p.Dispose(), Times.Once);
 		mocks.Plugin2.As<IDisposable>().Verify(p => p.Dispose(), Times.Once);

--- a/src/Whim.Tests/Workspace/RouteEventTests.cs
+++ b/src/Whim.Tests/Workspace/RouteEventTests.cs
@@ -1,7 +1,7 @@
 using Moq;
 using Xunit;
 
-namespace Whim;
+namespace Whim.Tests;
 
 public class RouteEventTests
 {

--- a/src/Whim/Commands/CommandManager.cs
+++ b/src/Whim/Commands/CommandManager.cs
@@ -10,9 +10,12 @@ internal class CommandManager : ICommandManager
 
 	public int Count => _commands.Count;
 
-	public bool IsReadOnly => false;
-
-	public void Add(ICommand item)
+	/// <summary>
+	/// Add a command from a plugin.
+	/// </summary>
+	/// <param name="item"></param>
+	/// <exception cref="InvalidOperationException"></exception>
+	internal void AddPluginCommand(ICommand item)
 	{
 		if (_commands.ContainsKey(item.Id))
 		{
@@ -21,6 +24,9 @@ internal class CommandManager : ICommandManager
 
 		_commands.Add(item.Id, item);
 	}
+
+	public void Add(string identifier, string title, Action callback, Func<bool>? condition = null) =>
+		AddPluginCommand(new Command($"whim.custom.{identifier}", title, callback, condition));
 
 	public ICommand? TryGetCommand(string commandId)
 	{
@@ -32,15 +38,7 @@ internal class CommandManager : ICommandManager
 		return null;
 	}
 
-	public void Clear() => _commands.Clear();
-
-	public bool Contains(ICommand item) => _commands.ContainsKey(item.Id);
-
-	public void CopyTo(ICommand[] array, int arrayIndex) => _commands.Values.CopyTo(array, arrayIndex);
-
 	public IEnumerator<ICommand> GetEnumerator() => _commands.Values.GetEnumerator();
-
-	public bool Remove(ICommand item) => _commands.Remove(item.Id);
 
 	IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 }

--- a/src/Whim/Commands/ICommandManager.cs
+++ b/src/Whim/Commands/ICommandManager.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 namespace Whim;
@@ -5,8 +6,33 @@ namespace Whim;
 /// <summary>
 /// ICommandManager is responsible for managing all the commands for Whim.
 /// </summary>
-public interface ICommandManager : ICollection<ICommand>
+public interface ICommandManager : IEnumerable<ICommand>
 {
+	/// <summary>
+	/// Gets the number of commands in the manager.
+	/// </summary>
+	public int Count { get; }
+
+	/// <summary>
+	/// Adds a new user-defined command to the manager.
+	/// </summary>
+	/// <param name="identifier">
+	/// The identifier of the command. This will be prefixed with <c>whim.custom.</c>
+	/// This must be unique.
+	/// </param>
+	/// <param name="title">The title of the command.</param>
+	/// <param name="callback">
+	/// The callback to execute.
+	/// This can include triggering a menu to be shown by Whim.CommandPalette,
+	/// or to perform some other action.
+	/// </param>
+	/// <param name="condition">
+	/// A condition to determine if the command should be visible, or able to be
+	/// executed.
+	/// If this is null, the command will always be accessible.
+	/// </param>
+	public void Add(string identifier, string title, Action callback, Func<bool>? condition = null);
+
 	/// <summary>
 	/// Tries to get the command with the given identifier.
 	/// </summary>

--- a/src/Whim/Context/Context.cs
+++ b/src/Whim/Context/Context.cs
@@ -22,7 +22,8 @@ internal class Context : IContext
 	public IMonitorManager MonitorManager { get; }
 	public IRouterManager RouterManager { get; }
 	public IFilterManager FilterManager { get; }
-	public ICommandManager CommandManager { get; }
+	private readonly CommandManager _commandManager;
+	public ICommandManager CommandManager => _commandManager;
 	public IPluginManager PluginManager { get; }
 	public IKeybindManager KeybindManager { get; }
 	internal KeybindHook KeybindHook { get; }
@@ -44,8 +45,8 @@ internal class Context : IContext
 		WindowManager = new WindowManager(this, CoreNativeManager);
 		MonitorManager = new MonitorManager(this, CoreNativeManager);
 		WorkspaceManager = new WorkspaceManager(this);
-		CommandManager = new CommandManager();
-		PluginManager = new PluginManager(this, FileManager);
+		_commandManager = new CommandManager();
+		PluginManager = new PluginManager(this, FileManager, _commandManager);
 		KeybindManager = new KeybindManager(this);
 		KeybindHook = new KeybindHook(this, CoreNativeManager);
 	}
@@ -57,7 +58,7 @@ internal class Context : IContext
 
 		foreach (ICommand command in coreCommands.Commands)
 		{
-			CommandManager.Add(command);
+			_commandManager.AddPluginCommand(command);
 		}
 
 		foreach ((string name, IKeybind keybind) in coreCommands.Keybinds)

--- a/src/Whim/Plugin/PluginManager.cs
+++ b/src/Whim/Plugin/PluginManager.cs
@@ -9,16 +9,18 @@ internal class PluginManager : IPluginManager
 {
 	private readonly IContext _context;
 	private readonly IFileManager _fileManager;
+	private readonly CommandManager _commandManager;
 	private readonly string _savedStateFilePath;
 	private readonly List<IPlugin> _plugins = new();
 	private bool _disposedValue;
 
 	public IReadOnlyCollection<IPlugin> LoadedPlugins => _plugins.AsReadOnly();
 
-	public PluginManager(IContext context, IFileManager fileManager)
+	public PluginManager(IContext context, IFileManager fileManager, CommandManager commandManager)
 	{
 		_context = context;
 		_fileManager = fileManager;
+		_commandManager = commandManager;
 		_savedStateFilePath = Path.Combine(_fileManager.SavedStateDir, "plugins.json");
 	}
 
@@ -94,7 +96,7 @@ internal class PluginManager : IPluginManager
 		// Add the commands and keybinds.
 		foreach (ICommand command in plugin.PluginCommands.Commands)
 		{
-			_context.CommandManager.Add(command);
+			_commandManager.AddPluginCommand(command);
 		}
 
 		foreach ((string commandId, IKeybind keybind) in plugin.PluginCommands.Keybinds)

--- a/src/Whim/Plugin/PluginManager.cs
+++ b/src/Whim/Plugin/PluginManager.cs
@@ -90,6 +90,10 @@ internal class PluginManager : IPluginManager
 		{
 			throw new InvalidOperationException($"Plugin with name '{plugin.Name}' already exists.");
 		}
+		else if (plugin.Name == "whim.custom")
+		{
+			throw new InvalidOperationException("Name 'whim.custom' is reserved for user-defined commands.");
+		}
 
 		_plugins.Add(plugin);
 


### PR DESCRIPTION
`ICommandManager` no longer extends `ICollection`. This lets us have more control over how to add commands to the manager. Now, the exposed `Add` method is only for user-defined commands. Plugin-defined commands are added through the internal `AddPluginCommand` method.

Whim now reserves `whim.core` and `whim.custom` for core commands, and user-defined commands respectively. This means that plugins can no longer define commands with these names. Additionally, `PluginManager` now has a regex to validate plugin names.