### PR TITLE
Keep minimized windows inside a given workspace

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -16,5 +16,6 @@
   "files.exclude": {
     "src/Whim*/bin": true,
     "src/Whim*/obj": true
-  }
+  },
+  "dotnet.defaultSolution": "Whim.sln"
 }

--- a/src/Whim.Tests/Window/WindowTests.cs
+++ b/src/Whim.Tests/Window/WindowTests.cs
@@ -409,4 +409,74 @@ public class WindowTests
 		// Then
 		Assert.Null(window);
 	}
+
+	[Fact]
+	public void Equals_Null()
+	{
+		// Given
+		Wrapper wrapper = new();
+		IWindow? window = Window.CreateWindow(wrapper.Context.Object, wrapper.CoreNativeManager.Object, new HWND(123))!;
+
+		// When
+		bool equals = window.Equals(null);
+
+		// Then
+		Assert.False(equals);
+	}
+
+	[Fact]
+	public void Equals_WrongType()
+	{
+		// Given
+		Wrapper wrapper = new();
+		IWindow? window = Window.CreateWindow(wrapper.Context.Object, wrapper.CoreNativeManager.Object, new HWND(123))!;
+
+		// When
+		bool equals = window.Equals(new object());
+
+		// Then
+		Assert.False(equals);
+	}
+
+	[Fact]
+	public void Equals_NotWindow()
+	{
+		// Given
+		Wrapper wrapper = new();
+		IWindow? window = Window.CreateWindow(wrapper.Context.Object, wrapper.CoreNativeManager.Object, new HWND(123))!;
+
+		// When
+		bool equals = window.Equals(new Mock<IWindow>().Object);
+
+		// Then
+		Assert.False(equals);
+	}
+
+	[Fact]
+	public void Equals_Success()
+	{
+		// Given
+		Wrapper wrapper = new();
+		IWindow? window = Window.CreateWindow(wrapper.Context.Object, wrapper.CoreNativeManager.Object, new HWND(123))!;
+
+		// When
+		bool equals = window.Equals(window);
+
+		// Then
+		Assert.True(equals);
+	}
+
+	[Fact]
+	public void GetHashCode_Success()
+	{
+		// Given
+		Wrapper wrapper = new();
+		IWindow? window = Window.CreateWindow(wrapper.Context.Object, wrapper.CoreNativeManager.Object, new HWND(123))!;
+
+		// When
+		int hashCode = window.GetHashCode();
+
+		// Then
+		Assert.Equal(hashCode, 123.GetHashCode());
+	}
 }

--- a/src/Whim.Tests/Window/WindowTests.cs
+++ b/src/Whim.Tests/Window/WindowTests.cs
@@ -1,7 +1,6 @@
 using Moq;
 using System.ComponentModel;
 using Windows.Win32.Foundation;
-using Windows.Win32.UI.Input.KeyboardAndMouse;
 using Xunit;
 
 namespace Whim.Tests;

