### PR TITLE
Add improved `FocusIndicator` reactivity

### DIFF
--- a/src/Whim.FocusIndicator/FocusIndicatorPlugin.cs
+++ b/src/Whim.FocusIndicator/FocusIndicatorPlugin.cs
@@ -57,6 +57,7 @@ public class FocusIndicatorPlugin : IFocusIndicatorPlugin
 		// Only subscribe to workspace changes once the indicator window has been created - we shouldn't
 		// show a window which doesn't yet exist (it'll just crash Whim).
 		_context.WorkspaceManager.MonitorWorkspaceChanged += WorkspaceManager_MonitorWorkspaceChanged;
+		_context.WorkspaceManager.ActiveLayoutEngineChanged += WorkspaceManager_ActiveLayoutEngineChanged;
 	}
 
 	private void DispatcherTimer_Tick(object? sender, object e) => Hide();
@@ -87,6 +88,12 @@ public class FocusIndicatorPlugin : IFocusIndicatorPlugin
 		}
 
 		Hide();
+	}
+
+	private void WorkspaceManager_ActiveLayoutEngineChanged(object? sender, ActiveLayoutEngineChangedEventArgs e)
+	{
+		Logger.Debug("Active layout engine changed");
+		Show();
 	}
 
 	private void WorkspaceManager_MonitorWorkspaceChanged(object? sender, MonitorWorkspaceChangedEventArgs e) => Show();
@@ -185,6 +192,8 @@ public class FocusIndicatorPlugin : IFocusIndicatorPlugin
 				_context.WindowManager.WindowMoveStart -= WindowManager_EventSink_Show;
 				_context.WindowManager.WindowMinimizeStart -= WindowManager_EventSink_Show;
 				_context.WindowManager.WindowMinimizeEnd -= WindowManager_EventSink_Show;
+				_context.WorkspaceManager.MonitorWorkspaceChanged -= WorkspaceManager_MonitorWorkspaceChanged;
+				_context.WorkspaceManager.ActiveLayoutEngineChanged -= WorkspaceManager_ActiveLayoutEngineChanged;
 				_focusIndicatorWindow?.Close();
 			}
 

--- a/src/Whim.FocusIndicator/FocusIndicatorPlugin.cs
+++ b/src/Whim.FocusIndicator/FocusIndicatorPlugin.cs
@@ -56,8 +56,7 @@ public class FocusIndicatorPlugin : IFocusIndicatorPlugin
 
 		// Only subscribe to workspace changes once the indicator window has been created - we shouldn't
 		// show a window which doesn't yet exist (it'll just crash Whim).
-		_context.WorkspaceManager.MonitorWorkspaceChanged += WorkspaceManager_MonitorWorkspaceChanged;
-		_context.WorkspaceManager.ActiveLayoutEngineChanged += WorkspaceManager_ActiveLayoutEngineChanged;
+		_context.WorkspaceManager.WorkspaceLayoutCompleted += WorkspaceManager_WorkspaceLayoutCompleted;
 	}
 
 	private void DispatcherTimer_Tick(object? sender, object e) => Hide();
@@ -90,13 +89,7 @@ public class FocusIndicatorPlugin : IFocusIndicatorPlugin
 		Hide();
 	}
 
-	private void WorkspaceManager_ActiveLayoutEngineChanged(object? sender, ActiveLayoutEngineChangedEventArgs e)
-	{
-		Logger.Debug("Active layout engine changed");
-		Show();
-	}
-
-	private void WorkspaceManager_MonitorWorkspaceChanged(object? sender, MonitorWorkspaceChangedEventArgs e) => Show();
+	private void WorkspaceManager_WorkspaceLayoutCompleted(object? sender, WorkspaceEventArgs e) => Show();
 
 	/// <inheritdoc/>
 	public void Show(IWindow? window = null)
@@ -192,8 +185,7 @@ public class FocusIndicatorPlugin : IFocusIndicatorPlugin
 				_context.WindowManager.WindowMoveStart -= WindowManager_EventSink_Show;
 				_context.WindowManager.WindowMinimizeStart -= WindowManager_EventSink_Show;
 				_context.WindowManager.WindowMinimizeEnd -= WindowManager_EventSink_Show;
