### PR TITLE
Replace public `Trigger*` methods with `WorkspaceManagerTriggers`

### DIFF
--- a/omnisharp.json
+++ b/omnisharp.json
@@ -1,6 +1,6 @@
 {
   "FileOptions": {
-    "ExcludeSearchPatterns": ["src/Whim.Runner/Template/whim.config.csx"]
+    "ExcludeSearchPatterns": ["./src/Whim/Template/**/*"]
   },
   "RoslynExtensionsOptions": {
     "EnableAnalyzersSupport": true

--- a/src/Whim.CommandPalette.Tests/CommandPaletteCommandsTests.cs
+++ b/src/Whim.CommandPalette.Tests/CommandPaletteCommandsTests.cs
@@ -136,7 +136,7 @@ public class CommandPaletteCommandsTests
 		// Setup the workspace factory
 		Mock<IWorkspace> newWorkspace = new();
 		wrapper.WorkspaceManager
-			.SetupGet(x => x.WorkspaceFactory)
+			.SetupGet(x => x.WorkspaceConfigCreator)
 			.Returns(
 				(_, name) =>
 				{

--- a/src/Whim.CommandPalette.Tests/CommandPaletteCommandsTests.cs
+++ b/src/Whim.CommandPalette.Tests/CommandPaletteCommandsTests.cs
@@ -133,18 +133,6 @@ public class CommandPaletteCommandsTests
 			"whim.command_palette.create_workspace"
 		);
 
-		// Setup the workspace factory
-		Mock<IWorkspace> newWorkspace = new();
-		wrapper.WorkspaceManager
-			.SetupGet(x => x.WorkspaceConfigCreator)
-			.Returns(
-				(_, name) =>
-				{
-					newWorkspace.SetupGet(w => w.Name).Returns(name);
-					return newWorkspace.Object;
-				}
-			);
-
 		List<FreeTextVariantConfig> configs = VerifyFreeTextActivated(wrapper.Plugin);
 		command.TryExecute();
 
@@ -155,10 +143,7 @@ public class CommandPaletteCommandsTests
 		configs[0].Callback("New workspace name");
 
 		// Verify that the workspace was created.
-		wrapper.Context.Verify(x => x.WorkspaceManager.Add(newWorkspace.Object), Times.Once);
-
-		// Verify the workspace name.
-		Assert.Equal("New workspace name", newWorkspace.Object.Name);
+		wrapper.Context.Verify(x => x.WorkspaceManager.Add("New workspace name", null), Times.Once);
 	}
 
 	[Fact]

--- a/src/Whim.CommandPalette/CommandPaletteCommands.cs
+++ b/src/Whim.CommandPalette/CommandPaletteCommands.cs
@@ -49,11 +49,7 @@ public class CommandPaletteCommands : PluginCommands
 					_commandPalettePlugin.Activate(
 						new FreeTextVariantConfig()
 						{
-							Callback = (text) =>
-							{
-								IWorkspace workspace = _context.WorkspaceManager.WorkspaceFactory(_context, text);
-								_context.WorkspaceManager.Add(workspace);
-							},
+							Callback = (name) => _context.WorkspaceManager.Add(name),
 							Hint = "Enter new workspace name",
 							Prompt = "Create workspace"
 						}

--- a/src/Whim.Tests/Files/FileManagerTests.cs
+++ b/src/Whim.Tests/Files/FileManagerTests.cs
@@ -2,7 +2,7 @@ using System;
 using System.IO;
 using Xunit;
 
-namespace Whim;
+namespace Whim.Tests;
 
 public class FileManagerTests
 {

--- a/src/Whim.Tests/Workspace/WorkspaceManagerTests.cs
+++ b/src/Whim.Tests/Workspace/WorkspaceManagerTests.cs
@@ -19,7 +19,7 @@ public class WorkspaceManagerTests
 		public void Add(IWorkspace workspace) => _workspaces.Add(workspace);
 	}
 
-	private class MocksBuilder
+	private class Wrapper
 	{
 		public Mock<IContext> Context { get; } = new();
 		public Mock<IMonitorManager> MonitorManager { get; } = new();
@@ -27,7 +27,7 @@ public class WorkspaceManagerTests
 		public Mock<IRouterManager> RouterManager { get; } = new();
 		public WorkspaceManagerTestWrapper WorkspaceManager { get; }
 
-		public MocksBuilder(
+		public Wrapper(
 			Mock<IWorkspace>[]? workspaces = null,
 			Mock<IMonitor>[]? monitors = null,
 			int activeMonitorIndex = 0
@@ -67,10 +67,10 @@ public class WorkspaceManagerTests
 	public void Initialize_RequireAtLeastNWorkspace()
 	{
 		// Given
-		MocksBuilder mocks = new();
+		Wrapper wrapper = new();
 
 		// Then
-		Assert.Throws<InvalidOperationException>(mocks.WorkspaceManager.Initialize);
+		Assert.Throws<InvalidOperationException>(wrapper.WorkspaceManager.Initialize);
 	}
 
 	[Fact]
@@ -79,13 +79,13 @@ public class WorkspaceManagerTests
 		// Given the workspace manager has two workspaces
 		Mock<IWorkspace> workspace = new();
 		Mock<IWorkspace> workspace2 = new();
-		MocksBuilder mocks = new(new[] { workspace, workspace2 });
+		Wrapper wrapper = new(new[] { workspace, workspace2 });
 
 		// When the workspace manager is initialized, then a MonitorWorkspaceChanged event is raised
 		Assert.Raises<MonitorWorkspaceChangedEventArgs>(
-			h => mocks.WorkspaceManager.MonitorWorkspaceChanged += h,
-			h => mocks.WorkspaceManager.MonitorWorkspaceChanged -= h,
-			mocks.WorkspaceManager.Initialize
+			h => wrapper.WorkspaceManager.MonitorWorkspaceChanged += h,
+			h => wrapper.WorkspaceManager.MonitorWorkspaceChanged -= h,
+			wrapper.WorkspaceManager.Initialize
 		);
 
 		// The workspaces are initialized
@@ -97,16 +97,16 @@ public class WorkspaceManagerTests
 	public void Add_AfterInitialize()
 	{
 		// Given the workspace manager is already initialized
-		MocksBuilder mocks = new(new[] { new Mock<IWorkspace>(), new Mock<IWorkspace>() });
+		Wrapper wrapper = new(new[] { new Mock<IWorkspace>(), new Mock<IWorkspace>() });
 		Mock<ProxyLayoutEngine> proxyLayoutEngine = new();
 
 		// When a workspace is added, then WorkspaceAdded is raised
-		mocks.WorkspaceManager.AddProxyLayoutEngine(proxyLayoutEngine.Object);
-		mocks.WorkspaceManager.Initialize();
+		wrapper.WorkspaceManager.AddProxyLayoutEngine(proxyLayoutEngine.Object);
+		wrapper.WorkspaceManager.Initialize();
 		Assert.Raises<WorkspaceEventArgs>(
-			h => mocks.WorkspaceManager.WorkspaceAdded += h,
-			h => mocks.WorkspaceManager.WorkspaceAdded -= h,
-			() => mocks.WorkspaceManager.Add("new workspace")
+			h => wrapper.WorkspaceManager.WorkspaceAdded += h,
+			h => wrapper.WorkspaceManager.WorkspaceAdded -= h,
+			() => wrapper.WorkspaceManager.Add("new workspace")
 		);
 
 		// Verify that the workspace was initialized
@@ -119,10 +119,10 @@ public class WorkspaceManagerTests
 		// Given the workspace manager is not initialized
 		Mock<IWorkspace> workspace = new();
 		Mock<IWorkspace> workspace1 = new();
-		MocksBuilder mocks = new(new[] { workspace, workspace1 });
+		Wrapper wrapper = new(new[] { workspace, workspace1 });
 
 		// When
-		mocks.WorkspaceManager.Initialize();
+		wrapper.WorkspaceManager.Initialize();
 
 		// Then
 		workspace.Verify(w => w.Initialize(), Times.Once);
@@ -134,10 +134,10 @@ public class WorkspaceManagerTests
 		// Given the workspace manager has two workspaces and there are two monitors
 		Mock<IWorkspace> workspace = new();
 		Mock<IWorkspace> workspace2 = new();
-		MocksBuilder mocks = new(new[] { workspace, workspace2 });
+		Wrapper wrapper = new(new[] { workspace, workspace2 });
 
 		// When a workspace is removed
-		bool result = mocks.WorkspaceManager.Remove(workspace.Object);
+		bool result = wrapper.WorkspaceManager.Remove(workspace.Object);
 
 		// Then it returns false, as there must be at least two workspaces, since there are two monitors
 		Assert.False(result);
@@ -151,10 +151,10 @@ public class WorkspaceManagerTests
 		Mock<IWorkspace> workspace = new();
 		Mock<IWorkspace> workspace2 = new();
 		Mock<IWorkspace> workspace3 = new();
-		MocksBuilder mocks = new(new[] { workspace, workspace2, workspace3 });
+		Wrapper wrapper = new(new[] { workspace, workspace2, workspace3 });
 
 		// When a workspace is removed
-		bool result = mocks.WorkspaceManager.Remove(new Mock<IWorkspace>().Object);
+		bool result = wrapper.WorkspaceManager.Remove(new Mock<IWorkspace>().Object);
 
 		// Then it returns false, as the workspace was not found
 		Assert.False(result);
@@ -166,17 +166,17 @@ public class WorkspaceManagerTests
 		// Given
 		Mock<IWorkspace> workspace = new();
 		Mock<IWorkspace> workspace2 = new();
-		Mock<IMonitor>[] monitorMocks = new[] { new Mock<IMonitor>() };
-		MocksBuilder mocks = new(new Mock<IWorkspace>[] { workspace, workspace2 }, monitorMocks);
+		Mock<IMonitor>[] monitorwrapper = new[] { new Mock<IMonitor>() };
+		Wrapper wrapper = new(new Mock<IWorkspace>[] { workspace, workspace2 }, monitorwrapper);
 
 		Mock<IWindow> window = new();
 		workspace.Setup(w => w.Windows).Returns(new[] { window.Object });
 
 		// When a workspace is removed, it returns true, WorkspaceRemoved is raised
 		var result = Assert.Raises<WorkspaceEventArgs>(
-			h => mocks.WorkspaceManager.WorkspaceRemoved += h,
-			h => mocks.WorkspaceManager.WorkspaceRemoved -= h,
-			() => Assert.True(mocks.WorkspaceManager.Remove(workspace.Object))
+			h => wrapper.WorkspaceManager.WorkspaceRemoved += h,
+			h => wrapper.WorkspaceManager.WorkspaceRemoved -= h,
+			() => Assert.True(wrapper.WorkspaceManager.Remove(workspace.Object))
 		);
 		Assert.Equal(workspace.Object, result.Arguments.Workspace);
 
@@ -191,10 +191,10 @@ public class WorkspaceManagerTests
 		// Given
 		Mock<IWorkspace> workspace = new();
 		Mock<IWorkspace> workspace2 = new();
-		MocksBuilder mocks = new(new[] { workspace, workspace2 });
+		Wrapper wrapper = new(new[] { workspace, workspace2 });
 
 		// When a workspace is removed, it returns false, as the workspace was not found
-		Assert.False(mocks.WorkspaceManager.Remove("not found"));
+		Assert.False(wrapper.WorkspaceManager.Remove("not found"));
 	}
 
 	[Fact]
@@ -202,16 +202,16 @@ public class WorkspaceManagerTests
 	{
 		// Given
 		Mock<IWorkspace> workspace = new();
-		MocksBuilder mocks =
+		Wrapper wrapper =
 			new(new Mock<IWorkspace>[] { workspace, new Mock<IWorkspace>() }, new[] { new Mock<IMonitor>() });
 
 		workspace.Setup(w => w.Name).Returns("workspace");
 
 		// When a workspace is removed, it returns true, and WorkspaceRemoved is raised
 		var result = Assert.Raises<WorkspaceEventArgs>(
-			h => mocks.WorkspaceManager.WorkspaceRemoved += h,
-			h => mocks.WorkspaceManager.WorkspaceRemoved -= h,
-			() => mocks.WorkspaceManager.Remove("workspace")
+			h => wrapper.WorkspaceManager.WorkspaceRemoved += h,
+			h => wrapper.WorkspaceManager.WorkspaceRemoved -= h,
+			() => wrapper.WorkspaceManager.Remove("workspace")
 		);
 		Assert.Equal(workspace.Object, result.Arguments.Workspace);
 	}
@@ -220,10 +220,10 @@ public class WorkspaceManagerTests
 	public void TryGet_Null()
 	{
 		// Given
-		MocksBuilder mocks = new();
+		Wrapper wrapper = new();
 
 		// When getting a workspace which does not exist, then null is returned
-		Assert.Null(mocks.WorkspaceManager.TryGet("not found"));
+		Assert.Null(wrapper.WorkspaceManager.TryGet("not found"));
 	}
 
 	[Fact]
@@ -232,10 +232,10 @@ public class WorkspaceManagerTests
 		// Given
 		Mock<IWorkspace> workspace = new();
 		workspace.Setup(w => w.Name).Returns("workspace");
-		MocksBuilder mocks = new(new[] { workspace });
+		Wrapper wrapper = new(new[] { workspace });
 
 		// When getting a workspace which does exist, then the workspace is returned
-		Assert.Equal(workspace.Object, mocks.WorkspaceManager.TryGet("workspace"));
+		Assert.Equal(workspace.Object, wrapper.WorkspaceManager.TryGet("workspace"));
 	}
 
 	[Fact]
@@ -244,10 +244,10 @@ public class WorkspaceManagerTests
 		// Given
 		Mock<IWorkspace> workspace = new();
 		workspace.Setup(w => w.Name).Returns("workspace");
-		MocksBuilder mocks = new(new[] { workspace });
+		Wrapper wrapper = new(new[] { workspace });
 
 		// When getting a workspace which does exist, then the workspace is returned
-		Assert.Equal(workspace.Object, mocks.WorkspaceManager["workspace"]);
+		Assert.Equal(workspace.Object, wrapper.WorkspaceManager["workspace"]);
 	}
 
 	[Fact]
@@ -256,10 +256,10 @@ public class WorkspaceManagerTests
 		// Given
 		Mock<IWorkspace> workspace = new();
 		Mock<IWorkspace> workspace2 = new();
-		MocksBuilder mocks = new(new[] { workspace, workspace2 });
+		Wrapper wrapper = new(new[] { workspace, workspace2 });
 
 		// When enumerating the workspaces, then the workspaces are returned
-		Assert.Equal(new[] { workspace.Object, workspace2.Object }, mocks.WorkspaceManager);
+		Assert.Equal(new[] { workspace.Object, workspace2.Object }, wrapper.WorkspaceManager);
 	}
 
 	[Fact]
@@ -268,26 +268,26 @@ public class WorkspaceManagerTests
 		// Given
 		Mock<IWorkspace> workspace = new();
 		Mock<IWorkspace> workspace2 = new();
-		MocksBuilder mocks = new(new[] { workspace, workspace2 });
+		Wrapper wrapper = new(new[] { workspace, workspace2 });
 
 		// When enumerating the workspaces, then the workspaces are returned
-		Assert.Equal(new[] { workspace.Object, workspace2.Object }, mocks.WorkspaceManager);
+		Assert.Equal(new[] { workspace.Object, workspace2.Object }, wrapper.WorkspaceManager);
 	}
 
 	[Fact]
 	public void Activate_NoOldWorkspace()
 	{
 		// Given
-		Mock<IMonitor>[] monitorMocks = new[] { new Mock<IMonitor>() };
+		Mock<IMonitor>[] monitorwrapper = new[] { new Mock<IMonitor>() };
 		Mock<IWorkspace> workspace = new();
-		MocksBuilder mocks = new(new[] { workspace }, monitorMocks);
+		Wrapper wrapper = new(new[] { workspace }, monitorwrapper);
 
 		// When a workspace is activated when there are no other workspaces activated, then it is
 		// focused on the active monitor and raises an event,
 		var result = Assert.Raises<MonitorWorkspaceChangedEventArgs>(
-			h => mocks.WorkspaceManager.MonitorWorkspaceChanged += h,
-			h => mocks.WorkspaceManager.MonitorWorkspaceChanged -= h,
-			() => mocks.WorkspaceManager.Activate(workspace.Object)
+			h => wrapper.WorkspaceManager.MonitorWorkspaceChanged += h,
+			h => wrapper.WorkspaceManager.MonitorWorkspaceChanged -= h,
+			() => wrapper.WorkspaceManager.Activate(workspace.Object)
 		);
 		Assert.Equal(workspace.Object, result.Arguments.NewWorkspace);
 		Assert.Null(result.Arguments.OldWorkspace);
@@ -303,21 +303,21 @@ public class WorkspaceManagerTests
 		// Given
 		Mock<IWorkspace> oldWorkspace = new();
 		Mock<IWorkspace> newWorkspace = new();
-		Mock<IMonitor>[] monitorMocks = new[] { new Mock<IMonitor>() };
-		MocksBuilder mocks = new(new[] { oldWorkspace, newWorkspace }, monitorMocks);
+		Mock<IMonitor>[] monitorwrapper = new[] { new Mock<IMonitor>() };
+		Wrapper wrapper = new(new[] { oldWorkspace, newWorkspace }, monitorwrapper);
 
-		mocks.WorkspaceManager.Activate(oldWorkspace.Object);
+		wrapper.WorkspaceManager.Activate(oldWorkspace.Object);
 
-		// Reset mocks
+		// Reset wrapper
 		oldWorkspace.Reset();
 		newWorkspace.Reset();
 
 		// When a workspace is activated when there is another workspace activated, then the old
 		// workspace is deactivated, the new workspace is activated, and an event is raised
 		var result = Assert.Raises<MonitorWorkspaceChangedEventArgs>(
-			h => mocks.WorkspaceManager.MonitorWorkspaceChanged += h,
-			h => mocks.WorkspaceManager.MonitorWorkspaceChanged -= h,
-			() => mocks.WorkspaceManager.Activate(newWorkspace.Object)
+			h => wrapper.WorkspaceManager.MonitorWorkspaceChanged += h,
+			h => wrapper.WorkspaceManager.MonitorWorkspaceChanged -= h,
+			() => wrapper.WorkspaceManager.Activate(newWorkspace.Object)
 		);
 		Assert.Equal(newWorkspace.Object, result.Arguments.NewWorkspace);
 		Assert.Equal(oldWorkspace.Object, result.Arguments.OldWorkspace);
@@ -336,23 +336,23 @@ public class WorkspaceManagerTests
 		// Given there are two workspaces and monitors
 		Mock<IWorkspace> workspace = new();
 		Mock<IWorkspace> workspace2 = new();
-		MocksBuilder mocks = new(new[] { workspace, workspace2 });
-		IMonitor monitor = mocks.Monitors[0].Object;
-		IMonitor monitor2 = mocks.Monitors[1].Object;
+		Wrapper wrapper = new(new[] { workspace, workspace2 });
+		IMonitor monitor = wrapper.Monitors[0].Object;
+		IMonitor monitor2 = wrapper.Monitors[1].Object;
 
-		mocks.WorkspaceManager.Activate(workspace.Object, monitor);
-		mocks.WorkspaceManager.Activate(workspace2.Object, monitor2);
+		wrapper.WorkspaceManager.Activate(workspace.Object, monitor);
+		wrapper.WorkspaceManager.Activate(workspace2.Object, monitor2);
 
-		// Reset mocks
+		// Reset wrapper
 		workspace.Reset();
 		workspace2.Reset();
 
 		// When a workspace is activated on a monitor which already has a workspace activated, then
 		// an event is raised
 		var result = Assert.Raises<MonitorWorkspaceChangedEventArgs>(
-			h => mocks.WorkspaceManager.MonitorWorkspaceChanged += h,
-			h => mocks.WorkspaceManager.MonitorWorkspaceChanged -= h,
-			() => mocks.WorkspaceManager.Activate(workspace2.Object, monitor)
+			h => wrapper.WorkspaceManager.MonitorWorkspaceChanged += h,
+			h => wrapper.WorkspaceManager.MonitorWorkspaceChanged -= h,
+			() => wrapper.WorkspaceManager.Activate(workspace2.Object, monitor)
 		);
 
 		Assert.Equal(monitor, result.Arguments.Monitor);
@@ -382,15 +382,15 @@ public class WorkspaceManagerTests
 		};
 
 		Mock<IMonitor>[] monitors = new[] { new Mock<IMonitor>() };
-		MocksBuilder mocks = new(workspaces, monitors);
+		Wrapper wrapper = new(workspaces, monitors);
 
-		mocks.WorkspaceManager.Activate(workspaces[currentIdx].Object);
+		wrapper.WorkspaceManager.Activate(workspaces[currentIdx].Object);
 
-		// Reset mocks
+		// Reset wrapper
 		workspaces[currentIdx].Reset();
 
 		// When the previous workspace is activated, then the previous workspace is activated
-		mocks.WorkspaceManager.ActivatePrevious();
+		wrapper.WorkspaceManager.ActivatePrevious();
 
 		workspaces[currentIdx].Verify(w => w.Deactivate(), Times.Once);
 		workspaces[currentIdx].Verify(w => w.DoLayout(), Times.Never);
@@ -415,15 +415,15 @@ public class WorkspaceManagerTests
 		};
 
 		Mock<IMonitor>[] monitors = new[] { new Mock<IMonitor>() };
-		MocksBuilder mocks = new(workspaces, monitors);
+		Wrapper wrapper = new(workspaces, monitors);
 
-		mocks.WorkspaceManager.Activate(workspaces[currentIdx].Object);
+		wrapper.WorkspaceManager.Activate(workspaces[currentIdx].Object);
 
-		// Reset mocks
+		// Reset wrapper
 		workspaces[currentIdx].Reset();
 
 		// When the next workspace is activated, then the next workspace is activated
-		mocks.WorkspaceManager.ActivateNext();
+		wrapper.WorkspaceManager.ActivateNext();
 
 		workspaces[currentIdx].Verify(w => w.Deactivate(), Times.Once);
 		workspaces[currentIdx].Verify(w => w.DoLayout(), Times.Never);
@@ -439,13 +439,13 @@ public class WorkspaceManagerTests
 	{
 		// Given
 		Mock<IWorkspace> workspace = new();
-		Mock<IMonitor>[] monitorMocks = new[] { new Mock<IMonitor>() };
-		MocksBuilder mocks = new(new[] { workspace }, monitorMocks);
+		Mock<IMonitor>[] monitorwrapper = new[] { new Mock<IMonitor>() };
+		Wrapper wrapper = new(new[] { workspace }, monitorwrapper);
 
-		mocks.WorkspaceManager.Activate(workspace.Object);
+		wrapper.WorkspaceManager.Activate(workspace.Object);
 
 		// When we get the monitor for a workspace which isn't in the workspace manager
-		IMonitor? monitor = mocks.WorkspaceManager.GetMonitorForWorkspace(new Mock<IWorkspace>().Object);
+		IMonitor? monitor = wrapper.WorkspaceManager.GetMonitorForWorkspace(new Mock<IWorkspace>().Object);
 
 		// Then null is returned
 		Assert.Null(monitor);
@@ -457,16 +457,16 @@ public class WorkspaceManagerTests
 		// Given
 		Mock<IWorkspace> workspace = new();
 		Mock<IWorkspace> workspace2 = new();
-		MocksBuilder mocks = new(new[] { workspace, workspace2 });
+		Wrapper wrapper = new(new[] { workspace, workspace2 });
 
-		mocks.WorkspaceManager.Activate(workspace.Object);
-		mocks.WorkspaceManager.Activate(workspace2.Object, mocks.Monitors[1].Object);
+		wrapper.WorkspaceManager.Activate(workspace.Object);
+		wrapper.WorkspaceManager.Activate(workspace2.Object, wrapper.Monitors[1].Object);
 
 		// When we get the monitor for a workspace which is in the workspace manager
-		IMonitor? monitor = mocks.WorkspaceManager.GetMonitorForWorkspace(workspace.Object);
+		IMonitor? monitor = wrapper.WorkspaceManager.GetMonitorForWorkspace(workspace.Object);
 
 		// Then the monitor is returned
-		Assert.Equal(mocks.Monitors[0].Object, monitor);
+		Assert.Equal(wrapper.Monitors[0].Object, monitor);
 	}
 
 	[Fact]
@@ -475,17 +475,17 @@ public class WorkspaceManagerTests
 		// Given
 		Mock<IWorkspace> workspace = new();
 		Mock<IWorkspace> workspace2 = new();
-		MocksBuilder mocks = new(new[] { workspace, workspace2 });
+		Wrapper wrapper = new(new[] { workspace, workspace2 });
 
-		mocks.WorkspaceManager.Activate(workspace.Object, mocks.Monitors[0].Object);
-		mocks.WorkspaceManager.Activate(workspace2.Object, mocks.Monitors[1].Object);
+		wrapper.WorkspaceManager.Activate(workspace.Object, wrapper.Monitors[0].Object);
+		wrapper.WorkspaceManager.Activate(workspace2.Object, wrapper.Monitors[1].Object);
 
-		// Reset the mocks
+		// Reset the wrapper
 		workspace.Reset();
 		workspace2.Reset();
 
 		// When we layout all active workspaces
-		mocks.WorkspaceManager.LayoutAllActiveWorkspaces();
+		wrapper.WorkspaceManager.LayoutAllActiveWorkspaces();
 
 		// Then all active workspaces are laid out
 		workspace.Verify(w => w.DoLayout(), Times.Once());
@@ -498,18 +498,18 @@ public class WorkspaceManagerTests
 		// Given
 		Mock<IWorkspace> workspace = new();
 		Mock<IWorkspace> workspace2 = new();
-		MocksBuilder mocks = new(new[] { workspace, workspace2 });
+		Wrapper wrapper = new(new[] { workspace, workspace2 });
 
-		mocks.WorkspaceManager.Activate(workspace.Object, mocks.Monitors[0].Object);
-		mocks.WorkspaceManager.Activate(workspace2.Object, mocks.Monitors[1].Object);
+		wrapper.WorkspaceManager.Activate(workspace.Object, wrapper.Monitors[0].Object);
+		wrapper.WorkspaceManager.Activate(workspace2.Object, wrapper.Monitors[1].Object);
 
-		// Reset the mocks
+		// Reset the wrapper
 		workspace.Reset();
 		workspace2.Reset();
 
 		// When a window is added
 		Mock<IWindow> window = new();
-		mocks.WorkspaceManager.WindowAdded(window.Object);
+		wrapper.WorkspaceManager.WindowAdded(window.Object);
 
 		// Then the window is added to the active workspace
 		workspace.Verify(w => w.AddWindow(window.Object), Times.Once());
@@ -522,20 +522,22 @@ public class WorkspaceManagerTests
 		// Given
 		Mock<IWorkspace> workspace = new();
 		Mock<IWorkspace> workspace2 = new();
-		MocksBuilder mocks = new(new[] { workspace, workspace2 });
+		Wrapper wrapper = new(new[] { workspace, workspace2 });
 
-		mocks.MonitorManager.Setup(m => m.GetMonitorAtPoint(It.IsAny<IPoint<int>>())).Returns(mocks.Monitors[0].Object);
+		wrapper.MonitorManager
+			.Setup(m => m.GetMonitorAtPoint(It.IsAny<IPoint<int>>()))
+			.Returns(wrapper.Monitors[0].Object);
 
-		mocks.WorkspaceManager.Activate(workspace.Object, mocks.Monitors[0].Object);
-		mocks.WorkspaceManager.Activate(workspace2.Object, mocks.Monitors[1].Object);
+		wrapper.WorkspaceManager.Activate(workspace.Object, wrapper.Monitors[0].Object);
+		wrapper.WorkspaceManager.Activate(workspace2.Object, wrapper.Monitors[1].Object);
 
-		// Reset the mocks
+		// Reset the wrapper
 		workspace.Reset();
 		workspace2.Reset();
 
 		// When a window is added
 		Mock<IWindow> window = new();
-		mocks.WorkspaceManager.WindowAdded(window.Object);
+		wrapper.WorkspaceManager.WindowAdded(window.Object);
 
 		// Then the window is added to the active workspace
 		workspace.Verify(w => w.AddWindow(window.Object), Times.Once());
@@ -548,21 +550,21 @@ public class WorkspaceManagerTests
 		// Given
 		Mock<IWorkspace> workspace = new();
 		Mock<IWorkspace> workspace2 = new();
-		MocksBuilder mocks = new(new[] { workspace, workspace2 });
+		Wrapper wrapper = new(new[] { workspace, workspace2 });
 
-		mocks.WorkspaceManager.Activate(workspace.Object, mocks.Monitors[0].Object);
-		mocks.WorkspaceManager.Activate(workspace2.Object, mocks.Monitors[1].Object);
+		wrapper.WorkspaceManager.Activate(workspace.Object, wrapper.Monitors[0].Object);
+		wrapper.WorkspaceManager.Activate(workspace2.Object, wrapper.Monitors[1].Object);
 
-		// Reset the mocks
+		// Reset the wrapper
 		workspace.Reset();
 		workspace2.Reset();
 
 		// There is a router which routes the window to a different workspace
 		Mock<IWindow> window = new();
-		mocks.RouterManager.Setup(r => r.RouteWindow(window.Object)).Returns(workspace2.Object);
+		wrapper.RouterManager.Setup(r => r.RouteWindow(window.Object)).Returns(workspace2.Object);
 
 		// When a window is added
-		mocks.WorkspaceManager.WindowAdded(window.Object);
+		wrapper.WorkspaceManager.WindowAdded(window.Object);
 
 		// Then the window is added to the workspace returned by the router
 		workspace.Verify(w => w.AddWindow(window.Object), Times.Never());
@@ -575,22 +577,22 @@ public class WorkspaceManagerTests
 		// Given
 		Mock<IWorkspace> workspace = new();
 		Mock<IWorkspace> workspace2 = new();
-		MocksBuilder mocks = new(new[] { workspace, workspace2 });
+		Wrapper wrapper = new(new[] { workspace, workspace2 });
 
-		mocks.WorkspaceManager.Activate(workspace.Object, mocks.Monitors[0].Object);
-		mocks.WorkspaceManager.Activate(workspace2.Object, mocks.Monitors[1].Object);
+		wrapper.WorkspaceManager.Activate(workspace.Object, wrapper.Monitors[0].Object);
+		wrapper.WorkspaceManager.Activate(workspace2.Object, wrapper.Monitors[1].Object);
 
-		// Reset the mocks
+		// Reset the wrapper
 		workspace.Reset();
 		workspace2.Reset();
 
 		// There is a router which routes the window to the active workspace
 		Mock<IWindow> window = new();
-		mocks.RouterManager.Setup(r => r.RouteWindow(window.Object)).Returns<IWorkspace?>(null);
-		mocks.RouterManager.Setup(r => r.RouteToActiveWorkspace).Returns(true);
+		wrapper.RouterManager.Setup(r => r.RouteWindow(window.Object)).Returns<IWorkspace?>(null);
+		wrapper.RouterManager.Setup(r => r.RouteToActiveWorkspace).Returns(true);
 
 		// When a window is added
-		mocks.WorkspaceManager.WindowAdded(window.Object);
+		wrapper.WorkspaceManager.WindowAdded(window.Object);
 
 		// Then the window is added to the active workspace
 		workspace.Verify(w => w.AddWindow(window.Object), Times.Once());
@@ -603,18 +605,18 @@ public class WorkspaceManagerTests
 		// Given
 		Mock<IWorkspace> workspace = new();
 		Mock<IWorkspace> workspace2 = new();
-		MocksBuilder mocks = new(new[] { workspace, workspace2 });
+		Wrapper wrapper = new(new[] { workspace, workspace2 });
 
-		mocks.WorkspaceManager.Activate(workspace.Object, mocks.Monitors[0].Object);
-		mocks.WorkspaceManager.Activate(workspace2.Object, mocks.Monitors[1].Object);
+		wrapper.WorkspaceManager.Activate(workspace.Object, wrapper.Monitors[0].Object);
+		wrapper.WorkspaceManager.Activate(workspace2.Object, wrapper.Monitors[1].Object);
 
-		// Reset the mocks
+		// Reset the wrapper
 		workspace.Reset();
 		workspace2.Reset();
 
 		// When a window is removed
 		Mock<IWindow> window = new();
-		mocks.WorkspaceManager.WindowRemoved(window.Object);
+		wrapper.WorkspaceManager.WindowRemoved(window.Object);
 
 		// Then the window is removed from all workspaces
 		workspace.Verify(w => w.RemoveWindow(window.Object), Times.Never());
@@ -627,19 +629,19 @@ public class WorkspaceManagerTests
 		// Given
 		Mock<IWorkspace> workspace = new();
 		Mock<IWorkspace> workspace2 = new();
-		MocksBuilder mocks = new(new[] { workspace, workspace2 });
+		Wrapper wrapper = new(new[] { workspace, workspace2 });
 
-		mocks.WorkspaceManager.Activate(workspace.Object, mocks.Monitors[0].Object);
-		mocks.WorkspaceManager.Activate(workspace2.Object, mocks.Monitors[1].Object);
+		wrapper.WorkspaceManager.Activate(workspace.Object, wrapper.Monitors[0].Object);
+		wrapper.WorkspaceManager.Activate(workspace2.Object, wrapper.Monitors[1].Object);
 
 		Mock<IWindow> window = new();
-		mocks.WorkspaceManager.WindowAdded(window.Object);
-		// Reset the mocks
+		wrapper.WorkspaceManager.WindowAdded(window.Object);
+		// Reset the wrapper
 		workspace.Reset();
 		workspace2.Reset();
 
 		// When a window which is in a workspace is removed
-		mocks.WorkspaceManager.WindowRemoved(window.Object);
+		wrapper.WorkspaceManager.WindowRemoved(window.Object);
 
 		// Then the window is removed from the workspace
 		workspace.Verify(w => w.RemoveWindow(window.Object), Times.Once());
@@ -652,17 +654,17 @@ public class WorkspaceManagerTests
 		// Given
 		Mock<IWorkspace> workspace = new();
 		Mock<IWorkspace> workspace2 = new();
-		MocksBuilder mocks = new(new[] { workspace, workspace2 });
+		Wrapper wrapper = new(new[] { workspace, workspace2 });
 
-		mocks.WorkspaceManager.Activate(workspace.Object, mocks.Monitors[0].Object);
-		mocks.WorkspaceManager.Activate(workspace2.Object, mocks.Monitors[1].Object);
+		wrapper.WorkspaceManager.Activate(workspace.Object, wrapper.Monitors[0].Object);
+		wrapper.WorkspaceManager.Activate(workspace2.Object, wrapper.Monitors[1].Object);
 
-		// Reset the mocks
+		// Reset the wrapper
 		workspace.Reset();
 		workspace2.Reset();
 
 		// When a window which is not in a workspace is moved to a workspace
-		mocks.WorkspaceManager.MoveWindowToWorkspace(workspace.Object);
+		wrapper.WorkspaceManager.MoveWindowToWorkspace(workspace.Object);
 
 		// Then the window is not added to the workspace
 		workspace.Verify(w => w.RemoveWindow(It.IsAny<IWindow>()), Times.Never());
@@ -675,19 +677,19 @@ public class WorkspaceManagerTests
 		// Given
 		Mock<IWorkspace> workspace = new();
 		Mock<IWorkspace> workspace2 = new();
-		MocksBuilder mocks = new(new[] { workspace, workspace2 });
+		Wrapper wrapper = new(new[] { workspace, workspace2 });
 
-		mocks.WorkspaceManager.Activate(workspace.Object, mocks.Monitors[0].Object);
-		mocks.WorkspaceManager.Activate(workspace2.Object, mocks.Monitors[1].Object);
+		wrapper.WorkspaceManager.Activate(workspace.Object, wrapper.Monitors[0].Object);
+		wrapper.WorkspaceManager.Activate(workspace2.Object, wrapper.Monitors[1].Object);
 
 		Mock<IWindow> window = new();
 		// When a phantom window is added
-		mocks.WorkspaceManager.AddPhantomWindow(workspace.Object, window.Object);
+		wrapper.WorkspaceManager.AddPhantomWindow(workspace.Object, window.Object);
 		workspace.Reset();
 		workspace2.Reset();
 
 		// and moved to a workspace
-		mocks.WorkspaceManager.MoveWindowToWorkspace(workspace.Object, window.Object);
+		wrapper.WorkspaceManager.MoveWindowToWorkspace(workspace.Object, window.Object);
 
 		// Then the window is not removed or added to any workspace
 		workspace.Verify(w => w.RemoveWindow(window.Object), Times.Never());
@@ -705,15 +707,15 @@ public class WorkspaceManagerTests
 		Mock<IWorkspace> workspace2 = new();
 		Mock<IWorkspace> workspace3 = new();
 
-		MocksBuilder mocks = new(new[] { workspace, workspace2, workspace3 });
+		Wrapper wrapper = new(new[] { workspace, workspace2, workspace3 });
 
-		// Reset the mocks
+		// Reset the wrapper
 		workspace.Reset();
 		workspace2.Reset();
 		workspace3.Reset();
 
 		// When a window not in any workspace is moved to a workspace
-		mocks.WorkspaceManager.MoveWindowToWorkspace(workspace.Object, window.Object);
+		wrapper.WorkspaceManager.MoveWindowToWorkspace(workspace.Object, window.Object);
 
 		// Then the window is not removed or added to any workspace
 		workspace.Verify(w => w.RemoveWindow(window.Object), Times.Never());
@@ -731,20 +733,20 @@ public class WorkspaceManagerTests
 		Mock<IWorkspace> workspace2 = new();
 		Mock<IWorkspace> workspace3 = new();
 
-		MocksBuilder mocks = new(new[] { workspace, workspace2, workspace3 });
+		Wrapper wrapper = new(new[] { workspace, workspace2, workspace3 });
 
-		mocks.WorkspaceManager.Activate(workspace.Object, mocks.Monitors[0].Object);
-		mocks.WorkspaceManager.Activate(workspace2.Object, mocks.Monitors[1].Object);
+		wrapper.WorkspaceManager.Activate(workspace.Object, wrapper.Monitors[0].Object);
+		wrapper.WorkspaceManager.Activate(workspace2.Object, wrapper.Monitors[1].Object);
 
 		// and the window is added
-		mocks.WorkspaceManager.WindowAdded(window.Object);
+		wrapper.WorkspaceManager.WindowAdded(window.Object);
 		workspace.Reset();
 		workspace2.Reset();
 		workspace3.Reset();
 		window.Reset();
 
 		// When a window in a workspace is moved to another workspace
-		mocks.WorkspaceManager.MoveWindowToWorkspace(workspace2.Object, window.Object);
+		wrapper.WorkspaceManager.MoveWindowToWorkspace(workspace2.Object, window.Object);
 
 		// Then the window is removed from the first workspace and added to the second
 		workspace.Verify(w => w.RemoveWindow(window.Object), Times.Once());
@@ -766,20 +768,20 @@ public class WorkspaceManagerTests
 		// and there are 3 monitors
 		Mock<IMonitor>[] monitors = new[] { new Mock<IMonitor>(), new Mock<IMonitor>(), new Mock<IMonitor>(), };
 
-		MocksBuilder mocks = new(new[] { workspace, workspace2, workspace3 }, monitors);
+		Wrapper wrapper = new(new[] { workspace, workspace2, workspace3 }, monitors);
 
-		mocks.WorkspaceManager.Activate(workspace.Object, mocks.Monitors[0].Object);
-		mocks.WorkspaceManager.Activate(workspace.Object, mocks.Monitors[1].Object);
+		wrapper.WorkspaceManager.Activate(workspace.Object, wrapper.Monitors[0].Object);
+		wrapper.WorkspaceManager.Activate(workspace.Object, wrapper.Monitors[1].Object);
 
 		// and the window is added
-		mocks.WorkspaceManager.WindowAdded(window.Object);
+		wrapper.WorkspaceManager.WindowAdded(window.Object);
 		workspace.Reset();
 		workspace2.Reset();
 		workspace3.Reset();
 		window.Reset();
 
 		// When a window in a workspace is moved to another workspace
-		mocks.WorkspaceManager.MoveWindowToWorkspace(workspace2.Object, window.Object);
+		wrapper.WorkspaceManager.MoveWindowToWorkspace(workspace2.Object, window.Object);
 
 		// Then the window is removed from the first workspace and added to the third
 		workspace.Verify(w => w.RemoveWindow(window.Object), Times.Once());
@@ -794,17 +796,17 @@ public class WorkspaceManagerTests
 		Mock<IWorkspace> workspace = new();
 		Mock<IWorkspace> workspace2 = new();
 
-		MocksBuilder mocks = new(new[] { workspace, workspace2 });
+		Wrapper wrapper = new(new[] { workspace, workspace2 });
 
-		mocks.WorkspaceManager.Activate(workspace.Object, mocks.Monitors[0].Object);
-		mocks.WorkspaceManager.Activate(workspace2.Object, mocks.Monitors[1].Object);
+		wrapper.WorkspaceManager.Activate(workspace.Object, wrapper.Monitors[0].Object);
+		wrapper.WorkspaceManager.Activate(workspace2.Object, wrapper.Monitors[1].Object);
 
-		// Reset the mocks
+		// Reset the wrapper
 		workspace.Reset();
 		workspace2.Reset();
 
 		// When there is no focused window
-		mocks.WorkspaceManager.MoveWindowToMonitor(mocks.Monitors[0].Object);
+		wrapper.WorkspaceManager.MoveWindowToMonitor(wrapper.Monitors[0].Object);
 
 		// Then the window is not added to the workspace
 		workspace.Verify(w => w.RemoveWindow(It.IsAny<IWindow>()), Times.Never());
@@ -818,19 +820,19 @@ public class WorkspaceManagerTests
 		Mock<IWorkspace> workspace = new();
 		Mock<IWorkspace> workspace2 = new();
 
-		MocksBuilder mocks = new(new[] { workspace, workspace2 });
+		Wrapper wrapper = new(new[] { workspace, workspace2 });
 
-		mocks.WorkspaceManager.Activate(workspace.Object, mocks.Monitors[0].Object);
-		mocks.WorkspaceManager.Activate(workspace2.Object, mocks.Monitors[1].Object);
+		wrapper.WorkspaceManager.Activate(workspace.Object, wrapper.Monitors[0].Object);
+		wrapper.WorkspaceManager.Activate(workspace2.Object, wrapper.Monitors[1].Object);
 
-		// Reset the mocks
+		// Reset the wrapper
 		workspace.Reset();
 		workspace2.Reset();
 
 		Mock<IWindow> window = new();
 
 		// When a window which is not in a workspace is moved to a monitor
-		mocks.WorkspaceManager.MoveWindowToMonitor(mocks.Monitors[0].Object, window.Object);
+		wrapper.WorkspaceManager.MoveWindowToMonitor(wrapper.Monitors[0].Object, window.Object);
 
 		// Then the window is not added to the workspace
 		workspace.Verify(w => w.RemoveWindow(window.Object), Times.Never());
@@ -844,18 +846,18 @@ public class WorkspaceManagerTests
 		Mock<IWorkspace> workspace = new();
 		Mock<IWorkspace> workspace2 = new();
 
-		MocksBuilder mocks = new(new[] { workspace, workspace2 });
+		Wrapper wrapper = new(new[] { workspace, workspace2 });
 
-		mocks.WorkspaceManager.Activate(workspace.Object, mocks.Monitors[0].Object);
-		mocks.WorkspaceManager.Activate(workspace2.Object, mocks.Monitors[1].Object);
+		wrapper.WorkspaceManager.Activate(workspace.Object, wrapper.Monitors[0].Object);
+		wrapper.WorkspaceManager.Activate(workspace2.Object, wrapper.Monitors[1].Object);
 
 		Mock<IWindow> window = new();
-		mocks.WorkspaceManager.WindowAdded(window.Object);
+		wrapper.WorkspaceManager.WindowAdded(window.Object);
 		workspace.Reset();
 		workspace2.Reset();
 
 		// When a window which is in a workspace is moved to the same monitor
-		mocks.WorkspaceManager.MoveWindowToMonitor(mocks.Monitors[0].Object, window.Object);
+		wrapper.WorkspaceManager.MoveWindowToMonitor(wrapper.Monitors[0].Object, window.Object);
 
 		// Then the window is not added to the workspace
 		workspace.Verify(w => w.RemoveWindow(window.Object), Times.Never());
@@ -869,18 +871,18 @@ public class WorkspaceManagerTests
 		Mock<IWorkspace> workspace = new();
 		Mock<IWorkspace> workspace2 = new();
 
-		MocksBuilder mocks = new(new[] { workspace, workspace2 });
+		Wrapper wrapper = new(new[] { workspace, workspace2 });
 
-		mocks.WorkspaceManager.Activate(workspace.Object, mocks.Monitors[0].Object);
-		mocks.WorkspaceManager.Activate(workspace2.Object, mocks.Monitors[1].Object);
+		wrapper.WorkspaceManager.Activate(workspace.Object, wrapper.Monitors[0].Object);
+		wrapper.WorkspaceManager.Activate(workspace2.Object, wrapper.Monitors[1].Object);
 
 		Mock<IWindow> window = new();
-		mocks.WorkspaceManager.WindowAdded(window.Object);
+		wrapper.WorkspaceManager.WindowAdded(window.Object);
 		workspace.Reset();
 		workspace2.Reset();
 
 		// When a window which is in a workspace is moved to a monitor which isn't registered
-		mocks.WorkspaceManager.MoveWindowToMonitor(new Mock<IMonitor>().Object, window.Object);
+		wrapper.WorkspaceManager.MoveWindowToMonitor(new Mock<IMonitor>().Object, window.Object);
 
 		// Then the window is not added to the workspace
 		workspace.Verify(w => w.RemoveWindow(window.Object), Times.Never());
@@ -893,18 +895,18 @@ public class WorkspaceManagerTests
 		// Given
 		Mock<IWorkspace> workspace = new();
 		Mock<IWorkspace> workspace2 = new();
-		MocksBuilder mocks = new(new[] { workspace, workspace2 });
+		Wrapper wrapper = new(new[] { workspace, workspace2 });
 
-		mocks.WorkspaceManager.Activate(workspace.Object, mocks.Monitors[0].Object);
-		mocks.WorkspaceManager.Activate(workspace2.Object, mocks.Monitors[1].Object);
+		wrapper.WorkspaceManager.Activate(workspace.Object, wrapper.Monitors[0].Object);
+		wrapper.WorkspaceManager.Activate(workspace2.Object, wrapper.Monitors[1].Object);
 
 		Mock<IWindow> window = new();
-		mocks.WorkspaceManager.WindowAdded(window.Object);
+		wrapper.WorkspaceManager.WindowAdded(window.Object);
 		workspace.Reset();
 		workspace2.Reset();
 
 		// When a window which is in a workspace is moved to a monitor
-		mocks.WorkspaceManager.MoveWindowToMonitor(mocks.Monitors[1].Object, window.Object);
+		wrapper.WorkspaceManager.MoveWindowToMonitor(wrapper.Monitors[1].Object, window.Object);
 
 		// Then the window is removed from the old workspace and added to the new workspace
 		workspace.Verify(w => w.RemoveWindow(window.Object), Times.Once());
@@ -918,21 +920,21 @@ public class WorkspaceManagerTests
 		Mock<IWorkspace> workspace = new();
 		Mock<IWorkspace> workspace2 = new();
 
-		MocksBuilder mocks = new(new[] { workspace, workspace2 });
-		mocks.MonitorManager
-			.Setup(m => m.GetPreviousMonitor(mocks.Monitors[0].Object))
-			.Returns(mocks.Monitors[1].Object);
+		Wrapper wrapper = new(new[] { workspace, workspace2 });
+		wrapper.MonitorManager
+			.Setup(m => m.GetPreviousMonitor(wrapper.Monitors[0].Object))
+			.Returns(wrapper.Monitors[1].Object);
 
-		mocks.WorkspaceManager.Activate(workspace.Object, mocks.Monitors[0].Object);
-		mocks.WorkspaceManager.Activate(workspace2.Object, mocks.Monitors[1].Object);
+		wrapper.WorkspaceManager.Activate(workspace.Object, wrapper.Monitors[0].Object);
+		wrapper.WorkspaceManager.Activate(workspace2.Object, wrapper.Monitors[1].Object);
 
 		Mock<IWindow> window = new();
-		mocks.WorkspaceManager.WindowAdded(window.Object);
+		wrapper.WorkspaceManager.WindowAdded(window.Object);
 		workspace.Reset();
 		workspace2.Reset();
 
 		// When a window which is in a workspace is moved to the previous monitor
-		mocks.WorkspaceManager.MoveWindowToPreviousMonitor(window.Object);
+		wrapper.WorkspaceManager.MoveWindowToPreviousMonitor(window.Object);
 
 		// Then the window is removed from the old workspace and added to the new workspace
 		workspace.Verify(w => w.RemoveWindow(window.Object), Times.Once());
@@ -946,19 +948,21 @@ public class WorkspaceManagerTests
 		Mock<IWorkspace> workspace = new();
 		Mock<IWorkspace> workspace2 = new();
 
-		MocksBuilder mocks = new(new[] { workspace, workspace2 });
-		mocks.MonitorManager.Setup(m => m.GetNextMonitor(mocks.Monitors[0].Object)).Returns(mocks.Monitors[1].Object);
+		Wrapper wrapper = new(new[] { workspace, workspace2 });
+		wrapper.MonitorManager
+			.Setup(m => m.GetNextMonitor(wrapper.Monitors[0].Object))
+			.Returns(wrapper.Monitors[1].Object);
 
-		mocks.WorkspaceManager.Activate(workspace.Object, mocks.Monitors[0].Object);
-		mocks.WorkspaceManager.Activate(workspace2.Object, mocks.Monitors[1].Object);
+		wrapper.WorkspaceManager.Activate(workspace.Object, wrapper.Monitors[0].Object);
+		wrapper.WorkspaceManager.Activate(workspace2.Object, wrapper.Monitors[1].Object);
 
 		Mock<IWindow> window = new();
-		mocks.WorkspaceManager.WindowAdded(window.Object);
+		wrapper.WorkspaceManager.WindowAdded(window.Object);
 		workspace.Reset();
 		workspace2.Reset();
 
 		// When a window which is in a workspace is moved to the next monitor
-		mocks.WorkspaceManager.MoveWindowToNextMonitor(window.Object);
+		wrapper.WorkspaceManager.MoveWindowToNextMonitor(window.Object);
 
 		// Then the window is removed from the old workspace and added to the new workspace
 		workspace.Verify(w => w.RemoveWindow(window.Object), Times.Once());
@@ -970,20 +974,20 @@ public class WorkspaceManagerTests
 	{
 		// Given
 		Mock<IWorkspace> workspace = new();
-		MocksBuilder mocks = new(new[] { workspace });
+		Wrapper wrapper = new(new[] { workspace });
 
-		mocks.WorkspaceManager.Activate(workspace.Object, mocks.Monitors[0].Object);
+		wrapper.WorkspaceManager.Activate(workspace.Object, wrapper.Monitors[0].Object);
 
 		Mock<IWindow> window = new();
-		mocks.WorkspaceManager.WindowAdded(window.Object);
+		wrapper.WorkspaceManager.WindowAdded(window.Object);
 		workspace.Reset();
 
-		mocks.MonitorManager
+		wrapper.MonitorManager
 			.Setup(m => m.GetMonitorAtPoint(It.IsAny<IPoint<int>>()))
 			.Returns(new Mock<IMonitor>().Object);
 
 		// When a window which is in a workspace is moved to a point which doesn't correspond to any workspaces
-		mocks.WorkspaceManager.MoveWindowToPoint(window.Object, new Point<int>() { X = 0, Y = 0 });
+		wrapper.WorkspaceManager.MoveWindowToPoint(window.Object, new Point<int>() { X = 0, Y = 0 });
 
 		// Then the window is not removed from the old workspace and not added to the new workspace
 		workspace.Verify(w => w.RemoveWindow(window.Object), Times.Never());
@@ -996,23 +1000,25 @@ public class WorkspaceManagerTests
 		// Given
 		Mock<IWorkspace> workspace = new();
 		Mock<IWorkspace> workspace2 = new();
-		MocksBuilder mocks = new(new[] { workspace, workspace2 });
+		Wrapper wrapper = new(new[] { workspace, workspace2 });
 
-		mocks.WorkspaceManager.Activate(workspace.Object, mocks.Monitors[0].Object);
-		mocks.WorkspaceManager.Activate(workspace2.Object, mocks.Monitors[1].Object);
+		wrapper.WorkspaceManager.Activate(workspace.Object, wrapper.Monitors[0].Object);
+		wrapper.WorkspaceManager.Activate(workspace2.Object, wrapper.Monitors[1].Object);
 
 		Mock<IWindow> window = new();
-		mocks.WorkspaceManager.AddPhantomWindow(workspace.Object, window.Object);
+		wrapper.WorkspaceManager.AddPhantomWindow(workspace.Object, window.Object);
 		workspace.Reset();
 		workspace2.Reset();
 
-		mocks.MonitorManager.Setup(m => m.GetMonitorAtPoint(It.IsAny<IPoint<int>>())).Returns(mocks.Monitors[1].Object);
+		wrapper.MonitorManager
+			.Setup(m => m.GetMonitorAtPoint(It.IsAny<IPoint<int>>()))
+			.Returns(wrapper.Monitors[1].Object);
 
 		// When a phantom is moved
-		mocks.WorkspaceManager.MoveWindowToPoint(window.Object, new Point<int>() { X = 0, Y = 0 });
+		wrapper.WorkspaceManager.MoveWindowToPoint(window.Object, new Point<int>() { X = 0, Y = 0 });
 
 		// Then nothing happens
-		mocks.MonitorManager.Verify(m => m.GetMonitorAtPoint(It.IsAny<IPoint<int>>()), Times.Never());
+		wrapper.MonitorManager.Verify(m => m.GetMonitorAtPoint(It.IsAny<IPoint<int>>()), Times.Never());
 		workspace.Verify(w => w.RemoveWindow(window.Object), Times.Never());
 		workspace.Verify(w => w.MoveWindowToPoint(window.Object, It.IsAny<Point<double>>()), Times.Never());
 	}
@@ -1023,24 +1029,26 @@ public class WorkspaceManagerTests
 		// Given
 		Mock<IWorkspace> workspace = new();
 		Mock<IWorkspace> workspace2 = new();
-		MocksBuilder mocks = new(new[] { workspace, workspace2 });
+		Wrapper wrapper = new(new[] { workspace, workspace2 });
 
-		mocks.WorkspaceManager.Activate(workspace.Object, mocks.Monitors[0].Object);
-		mocks.WorkspaceManager.Activate(workspace2.Object, mocks.Monitors[1].Object);
+		wrapper.WorkspaceManager.Activate(workspace.Object, wrapper.Monitors[0].Object);
+		wrapper.WorkspaceManager.Activate(workspace2.Object, wrapper.Monitors[1].Object);
 
 		Mock<IWindow> window = new();
-		mocks.WorkspaceManager.WindowAdded(window.Object);
+		wrapper.WorkspaceManager.WindowAdded(window.Object);
 		workspace.Reset();
 
-		mocks.MonitorManager.Setup(m => m.GetMonitorAtPoint(It.IsAny<IPoint<int>>())).Returns(mocks.Monitors[1].Object);
+		wrapper.MonitorManager
+			.Setup(m => m.GetMonitorAtPoint(It.IsAny<IPoint<int>>()))
+			.Returns(wrapper.Monitors[1].Object);
 		workspace.Setup(w => w.RemoveWindow(window.Object)).Returns(false);
 
 		// When a window is moved to a point, but the window cannot be removed from the old workspace
-		mocks.WorkspaceManager.MoveWindowToPoint(window.Object, new Point<int>() { X = 0, Y = 0 });
+		wrapper.WorkspaceManager.MoveWindowToPoint(window.Object, new Point<int>() { X = 0, Y = 0 });
 
 		// Then nothing happens
-		mocks.Monitors[0].VerifyGet(m => m.WorkingArea, Times.Never());
-		mocks.Monitors[1].VerifyGet(m => m.WorkingArea, Times.Never());
+		wrapper.Monitors[0].VerifyGet(m => m.WorkingArea, Times.Never());
+		wrapper.Monitors[1].VerifyGet(m => m.WorkingArea, Times.Never());
 		workspace.Verify(w => w.RemoveWindow(window.Object), Times.Once());
 		workspace.Verify(w => w.MoveWindowToPoint(window.Object, It.IsAny<Point<double>>()), Times.Never());
 	}