--- a/src/Whim.Tests/Window/WindowTests.cs
+++ b/src/Whim.Tests/Window/WindowTests.cs
@@ -1,0 +1,412 @@
+using Moq;
+using System.ComponentModel;
+using Windows.Win32.Foundation;
+using Windows.Win32.UI.Input.KeyboardAndMouse;
+using Xunit;
+
+namespace Whim.Tests;
+
+public class WindowTests
+{
+	private class Wrapper
+	{
+		public Mock<IContext> Context { get; } = new();
+		public Mock<ICoreNativeManager> CoreNativeManager { get; } = new();
+		public Mock<INativeManager> NativeManager { get; } = new();
+
+		public Wrapper()
+		{
+			Context.Setup(c => c.NativeManager).Returns(NativeManager.Object);
+
+			CoreNativeManager
+				.Setup(cnm => cnm.GetWindowThreadProcessId(It.IsAny<HWND>(), out It.Ref<uint>.IsAny))
+				.Callback(
+					(HWND hwnd, out uint processId) =>
+					{
+						processId = 456;
+					}
+				);
+
+			CoreNativeManager
+				.Setup(cnm => cnm.GetProcessNameAndPath(It.IsAny<int>()))
+				.Returns(("processName", "processFileName"));
+		}
+	}
+
+	[Fact]
+	public void Handle()
+	{
+		// Given
+		Wrapper wrapper = new();
+		IWindow window = Window.CreateWindow(wrapper.Context.Object, wrapper.CoreNativeManager.Object, new HWND(123))!;
+
+		// When
+		HWND handle = window.Handle;
+
+		// Then
+		Assert.Equal(123, handle.Value);
+	}
+
+	[Fact]
+	public void Title()
+	{
+		// Given
+		Wrapper wrapper = new();
+		wrapper.CoreNativeManager.Setup(cnm => cnm.GetWindowText(It.IsAny<HWND>())).Returns("title");
+
+		IWindow window = Window.CreateWindow(wrapper.Context.Object, wrapper.CoreNativeManager.Object, new HWND(123))!;
+
+		// When
+		string title = window.Title;
+
+		// Then
+		Assert.Equal("title", title);
+	}
+
+	[Fact]
+	public void WindowClass()
+	{
+		// Given
+		Wrapper wrapper = new();
+		wrapper.NativeManager.Setup(cnm => cnm.GetClassName(It.IsAny<HWND>())).Returns("windowClass");
+
+		IWindow window = Window.CreateWindow(wrapper.Context.Object, wrapper.CoreNativeManager.Object, new HWND(123))!;
+
+		// When
+		string windowClass = window.WindowClass;
+
+		// Then
+		Assert.Equal("windowClass", windowClass);
+	}
+
+	[Fact]
+	public void Location()
+	{
+		// Given
+		Wrapper wrapper = new();
+		wrapper.CoreNativeManager
+			.Setup(cnm => cnm.GetWindowRect(It.IsAny<HWND>(), out It.Ref<RECT>.IsAny))
+			.Callback(
+				(HWND hwnd, out RECT rect) =>
+				{
+					rect = new RECT()
+					{
+						left = 0,
+						top = 0,
+						right = 100,
+						bottom = 200
+					};
+				}
+			);
+
+		IWindow window = Window.CreateWindow(wrapper.Context.Object, wrapper.CoreNativeManager.Object, new HWND(123))!;
+
+		// When
+		ILocation<int> location = window.Location;
+
+		// Then
+		Assert.Equal(0, location.X);
+		Assert.Equal(0, location.Y);
+		Assert.Equal(100, location.Width);
+		Assert.Equal(200, location.Height);
+	}
+
+	[Fact]
+	public void Center()
+	{
+		// Given
+		Wrapper wrapper = new();
+		wrapper.CoreNativeManager
+			.Setup(cnm => cnm.GetWindowRect(It.IsAny<HWND>(), out It.Ref<RECT>.IsAny))
+			.Callback(
+				(HWND hwnd, out RECT rect) =>
+				{
+					rect = new RECT()
+					{
+						left = 0,
+						top = 0,
+						right = 100,
+						bottom = 200
+					};
+				}
+			);
+
+		IWindow window = Window.CreateWindow(wrapper.Context.Object, wrapper.CoreNativeManager.Object, new HWND(123))!;
+
+		// When
+		IPoint<int> center = window.Center;
+
+		// Then
+		Assert.Equal(50, center.X);
+		Assert.Equal(100, center.Y);
+	}
+
+	[Fact]
+	public void ProcessId()
+	{
+		// Given
+		Wrapper wrapper = new();
+		IWindow window = Window.CreateWindow(wrapper.Context.Object, wrapper.CoreNativeManager.Object, new HWND(123))!;
+
+		// When
+		int processId = window.ProcessId;
+
+		// Then
+		Assert.Equal(456, processId);
+	}
+
+	[Fact]
+	public void ProcessFileName()
+	{
+		// Given
+		Wrapper wrapper = new();
+		IWindow window = Window.CreateWindow(wrapper.Context.Object, wrapper.CoreNativeManager.Object, new HWND(123))!;
+
+		// When
+		string processFileName = window.ProcessFileName;
+
+		// Then
+		Assert.Equal("processFileName", processFileName);
+	}
+
+	[Fact]
+	public void ProcessFileName_NA()
+	{
+		// Given
+		Wrapper wrapper = new();
+
+		// This is actually wrong - the error is thrown by Path.GetFileName.
+		// However, I can't be bothered to mock that out.
+		wrapper.CoreNativeManager
+			.Setup(cnm => cnm.GetProcessNameAndPath(It.IsAny<int>()))
+			.Returns((string.Empty, null));
+
+		IWindow window = Window.CreateWindow(wrapper.Context.Object, wrapper.CoreNativeManager.Object, new HWND(123))!;
+
+		// When
+		string processFileName = window.ProcessFileName;
+
+		// Then
+		Assert.Equal("--NA--", processFileName);
+	}
+
+	[Fact]
+	public void ProcessName()
+	{
+		// Given
+		Wrapper wrapper = new();
+		IWindow window = Window.CreateWindow(wrapper.Context.Object, wrapper.CoreNativeManager.Object, new HWND(123))!;
+
+		// When
+		string processName = window.ProcessName;
+
+		// Then
+		Assert.Equal("processName", processName);
+	}
+
+	[Fact]
+	public void IsFocused()
+	{
+		// Given
+		Wrapper wrapper = new();
+		wrapper.CoreNativeManager.Setup(cnm => cnm.GetForegroundWindow()).Returns(new HWND(123));
+
+		IWindow window = Window.CreateWindow(wrapper.Context.Object, wrapper.CoreNativeManager.Object, new HWND(123))!;
+
+		// When
+		bool isFocused = window.IsFocused;
+
+		// Then
+		Assert.True(isFocused);
+	}
+
+	[Fact]
+	public void IsMinimized()
+	{
+		// Given
+		Wrapper wrapper = new();
+		wrapper.CoreNativeManager.Setup(cnm => cnm.IsWindowMinimized(It.IsAny<HWND>())).Returns(true);
+
+		IWindow window = Window.CreateWindow(wrapper.Context.Object, wrapper.CoreNativeManager.Object, new HWND(123))!;
+
+		// When
+		bool isMinimized = window.IsMinimized;
+
+		// Then
+		Assert.True(isMinimized);
+	}
+
+	[Fact]
+	public void IsMaximized()
+	{
+		// Given
+		Wrapper wrapper = new();
+		wrapper.CoreNativeManager.Setup(cnm => cnm.IsWindowMaximized(It.IsAny<HWND>())).Returns(true);
+
+		IWindow window = Window.CreateWindow(wrapper.Context.Object, wrapper.CoreNativeManager.Object, new HWND(123))!;
+
+		// When
+		bool isMaximized = window.IsMaximized;
+
+		// Then
+		Assert.True(isMaximized);
+	}
+
+	[Fact]
+	public void IsMouseMoving()
+	{
+		// Given
+		Wrapper wrapper = new();
+
+		IWindow window = Window.CreateWindow(wrapper.Context.Object, wrapper.CoreNativeManager.Object, new HWND(123))!;
+
+		// Then
+		Assert.False(window.IsMouseMoving);
+		window.IsMouseMoving = true;
+		Assert.True(window.IsMouseMoving);
+	}
+
+	[Fact]
+	public void BringToTop()
+	{
+		// Given
+		Wrapper wrapper = new();
+		wrapper.CoreNativeManager.Setup(cnm => cnm.BringWindowToTop(It.IsAny<HWND>()));
+
+		IWindow window = Window.CreateWindow(wrapper.Context.Object, wrapper.CoreNativeManager.Object, new HWND(123))!;
+
+		// When
+		window.BringToTop();
+
+		// Then
+		wrapper.CoreNativeManager.Verify(cnm => cnm.BringWindowToTop(It.IsAny<HWND>()), Times.Once);
+	}
+
+	[Fact]
+	public void Close()
+	{
+		// Given
+		Wrapper wrapper = new();
+		wrapper.NativeManager.Setup(cnm => cnm.QuitWindow(It.IsAny<HWND>()));
+
+		IWindow window = Window.CreateWindow(wrapper.Context.Object, wrapper.CoreNativeManager.Object, new HWND(123))!;
+
+		// When
+		window.Close();
+
+		// Then
+		wrapper.NativeManager.Verify(cnm => cnm.QuitWindow(It.IsAny<HWND>()), Times.Once);
+	}
+
+	[Fact]
+	public void Focus()
+	{
+		// Given
+		Wrapper wrapper = new();
+		wrapper.CoreNativeManager.Setup(cnm => cnm.SetForegroundWindow(It.IsAny<HWND>()));
+
+		IWindow window = Window.CreateWindow(wrapper.Context.Object, wrapper.CoreNativeManager.Object, new HWND(123))!;
+
+		// When
+		window.Focus();
+
+		// Then
+		wrapper.CoreNativeManager.Verify(cnm => cnm.SetForegroundWindow(It.IsAny<HWND>()), Times.Once);
+	}
+
+	[Fact]
+	public void FocusForceForeground()
+	{
+		// Given
+		Wrapper wrapper = new();
+		wrapper.CoreNativeManager.Setup(cnm => cnm.SetForegroundWindow(It.IsAny<HWND>()));
+
+		IWindow window = Window.CreateWindow(wrapper.Context.Object, wrapper.CoreNativeManager.Object, new HWND(123))!;
+
+		// When
+		window.Focus();
+
+		// Then
+		wrapper.CoreNativeManager.Verify(cnm => cnm.SetForegroundWindow(It.IsAny<HWND>()), Times.Once);
+		// The following code doesn't work because SendInput accepts a Span.
+		// wrapper.CoreNativeManager.Verify(cnm => cnm.SendInput(It.IsAny<INPUT[]>(), It.IsAny<int>()), Times.Once);
+	}
+
+	[Fact]
+	public void Hide()
+	{
+		// Given
+		Wrapper wrapper = new();
+		wrapper.NativeManager.Setup(cnm => cnm.HideWindow(It.IsAny<HWND>()));
+
+		IWindow window = Window.CreateWindow(wrapper.Context.Object, wrapper.CoreNativeManager.Object, new HWND(123))!;
+
+		// When
+		window.Hide();
+
+		// Then
+		wrapper.NativeManager.Verify(cnm => cnm.HideWindow(It.IsAny<HWND>()), Times.Once);
+	}
+
+	[Fact]
+	public void ShowMaximized()
+	{
+		// Given
+		Wrapper wrapper = new();
+		wrapper.NativeManager.Setup(cnm => cnm.ShowWindowMaximized(It.IsAny<HWND>()));
+
+		IWindow window = Window.CreateWindow(wrapper.Context.Object, wrapper.CoreNativeManager.Object, new HWND(123))!;
+
+		// When
+		window.ShowMaximized();
+
+		// Then
+		wrapper.NativeManager.Verify(cnm => cnm.ShowWindowMaximized(It.IsAny<HWND>()), Times.Once);
+	}
+
+	[Fact]
+	public void ShowMinimized()
+	{
+		// Given
+		Wrapper wrapper = new();
+		wrapper.NativeManager.Setup(cnm => cnm.ShowWindowMinimized(It.IsAny<HWND>()));
+
+		IWindow window = Window.CreateWindow(wrapper.Context.Object, wrapper.CoreNativeManager.Object, new HWND(123))!;
+
+		// When
+		window.ShowMinimized();
+
+		// Then
+		wrapper.NativeManager.Verify(cnm => cnm.ShowWindowMinimized(It.IsAny<HWND>()), Times.Once);
+	}
+
+	[Fact]
+	public void ShowNormal()
+	{
+		// Given
+		Wrapper wrapper = new();
+		wrapper.NativeManager.Setup(cnm => cnm.ShowWindowNoActivate(It.IsAny<HWND>()));
+
+		IWindow window = Window.CreateWindow(wrapper.Context.Object, wrapper.CoreNativeManager.Object, new HWND(123))!;
+
+		// When
+		window.ShowNormal();
+
+		// Then
+		wrapper.NativeManager.Verify(cnm => cnm.ShowWindowNoActivate(It.IsAny<HWND>()), Times.Once);
+	}
+
+	[Fact]
+	public void CreateWindow_Null()
+	{
+		// Given
+		Wrapper wrapper = new();
+		wrapper.CoreNativeManager.Setup(cnm => cnm.GetProcessNameAndPath(It.IsAny<int>())).Throws(new Win32Exception());
+
+		// When
+		IWindow? window = Window.CreateWindow(wrapper.Context.Object, wrapper.CoreNativeManager.Object, new HWND(123));
+
+		// Then
+		Assert.Null(window);
+	}
+}