-				_context.WorkspaceManager.MonitorWorkspaceChanged -= WorkspaceManager_MonitorWorkspaceChanged;
-				_context.WorkspaceManager.ActiveLayoutEngineChanged -= WorkspaceManager_ActiveLayoutEngineChanged;
+				_context.WorkspaceManager.WorkspaceLayoutCompleted -= WorkspaceManager_WorkspaceLayoutCompleted;
 				_focusIndicatorWindow?.Close();
 			}
 

--- a/src/Whim.FocusIndicator/FocusIndicatorPlugin.cs
+++ b/src/Whim.FocusIndicator/FocusIndicatorPlugin.cs
@@ -56,6 +56,7 @@ public class FocusIndicatorPlugin : IFocusIndicatorPlugin
 
 		// Only subscribe to workspace changes once the indicator window has been created - we shouldn't
 		// show a window which doesn't yet exist (it'll just crash Whim).
+		_context.WorkspaceManager.WorkspaceLayoutStarted += WorkspaceManager_WorkspaceLayoutStarted;
 		_context.WorkspaceManager.WorkspaceLayoutCompleted += WorkspaceManager_WorkspaceLayoutCompleted;
 	}
 
@@ -88,6 +89,8 @@ public class FocusIndicatorPlugin : IFocusIndicatorPlugin
 
 		Hide();
 	}
+
+	private void WorkspaceManager_WorkspaceLayoutStarted(object? sender, WorkspaceEventArgs e) => Hide();
 
 	private void WorkspaceManager_WorkspaceLayoutCompleted(object? sender, WorkspaceEventArgs e) => Show();
 
@@ -185,6 +188,7 @@ public class FocusIndicatorPlugin : IFocusIndicatorPlugin
 				_context.WindowManager.WindowMoveStart -= WindowManager_EventSink_Show;
 				_context.WindowManager.WindowMinimizeStart -= WindowManager_EventSink_Show;
 				_context.WindowManager.WindowMinimizeEnd -= WindowManager_EventSink_Show;
+				_context.WorkspaceManager.WorkspaceLayoutStarted -= WorkspaceManager_WorkspaceLayoutStarted;
 				_context.WorkspaceManager.WorkspaceLayoutCompleted -= WorkspaceManager_WorkspaceLayoutCompleted;
 				_focusIndicatorWindow?.Close();
 			}

--- a/src/Whim.FocusIndicator/FocusIndicatorWindow.xaml.cs
+++ b/src/Whim.FocusIndicator/FocusIndicatorWindow.xaml.cs
@@ -26,10 +26,10 @@ internal sealed partial class FocusIndicatorWindow : Microsoft.UI.Xaml.Window
 	/// <summary>
 	/// Activates the window behind the given window.
 	/// </summary>
-	/// <param name="windowLocation">The location of the window.</param>
-	public void Activate(IWindowState windowLocation)
+	/// <param name="windowState">The window to show the indicator for.</param>
+	public void Activate(IWindowState windowState)
 	{
-		ILocation<int> focusedWindowLocation = windowLocation.Location;
+		ILocation<int> focusedWindowLocation = windowState.Location;
 		int borderSize = FocusIndicatorConfig.BorderSize;
 
 		ILocation<int> borderLocation = new Location<int>()
@@ -44,6 +44,8 @@ internal sealed partial class FocusIndicatorWindow : Microsoft.UI.Xaml.Window
 		_context.NativeManager.PreventWindowActivation(_window.Handle);
 
 		using WindowDeferPosHandle windowDeferPos = new(_context);
+
+		// Layout the focus indicator window.
 		windowDeferPos.DeferWindowPos(
 			new WindowState()
 			{
@@ -51,7 +53,19 @@ internal sealed partial class FocusIndicatorWindow : Microsoft.UI.Xaml.Window
 				Location = borderLocation,
 				WindowSize = WindowSize.Normal
 			},
-			new HWND(1)
+			windowState.Window.Handle
+		);
+
+		// Layout the actual window. This is to ensure that the focus indicator window is always
+		// behind the actual window.
+		windowDeferPos.DeferWindowPos(
+			new WindowState()
+			{
+				Window = windowState.Window,
+				Location = windowState.Location,
+				WindowSize = windowState.WindowSize
+			},
+			(HWND)0
 		);
 	}
 }