@@ -1051,28 +1059,30 @@ public class WorkspaceManagerTests
 		// Given
 		Mock<IWorkspace> activeWorkspace = new();
 		Mock<IWorkspace> targetWorkspace = new();
-		MocksBuilder mocks = new(new[] { activeWorkspace, targetWorkspace });
+		Wrapper wrapper = new(new[] { activeWorkspace, targetWorkspace });
 
-		mocks.WorkspaceManager.Activate(activeWorkspace.Object, mocks.Monitors[0].Object);
-		mocks.WorkspaceManager.Activate(targetWorkspace.Object, mocks.Monitors[1].Object);
+		wrapper.WorkspaceManager.Activate(activeWorkspace.Object, wrapper.Monitors[0].Object);
+		wrapper.WorkspaceManager.Activate(targetWorkspace.Object, wrapper.Monitors[1].Object);
 
 		Mock<IWindow> window = new();
-		mocks.WorkspaceManager.WindowAdded(window.Object);
+		wrapper.WorkspaceManager.WindowAdded(window.Object);
 		activeWorkspace.Reset();
 		targetWorkspace.Reset();
 
-		mocks.MonitorManager.Setup(m => m.GetMonitorAtPoint(It.IsAny<IPoint<int>>())).Returns(mocks.Monitors[1].Object);
-		mocks.Monitors[1].Setup(m => m.WorkingArea).Returns(new Location<int>());
+		wrapper.MonitorManager
+			.Setup(m => m.GetMonitorAtPoint(It.IsAny<IPoint<int>>()))
+			.Returns(wrapper.Monitors[1].Object);
+		wrapper.Monitors[1].Setup(m => m.WorkingArea).Returns(new Location<int>());
 		activeWorkspace.Setup(w => w.RemoveWindow(window.Object)).Returns(true);
 
 		// When a window is moved to a point