--- a/src/Whim.Tests/Workspace/WorkspaceManagerTests.cs
+++ b/src/Whim.Tests/Workspace/WorkspaceManagerTests.cs
@@ -1204,7 +1204,7 @@ public class WorkspaceManagerTests
 		// When a window is minimized
 		wrapper.WorkspaceManager.WindowMinimizeStart(window.Object);
 
-		// Then the window is removed from the workspace
+		// Then the workspace is notified
 		internalWorkspace.Verify(w => w.WindowMinimizeStart(window.Object), Times.Once());
 	}
 
@@ -1230,6 +1230,28 @@ public class WorkspaceManagerTests
 
 		// Then the window is routed to the workspace
 		internalWorkspace.Verify(w => w.WindowMinimizeEnd(window.Object), Times.Once());
+	}
+
+	[Fact]
+	public void WindowMinizeEnd_Fail()
+	{
+		// Given
+		Mock<IWorkspace> workspace = new();
+		Mock<IInternalWorkspace> internalWorkspace = workspace.As<IInternalWorkspace>();
+
+		Wrapper wrapper = new(new[] { workspace });
+
+		Mock<IRouterManager> routerManager = new();
+		routerManager.Setup(r => r.RouteWindow(It.IsAny<IWindow>())).Returns(workspace.Object);
+		wrapper.Context.Setup(c => c.RouterManager).Returns(routerManager.Object);
+
+		Mock<IWindow> window = new();
+
+		// When a window which isn't tracked is restored
+		wrapper.WorkspaceManager.WindowMinimizeEnd(window.Object);
+
+		// Then the workspace is not notified
+		internalWorkspace.Verify(w => w.WindowMinimizeEnd(window.Object), Times.Never());
 	}
 
 	[Fact]

--- a/src/Whim.Tests/Workspace/WorkspaceManagerTests.cs
+++ b/src/Whim.Tests/Workspace/WorkspaceManagerTests.cs
@@ -1127,21 +1127,11 @@ public class WorkspaceManagerTests
 		// Given
 		Wrapper wrapper = new();
 
-		Mock<ILayoutEngine> layoutEngine = new();
-		Mock<Workspace> workspace =
-			new(
-				wrapper.Context.Object,
-				wrapper.WorkspaceManager.InternalTriggers,
-				"test",
-				new ILayoutEngine[] { layoutEngine.Object }
-			);
-		Mock<Workspace> workspace2 =
-			new(
-				wrapper.Context.Object,
-				wrapper.WorkspaceManager.InternalTriggers,
-				"test",
-				new ILayoutEngine[] { layoutEngine.Object }
-			);
+		Mock<IWorkspace> workspace = new();
+		Mock<IInternalWorkspace> internalWorkspace = workspace.As<IInternalWorkspace>();
+
+		Mock<IWorkspace> workspace2 = new();
+		Mock<IInternalWorkspace> internalWorkspace2 = workspace2.As<IInternalWorkspace>();
 
 		wrapper.WorkspaceManager.Add(workspace.Object);
 		wrapper.WorkspaceManager.Add(workspace2.Object);
@@ -1152,8 +1142,8 @@ public class WorkspaceManagerTests
 		wrapper.WorkspaceManager.WindowFocused(window.Object);
 
 		// Then the window is focused in all workspaces
-		workspace.Verify(w => w.WindowFocused(window.Object), Times.Once());
-		workspace2.Verify(w => w.WindowFocused(window.Object), Times.Once());
+		internalWorkspace.Verify(w => w.WindowFocused(window.Object), Times.Once());
+		internalWorkspace2.Verify(w => w.WindowFocused(window.Object), Times.Once());
 	}
 
 	[Fact]