--- a/src/Whim.FocusIndicator/FocusIndicatorWindow.xaml.cs
+++ b/src/Whim.FocusIndicator/FocusIndicatorWindow.xaml.cs
@@ -1,4 +1,4 @@
-﻿using Windows.Win32.Foundation;
+﻿using Windows.Win32.UI.WindowsAndMessaging;
 
 namespace Whim.FocusIndicator;
 
@@ -53,19 +53,8 @@ internal sealed partial class FocusIndicatorWindow : Microsoft.UI.Xaml.Window
 				Location = borderLocation,
 				WindowSize = WindowSize.Normal
 			},
-			windowState.Window.Handle
-		);
-
-		// Layout the actual window. This is to ensure that the focus indicator window is always
-		// behind the actual window.
-		windowDeferPos.DeferWindowPos(
-			new WindowState()
-			{
-				Window = windowState.Window,
-				Location = windowState.Location,
-				WindowSize = windowState.WindowSize
-			},
-			(HWND)0
+			windowState.Window.Handle,
+			SET_WINDOW_POS_FLAGS.SWP_NOREDRAW | SET_WINDOW_POS_FLAGS.SWP_NOACTIVATE
 		);
 	}
 }

--- a/src/Whim.Tests/Workspace/WorkspaceManagerTests.cs
+++ b/src/Whim.Tests/Workspace/WorkspaceManagerTests.cs
@@ -1365,6 +1365,36 @@ public class WorkspaceManagerTests
 	}
 
 	[Fact]
+	public void TriggerWorkspaceLayoutStarted()
+	{
+		// Given
+		MocksBuilder mocks = new();
+		WorkspaceEventArgs eventArgs = new() { Workspace = new Mock<IWorkspace>().Object, };
+
+		// When the workspace layout is started, then the event is triggered
+		Assert.Raises<WorkspaceEventArgs>(
+			h => mocks.WorkspaceManager.WorkspaceLayoutStarted += h,
+			h => mocks.WorkspaceManager.WorkspaceLayoutStarted -= h,
+			() => mocks.WorkspaceManager.TriggerWorkspaceLayoutStarted(eventArgs)
+		);
+	}
+
+	[Fact]
+	public void TriggerWorkspaceLayoutCompleted()
+	{
+		// Given
+		MocksBuilder mocks = new();
+		WorkspaceEventArgs eventArgs = new() { Workspace = new Mock<IWorkspace>().Object, };
+
+		// When the workspace layout is ended, then the event is triggered
+		Assert.Raises<WorkspaceEventArgs>(
+			h => mocks.WorkspaceManager.WorkspaceLayoutCompleted += h,
+			h => mocks.WorkspaceManager.WorkspaceLayoutCompleted -= h,
+			() => mocks.WorkspaceManager.TriggerWorkspaceLayoutCompleted(eventArgs)
+		);
+	}
+
+	[Fact]
 	public void AddPhantomWindow()
 	{
 		// Given

--- a/src/Whim/Logging/LoggerConfig.cs
+++ b/src/Whim/Logging/LoggerConfig.cs
@@ -29,7 +29,7 @@ public class LoggerConfig
 		new FileSinkConfig()
 		{
 			FileName = "whim.log",
-			MinLogLevel = LogLevel.Error,
+			MinLogLevel = LogLevel.Verbose,
 			RollingInterval = FileSinkConfigRollingInterval.Day
 		};
 

--- a/src/Whim/Native/WindowDeferPosHandle.cs
+++ b/src/Whim/Native/WindowDeferPosHandle.cs
@@ -16,7 +16,8 @@ namespace Whim;
 public sealed class WindowDeferPosHandle : IDisposable
 {
 	private readonly IContext _context;
-	private readonly List<(IWindowState windowState, HWND hwndInsertAfter)> _windowStates = new();
+	private readonly List<(IWindowState windowState, HWND hwndInsertAfter, SET_WINDOW_POS_FLAGS? flags)> _windowStates =
+		new();
 
 	/// <summary>
 	/// Create a new <see cref="WindowDeferPosHandle"/> to set the position of multiple windows at once.
@@ -35,14 +36,22 @@ public sealed class WindowDeferPosHandle : IDisposable
 	/// </summary>
 	/// <param name="windowState"></param>
 	/// <param name="hwndInsertAfter">The window handle to insert show the given window behind.</param>
-	public void DeferWindowPos(IWindowState windowState, HWND? hwndInsertAfter = null)
+	/// <param name="flags">
+	/// The flags to use when setting the window position.
+	/// If the window is maximized or minimized, additional flags will be added by Whim.
+	/// </param>
+	public void DeferWindowPos(
+		IWindowState windowState,
+		HWND? hwndInsertAfter = null,
+		SET_WINDOW_POS_FLAGS? flags = null
+	)
 	{
 		// We use HWND_BOTTOM, as modifying the Z-order of a window
 		// may cause EVENT_SYSTEM_FOREGROUND to be set, which in turn
 		// causes the relevant window to be focused, when the user hasn't
 		// actually changed the focus.
 		HWND targetHwndInsertAfter = hwndInsertAfter ?? (HWND)1; // HWND_BOTTOM
-		_windowStates.Add((windowState, targetHwndInsertAfter));
+		_windowStates.Add((windowState, targetHwndInsertAfter, flags));
 	}
 
 	/// <inheritdoc />
@@ -66,8 +75,8 @@ public sealed class WindowDeferPosHandle : IDisposable
 			using InternalWindowDeferPosHandle handle = new(_context, count);
 			for (int j = 0; j < count; j++)
 			{
-				(IWindowState windowState, HWND hwndInsertAfter) = _windowStates[j];
-				handle.DeferWindowPos(windowState, hwndInsertAfter);
+				(IWindowState windowState, HWND hwndInsertAfter, SET_WINDOW_POS_FLAGS? flags) = _windowStates[j];
+				handle.DeferWindowPos(windowState, hwndInsertAfter, flags);
 			}
 		}
 	}