-		mocks.WorkspaceManager.MoveWindowToPoint(window.Object, new Point<int>() { X = 0, Y = 0 });
+		wrapper.WorkspaceManager.MoveWindowToPoint(window.Object, new Point<int>() { X = 0, Y = 0 });
 
 		// Then the window is removed from the old workspace and added to the new workspace
 		activeWorkspace.Verify(w => w.RemoveWindow(window.Object), Times.Once());
 		activeWorkspace.Verify(w => w.MoveWindowToPoint(window.Object, It.IsAny<Point<double>>()), Times.Never());
 
-		Assert.Equal(targetWorkspace.Object, mocks.WorkspaceManager.GetWorkspaceForWindow(window.Object));
+		Assert.Equal(targetWorkspace.Object, wrapper.WorkspaceManager.GetWorkspaceForWindow(window.Object));
 
 		window.Verify(w => w.Focus(), Times.Once());
 	}
@@ -1083,27 +1093,29 @@ public class WorkspaceManagerTests
 		// Given
 		Mock<IWorkspace> activeWorkspace = new();
 		Mock<IWorkspace> anotherWorkspace = new();
-		MocksBuilder mocks = new(new[] { activeWorkspace, anotherWorkspace });
+		Wrapper wrapper = new(new[] { activeWorkspace, anotherWorkspace });
 