@@ -1199,6 +1189,8 @@ public class WorkspaceManagerTests
 	{
 		// Given
 		Mock<IWorkspace> workspace = new();
+		Mock<IInternalWorkspace> internalWorkspace = workspace.As<IInternalWorkspace>();
+
 		Wrapper wrapper = new(new[] { workspace });
 
 		Mock<IRouterManager> routerManager = new();
@@ -1213,7 +1205,7 @@ public class WorkspaceManagerTests
 		wrapper.WorkspaceManager.WindowMinimizeStart(window.Object);
 
 		// Then the window is removed from the workspace
-		workspace.Verify(w => w.RemoveWindow(window.Object), Times.Once());
+		internalWorkspace.Verify(w => w.WindowMinimizeStart(window.Object), Times.Once());
 	}
 
 	[Fact]
@@ -1221,19 +1213,23 @@ public class WorkspaceManagerTests
 	{
 		// Given
 		Mock<IWorkspace> workspace = new();
+		Mock<IInternalWorkspace> internalWorkspace = workspace.As<IInternalWorkspace>();
+
 		Wrapper wrapper = new(new[] { workspace });
 
 		Mock<IRouterManager> routerManager = new();
 		routerManager.Setup(r => r.RouteWindow(It.IsAny<IWindow>())).Returns(workspace.Object);
 		wrapper.Context.Setup(c => c.RouterManager).Returns(routerManager.Object);
 
+		// A window is added to the workspace
 		Mock<IWindow> window = new();
+		wrapper.WorkspaceManager.WindowAdded(window.Object);
 
 		// When a window is restored
 		wrapper.WorkspaceManager.WindowMinimizeEnd(window.Object);
 
 		// Then the window is routed to the workspace
-		routerManager.Verify(r => r.RouteWindow(window.Object), Times.Once());
+		internalWorkspace.Verify(w => w.WindowMinimizeEnd(window.Object), Times.Once());
 	}
 
 	[Fact]

--- a/src/Whim.Tests/Workspace/WorkspaceTests.cs
+++ b/src/Whim.Tests/Workspace/WorkspaceTests.cs
@@ -512,7 +512,7 @@ public class WorkspaceTests
 			new(mocks.Context.Object, mocks.Triggers, "Workspace", new ILayoutEngine[] { mocks.LayoutEngine.Object });
 
 		workspace.AddPhantomWindow(mocks.LayoutEngine.Object, window.Object);
-		mocks.WorkspaceManager.Reset();
+		mocks.WorkspaceManager.Invocations.Clear();
 
 		// Reset mocks
 		window.Reset();
@@ -607,7 +607,7 @@ public class WorkspaceTests
 
 		// Phantom window is added
 		workspace.AddPhantomWindow(mocks.LayoutEngine.Object, window.Object);
-		mocks.WorkspaceManager.Reset();
+		mocks.WorkspaceManager.Invocations.Clear();
 		mocks.LayoutEngine.Setup(l => l.Remove(window.Object)).Returns(false);
 
 		// When RemoveWindow is called
@@ -630,7 +630,7 @@ public class WorkspaceTests
 
 		// Phantom window is added
 		workspace.AddPhantomWindow(mocks.LayoutEngine.Object, window.Object);
-		mocks.WorkspaceManager.Reset();
+		mocks.WorkspaceManager.Invocations.Clear();
 		mocks.LayoutEngine.Setup(l => l.Remove(window.Object)).Returns(true);
 
 		// When RemoveWindow is called
@@ -651,7 +651,7 @@ public class WorkspaceTests
 		Workspace workspace =
 			new(mocks.Context.Object, mocks.Triggers, "Workspace", new ILayoutEngine[] { mocks.LayoutEngine.Object });
 		workspace.AddWindow(window.Object);
-		mocks.WorkspaceManager.Reset();
+		mocks.WorkspaceManager.Invocations.Clear();
 
 		// When RemoveWindow is called
 		bool result = workspace.RemoveWindow(window.Object);
@@ -672,7 +672,7 @@ public class WorkspaceTests
 			new(mocks.Context.Object, mocks.Triggers, "Workspace", new ILayoutEngine[] { mocks.LayoutEngine.Object });
 		workspace.AddWindow(window.Object);
 		workspace.WindowFocused(window.Object);
-		mocks.WorkspaceManager.Reset();
+		mocks.WorkspaceManager.Invocations.Clear();
 		mocks.LayoutEngine.Setup(l => l.Remove(window.Object)).Returns(true);
 
 		// When RemoveWindow is called
@@ -694,9 +694,10 @@ public class WorkspaceTests
 		Workspace workspace =
 			new(mocks.Context.Object, mocks.Triggers, "Workspace", new ILayoutEngine[] { mocks.LayoutEngine.Object });
 		workspace.AddWindow(window.Object);
-		workspace.WindowFocused(window.Object);
-		mocks.WorkspaceManager.Reset();
-		mocks.LayoutEngine.Setup(l => l.Remove(window.Object)).Returns(true);
+		workspace.WindowMinimizeStart(window.Object);
+
+		mocks.WorkspaceManager.Invocations.Clear();
+		mocks.LayoutEngine.Invocations.Clear();
 
 		// When RemoveWindow is called
 		bool result = workspace.RemoveWindow(window.Object);
@@ -931,7 +932,7 @@ public class WorkspaceTests
 		workspace.AddWindow(window.Object);
 		workspace.AddWindow(window2.Object);
 		workspace.AddPhantomWindow(mocks.LayoutEngine.Object, phantomWindow.Object);
-		mocks.WorkspaceManager.Reset();
+		mocks.WorkspaceManager.Invocations.Clear();
 
 		// When Deactivate is called
 		workspace.Deactivate();

--- a/src/Whim.Tests/Workspace/WorkspaceTests.cs
+++ b/src/Whim.Tests/Workspace/WorkspaceTests.cs
@@ -685,6 +685,29 @@ public class WorkspaceTests
 	}
 
 	[Fact]