@@ -99,7 +108,7 @@ public sealed class WindowDeferPosHandle : IDisposable
 			_toNormal = new List<IWindow>();
 		}
 
-		public void DeferWindowPos(IWindowState windowState, HWND hwndInsertAfter)
+		public void DeferWindowPos(IWindowState windowState, HWND hwndInsertAfter, SET_WINDOW_POS_FLAGS? flags)
 		{
 			IWindow window = windowState.Window;
 
@@ -113,22 +122,23 @@ public sealed class WindowDeferPosHandle : IDisposable
 
 			WindowSize windowSize = windowState.WindowSize;
 
-			SET_WINDOW_POS_FLAGS flags =
-				SET_WINDOW_POS_FLAGS.SWP_FRAMECHANGED
-				| SET_WINDOW_POS_FLAGS.SWP_NOACTIVATE
-				| SET_WINDOW_POS_FLAGS.SWP_NOCOPYBITS
-				| SET_WINDOW_POS_FLAGS.SWP_NOZORDER
-				| SET_WINDOW_POS_FLAGS.SWP_NOOWNERZORDER;
+			SET_WINDOW_POS_FLAGS uFlags =
+				flags
+				?? SET_WINDOW_POS_FLAGS.SWP_FRAMECHANGED
+					| SET_WINDOW_POS_FLAGS.SWP_NOACTIVATE
+					| SET_WINDOW_POS_FLAGS.SWP_NOCOPYBITS
+					| SET_WINDOW_POS_FLAGS.SWP_NOZORDER
+					| SET_WINDOW_POS_FLAGS.SWP_NOOWNERZORDER;
 
 			if (windowSize == WindowSize.Maximized)
 			{
 				_toMaximize.Add(window);
-				flags = flags | SET_WINDOW_POS_FLAGS.SWP_NOMOVE | SET_WINDOW_POS_FLAGS.SWP_NOSIZE;
+				uFlags = uFlags | SET_WINDOW_POS_FLAGS.SWP_NOMOVE | SET_WINDOW_POS_FLAGS.SWP_NOSIZE;
 			}
 			else if (windowSize == WindowSize.Minimized)
 			{
 				_toMinimize.Add(window);
-				flags = flags | SET_WINDOW_POS_FLAGS.SWP_NOMOVE | SET_WINDOW_POS_FLAGS.SWP_NOSIZE;
+				uFlags = uFlags | SET_WINDOW_POS_FLAGS.SWP_NOMOVE | SET_WINDOW_POS_FLAGS.SWP_NOSIZE;
 			}
 			else
 			{
@@ -143,7 +153,7 @@ public sealed class WindowDeferPosHandle : IDisposable
 				location.Y,
 				location.Width,
 				location.Height,
-				flags
+				uFlags
 			);
 		}
 

