### PR TITLE
Fixed scoring in `MostRecentlyUsedMatcher`

### DIFF
--- a/src/Whim.CommandPalette.Tests/MostRecentlyUsedMatcherTests.cs
+++ b/src/Whim.CommandPalette.Tests/MostRecentlyUsedMatcherTests.cs
@@ -40,7 +40,7 @@ public class MostRecentlyUsedMatcherTests
 		// Then
 		Assert.Equal(1, matchCount);
 		Assert.Equal("A", matches[0].Model.Data.Command.Title);
-		Assert.Equal((uint)0, matches[0].Score);
+		Assert.Equal(0, matches[0].Score);
 	}
 
 	[Fact]
@@ -58,9 +58,9 @@ public class MostRecentlyUsedMatcherTests
 		// Then
 		Assert.Equal(2, matchCount);
 		Assert.Equal("A", matches[0].Model.Data.Command.Title);
-		Assert.Equal((uint)0, matches[0].Score);
+		Assert.Equal(0, matches[0].Score);
 		Assert.Equal("B", matches[1].Model.Data.Command.Title);
-		Assert.Equal((uint)0, matches[1].Score);
+		Assert.Equal(0, matches[1].Score);
 	}
 
 	[Fact]
@@ -176,8 +176,8 @@ public class MostRecentlyUsedMatcherTests
 
 		// Then
 		Assert.Equal(2, matcher._commandLastExecutionTime.Count);
-		Assert.Equal<uint>(1, matcher._commandLastExecutionTime["A"]);
-		Assert.Equal<uint>(2, matcher._commandLastExecutionTime["B"]);
+		Assert.Equal<long>(1, matcher._commandLastExecutionTime["A"]);
+		Assert.Equal<long>(2, matcher._commandLastExecutionTime["B"]);
 	}
 
 	[Fact]
@@ -210,7 +210,7 @@ public class MostRecentlyUsedMatcherTests
 		// Then
 		Assert.NotNull(state);
 
-		Dictionary<string, uint> commandLastExecutionTime = JsonSerializer.Deserialize<Dictionary<string, uint>>(
+		Dictionary<string, long> commandLastExecutionTime = JsonSerializer.Deserialize<Dictionary<string, long>>(
 			state?.GetRawText()!
 		)!;
 

--- a/src/Whim.CommandPalette/Matchers/MatcherResult.cs
+++ b/src/Whim.CommandPalette/Matchers/MatcherResult.cs
@@ -19,7 +19,7 @@ public record MatcherResult<T>
 	/// <summary>
 	/// The score of the result.
 	/// </summary>
-	public uint Score { get; }
+	public long Score { get; }
 
 	/// <summary>
 	/// Creates a new <see cref="MatcherResult{T}"/>.
@@ -27,7 +27,7 @@ public record MatcherResult<T>
 	/// <param name="model">The associated model of the result.</param>
 	/// <param name="textSegments">The text matches from the query.</param>
 	/// <param name="score">The score of the result.</param>
-	public MatcherResult(IVariantRowModel<T> model, FilterTextMatch[] textSegments, uint score)
+	public MatcherResult(IVariantRowModel<T> model, FilterTextMatch[] textSegments, long score)
 	{
 		Model = model;
 		_textSegments = textSegments;

--- a/src/Whim.CommandPalette/Matchers/MostRecentlyUsedMatcher.cs
+++ b/src/Whim.CommandPalette/Matchers/MostRecentlyUsedMatcher.cs
@@ -13,7 +13,7 @@ public class MostRecentlyUsedMatcher<T> : IMatcher<T>
 {
 	private static readonly MatcherItemComparer<T> _sorter = new();
 
-	internal readonly Dictionary<string, uint> _commandLastExecutionTime = new();
+	internal readonly Dictionary<string, long> _commandLastExecutionTime = new();
 
 	/// <summary>
 	/// The filter to use when matching commands.
@@ -65,7 +65,7 @@ public class MostRecentlyUsedMatcher<T> : IMatcher<T>
 				continue;
 			}
 
-			uint count = _commandLastExecutionTime.GetValueOrDefault<string, uint>(item.Id, 0);
+			long count = _commandLastExecutionTime.GetValueOrDefault<string, long>(item.Id, 0);
 			matches[matchCount++] = new MatcherResult<T>(item, filterMatches, count);
 		}
 
@@ -83,7 +83,7 @@ public class MostRecentlyUsedMatcher<T> : IMatcher<T>
 
 		foreach (IVariantRowModel<T> item in items)
 		{
-			uint lastExecutionTime = _commandLastExecutionTime.TryGetValue(item.Id, out uint value) ? value : 0;
+			long lastExecutionTime = _commandLastExecutionTime.TryGetValue(item.Id, out long value) ? value : 0;
 			matches[matchCount++] = new MatcherResult<T>(item, Array.Empty<FilterTextMatch>(), lastExecutionTime);
 		}
 
@@ -96,7 +96,7 @@ public class MostRecentlyUsedMatcher<T> : IMatcher<T>
 	/// </summary>
 	public void OnMatchExecuted(IVariantRowModel<T> item)
 	{
-		_commandLastExecutionTime[item.Id] = (uint)DateTime.Now.Ticks;
+		_commandLastExecutionTime[item.Id] = DateTime.Now.Ticks;
 	}
 
 	/// <inheritdoc/>
@@ -116,7 +116,7 @@ public class MostRecentlyUsedMatcher<T> : IMatcher<T>
 				continue;
 			}
 
-			_commandLastExecutionTime[property.Name] = (uint)property.Value.GetUInt64();
+			_commandLastExecutionTime[property.Name] = property.Value.GetInt64();
 		}
 	}
 


### PR DESCRIPTION
`DateTime.Now.Ticks` is used when ranking commands in `MostRecentlyUsedMatcher`. `Ticks` is `long`, but `MostRecentlyUsedMatcher` used `uint`. The integer conversion was lossy, resulting in inaccurate time numbers. This has been fixed by switching to storing `long`.