+	public void RemoveWindow_MinimizedWindow()
+	{
+		// Given
+		MocksBuilder mocks = new();
+		Mock<IWindow> window = new();
+		window.Setup(w => w.IsMinimized).Returns(true);
+		Workspace workspace =
+			new(mocks.Context.Object, mocks.Triggers, "Workspace", new ILayoutEngine[] { mocks.LayoutEngine.Object });
+		workspace.AddWindow(window.Object);
+		workspace.WindowFocused(window.Object);
+		mocks.WorkspaceManager.Reset();
+		mocks.LayoutEngine.Setup(l => l.Remove(window.Object)).Returns(true);
+
+		// When RemoveWindow is called
+		bool result = workspace.RemoveWindow(window.Object);
+
+		// Then the window is not removed from the layout engine
+		Assert.True(result);
+		mocks.LayoutEngine.Verify(l => l.Remove(window.Object), Times.Never);
+		mocks.WorkspaceManager.Verify(wm => wm.GetMonitorForWorkspace(workspace), Times.Once);
+	}
+
+	[Fact]
 	public void FocusWindowInDirection_Fails_DoesNotContainWindow()
 	{
 		// Given

--- a/src/Whim.Tests/Workspace/WorkspaceTests.cs
+++ b/src/Whim.Tests/Workspace/WorkspaceTests.cs
@@ -1122,4 +1122,76 @@ public class WorkspaceTests
 		// Then the window is minimized
 		window.Verify(w => w.ShowMinimized(), Times.Once);
 	}
+
+	[Fact]
+	public void WindowMinimizeStart()
+	{
+		// Given
+		MocksBuilder mocks = new();
+		Mock<IWindow> window = new();
+		Workspace workspace =
+			new(mocks.Context.Object, mocks.Triggers, "Workspace", new ILayoutEngine[] { mocks.LayoutEngine.Object });
+		workspace.AddWindow(window.Object);
+
+		// When WindowMinimizeStart is called
+		workspace.WindowMinimizeStart(window.Object);
+
+		// Then
+		mocks.LayoutEngine.Verify(e => e.Remove(window.Object), Times.Once);
+	}
+
+	[Fact]
+	public void WindowMinimizeStart_Twice()
+	{
+		// Given
+		MocksBuilder mocks = new();
+		Mock<IWindow> window = new();
+		Workspace workspace =
+			new(mocks.Context.Object, mocks.Triggers, "Workspace", new ILayoutEngine[] { mocks.LayoutEngine.Object });
+		workspace.AddWindow(window.Object);
+
+		// When WindowMinimizeStart is called
+		workspace.WindowMinimizeStart(window.Object);
+		workspace.WindowMinimizeStart(window.Object);
+
+		// Then the window is only removed the first time
+		mocks.LayoutEngine.Verify(e => e.Remove(window.Object), Times.Once);
+	}
+
+	[Fact]
+	public void WindowMinimizeEnd()
+	{
+		// Given
+		MocksBuilder mocks = new();
+		Mock<IWindow> window = new();
+		Workspace workspace =
+			new(mocks.Context.Object, mocks.Triggers, "Workspace", new ILayoutEngine[] { mocks.LayoutEngine.Object });
+		workspace.AddWindow(window.Object);
+		workspace.WindowMinimizeStart(window.Object);
+		mocks.LayoutEngine.Invocations.Clear();
+
+		// When WindowMinimizeEnd is called
+		workspace.WindowMinimizeEnd(window.Object);
+
+		// Then
+		mocks.LayoutEngine.Verify(e => e.Add(window.Object), Times.Once);
+	}
+
+	[Fact]
+	public void WindowMinimizeEnd_NotMinimized()
+	{
+		// Given
+		MocksBuilder mocks = new();
+		Mock<IWindow> window = new();
+		Workspace workspace =
+			new(mocks.Context.Object, mocks.Triggers, "Workspace", new ILayoutEngine[] { mocks.LayoutEngine.Object });
+		workspace.AddWindow(window.Object);
+		mocks.LayoutEngine.Invocations.Clear();
+
+		// When WindowMinimizeEnd is called
+		workspace.WindowMinimizeEnd(window.Object);
+
+		// Then
+		mocks.LayoutEngine.Verify(e => e.Add(window.Object), Times.Never);
+	}
 }

--- a/src/Whim.Tests/Workspace/WorkspaceTests.cs
+++ b/src/Whim.Tests/Workspace/WorkspaceTests.cs
@@ -725,6 +725,25 @@ public class WorkspaceTests
 	}
 
 	[Fact]
+	public void FocusWindowInDirection_Fails_WindowIsMinimized()
+	{
+		// Given
+		MocksBuilder mocks = new();
+		Mock<IWindow> window = new();
+		Workspace workspace =
+			new(mocks.Context.Object, mocks.Triggers, "Workspace", new ILayoutEngine[] { mocks.LayoutEngine.Object });
+
+		workspace.AddWindow(window.Object);
+		workspace.WindowMinimizeStart(window.Object);
+
+		// When FocusWindowInDirection is called
+		workspace.FocusWindowInDirection(Direction.Up, window.Object);
+
+		// Then the layout engine is not told to focus the window
+		mocks.LayoutEngine.Verify(l => l.FocusWindowInDirection(Direction.Up, window.Object), Times.Never);
+	}
+
+	[Fact]
 	public void FocusWindowInDirection_Success()
 	{
 		// Given

--- a/src/Whim.Tests/Workspace/WorkspaceTests.cs
+++ b/src/Whim.Tests/Workspace/WorkspaceTests.cs
@@ -900,6 +900,29 @@ public class WorkspaceTests
 	}
 
 	[Fact]
+	public void MoveWindowToPoint_Success_WindowIsMinimized()
+	{
+		// Given
+		MocksBuilder mocks = new();
+		Mock<IWindow> window = new();
+		Workspace workspace =
+			new(mocks.Context.Object, mocks.Triggers, "Workspace", new ILayoutEngine[] { mocks.LayoutEngine.Object });
+		IPoint<double> point = new Point<double>() { X = 0.3, Y = 0.3 };
+
+		workspace.AddWindow(window.Object);
+		workspace.WindowMinimizeStart(window.Object);
+
+		mocks.LayoutEngine.Invocations.Clear();
+
+		// When MoveWindowToPoint is called
+		workspace.MoveWindowToPoint(window.Object, point);
+
+		// Then the layout engine is told to move the window
+		mocks.LayoutEngine.Verify(l => l.AddWindowAtPoint(window.Object, point), Times.Once);
+		mocks.LayoutEngine.Verify(l => l.Remove(window.Object), Times.Never);
+	}
+
+	[Fact]
 	public void MoveWindowToPoint_Success_WindowAlreadyExists()
 	{
 		// Given
@@ -1020,6 +1043,29 @@ public class WorkspaceTests
 
 		// Then the result is as expected
 		Assert.NotNull(result);
+	}
+
+	[Fact]
+	public void TryGetWindowLocation_MinimizedWindow()
+	{
+		// Given
+		MocksBuilder mocks = new();
+		Mock<IWindow> window = new();
+		Workspace workspace =
+			new(mocks.Context.Object, mocks.Triggers, "Workspace", new ILayoutEngine[] { mocks.LayoutEngine.Object });
+
+		// When
+		workspace.AddWindow(window.Object);
+		workspace.WindowMinimizeStart(window.Object);
+		IWindowState windowState = workspace.TryGetWindowLocation(window.Object)!;
+
+		// Then
+		Assert.Equal(window.Object, windowState.Window);
+		Assert.Equal(0, windowState.Location.X);
+		Assert.Equal(0, windowState.Location.Y);
+		Assert.Equal(0, windowState.Location.Width);
+		Assert.Equal(0, windowState.Location.Height);
+		Assert.Equal(WindowSize.Minimized, windowState.WindowSize);
 	}
 
 	[Fact]