--- a/src/Whim/Native/WindowDeferPosHandle.cs
+++ b/src/Whim/Native/WindowDeferPosHandle.cs
@@ -19,6 +19,13 @@ public sealed class WindowDeferPosHandle : IDisposable
 	private readonly List<(IWindowState windowState, HWND hwndInsertAfter, SET_WINDOW_POS_FLAGS? flags)> _windowStates =
 		new();
 
+	public const SET_WINDOW_POS_FLAGS DefaultFlags =
+		SET_WINDOW_POS_FLAGS.SWP_FRAMECHANGED
+		| SET_WINDOW_POS_FLAGS.SWP_NOACTIVATE
+		| SET_WINDOW_POS_FLAGS.SWP_NOCOPYBITS
+		| SET_WINDOW_POS_FLAGS.SWP_NOZORDER
+		| SET_WINDOW_POS_FLAGS.SWP_NOOWNERZORDER;
+
 	/// <summary>
 	/// Create a new <see cref="WindowDeferPosHandle"/> to set the position of multiple windows at once.
 	///
@@ -37,8 +44,8 @@ public sealed class WindowDeferPosHandle : IDisposable
 	/// <param name="windowState"></param>
 	/// <param name="hwndInsertAfter">The window handle to insert show the given window behind.</param>
 	/// <param name="flags">