-		mocks.WorkspaceManager.Activate(activeWorkspace.Object, mocks.Monitors[0].Object);
+		wrapper.WorkspaceManager.Activate(activeWorkspace.Object, wrapper.Monitors[0].Object);
 
 		Mock<IWindow> window = new();
-		mocks.WorkspaceManager.WindowAdded(window.Object);
+		wrapper.WorkspaceManager.WindowAdded(window.Object);
 		activeWorkspace.Reset();
 
-		mocks.MonitorManager.Setup(m => m.GetMonitorAtPoint(It.IsAny<IPoint<int>>())).Returns(mocks.Monitors[0].Object);
-		mocks.Monitors[0].Setup(m => m.WorkingArea).Returns(new Location<int>());
+		wrapper.MonitorManager
+			.Setup(m => m.GetMonitorAtPoint(It.IsAny<IPoint<int>>()))
+			.Returns(wrapper.Monitors[0].Object);
+		wrapper.Monitors[0].Setup(m => m.WorkingArea).Returns(new Location<int>());
 		activeWorkspace.Setup(w => w.RemoveWindow(window.Object)).Returns(true);
 
 		// When a window is moved to a point
-		mocks.WorkspaceManager.MoveWindowToPoint(window.Object, new Point<int>() { X = 0, Y = 0 });
+		wrapper.WorkspaceManager.MoveWindowToPoint(window.Object, new Point<int>() { X = 0, Y = 0 });
 
 		// Then the window is removed from the old workspace and added to the new workspace
 		activeWorkspace.Verify(w => w.RemoveWindow(window.Object), Times.Never());
 		activeWorkspace.Verify(w => w.MoveWindowToPoint(window.Object, It.IsAny<Point<double>>()), Times.Once());
 		anotherWorkspace.Verify(w => w.MoveWindowToPoint(window.Object, It.IsAny<Point<double>>()), Times.Never());
 