--- a/src/Whim.Tests/Workspace/WorkspaceTests.cs
+++ b/src/Whim.Tests/Workspace/WorkspaceTests.cs
@@ -422,6 +422,23 @@ public class WorkspaceTests
 	}
 
 	[Fact]
+	public void WindowFocused_DoesNotContainWindow()
+	{
+		// Given the window is not in the workspace
+		MocksBuilder mocks = new();
+		Mock<IWindow> window = new();
+
+		Workspace workspace =
+			new(mocks.Context.Object, mocks.Triggers, "Workspace", new ILayoutEngine[] { mocks.LayoutEngine.Object });
+
+		// When
+		workspace.WindowFocused(window.Object);
+
+		// Then
+		Assert.Null(workspace.LastFocusedWindow);
+	}
+
+	[Fact]
 	public void FocusFirstWindow()
 	{
 		// Given

--- a/src/Whim/Native/CoreNativeManager.cs
+++ b/src/Whim/Native/CoreNativeManager.cs
@@ -1,6 +1,7 @@
 using Microsoft.UI.Dispatching;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Drawing;
 using System.Runtime.InteropServices;
 using Windows.Win32;
@@ -322,5 +323,12 @@ internal class CoreNativeManager : ICoreNativeManager
 
 			return _window.GetHandle();
 		}
+	}
+
+	/// <inheritdoc/>
+	public (string processName, string? processPath) GetProcessNameAndPath(int processId)
+	{
+		using Process process = Process.GetProcessById(processId);
+		return (process.ProcessName, process.MainModule?.FileName);
 	}
 }

--- a/src/Whim/Native/ICoreNativeManager.cs
+++ b/src/Whim/Native/ICoreNativeManager.cs
@@ -485,4 +485,11 @@ internal interface ICoreNativeManager
 	/// </remarks>
 	/// <returns>The <see cref="HWND" /> of the window.</returns>
 	HWND WindowMessageMonitorWindowHandle { get; }
+
+	/// <summary>
+	/// Get the process name and process path for the given process ID.
+	/// </summary>
+	/// <param name="processId">The process ID.</param>
+	/// <returns>The process name and process path.</returns>
+	(string processName, string? processPath) GetProcessNameAndPath(int processId);
 }

--- a/src/Whim/Window/IWindow.cs
+++ b/src/Whim/Window/IWindow.cs
@@ -98,20 +98,6 @@ public interface IWindow
 	public void ShowMinimized();
 
 	/// <summary>
-	/// Shows the window in the current state. <br/>
-	///
-	/// If the window is minimized, the window is shown minimized
-	/// (see <see cref="ShowMinimized"/>)<br/>
-	///
-	/// If the window is maximized, the window is shown maximized
-	/// (see <see cref="ShowMaximized"/>). <br/>
-	///
-	/// Otherwise, the window is shown in its most recent size and position
-	/// (see <see cref="ShowNormal"/>).
-	/// </summary>
-	public void ShowInCurrentState();
-
-	/// <summary>
 	/// Brings the window to the top.
 	/// </summary>
 	public void BringToTop();

--- a/src/Whim/Window/Window.cs
+++ b/src/Whim/Window/Window.cs
@@ -1,5 +1,4 @@
 using System.ComponentModel;
-using System.Diagnostics;
 using System.IO;
 using Windows.Win32.Foundation;
 using Windows.Win32.UI.Input.KeyboardAndMouse;
@@ -165,18 +164,16 @@ internal class Window : IWindow
 	/// <returns></returns>
 	public static IWindow? CreateWindow(IContext context, ICoreNativeManager coreNativeManager, HWND hwnd)
 	{
-		string processName;
-		string processFileName;
-
 		_ = coreNativeManager.GetWindowThreadProcessId(hwnd, out uint pid);
 		int processId = (int)pid;
-
-		Process process = Process.GetProcessById(processId);
-		processName = process.ProcessName;
+		string processName;
+		string? processPath;
+		string processFileName;
 
 		try
 		{
-			processFileName = Path.GetFileName(process.MainModule?.FileName) ?? "--NA--";
+			(processName, processPath) = coreNativeManager.GetProcessNameAndPath(processId);
+			processFileName = Path.GetFileName(processPath) ?? "--NA--";
 		}
 		catch (Win32Exception ex)
 		{
@@ -184,6 +181,7 @@ internal class Window : IWindow
 			// https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.process?view=net-6.0#remarks
 			// The exception will usually have a message of:
 			// "Unable to enumerate the process modules."
+			// This will be thrown by Path.GetFileName.
 			Logger.Error($"Could not create a Window instance for {hwnd.Value}, {ex.Message}");
 			return null;
 		}

--- a/src/Whim/Window/Window.cs
+++ b/src/Whim/Window/Window.cs
@@ -123,24 +123,6 @@ internal class Window : IWindow
 	}
 
 	/// <inheritdoc/>