-	/// The flags to use when setting the window position.
-	/// If the window is maximized or minimized, additional flags will be added by Whim.
+	/// The flags to use when setting the window position. This overrides the default flags Whim sets,
+	/// except when the window is maximized or minimized.
 	/// </param>
 	public void DeferWindowPos(
 		IWindowState windowState,
@@ -122,13 +129,7 @@ public sealed class WindowDeferPosHandle : IDisposable
 
 			WindowSize windowSize = windowState.WindowSize;
 
-			SET_WINDOW_POS_FLAGS uFlags =
-				flags
-				?? SET_WINDOW_POS_FLAGS.SWP_FRAMECHANGED
-					| SET_WINDOW_POS_FLAGS.SWP_NOACTIVATE
-					| SET_WINDOW_POS_FLAGS.SWP_NOCOPYBITS
-					| SET_WINDOW_POS_FLAGS.SWP_NOZORDER
-					| SET_WINDOW_POS_FLAGS.SWP_NOOWNERZORDER;
+			SET_WINDOW_POS_FLAGS uFlags = flags ?? DefaultFlags;
 
 			if (windowSize == WindowSize.Maximized)
 			{

--- a/src/Whim/Native/WindowDeferPosHandle.cs
+++ b/src/Whim/Native/WindowDeferPosHandle.cs
@@ -19,6 +19,9 @@ public sealed class WindowDeferPosHandle : IDisposable
 	private readonly List<(IWindowState windowState, HWND hwndInsertAfter, SET_WINDOW_POS_FLAGS? flags)> _windowStates =
 		new();
 
+	/// <summary>
+	/// The default flags to use when setting the window position.
+	/// </summary>
 	public const SET_WINDOW_POS_FLAGS DefaultFlags =
 		SET_WINDOW_POS_FLAGS.SWP_FRAMECHANGED
 		| SET_WINDOW_POS_FLAGS.SWP_NOACTIVATE

--- a/src/Whim/Workspace/IWorkspaceManager.cs
+++ b/src/Whim/Workspace/IWorkspaceManager.cs
@@ -45,6 +45,11 @@ public interface IWorkspaceManager : IEnumerable<IWorkspace>, IDisposable
 	public event EventHandler<WorkspaceEventArgs>? WorkspaceRemoved;
 
 	/// <summary>
+	/// Event for when <see cref="IWorkspace.DoLayout"/> has started.
+	/// </summary>
+	public event EventHandler<WorkspaceEventArgs>? WorkspaceLayoutStarted;
+
+	/// <summary>
 	/// Event for when <see cref="IWorkspace.DoLayout"/> has completed.
 	/// </summary>
 	public event EventHandler<WorkspaceEventArgs>? WorkspaceLayoutCompleted;
@@ -181,7 +186,12 @@ public interface IWorkspaceManager : IEnumerable<IWorkspace>, IDisposable
 	public void TriggerWorkspaceRenamed(WorkspaceRenamedEventArgs args);
 
 	/// <summary>
-	/// Used by <see cref="IWorkspace"/> to trigger <see cref="WorkspaceLayout"/>.
+	/// Used by <see cref="IWorkspace"/> to trigger <see cref="WorkspaceLayoutStarted"/>.
+	/// </summary>
+	public void TriggerWorkspaceLayoutStarted(WorkspaceEventArgs args);
+
+	/// <summary>
+	/// Used by <see cref="IWorkspace"/> to trigger <see cref="WorkspaceLayoutCompleted"/>.
 	/// </summary>
 	public void TriggerWorkspaceLayoutCompleted(WorkspaceEventArgs args);
 

--- a/src/Whim/Workspace/IWorkspaceManager.cs
+++ b/src/Whim/Workspace/IWorkspaceManager.cs
@@ -45,9 +45,9 @@ public interface IWorkspaceManager : IEnumerable<IWorkspace>, IDisposable
 	public event EventHandler<WorkspaceEventArgs>? WorkspaceRemoved;
 
 	/// <summary>
-	/// Event for when <see cref="IWorkspace.DoLayout"/> has been called.
+	/// Event for when <see cref="IWorkspace.DoLayout"/> has completed.
 	/// </summary>
-	public event EventHandler<WorkspaceEventArgs>? WorkspaceLayout;
+	public event EventHandler<WorkspaceEventArgs>? WorkspaceLayoutCompleted;
 
 	/// <summary>
 	/// Event for when a monitor's workspace has changed.
@@ -183,7 +183,7 @@ public interface IWorkspaceManager : IEnumerable<IWorkspace>, IDisposable
 	/// <summary>
 	/// Used by <see cref="IWorkspace"/> to trigger <see cref="WorkspaceLayout"/>.
 	/// </summary>
-	public void TriggerWorkspaceLayout(WorkspaceEventArgs args);
+	public void TriggerWorkspaceLayoutCompleted(WorkspaceEventArgs args);
 
 	/// <summary>
 	/// Moves the given <paramref name="window"/> to the given <paramref name="workspace"/>.

--- a/src/Whim/Workspace/IWorkspaceManager.cs
+++ b/src/Whim/Workspace/IWorkspaceManager.cs
@@ -45,6 +45,11 @@ public interface IWorkspaceManager : IEnumerable<IWorkspace>, IDisposable
 	public event EventHandler<WorkspaceEventArgs>? WorkspaceRemoved;
 
 	/// <summary>
+	/// Event for when <see cref="IWorkspace.DoLayout"/> has been called.
+	/// </summary>
+	public event EventHandler<WorkspaceEventArgs>? WorkspaceLayout;
+
+	/// <summary>
 	/// Event for when a monitor's workspace has changed.
 	/// </summary>
 	public event EventHandler<MonitorWorkspaceChangedEventArgs>? MonitorWorkspaceChanged;
@@ -174,6 +179,11 @@ public interface IWorkspaceManager : IEnumerable<IWorkspace>, IDisposable
 	/// Used by <see cref="IWorkspace"/> to trigger <see cref="WorkspaceRenamed"/>.
 	/// </summary>
 	public void TriggerWorkspaceRenamed(WorkspaceRenamedEventArgs args);
+
+	/// <summary>
+	/// Used by <see cref="IWorkspace"/> to trigger <see cref="WorkspaceLayout"/>.
+	/// </summary>
+	public void TriggerWorkspaceLayout(WorkspaceEventArgs args);
 
 	/// <summary>
 	/// Moves the given <paramref name="window"/> to the given <paramref name="workspace"/>.

--- a/src/Whim/Workspace/Workspace.cs
+++ b/src/Whim/Workspace/Workspace.cs
@@ -360,6 +360,8 @@ internal class Workspace : IWorkspace
 	{
 		Logger.Debug($"Workspace {Name}");
 
+		_context.WorkspaceManager.TriggerWorkspaceLayoutStarted(new WorkspaceEventArgs() { Workspace = this });
+
 		// Get the monitor for this workspace
 		IMonitor? monitor = _context.WorkspaceManager.GetMonitorForWorkspace(this);
 		if (monitor == null)

--- a/src/Whim/Workspace/Workspace.cs
+++ b/src/Whim/Workspace/Workspace.cs
@@ -407,6 +407,8 @@ internal class Workspace : IWorkspace
 			_windowLocations[loc.Window] = loc;
 		}
 		Logger.Verbose($"Layout for workspace {Name} complete");
+
+		_context.WorkspaceManager.TriggerWorkspaceLayout(new WorkspaceEventArgs() { Workspace = this });
 	}
 
 	#region Phantom Windows

--- a/src/Whim/Workspace/Workspace.cs
+++ b/src/Whim/Workspace/Workspace.cs
@@ -109,10 +109,9 @@ internal class Workspace : IWorkspace
 		ActiveLayoutEngine.GetFirstWindow()?.Focus();
 	}
 