-		Assert.Equal(activeWorkspace.Object, mocks.WorkspaceManager.GetWorkspaceForWindow(window.Object));
+		Assert.Equal(activeWorkspace.Object, wrapper.WorkspaceManager.GetWorkspaceForWindow(window.Object));
 
 		window.Verify(w => w.Focus(), Times.Once());
 	}
@@ -1112,31 +1124,31 @@ public class WorkspaceManagerTests
 	public void WindowFocused()
 	{
 		// Given
-		MocksBuilder mocks = new();
+		Wrapper wrapper = new();
 
 		Mock<ILayoutEngine> layoutEngine = new();
 		Mock<Workspace> workspace =
 			new(
-				mocks.Context.Object,
-				mocks.WorkspaceManager.InternalTriggers,
+				wrapper.Context.Object,
+				wrapper.WorkspaceManager.InternalTriggers,
 				"test",
 				new ILayoutEngine[] { layoutEngine.Object }
 			);
 		Mock<Workspace> workspace2 =
 			new(
-				mocks.Context.Object,
-				mocks.WorkspaceManager.InternalTriggers,
+				wrapper.Context.Object,
+				wrapper.WorkspaceManager.InternalTriggers,
 				"test",
 				new ILayoutEngine[] { layoutEngine.Object }
 			);
 
-		mocks.WorkspaceManager.Add(workspace.Object);
-		mocks.WorkspaceManager.Add(workspace2.Object);
+		wrapper.WorkspaceManager.Add(workspace.Object);
+		wrapper.WorkspaceManager.Add(workspace2.Object);
 
 		Mock<IWindow> window = new();
 
 		// When a window is focused
-		mocks.WorkspaceManager.WindowFocused(window.Object);
+		wrapper.WorkspaceManager.WindowFocused(window.Object);
 
 		// Then the window is focused in all workspaces
 		workspace.Verify(w => w.WindowFocused(window.Object), Times.Once());
@@ -1149,18 +1161,18 @@ public class WorkspaceManagerTests
 		// Given
 		Mock<IWorkspace>[] workspaces = new[] { new Mock<IWorkspace>(), new Mock<IWorkspace>() };
 		Mock<IMonitor> monitor = new();
-		MocksBuilder mocks = new(workspaces, new Mock<IMonitor>[] { monitor });
+		Wrapper wrapper = new(workspaces, new Mock<IMonitor>[] { monitor });
 
 		Mock<ILayoutEngine> layoutEngine = new();
 		Mock<IWindow> window = new();
 
-		mocks.WorkspaceManager.Activate(workspaces[0].Object, monitor.Object);
+		wrapper.WorkspaceManager.Activate(workspaces[0].Object, monitor.Object);
 		workspaces[0].Reset();
 
 		// When a window is added to the first workspace, the second workspace is activated, and the window is focused
-		mocks.WorkspaceManager.WindowAdded(window.Object);
-		mocks.WorkspaceManager.Activate(workspaces[1].Object, monitor.Object);
-		mocks.WorkspaceManager.WindowFocused(window.Object);
+		wrapper.WorkspaceManager.WindowAdded(window.Object);
+		wrapper.WorkspaceManager.Activate(workspaces[1].Object, monitor.Object);
+		wrapper.WorkspaceManager.WindowFocused(window.Object);
 
 		// Then the first workspace is activated
 		workspaces[0].Verify(w => w.DoLayout(), Times.Once());
@@ -1171,11 +1183,11 @@ public class WorkspaceManagerTests
 	{
 		// Given
 		Mock<IWorkspace> workspace = new();
-		MocksBuilder mocks = new(new[] { workspace });
+		Wrapper wrapper = new(new[] { workspace });
 		Mock<IWindow> window = new();
 
 		// When a window is minimized, but the window is not found in any workspace
-		mocks.WorkspaceManager.WindowMinimizeStart(window.Object);
+		wrapper.WorkspaceManager.WindowMinimizeStart(window.Object);
 
 		// Then nothing happens
 		workspace.Verify(w => w.RemoveWindow(window.Object), Times.Never());
@@ -1186,18 +1198,18 @@ public class WorkspaceManagerTests
 	{
 		// Given
 		Mock<IWorkspace> workspace = new();
-		MocksBuilder mocks = new(new[] { workspace });
+		Wrapper wrapper = new(new[] { workspace });
 
 		Mock<IRouterManager> routerManager = new();
 		routerManager.Setup(r => r.RouteWindow(It.IsAny<IWindow>())).Returns(workspace.Object);
-		mocks.Context.Setup(c => c.RouterManager).Returns(routerManager.Object);
+		wrapper.Context.Setup(c => c.RouterManager).Returns(routerManager.Object);
 
 		// A window is added to the workspace
 		Mock<IWindow> window = new();
-		mocks.WorkspaceManager.WindowAdded(window.Object);
+		wrapper.WorkspaceManager.WindowAdded(window.Object);
 
 		// When a window is minimized
-		mocks.WorkspaceManager.WindowMinimizeStart(window.Object);
+		wrapper.WorkspaceManager.WindowMinimizeStart(window.Object);
 
 		// Then the window is removed from the workspace
 		workspace.Verify(w => w.RemoveWindow(window.Object), Times.Once());
@@ -1208,16 +1220,16 @@ public class WorkspaceManagerTests
 	{
 		// Given
 		Mock<IWorkspace> workspace = new();
-		MocksBuilder mocks = new(new[] { workspace });
+		Wrapper wrapper = new(new[] { workspace });
 
 		Mock<IRouterManager> routerManager = new();
 		routerManager.Setup(r => r.RouteWindow(It.IsAny<IWindow>())).Returns(workspace.Object);
-		mocks.Context.Setup(c => c.RouterManager).Returns(routerManager.Object);
+		wrapper.Context.Setup(c => c.RouterManager).Returns(routerManager.Object);
 
 		Mock<IWindow> window = new();
 
 		// When a window is restored
-		mocks.WorkspaceManager.WindowMinimizeEnd(window.Object);
+		wrapper.WorkspaceManager.WindowMinimizeEnd(window.Object);
 
 		// Then the window is routed to the workspace
 		routerManager.Verify(r => r.RouteWindow(window.Object), Times.Once());
@@ -1230,19 +1242,19 @@ public class WorkspaceManagerTests
 		Mock<IWorkspace> workspace = new();
 		Mock<IWorkspace> workspace2 = new();
 
-		MocksBuilder mocks = new(new[] { workspace, workspace2 });
+		Wrapper wrapper = new(new[] { workspace, workspace2 });
 
-		mocks.WorkspaceManager.Activate(workspace.Object, mocks.Monitors[0].Object);
-		mocks.WorkspaceManager.Activate(workspace2.Object, mocks.Monitors[1].Object);
+		wrapper.WorkspaceManager.Activate(workspace.Object, wrapper.Monitors[0].Object);
+		wrapper.WorkspaceManager.Activate(workspace2.Object, wrapper.Monitors[1].Object);
 
 		// When a monitor is removed
-		mocks.WorkspaceManager.MonitorManager_MonitorsChanged(
+		wrapper.WorkspaceManager.MonitorManager_MonitorsChanged(
 			this,
 			new MonitorsChangedEventArgs()
 			{
 				AddedMonitors = Array.Empty<IMonitor>(),
-				RemovedMonitors = new IMonitor[] { mocks.Monitors[0].Object },
-				UnchangedMonitors = new IMonitor[] { mocks.Monitors[1].Object }
+				RemovedMonitors = new IMonitor[] { wrapper.Monitors[0].Object },
+				UnchangedMonitors = new IMonitor[] { wrapper.Monitors[1].Object }
 			}
 		);
 
@@ -1259,24 +1271,24 @@ public class WorkspaceManagerTests
 		Mock<IMonitor> monitor = new();
 		monitor.Setup(m => m.WorkingArea).Returns(new Location<int>());
 
-		MocksBuilder mocks = new(new[] { workspace, workspace2 });
-		mocks.Context.Setup(c => c.NativeManager).Returns(new Mock<INativeManager>().Object);
+		Wrapper wrapper = new(new[] { workspace, workspace2 });
+		wrapper.Context.Setup(c => c.NativeManager).Returns(new Mock<INativeManager>().Object);
 
 		Mock<Func<IList<ILayoutEngine>>> CreateDefaultLayoutEngines = new();
 		CreateDefaultLayoutEngines.Setup(c => c()).Returns(new ILayoutEngine[] { new Mock<ILayoutEngine>().Object });
-		mocks.WorkspaceManager.CreateDefaultLayoutEngines = CreateDefaultLayoutEngines.Object;
+		wrapper.WorkspaceManager.CreateDefaultLayoutEngines = CreateDefaultLayoutEngines.Object;
 
-		mocks.WorkspaceManager.Activate(workspace.Object, mocks.Monitors[0].Object);
-		mocks.WorkspaceManager.Activate(workspace2.Object, mocks.Monitors[1].Object);
+		wrapper.WorkspaceManager.Activate(workspace.Object, wrapper.Monitors[0].Object);
+		wrapper.WorkspaceManager.Activate(workspace2.Object, wrapper.Monitors[1].Object);
 
 		// When a monitor is added
-		mocks.WorkspaceManager.MonitorManager_MonitorsChanged(
+		wrapper.WorkspaceManager.MonitorManager_MonitorsChanged(
 			this,
 			new MonitorsChangedEventArgs()
 			{
 				AddedMonitors = new IMonitor[] { monitor.Object },
 				RemovedMonitors = Array.Empty<IMonitor>(),
-				UnchangedMonitors = new IMonitor[] { mocks.Monitors[0].Object, mocks.Monitors[1].Object }
+				UnchangedMonitors = new IMonitor[] { wrapper.Monitors[0].Object, wrapper.Monitors[1].Object }
 			}
 		);
 
@@ -1294,24 +1306,24 @@ public class WorkspaceManagerTests
 
 		Mock<IMonitor> monitor = new();
 
-		MocksBuilder mocks = new(new[] { workspace, workspace2, workspace3 });
+		Wrapper wrapper = new(new[] { workspace, workspace2, workspace3 });
 
-		mocks.WorkspaceManager.Activate(workspace.Object, mocks.Monitors[0].Object);
-		mocks.WorkspaceManager.Activate(workspace2.Object, mocks.Monitors[1].Object);
+		wrapper.WorkspaceManager.Activate(workspace.Object, wrapper.Monitors[0].Object);
+		wrapper.WorkspaceManager.Activate(workspace2.Object, wrapper.Monitors[1].Object);
 
-		// Reset the mocks
+		// Reset the wrapper
 		workspace.Reset();
 		workspace2.Reset();
 		workspace3.Reset();
 
 		// When a monitor is added
-		mocks.WorkspaceManager.MonitorManager_MonitorsChanged(
+		wrapper.WorkspaceManager.MonitorManager_MonitorsChanged(
 			this,
 			new MonitorsChangedEventArgs()
 			{
 				AddedMonitors = new IMonitor[] { monitor.Object },
 				RemovedMonitors = Array.Empty<IMonitor>(),
-				UnchangedMonitors = new IMonitor[] { mocks.Monitors[0].Object, mocks.Monitors[1].Object }
+				UnchangedMonitors = new IMonitor[] { wrapper.Monitors[0].Object, wrapper.Monitors[1].Object }
 			}
 		);
 
@@ -1325,14 +1337,14 @@ public class WorkspaceManagerTests
 	public void AddProxyLayoutEngine()
 	{
 		// Given
-		MocksBuilder mocks = new();
+		Wrapper wrapper = new();
 		Mock<ProxyLayoutEngine> proxyLayoutEngine = new();
 
 		// When a proxy layout engine is added
-		mocks.WorkspaceManager.AddProxyLayoutEngine(proxyLayoutEngine.Object);
+		wrapper.WorkspaceManager.AddProxyLayoutEngine(proxyLayoutEngine.Object);
 
 		// Then the proxy layout engine is added to the list
-		Assert.Contains(proxyLayoutEngine.Object, mocks.WorkspaceManager.ProxyLayoutEngines);
+		Assert.Contains(proxyLayoutEngine.Object, wrapper.WorkspaceManager.ProxyLayoutEngines);
 	}
 
 	[Fact]
@@ -1341,13 +1353,13 @@ public class WorkspaceManagerTests
 		// Given
 		Mock<IWorkspace> workspace = new();
 		Mock<IWindow> window = new();
-		MocksBuilder mocks = new(new[] { workspace });
+		Wrapper wrapper = new(new[] { workspace });
 
 		// When a phantom window is added
-		mocks.WorkspaceManager.AddPhantomWindow(workspace.Object, window.Object);
+		wrapper.WorkspaceManager.AddPhantomWindow(workspace.Object, window.Object);
 
 		// Then the phantom window is added to the list
-		Assert.Contains(window.Object, mocks.WorkspaceManager.PhantomWindows);
+		Assert.Contains(window.Object, wrapper.WorkspaceManager.PhantomWindows);
 	}
 
 	[Fact]
@@ -1356,16 +1368,16 @@ public class WorkspaceManagerTests
 		// Given
 		Mock<IWorkspace> workspace = new();
 		Mock<IWindow> window = new();
-		MocksBuilder mocks = new(new[] { workspace });
+		Wrapper wrapper = new(new[] { workspace });
 
-		mocks.WorkspaceManager.AddPhantomWindow(workspace.Object, window.Object);
+		wrapper.WorkspaceManager.AddPhantomWindow(workspace.Object, window.Object);
 
 		// When a phantom window is removed
-		mocks.WorkspaceManager.RemovePhantomWindow(window.Object);
+		wrapper.WorkspaceManager.RemovePhantomWindow(window.Object);
 
 		// Then the phantom window is removed from the list
-		Assert.DoesNotContain(window.Object, mocks.WorkspaceManager.PhantomWindows);
-		Assert.Null(mocks.WorkspaceManager.GetMonitorForWindow(window.Object));
+		Assert.DoesNotContain(window.Object, wrapper.WorkspaceManager.PhantomWindows);
+		Assert.Null(wrapper.WorkspaceManager.GetMonitorForWindow(window.Object));
 	}
 
 	[Fact]
@@ -1374,10 +1386,10 @@ public class WorkspaceManagerTests
 		// Given
 		Mock<IWorkspace> workspace = new();
 		Mock<IWorkspace> workspace2 = new();
-		MocksBuilder mocks = new(new[] { workspace, workspace2 });
+		Wrapper wrapper = new(new[] { workspace, workspace2 });
 
 		// When the workspace manager is disposed
-		mocks.WorkspaceManager.Dispose();
+		wrapper.WorkspaceManager.Dispose();
 
 		// Then the workspaces are disposed
 		workspace.Verify(w => w.Dispose(), Times.Once());

--- a/src/Whim.Tests/Workspace/WorkspaceManagerTests.cs
+++ b/src/Whim.Tests/Workspace/WorkspaceManagerTests.cs
@@ -1274,9 +1274,9 @@ public class WorkspaceManagerTests
 
 		Wrapper wrapper = new(new[] { workspace, workspace2 });
 
-		Mock<Func<IList<ILayoutEngine>>> CreateDefaultLayoutEngines = new();
-		CreateDefaultLayoutEngines.Setup(c => c()).Returns(new ILayoutEngine[] { new Mock<ILayoutEngine>().Object });
-		wrapper.WorkspaceManager.CreateDefaultLayoutEngines = CreateDefaultLayoutEngines.Object;
+		Mock<Func<IList<ILayoutEngine>>> CreateLayoutEngines = new();
+		CreateLayoutEngines.Setup(c => c()).Returns(new ILayoutEngine[] { new Mock<ILayoutEngine>().Object });
+		wrapper.WorkspaceManager.CreateLayoutEngines = CreateLayoutEngines.Object;
 
 		wrapper.WorkspaceManager.Activate(workspace.Object, wrapper.Monitors[0].Object);
 		wrapper.WorkspaceManager.Activate(workspace2.Object, wrapper.Monitors[1].Object);
@@ -1293,7 +1293,7 @@ public class WorkspaceManagerTests
 		);
 
 		// Then a new workspace is created
-		CreateDefaultLayoutEngines.Verify(f => f(), Times.Once());
+		CreateLayoutEngines.Verify(f => f(), Times.Once());
 	}
 
 	[Fact]
@@ -1437,9 +1437,9 @@ public class WorkspaceManagerTests
 	{
 		// Given
 		Wrapper wrapper = new(Array.Empty<Mock<IWorkspace>>());
-		Mock<Func<IList<ILayoutEngine>>> CreateDefaultLayoutEngines = new();
-		CreateDefaultLayoutEngines.Setup(c => c()).Returns(new ILayoutEngine[] { new Mock<ILayoutEngine>().Object });
-		wrapper.WorkspaceManager.CreateDefaultLayoutEngines = CreateDefaultLayoutEngines.Object;
+		Mock<Func<IList<ILayoutEngine>>> CreateLayoutEngines = new();
+		CreateLayoutEngines.Setup(c => c()).Returns(new ILayoutEngine[] { new Mock<ILayoutEngine>().Object });
+		wrapper.WorkspaceManager.CreateLayoutEngines = CreateLayoutEngines.Object;
 
 		// When creating a workspace
 		wrapper.WorkspaceManager.Add("workspace");
@@ -1459,9 +1459,9 @@ public class WorkspaceManagerTests
 	{
 		// Given
 		Wrapper wrapper = new(Array.Empty<Mock<IWorkspace>>());
-		Mock<Func<IList<ILayoutEngine>>> CreateDefaultLayoutEngines = new();
-		CreateDefaultLayoutEngines.Setup(c => c()).Returns(new ILayoutEngine[] { new Mock<ILayoutEngine>().Object });
-		wrapper.WorkspaceManager.CreateDefaultLayoutEngines = CreateDefaultLayoutEngines.Object;
+		Mock<Func<IList<ILayoutEngine>>> CreateLayoutEngines = new();
+		CreateLayoutEngines.Setup(c => c()).Returns(new ILayoutEngine[] { new Mock<ILayoutEngine>().Object });
+		wrapper.WorkspaceManager.CreateLayoutEngines = CreateLayoutEngines.Object;
 
 		// When
 		wrapper.WorkspaceManager.Add("workspace");

--- a/src/Whim.Tests/Workspace/WorkspaceManagerTests.cs
+++ b/src/Whim.Tests/Workspace/WorkspaceManagerTests.cs
@@ -1251,7 +1251,7 @@ public class WorkspaceManagerTests
 
 		Mock<Func<IContext, string, IWorkspace>> workspaceFactory = new();
 		workspaceFactory.Setup(f => f(mocks.Context.Object, It.IsAny<string>())).Returns(new Mock<IWorkspace>().Object);
-		mocks.WorkspaceManager.WorkspaceFactory = workspaceFactory.Object;
+		mocks.WorkspaceManager.WorkspaceConfigCreator = workspaceFactory.Object;
 
 		mocks.WorkspaceManager.Activate(workspace.Object, mocks.Monitors[0].Object);
 		mocks.WorkspaceManager.Activate(workspace2.Object, mocks.Monitors[1].Object);

--- a/src/Whim.Tests/Workspace/WorkspaceTests.cs
+++ b/src/Whim.Tests/Workspace/WorkspaceTests.cs
@@ -271,6 +271,41 @@ public class WorkspaceTests
 	}
 
 	[Fact]
+	public void ContainsWindow_False()
+	{
+		// Given
+		MocksBuilder mocks = new();
+		Mock<IWindow> window = new();
+
+		Workspace workspace =
+			new(mocks.Context.Object, mocks.Triggers, "Workspace", new ILayoutEngine[] { mocks.LayoutEngine.Object });
+
+		// When
+		bool result = workspace.ContainsWindow(window.Object);
+
+		// Then
+		Assert.False(result);
+	}
+
+	[Fact]
+	public void ContainsWindow_True()
+	{
+		// Given
+		MocksBuilder mocks = new();
+		Mock<IWindow> window = new();
+
+		Workspace workspace =
+			new(mocks.Context.Object, mocks.Triggers, "Workspace", new ILayoutEngine[] { mocks.LayoutEngine.Object });
+		workspace.AddWindow(window.Object);
+
+		// When
+		bool result = workspace.ContainsWindow(window.Object);
+
+		// Then
+		Assert.True(result);
+	}
+
+	[Fact]
 	public void WindowFocused_ContainsWindow()
 	{
 		// Given the window is in the workspace

--- a/src/Whim.Tests/Workspace/WorkspaceTests.cs
+++ b/src/Whim.Tests/Workspace/WorkspaceTests.cs
@@ -235,6 +235,42 @@ public class WorkspaceTests
 	}
 
 	[Fact]
+	public void Initialize_AlreadyInitialized()
+	{
+		// Given
+		MocksBuilder mocks = new();
+
+		Mock<ProxyLayoutEngine> proxyLayoutEngine = new();
+		proxyLayoutEngine.Setup(p => p(It.IsAny<ILayoutEngine>())).Returns((ILayoutEngine e) => e);
+		Mock<ProxyLayoutEngine> proxyLayoutEngine2 = new();
+		mocks.WorkspaceManager
+			.SetupGet(m => m.ProxyLayoutEngines)
+			.Returns(new ProxyLayoutEngine[] { proxyLayoutEngine.Object, proxyLayoutEngine2.Object });
+
+		Mock<ILayoutEngine> layoutEngine = new();
+		Mock<ILayoutEngine> layoutEngine2 = new();
+
+		Workspace workspace =
+			new(
+				mocks.Context.Object,
+				mocks.Triggers,
+				"Workspace",
+				new ILayoutEngine[] { layoutEngine.Object, layoutEngine2.Object }
+			);
+
+		workspace.Initialize();
+
+		// When
+		workspace.Initialize();
+
+		// Then it shouldn't run an extra time
+		proxyLayoutEngine.Verify(e => e(layoutEngine.Object), Times.Once);
+		proxyLayoutEngine.Verify(e => e(layoutEngine2.Object), Times.Once);
+		proxyLayoutEngine2.Verify(e => e(layoutEngine.Object), Times.Once);
+		proxyLayoutEngine2.Verify(e => e(layoutEngine2.Object), Times.Once);
+	}
+
+	[Fact]
 	public void WindowFocused_ContainsWindow()
 	{
 		// Given the window is in the workspace

--- a/src/Whim.TreeLayout/ITreeLayoutPlugin.cs
+++ b/src/Whim.TreeLayout/ITreeLayoutPlugin.cs
@@ -5,7 +5,7 @@ namespace Whim.TreeLayout;
 /// <summary>
 /// TreeLayoutPlugin provides commands and functionality for the <see cref="TreeLayoutEngine"/>.
 /// TreeLayoutPlugin does not load the <see cref="TreeLayoutEngine"/> - that is done when creating
-/// a workspace via <see cref="IWorkspace.CreateWorkspace"/>, or in <see cref="IWorkspaceManager.WorkspaceConfigCreator"/>.
+/// a workspace via <see cref="IWorkspaceManager.Add"/>.
 /// </summary>
 public interface ITreeLayoutPlugin : IPlugin
 {

--- a/src/Whim.TreeLayout/ITreeLayoutPlugin.cs
+++ b/src/Whim.TreeLayout/ITreeLayoutPlugin.cs
@@ -5,7 +5,7 @@ namespace Whim.TreeLayout;
 /// <summary>
 /// TreeLayoutPlugin provides commands and functionality for the <see cref="TreeLayoutEngine"/>.
 /// TreeLayoutPlugin does not load the <see cref="TreeLayoutEngine"/> - that is done when creating
-/// a workspace via <see cref="IWorkspace.CreateWorkspace"/>, or in <see cref="IWorkspaceManager.WorkspaceFactory"/>.
+/// a workspace via <see cref="IWorkspace.CreateWorkspace"/>, or in <see cref="IWorkspaceManager.WorkspaceConfigCreator"/>.
 /// </summary>
 public interface ITreeLayoutPlugin : IPlugin
 {

--- a/src/Whim/Template/whim.config.csx
+++ b/src/Whim/Template/whim.config.csx
@@ -30,64 +30,64 @@ using Microsoft.UI.Xaml.Media;
 /// <param name="context"></param>
 void DoConfig(IContext context)
 {
-    context.Logger.Config = new LoggerConfig();
+	context.Logger.Config = new LoggerConfig();
 
-    context.WorkspaceManager.CreateDefaultLayoutEngines = () => new ILayoutEngine[]
-    {
-        new TreeLayoutEngine(context),
-        new ColumnLayoutEngine()
-    };
+	context.WorkspaceManager.CreateDefaultLayoutEngines = () => new ILayoutEngine[]
+	{
+		new TreeLayoutEngine(context),
+		new ColumnLayoutEngine()
+	};
 
-    // Add workspaces.
-    context.WorkspaceManager.Add("1");
-    context.WorkspaceManager.Add("2");
-    context.WorkspaceManager.Add("3");
-    context.WorkspaceManager.Add("4");
+	// Add workspaces.
+	context.WorkspaceManager.Add("1");
+	context.WorkspaceManager.Add("2");
+	context.WorkspaceManager.Add("3");
+	context.WorkspaceManager.Add("4");
 
-    // Bar plugin.
-    List<BarComponent> leftComponents = new() { WorkspaceWidget.CreateComponent() };
-    List<BarComponent> centerComponents = new() { FocusedWindowWidget.CreateComponent() };
-    List<BarComponent> rightComponents = new()
-    {
-        ActiveLayoutWidget.CreateComponent(),
-        DateTimeWidget.CreateComponent()
-    };
+	// Bar plugin.
+	List<BarComponent> leftComponents = new() { WorkspaceWidget.CreateComponent() };
+	List<BarComponent> centerComponents = new() { FocusedWindowWidget.CreateComponent() };
+	List<BarComponent> rightComponents = new()
+	{
+		ActiveLayoutWidget.CreateComponent(),
+		DateTimeWidget.CreateComponent()
+	};
 
-    BarConfig barConfig = new(leftComponents, centerComponents, rightComponents);
-    BarPlugin barPlugin = new(context, barConfig);
-    context.PluginManager.AddPlugin(barPlugin);
+	BarConfig barConfig = new(leftComponents, centerComponents, rightComponents);
+	BarPlugin barPlugin = new(context, barConfig);
+	context.PluginManager.AddPlugin(barPlugin);
 
-    // Floating window plugin.
-    FloatingLayoutPlugin floatingLayoutPlugin = new(context);
-    context.PluginManager.AddPlugin(floatingLayoutPlugin);
+	// Floating window plugin.
+	FloatingLayoutPlugin floatingLayoutPlugin = new(context);
+	context.PluginManager.AddPlugin(floatingLayoutPlugin);
 
-    // Gap plugin.
-    GapsConfig gapsConfig = new() { OuterGap = 0, InnerGap = 10 };
-    GapsPlugin gapsPlugin = new(context, gapsConfig);
-    context.PluginManager.AddPlugin(gapsPlugin);
+	// Gap plugin.
+	GapsConfig gapsConfig = new() { OuterGap = 0, InnerGap = 10 };
+	GapsPlugin gapsPlugin = new(context, gapsConfig);
+	context.PluginManager.AddPlugin(gapsPlugin);
 
-    // Focus indicator.
-    FocusIndicatorConfig focusIndicatorConfig = new() { Color = new SolidColorBrush(Colors.Red), FadeEnabled = true };
-    FocusIndicatorPlugin focusIndicatorPlugin = new(context, focusIndicatorConfig);
-    context.PluginManager.AddPlugin(focusIndicatorPlugin);
+	// Focus indicator.
+	FocusIndicatorConfig focusIndicatorConfig = new() { Color = new SolidColorBrush(Colors.Red), FadeEnabled = true };
+	FocusIndicatorPlugin focusIndicatorPlugin = new(context, focusIndicatorConfig);
+	context.PluginManager.AddPlugin(focusIndicatorPlugin);
 
-    // Command palette.
-    CommandPaletteConfig commandPaletteConfig = new(context);
-    CommandPalettePlugin commandPalettePlugin = new(context, commandPaletteConfig);
-    context.PluginManager.AddPlugin(commandPalettePlugin);
+	// Command palette.
+	CommandPaletteConfig commandPaletteConfig = new(context);
+	CommandPalettePlugin commandPalettePlugin = new(context, commandPaletteConfig);
+	context.PluginManager.AddPlugin(commandPalettePlugin);
 
-    // Tree layout.
-    TreeLayoutPlugin treeLayoutPlugin = new(context);
-    context.PluginManager.AddPlugin(treeLayoutPlugin);
+	// Tree layout.
+	TreeLayoutPlugin treeLayoutPlugin = new(context);
+	context.PluginManager.AddPlugin(treeLayoutPlugin);
 
-    // Tree layout bar.
-    TreeLayoutBarPlugin treeLayoutBarPlugin = new(treeLayoutPlugin);
-    context.PluginManager.AddPlugin(treeLayoutBarPlugin);
-    rightComponents.Add(treeLayoutBarPlugin.CreateComponent());
+	// Tree layout bar.
+	TreeLayoutBarPlugin treeLayoutBarPlugin = new(treeLayoutPlugin);
+	context.PluginManager.AddPlugin(treeLayoutBarPlugin);
+	rightComponents.Add(treeLayoutBarPlugin.CreateComponent());
 
-    // Tree layout command palette.
-    TreeLayoutCommandPalettePlugin treeLayoutCommandPalettePlugin = new(context, treeLayoutPlugin, commandPalettePlugin);
-    context.PluginManager.AddPlugin(treeLayoutCommandPalettePlugin);
+	// Tree layout command palette.
+	TreeLayoutCommandPalettePlugin treeLayoutCommandPalettePlugin = new(context, treeLayoutPlugin, commandPalettePlugin);
+	context.PluginManager.AddPlugin(treeLayoutCommandPalettePlugin);
 }
 
 #pragma warning disable CS8974 // Methods should not return 'this'.

--- a/src/Whim/Template/whim.config.csx
+++ b/src/Whim/Template/whim.config.csx
@@ -21,22 +21,8 @@ using Whim.TreeLayout;
 using Whim.TreeLayout.Bar;
 using Whim.TreeLayout.CommandPalette;
 using Windows.Win32.UI.Input.KeyboardAndMouse;
-
-/// <summary>
-/// Returns a new workspace with <paramref name="name"/> and layout engines.
-/// </summary>
-/// <param name="context"></param>
-/// <param name="name"></param>
-/// <returns></returns>
-IWorkspace CreateWorkspace(IContext context, string name)
-{
-    return IWorkspace.CreateWorkspace(
-        context,
-        name,
-        new TreeLayoutEngine(context),
-        new ColumnLayoutEngine(),
-        new ColumnLayoutEngine("Right to left", false));
-}
+using Microsoft.UI;
+using Microsoft.UI.Xaml.Media;
 
 /// <summary>
 /// This is what's called when Whim is loaded.
@@ -44,15 +30,19 @@ IWorkspace CreateWorkspace(IContext context, string name)
 /// <param name="context"></param>
 void DoConfig(IContext context)
 {
-    context.Logger.Config = new LoggerConfig() { BaseMinLogLevel = LogLevel.Error };
+    context.Logger.Config = new LoggerConfig();
 
-    context.WorkspaceManager.WorkspaceFactory = CreateWorkspace;
+    context.WorkspaceManager.CreateDefaultLayoutEngines = () => new ILayoutEngine[]
+    {
+        new TreeLayoutEngine(context),
+        new ColumnLayoutEngine()
+    };
 
     // Add workspaces.
-    context.WorkspaceManager.Add(CreateWorkspace(context, "1"));
-    context.WorkspaceManager.Add(CreateWorkspace(context, "2"));
-    context.WorkspaceManager.Add(CreateWorkspace(context, "3"));
-    context.WorkspaceManager.Add(CreateWorkspace(context, "4"));
+    context.WorkspaceManager.Add("1");
+    context.WorkspaceManager.Add("2");
+    context.WorkspaceManager.Add("3");
+    context.WorkspaceManager.Add("4");
 
     // Bar plugin.
     List<BarComponent> leftComponents = new() { WorkspaceWidget.CreateComponent() };
@@ -77,7 +67,7 @@ void DoConfig(IContext context)
     context.PluginManager.AddPlugin(gapsPlugin);
 
     // Focus indicator.
-    FocusIndicatorConfig focusIndicatorConfig = new() { FadeEnabled = true };
+    FocusIndicatorConfig focusIndicatorConfig = new() { Color = new SolidColorBrush(Colors.Red), FadeEnabled = true };
     FocusIndicatorPlugin focusIndicatorPlugin = new(context, focusIndicatorConfig);
     context.PluginManager.AddPlugin(focusIndicatorPlugin);
 

--- a/src/Whim/Template/whim.config.csx
+++ b/src/Whim/Template/whim.config.csx
@@ -32,7 +32,7 @@ void DoConfig(IContext context)
 {
 	context.Logger.Config = new LoggerConfig();
 
-	context.WorkspaceManager.CreateDefaultLayoutEngines = () => new ILayoutEngine[]
+	context.WorkspaceManager.CreateLayoutEngines = () => new ILayoutEngine[]
 	{
 		new TreeLayoutEngine(context),
 		new ColumnLayoutEngine()

--- a/src/Whim/Workspace/IWorkspace.cs
+++ b/src/Whim/Workspace/IWorkspace.cs
@@ -160,16 +160,4 @@ public interface IWorkspace : IDisposable
 	/// <param name="window">The phantom window to remove.</param>
 	public void RemovePhantomWindow(ILayoutEngine engine, IWindow window);
 	#endregion
-
-	/// <summary>
-	/// Creates a new workspace.
-	/// </summary>
-	/// <param name="context"></param>
-	/// <param name="name">The name of the workspace.</param>
-	/// <param name="layoutEngines">The layout engines to load into the workspace.</param>
-	/// <returns></returns>
-	public static IWorkspace CreateWorkspace(IContext context, string name, params ILayoutEngine[] layoutEngines)
-	{
-		return new Workspace(context, name, layoutEngines);
-	}
 }

--- a/src/Whim/Workspace/IWorkspaceManager.cs
+++ b/src/Whim/Workspace/IWorkspaceManager.cs
@@ -15,14 +15,9 @@ public interface IWorkspaceManager : IEnumerable<IWorkspace>, IDisposable
 	public IWorkspace ActiveWorkspace { get; }
 
 	/// <summary>
-	/// Creates a workspace, named with the provided string.
-	///
-	/// <br/>
-	///
-	/// <b>NOTE</b>: This will not add the workspace to the manager, nor will it activate it.
-	/// Call <see cref="Add"/>.
+	/// Creates the default layout engines to add to a workspace.
 	/// </summary>
-	public Func<IContext, string, IWorkspace> WorkspaceFactory { get; set; }
+	public Func<IList<ILayoutEngine>> CreateDefaultLayoutEngines { get; set; }
 
 	/// <summary>
 	/// Initialize the event listeners.
@@ -65,7 +60,7 @@ public interface IWorkspaceManager : IEnumerable<IWorkspace>, IDisposable
 	public event EventHandler<ActiveLayoutEngineChangedEventArgs>? ActiveLayoutEngineChanged;
 
 	/// <summary>
-	/// Triggered when workspace is renamed.
+	/// Event for when a workspace is renamed.
 	/// </summary>
 	public event EventHandler<WorkspaceRenamedEventArgs>? WorkspaceRenamed;
 
@@ -76,10 +71,17 @@ public interface IWorkspaceManager : IEnumerable<IWorkspace>, IDisposable
 	public void LayoutAllActiveWorkspaces();
 
 	/// <summary>
-	/// The <see cref="IWorkspace"/> to add.
+	/// Add a new workspace.
 	/// </summary>
-	/// <param name="workspace"></param>
-	public void Add(IWorkspace workspace);
+	/// <param name="name">
+	/// The name of the workspace. Defaults to <see langword="null"/>, which will generate the name
+	/// <c>Workspace {n}</c>.
+	/// </param>
+	/// <param name="layoutEngines">
+	/// The layout engines to add to the workspace. Defaults to <see langword="null"/>, which will
+	/// use the <see cref="CreateDefaultLayoutEngines"/> function.
+	/// </param>
+	public void Add(string? name = null, IEnumerable<ILayoutEngine>? layoutEngines = null);
 
 	/// <summary>
 	/// Tries to remove the given workspace.
@@ -174,26 +176,6 @@ public interface IWorkspaceManager : IEnumerable<IWorkspace>, IDisposable
 	/// The proxy layout engines.
 	/// </summary>
 	public IEnumerable<ProxyLayoutEngine> ProxyLayoutEngines { get; }
-
-	/// <summary>
-	/// Used by <see cref="IWorkspace"/> to trigger <see cref="ActiveLayoutEngineChanged"/>.
-	/// </summary>
-	public void TriggerActiveLayoutEngineChanged(ActiveLayoutEngineChangedEventArgs args);
-
-	/// <summary>
-	/// Used by <see cref="IWorkspace"/> to trigger <see cref="WorkspaceRenamed"/>.
-	/// </summary>
-	public void TriggerWorkspaceRenamed(WorkspaceRenamedEventArgs args);
-
-	/// <summary>
-	/// Used by <see cref="IWorkspace"/> to trigger <see cref="WorkspaceLayoutStarted"/>.
-	/// </summary>
-	public void TriggerWorkspaceLayoutStarted(WorkspaceEventArgs args);
-
-	/// <summary>
-	/// Used by <see cref="IWorkspace"/> to trigger <see cref="WorkspaceLayoutCompleted"/>.
-	/// </summary>
-	public void TriggerWorkspaceLayoutCompleted(WorkspaceEventArgs args);
 
 	/// <summary>
 	/// Moves the given <paramref name="window"/> to the given <paramref name="workspace"/>.

--- a/src/Whim/Workspace/IWorkspaceManager.cs
+++ b/src/Whim/Workspace/IWorkspaceManager.cs
@@ -17,7 +17,7 @@ public interface IWorkspaceManager : IEnumerable<IWorkspace>, IDisposable
 	/// <summary>
 	/// Creates the default layout engines to add to a workspace.
 	/// </summary>
-	public Func<IList<ILayoutEngine>> CreateDefaultLayoutEngines { get; set; }
+	public Func<IList<ILayoutEngine>> CreateLayoutEngines { get; set; }
 
 	/// <summary>
 	/// Initialize the event listeners.
@@ -79,7 +79,7 @@ public interface IWorkspaceManager : IEnumerable<IWorkspace>, IDisposable
 	/// </param>
 	/// <param name="layoutEngines">
 	/// The layout engines to add to the workspace. Defaults to <see langword="null"/>, which will
-	/// use the <see cref="CreateDefaultLayoutEngines"/> function.
+	/// use the <see cref="CreateLayoutEngines"/> function.
 	/// </param>
 	public void Add(string? name = null, IEnumerable<ILayoutEngine>? layoutEngines = null);
 

--- a/src/Whim/Workspace/Workspace.cs
+++ b/src/Whim/Workspace/Workspace.cs
@@ -6,7 +6,9 @@ namespace Whim;
 
 internal class Workspace : IWorkspace
 {
+	private bool _initialized;
 	private readonly IContext _context;
+	private readonly WorkspaceManagerTriggers _triggers;
 
 	private string _name;
 	public string Name
@@ -16,7 +18,7 @@ internal class Workspace : IWorkspace
 		{
 			string oldName = _name;
 			_name = value;
-			(_context.WorkspaceManager as WorkspaceManager)?.TriggerWorkspaceRenamed(
+			_triggers.WorkspaceRenamed(
 				new WorkspaceRenamedEventArgs()
 				{
 					Workspace = this,
@@ -32,7 +34,7 @@ internal class Workspace : IWorkspace
 	/// </summary>
 	public IWindow? LastFocusedWindow { get; private set; }
 
-	private readonly List<ILayoutEngine> _layoutEngines = new();
+	private readonly ILayoutEngine[] _layoutEngines;
 	private int _activeLayoutEngineIndex;
 	private bool _disposedValue;
 
@@ -58,25 +60,39 @@ internal class Workspace : IWorkspace
 	/// </summary>
 	private readonly Dictionary<IWindow, IWindowState> _windowLocations = new();
 
-	public Workspace(IContext context, string name, params ILayoutEngine[] layoutEngines)
+	public Workspace(
+		IContext context,
+		WorkspaceManagerTriggers triggers,
+		string name,
+		IEnumerable<ILayoutEngine> layoutEngines
+	)
 	{
 		_context = context;
-		_name = name;
+		_triggers = triggers;
 
-		if (layoutEngines.Length == 0)
+		_name = name;
+		_layoutEngines = layoutEngines.ToArray();
+
+		if (_layoutEngines.Length == 0)
 		{
 			throw new ArgumentException("At least one layout engine must be provided.");
 		}
-
-		_layoutEngines = layoutEngines.ToList();
 	}
 
 	public void Initialize()
 	{
+		if (_initialized)
+		{
+			Logger.Error($"Workspace {Name} has already been initialized.");
+			return;
+		}
+
+		_initialized = true;
+
 		// Apply the proxy layout engines
 		foreach (ProxyLayoutEngine proxyLayout in _context.WorkspaceManager.ProxyLayoutEngines)
 		{
-			for (int i = 0; i < _layoutEngines.Count; i++)
+			for (int i = 0; i < _layoutEngines.Length; i++)
 			{
 				_layoutEngines[i] = proxyLayout(_layoutEngines[i]);
 			}
@@ -124,7 +140,7 @@ internal class Workspace : IWorkspace
 		_activeLayoutEngineIndex = nextIdx;
 		DoLayout();
 
-		_context.WorkspaceManager.TriggerActiveLayoutEngineChanged(
+		_triggers.ActiveLayoutEngineChanged(
 			new ActiveLayoutEngineChangedEventArgs()
 			{
 				Workspace = this,
@@ -137,13 +153,13 @@ internal class Workspace : IWorkspace
 	public void NextLayoutEngine()
 	{
 		Logger.Debug(Name);
-		UpdateLayoutEngine((_activeLayoutEngineIndex + 1).Mod(_layoutEngines.Count));
+		UpdateLayoutEngine((_activeLayoutEngineIndex + 1).Mod(_layoutEngines.Length));
 	}
 
 	public void PreviousLayoutEngine()
 	{
 		Logger.Debug(Name);
-		UpdateLayoutEngine((_activeLayoutEngineIndex - 1).Mod(_layoutEngines.Count));
+		UpdateLayoutEngine((_activeLayoutEngineIndex - 1).Mod(_layoutEngines.Length));
 	}
 
 	public bool TrySetLayoutEngine(string name)
@@ -151,7 +167,7 @@ internal class Workspace : IWorkspace
 		Logger.Debug($"Trying to set layout engine {name} for workspace {Name}");
 
 		int nextIdx = -1;
-		for (int idx = 0; idx < _layoutEngines.Count; idx++)
+		for (int idx = 0; idx < _layoutEngines.Length; idx++)
 		{
 			ILayoutEngine engine = _layoutEngines[idx];
 			if (engine.Name == name)
@@ -360,7 +376,7 @@ internal class Workspace : IWorkspace
 	{
 		Logger.Debug($"Workspace {Name}");
 
-		_context.WorkspaceManager.TriggerWorkspaceLayoutStarted(new WorkspaceEventArgs() { Workspace = this });
+		_triggers.WorkspaceLayoutStarted(new WorkspaceEventArgs() { Workspace = this });
 
 		// Get the monitor for this workspace
 		IMonitor? monitor = _context.WorkspaceManager.GetMonitorForWorkspace(this);
@@ -412,7 +428,7 @@ internal class Workspace : IWorkspace
 			Logger.Verbose($"Layout for workspace {Name} complete");
 		}
 
-		_context.WorkspaceManager.TriggerWorkspaceLayoutCompleted(new WorkspaceEventArgs() { Workspace = this });
+		_triggers.WorkspaceLayoutCompleted(new WorkspaceEventArgs() { Workspace = this });
 	}
 
 	#region Phantom Windows

--- a/src/Whim/Workspace/Workspace.cs
+++ b/src/Whim/Workspace/Workspace.cs
@@ -376,8 +376,6 @@ internal class Workspace : IWorkspace
 	{
 		Logger.Debug($"Workspace {Name}");
 
-		_triggers.WorkspaceLayoutStarted(new WorkspaceEventArgs() { Workspace = this });
-
 		// Get the monitor for this workspace
 		IMonitor? monitor = _context.WorkspaceManager.GetMonitorForWorkspace(this);
 		if (monitor == null)
@@ -386,6 +384,7 @@ internal class Workspace : IWorkspace
 			return;
 		}
 
+		_triggers.WorkspaceLayoutStarted(new WorkspaceEventArgs() { Workspace = this });
 		_windowLocations.Clear();
 
 		Logger.Verbose($"Starting layout for workspace {Name} with layout engine {ActiveLayoutEngine.Name}");

--- a/src/Whim/Workspace/WorkspaceManager.cs
+++ b/src/Whim/Workspace/WorkspaceManager.cs
@@ -21,8 +21,9 @@ internal record WorkspaceManagerTriggers
 /// </summary>
 internal class WorkspaceManager : IWorkspaceManager
 {
+	private bool _initialized;
 	private readonly IContext _context;
-	private readonly WorkspaceManagerTriggers _triggers;
+	protected readonly WorkspaceManagerTriggers _triggers;
 
 	/// <summary>
 	/// The <see cref="IWorkspace"/>s stored by this manager.
@@ -93,6 +94,8 @@ internal class WorkspaceManager : IWorkspaceManager
 	{
 		Logger.Debug("Initializing workspace manager...");
 
+		_initialized = true;
+
 		_context.MonitorManager.MonitorsChanged += MonitorManager_MonitorsChanged;
 
 		// Ensure there's at least n workspaces, for n monitors.
@@ -136,6 +139,12 @@ internal class WorkspaceManager : IWorkspaceManager
 			);
 
 		_workspaces.Add(workspace);
+
+		if (_initialized)
+		{
+			workspace.Initialize();
+		}
+
 		WorkspaceAdded?.Invoke(this, new WorkspaceEventArgs() { Workspace = workspace });
 	}
 

--- a/src/Whim/Workspace/WorkspaceManager.cs
+++ b/src/Whim/Workspace/WorkspaceManager.cs
@@ -27,7 +27,7 @@ internal class WorkspaceManager : IWorkspaceManager
 	/// <summary>
 	/// The <see cref="IWorkspace"/>s stored by this manager.
 	/// </summary>
-	private readonly List<IWorkspace> _workspaces = new();
+	protected readonly List<IWorkspace> _workspaces = new();
 
 	/// <summary>
 	/// Maps windows to their workspace.

--- a/src/Whim/Workspace/WorkspaceManager.cs
+++ b/src/Whim/Workspace/WorkspaceManager.cs
@@ -63,7 +63,7 @@ internal class WorkspaceManager : IWorkspaceManager
 
 	public event EventHandler<WorkspaceEventArgs>? WorkspaceLayoutCompleted;
 
-	public Func<IList<ILayoutEngine>> CreateDefaultLayoutEngines { get; set; } =
+	public Func<IList<ILayoutEngine>> CreateLayoutEngines { get; set; } =
 		() => new ILayoutEngine[] { new ColumnLayoutEngine() };
 
 	/// <summary>
@@ -112,7 +112,7 @@ internal class WorkspaceManager : IWorkspaceManager
 			IWorkspace workspace =
 				idx < _workspaces.Count
 					? _workspaces[idx]
-					: new Workspace(_context, _triggers, $"Workspace {idx + 1}", CreateDefaultLayoutEngines());
+					: new Workspace(_context, _triggers, $"Workspace {idx + 1}", CreateLayoutEngines());
 
 			Activate(workspace, monitor);
 			idx++;
@@ -135,7 +135,7 @@ internal class WorkspaceManager : IWorkspaceManager
 				_context,
 				_triggers,
 				name ?? $"Workspace {_workspaces.Count + 1}",
-				layoutEngines ?? CreateDefaultLayoutEngines()
+				layoutEngines ?? CreateLayoutEngines()
 			);
 
 		_workspaces.Add(workspace);
@@ -451,7 +451,7 @@ internal class WorkspaceManager : IWorkspaceManager
 					_context,
 					_triggers,
 					$"Workspace {_workspaces.Count + 1}",
-					CreateDefaultLayoutEngines()
+					CreateLayoutEngines()
 				);
 				workspace.Initialize();
 			}


### PR DESCRIPTION
This replaces the internal `Trigger` methods with a `Trigger` method with a `WorkspaceManagerTriggers` class, which contains references to `WorkspaceManager` methods which triggers events. The `WorkspaceManagerTriggers` are passed to the `Workspace` constructor.

As a result of this change, it is no longer possible to create a `Workspace` methods outside of the `WorkspaceManager`. Instead, it's possible to set the property `CreateLayoutEngines`, a function which creates an array of layout engines to use when creating workspaces. `CreateLayoutEngines` replaces `WorkspaceFactory`.