-	public void ShowInCurrentState()
-	{
-		Logger.Debug(ToString());
-		if (IsMinimized)
-		{
-			ShowMinimized();
-		}
-		else if (IsMaximized)
-		{
-			ShowMaximized();
-		}
-		else
-		{
-			ShowNormal();
-		}
-	}
-
-	/// <inheritdoc/>
 	public void ShowMaximized()
 	{
 		Logger.Debug(ToString());

--- a/src/Whim/Workspace/IInternalWorkspace.cs
+++ b/src/Whim/Workspace/IInternalWorkspace.cs
@@ -1,0 +1,25 @@
+namespace Whim;
+
+/// <summary>
+/// A workspace, with internal methods.
+/// </summary>
+internal interface IInternalWorkspace
+{
+	/// <summary>
+	/// Called when a window is focused, regardless of whether it's in this workspace.
+	/// </summary>
+	/// <param name="window"></param>
+	void WindowFocused(IWindow window);
+
+	/// <summary>
+	/// Called when a window is about to be minimized.
+	/// </summary>
+	/// <param name="window"></param>
+	void WindowMinimizeStart(IWindow window);
+
+	/// <summary>
+	/// Called when a window is about to be unminimized.
+	/// </summary>
+	/// <param name="window"></param>
+	void WindowMinimizeEnd(IWindow window);
+}

--- a/src/Whim/Workspace/IWorkspace.cs
+++ b/src/Whim/Workspace/IWorkspace.cs
@@ -12,77 +12,77 @@ public interface IWorkspace : IDisposable
 	/// The name of the workspace. When the <c>Name</c> is set, the
 	/// <see cref="IWorkspaceManager.WorkspaceRenamed"/> event is triggered.
 	/// </summary>
-	public string Name { get; set; }
+	string Name { get; set; }
 
 	/// <summary>
 	/// Initializes the workspace. This includes wrapping its layout engines with
 	/// proxies from <see cref="IWorkspaceManager"/>.
 	/// </summary>
-	public void Initialize();
+	void Initialize();
 
 	#region Layout engine
 	/// <summary>
 	/// The active layout engine.
 	/// </summary>
-	public ILayoutEngine ActiveLayoutEngine { get; }
+	ILayoutEngine ActiveLayoutEngine { get; }
 
 	/// <summary>
 	/// Rotate to the next layout engine.
 	/// </summary>
-	public void NextLayoutEngine();
+	void NextLayoutEngine();
 
 	/// <summary>
 	/// Rotate to the previous layout engine.
 	/// </summary>
-	public void PreviousLayoutEngine();
+	void PreviousLayoutEngine();
 
 	/// <summary>
 	/// Tries to set the layout engine to one with the <c>name</c>.
 	/// </summary>
 	/// <param name="name">The name of the layout engine to make active.</param>
 	/// <returns></returns>
-	public bool TrySetLayoutEngine(string name);
+	bool TrySetLayoutEngine(string name);
 
 	/// <summary>
 	/// Trigger a layout.
 	/// </summary>
-	public void DoLayout();
+	void DoLayout();
 	#endregion
 
 	#region Windows
 	/// <summary>
 	/// The windows in the workspace.
 	/// </summary>
-	public IEnumerable<IWindow> Windows { get; }
+	IEnumerable<IWindow> Windows { get; }
 
 	/// <summary>
 	/// The currently focused window.
 	/// </summary>
-	public IWindow? LastFocusedWindow { get; }
+	IWindow? LastFocusedWindow { get; }
 
 	/// <summary>
 	/// Adds the window to the workspace.
 	/// </summary>
 	/// <param name="window"></param>
-	public void AddWindow(IWindow window);
+	void AddWindow(IWindow window);
 
 	/// <summary>
 	/// Removes the window from the workspace.
 	/// </summary>
 	/// <param name="window"></param>
-	public bool RemoveWindow(IWindow window);
+	bool RemoveWindow(IWindow window);
 
 	/// <summary>
 	/// Returns true when the workspace contains the provided <paramref name="window"/>.
 	/// </summary>
 	/// <param name="window">The window to check for.</param>
 	/// <returns>True when the workspace contains the provided <paramref name="window"/>.</returns>
-	public bool ContainsWindow(IWindow window);
+	bool ContainsWindow(IWindow window);
 
 	/// <summary>
 	/// Deactivates the workspace.
 	/// </summary>
-	public void Deactivate();
+	void Deactivate();
 
 	/// <summary>
 	/// Gets the current location (as of the last <see cref="DoLayout"/>) of the window.
@@ -92,12 +92,12 @@ public interface IWorkspace : IDisposable
 	/// If the window is not in the workspace, or the workspace is not focused,
 	/// <c>null</c> is returned.
 	/// </returns>
-	public IWindowState? TryGetWindowLocation(IWindow window);
+	IWindowState? TryGetWindowLocation(IWindow window);
 
 	/// <summary>
 	/// Focuses on the first window in the workspace.
 	/// </summary>
-	public void FocusFirstWindow();
+	void FocusFirstWindow();
 
 	/// <summary>
 	/// Focuses the <paramref name="window"/> in the <paramref name="direction"/>.
@@ -106,7 +106,7 @@ public interface IWorkspace : IDisposable
 	/// <param name="window">
 	/// The origin window
 	/// </param>
-	public void FocusWindowInDirection(Direction direction, IWindow? window = null);
+	void FocusWindowInDirection(Direction direction, IWindow? window = null);
 
 	/// <summary>
 	/// Swaps the <paramref name="window"/> in the <paramref name="direction"/>.
@@ -115,7 +115,7 @@ public interface IWorkspace : IDisposable
 	/// <param name="window">
 	/// The window to swap. If null, the currently focused window is swapped.
 	/// </param>
-	public void SwapWindowInDirection(Direction direction, IWindow? window = null);
+	void SwapWindowInDirection(Direction direction, IWindow? window = null);
 
 	/// <summary>
 	/// Change the <paramref name="window"/>'s <paramref name="edge"/> direction by
@@ -127,14 +127,14 @@ public interface IWorkspace : IDisposable
 	/// The window to change the edge of. If null, the currently focused window is
 	/// used.
 	/// </param>
-	public void MoveWindowEdgeInDirection(Direction edge, double delta, IWindow? window = null);
+	void MoveWindowEdgeInDirection(Direction edge, double delta, IWindow? window = null);
 
 	/// <summary>
 	/// Moves or adds the given <paramref name="window"/> to the given <paramref name="point"/>.
 	/// </summary>
 	/// <param name="window">The window to move.</param>
 	/// <param name="point">The point to move the window to.</param>
-	public void MoveWindowToPoint(IWindow window, IPoint<double> point);
+	void MoveWindowToPoint(IWindow window, IPoint<double> point);
 	#endregion
 
 	#region Phantom Windows
@@ -150,7 +150,7 @@ public interface IWorkspace : IDisposable
 	/// </remarks>
 	/// <param name="engine">The layout engine to add the phantom window to.</param>
 	/// <param name="window">The phantom window to add.</param>
-	public void AddPhantomWindow(ILayoutEngine engine, IWindow window);
+	void AddPhantomWindow(ILayoutEngine engine, IWindow window);
 
 	/// <summary>
 	/// Remove a phantom window. This can only be done by the active layout engine,
@@ -158,6 +158,6 @@ public interface IWorkspace : IDisposable
 	/// </summary>
 	/// <param name="engine">The layout engine to remove the phantom window from.</param>
 	/// <param name="window">The phantom window to remove.</param>
-	public void RemovePhantomWindow(ILayoutEngine engine, IWindow window);
+	void RemovePhantomWindow(ILayoutEngine engine, IWindow window);
 	#endregion
 }

--- a/src/Whim/Workspace/IWorkspace.cs
+++ b/src/Whim/Workspace/IWorkspace.cs
@@ -73,10 +73,10 @@ public interface IWorkspace : IDisposable
 	public bool RemoveWindow(IWindow window);
 
 	/// <summary>
-	/// Indicates whether the workspace contains the window.
+	/// Returns true when the workspace contains the provided <paramref name="window"/>.
 	/// </summary>
-	/// <param name="window"></param>
-	/// <returns></returns>
+	/// <param name="window">The window to check for.</param>
+	/// <returns>True when the workspace contains the provided <paramref name="window"/>.</returns>
 	public bool ContainsWindow(IWindow window);
 
 	/// <summary>