-	private void UpdateLayoutEngine(int delta)
+	private void UpdateLayoutEngine(int nextIdx)
 	{
 		int prevIdx = _activeLayoutEngineIndex;
-		_activeLayoutEngineIndex = (_activeLayoutEngineIndex + delta).Mod(_layoutEngines.Count);
 
 		// If the LastFocusedWindow is a phantom window, remove it.
 		// This is because phantom windows belong to a specific layout engine.
@@ -121,6 +120,10 @@ internal class Workspace : IWorkspace
 			LastFocusedWindow = null;
 		}
 
+		_layoutEngines[prevIdx].HidePhantomWindows();
+		_activeLayoutEngineIndex = nextIdx;
+		DoLayout();
+
 		_context.WorkspaceManager.TriggerActiveLayoutEngineChanged(
 			new ActiveLayoutEngineChangedEventArgs()
 			{
@@ -129,60 +132,47 @@ internal class Workspace : IWorkspace
 				CurrentLayoutEngine = _layoutEngines[_activeLayoutEngineIndex]
 			}
 		);
-
-		_layoutEngines[prevIdx].HidePhantomWindows();
-		DoLayout();
 	}
 
 	public void NextLayoutEngine()
 	{
 		Logger.Debug(Name);
-		UpdateLayoutEngine(1);
+		UpdateLayoutEngine((_activeLayoutEngineIndex + 1).Mod(_layoutEngines.Count));
 	}
 
 	public void PreviousLayoutEngine()
 	{
 		Logger.Debug(Name);
-		UpdateLayoutEngine(-1);
+		UpdateLayoutEngine((_activeLayoutEngineIndex - 1).Mod(_layoutEngines.Count));
 	}
 
 	public bool TrySetLayoutEngine(string name)
 	{
 		Logger.Debug($"Trying to set layout engine {name} for workspace {Name}");
 
-		int prevIdx = -1;
+		int nextIdx = -1;
 		for (int idx = 0; idx < _layoutEngines.Count; idx++)
 		{
 			ILayoutEngine engine = _layoutEngines[idx];
 			if (engine.Name == name)
 			{
-				prevIdx = _activeLayoutEngineIndex;
-				_activeLayoutEngineIndex = idx;
+				nextIdx = idx;
 				break;
 			}
 		}
 
-		if (prevIdx == -1)
+		if (nextIdx == -1)
 		{
 			Logger.Error($"Layout engine {name} not found for workspace {Name}");
 			return false;
 		}
-		else if (_activeLayoutEngineIndex == prevIdx)
+		else if (_activeLayoutEngineIndex == nextIdx)
 		{
 			Logger.Debug($"Layout engine {name} is already active for workspace {Name}");
 			return true;
 		}
 
-		_context.WorkspaceManager.TriggerActiveLayoutEngineChanged(
-			new ActiveLayoutEngineChangedEventArgs()
-			{
-				Workspace = this,
-				PreviousLayoutEngine = _layoutEngines[prevIdx],
-				CurrentLayoutEngine = _layoutEngines[_activeLayoutEngineIndex]
-			}
-		);
-
-		DoLayout();
+		UpdateLayoutEngine(nextIdx);
 		return true;
 	}
 

--- a/src/Whim/Workspace/WorkspaceManager.cs
+++ b/src/Whim/Workspace/WorkspaceManager.cs
@@ -48,7 +48,7 @@ internal class WorkspaceManager : IWorkspaceManager
 
 	public event EventHandler<WorkspaceRenamedEventArgs>? WorkspaceRenamed;
 
-	public event EventHandler<WorkspaceEventArgs>? WorkspaceLayout;
+	public event EventHandler<WorkspaceEventArgs>? WorkspaceLayoutCompleted;
 
 	public Func<IContext, string, IWorkspace> WorkspaceFactory { get; set; } =
 		(context, name) =>
@@ -473,9 +473,9 @@ internal class WorkspaceManager : IWorkspaceManager
 		WorkspaceRenamed?.Invoke(this, args);
 	}
 
-	public void TriggerWorkspaceLayout(WorkspaceEventArgs args)
+	public void TriggerWorkspaceLayoutCompleted(WorkspaceEventArgs args)
 	{
-		WorkspaceLayout?.Invoke(this, args);
+		WorkspaceLayoutCompleted?.Invoke(this, args);
 	}
 
 	public void MoveWindowToWorkspace(IWorkspace workspace, IWindow? window = null)

--- a/src/Whim/Workspace/WorkspaceManager.cs
+++ b/src/Whim/Workspace/WorkspaceManager.cs
@@ -48,6 +48,8 @@ internal class WorkspaceManager : IWorkspaceManager
 
 	public event EventHandler<WorkspaceRenamedEventArgs>? WorkspaceRenamed;
 
+	public event EventHandler<WorkspaceEventArgs>? WorkspaceLayoutStarted;
+
 	public event EventHandler<WorkspaceEventArgs>? WorkspaceLayoutCompleted;
 
 	public Func<IContext, string, IWorkspace> WorkspaceFactory { get; set; } =
@@ -471,6 +473,11 @@ internal class WorkspaceManager : IWorkspaceManager
 	public void TriggerWorkspaceRenamed(WorkspaceRenamedEventArgs args)
 	{
 		WorkspaceRenamed?.Invoke(this, args);
+	}
+
+	public void TriggerWorkspaceLayoutStarted(WorkspaceEventArgs args)
+	{
+		WorkspaceLayoutStarted?.Invoke(this, args);
 	}
 
 	public void TriggerWorkspaceLayoutCompleted(WorkspaceEventArgs args)

--- a/src/Whim/Workspace/WorkspaceManager.cs
+++ b/src/Whim/Workspace/WorkspaceManager.cs
@@ -48,6 +48,8 @@ internal class WorkspaceManager : IWorkspaceManager
 
 	public event EventHandler<WorkspaceRenamedEventArgs>? WorkspaceRenamed;
 
+	public event EventHandler<WorkspaceEventArgs>? WorkspaceLayout;
+
 	public Func<IContext, string, IWorkspace> WorkspaceFactory { get; set; } =
 		(context, name) =>
 		{
@@ -469,6 +471,11 @@ internal class WorkspaceManager : IWorkspaceManager
 	public void TriggerWorkspaceRenamed(WorkspaceRenamedEventArgs args)
 	{
 		WorkspaceRenamed?.Invoke(this, args);
+	}
+
+	public void TriggerWorkspaceLayout(WorkspaceEventArgs args)
+	{
+		WorkspaceLayout?.Invoke(this, args);
 	}
 
 	public void MoveWindowToWorkspace(IWorkspace workspace, IWindow? window = null)


### PR DESCRIPTION
The focus indicator is now more reactive. Previously, it would not update when a window's size had changed or the active layout engine had changed. Now, it will update in these cases.

This was achieved by adding events for when `IWorkspace.DoLayout` has started and completed, and subscribing to these events in the `FocusIndicatorPlugin`.