--- a/src/Whim/Workspace/Workspace.cs
+++ b/src/Whim/Workspace/Workspace.cs
@@ -470,6 +470,11 @@ internal class Workspace : IWorkspace
 			Logger.Verbose($"Layout for workspace {Name} complete");
 		}
 
+		foreach (IWindow window in _minimizedWindows)
+		{
+			window.ShowMinimized();
+		}
+
 		_triggers.WorkspaceLayoutCompleted(new WorkspaceEventArgs() { Workspace = this });
 	}
 

--- a/src/Whim/Workspace/Workspace.cs
+++ b/src/Whim/Workspace/Workspace.cs
@@ -126,6 +126,7 @@ internal class Workspace : IWorkspace, IInternalWorkspace
 		if (!_normalWindows.Contains(window))
 		{
 			Logger.Error($"Window {window} is not a normal window in workspace {Name}");
+			return;
 		}
 
 		_normalWindows.Remove(window);
@@ -144,6 +145,7 @@ internal class Workspace : IWorkspace, IInternalWorkspace
 		if (!_minimizedWindows.Contains(window))
 		{
 			Logger.Error($"Window {window} is not a minimized window in workspace {Name}");
+			return;
 		}
 
 		_minimizedWindows.Remove(window);

--- a/src/Whim/Workspace/Workspace.cs
+++ b/src/Whim/Workspace/Workspace.cs
@@ -278,26 +278,29 @@ internal class Workspace : IWorkspace, IInternalWorkspace
 		}
 
 		bool success = true;
-		foreach (ILayoutEngine layoutEngine in _layoutEngines)
+		if (isNormalWindow)
 		{
-			if (!layoutEngine.Remove(window))
+			foreach (ILayoutEngine layoutEngine in _layoutEngines)
 			{
-				Logger.Error($"Window {window} could not be removed from layout engine {layoutEngine}");
-				success = false;
+				if (!layoutEngine.Remove(window))
+				{
+					Logger.Error($"Window {window} could not be removed from layout engine {layoutEngine}");
+					success = false;
+				}
 			}
+
+			if (success)
+			{
+				_normalWindows.Remove(window);
+			}
+		}
+		else
+		{
+			_minimizedWindows.Remove(window);
 		}
 
 		if (success)
 		{
-			if (isNormalWindow)
-			{
-				_normalWindows.Remove(window);
-			}
-			else
-			{
-				_minimizedWindows.Remove(window);
-			}
-
 			DoLayout();
 		}
 

--- a/src/Whim/Workspace/Workspace.cs
+++ b/src/Whim/Workspace/Workspace.cs
@@ -4,7 +4,7 @@ using System.Linq;
 
 namespace Whim;
 
-internal class Workspace : IWorkspace
+internal class Workspace : IWorkspace, IInternalWorkspace
 {
 	private bool _initialized;
 	private readonly IContext _context;
@@ -105,11 +105,7 @@ internal class Workspace : IWorkspace
 		}
 	}
 
-	/// <summary>
-	/// Called when a window is focused, regardless of whether it's in this workspace.
-	/// </summary>
-	/// <param name="window"></param>
-	internal virtual void WindowFocused(IWindow window)
+	public void WindowFocused(IWindow window)
 	{
 		if (
 			_normalWindows.Contains(window)
@@ -125,11 +121,7 @@ internal class Workspace : IWorkspace
 		}
 	}
 
-	/// <summary>
-	/// Called when a window is about to be minimized.
-	/// </summary>
-	/// <param name="window"></param>
-	internal virtual void WindowMinimizeStart(IWindow window)
+	public void WindowMinimizeStart(IWindow window)
 	{
 		if (!_normalWindows.Contains(window))
 		{
@@ -147,11 +139,7 @@ internal class Workspace : IWorkspace
 		DoLayout();
 	}
 
-	/// <summary>
-	/// Called when a window is about to be unminimized.
-	/// </summary>
-	/// <param name="window"></param>
-	internal virtual void WindowMinimizeEnd(IWindow window)
+	public void WindowMinimizeEnd(IWindow window)
 	{
 		if (!_minimizedWindows.Contains(window))
 		{

--- a/src/Whim/Workspace/WorkspaceManager.cs
+++ b/src/Whim/Workspace/WorkspaceManager.cs
@@ -382,7 +382,7 @@ internal class WorkspaceManager : IWorkspaceManager
 
 		foreach (IWorkspace workspace in _workspaces)
 		{
-			if (workspace is Workspace ws)
+			if (workspace is IInternalWorkspace ws)
 			{
 				ws.WindowFocused(window);
 			}
@@ -409,7 +409,7 @@ internal class WorkspaceManager : IWorkspaceManager
 			return;
 		}
 
-		if (workspace is Workspace ws)
+		if (workspace is IInternalWorkspace ws)
 		{
 			ws.WindowMinimizeStart(window);
 		}
@@ -429,7 +429,7 @@ internal class WorkspaceManager : IWorkspaceManager
 			return;
 		}
 
-		if (workspace is Workspace ws)
+		if (workspace is IInternalWorkspace ws)
 		{
 			ws.WindowMinimizeEnd(window);
 		}

--- a/src/Whim/Workspace/WorkspaceManager.cs
+++ b/src/Whim/Workspace/WorkspaceManager.cs
@@ -409,7 +409,10 @@ internal class WorkspaceManager : IWorkspaceManager
 			return;
 		}
 
-		workspace.RemoveWindow(window);
+		if (workspace is Workspace ws)
+		{
+			ws.WindowMinimizeStart(window);
+		}
 	}
 
 	/// <summary>
@@ -420,7 +423,16 @@ internal class WorkspaceManager : IWorkspaceManager
 	{
 		Logger.Debug($"Window minimize end: {window}");
 
-		WindowAdded(window);
+		if (!_windowWorkspaceMap.TryGetValue(window, out IWorkspace? workspace))
+		{
+			Logger.Error($"Window {window} was not found in any workspace");
+			return;
+		}
+
+		if (workspace is Workspace ws)
+		{
+			ws.WindowMinimizeEnd(window);
+		}
 	}
 	#endregion
 


### PR DESCRIPTION
Minimized windows now stay within a given workspace - windows hide from the taskbar on workspace deactivation and show in the taskbar on workspace activation. This is achieved by tracking the minimized windows within a `Workspace`, even though the windows have been removed from the child `ILayoutEngine` instances. 

`Workspace` now inherits from `IInternalWorkspace`, an interface which contains methods with `internal`-only use. This allow the mocking of methods like `Window.WindowFocused` by creating a mock for `IInternalWorkspace`.

The opportunity was also taken to increase `IWindow` coverage.
