### PR TITLE
`MoveWindowEdgesInDirection` now takes in coordinates in the unit square

### DIFF
--- a/src/Whim.Tests/Commands/CoreCommandsTests.cs
+++ b/src/Whim.Tests/Commands/CoreCommandsTests.cs
@@ -147,7 +147,7 @@ public class CoreCommandsTests
 		MocksWrapper mocks = new();
 		CoreCommands commands = new(mocks.Context.Object);
 		PluginCommandsTestUtils testUtils = new(commands);
-		IPoint<int> pixelDeltas = new Point<int>()
+		IPoint<int> pixelsDeltas = new Point<int>()
 		{
 			X = x * CoreCommands.MoveWindowEdgeDelta,
 			Y = y * CoreCommands.MoveWindowEdgeDelta
@@ -160,7 +160,7 @@ public class CoreCommandsTests
 
 		// Then
 		mocks.Context.Verify(
-			x => x.WorkspaceManager.ActiveWorkspace.MoveWindowEdgesInDirection(direction, pixelDeltas, null),
+			x => x.WorkspaceManager.MoveWindowEdgesInDirection(direction, pixelsDeltas, null),
 			Times.Once
 		);
 	}

--- a/src/Whim.Tests/Layout/BaseStackLayoutEngineTests.cs
+++ b/src/Whim.Tests/Layout/BaseStackLayoutEngineTests.cs
@@ -19,7 +19,7 @@ public class BaseStackLayoutEngineTests
 		public override void FocusWindowInDirection(Direction direction, IWindow window) =>
 			throw new System.NotImplementedException();
 
-		public override void MoveWindowEdgesInDirection(Direction edge, IPoint<int> pointDeltas, IWindow window) =>
+		public override void MoveWindowEdgesInDirection(Direction edge, IPoint<double> deltas, IWindow window) =>
 			throw new System.NotImplementedException();
 
 		public override void SwapWindowInDirection(Direction direction, IWindow window) =>

--- a/src/Whim.Tests/Layout/ProxyLayoutEngineTests.cs
+++ b/src/Whim.Tests/Layout/ProxyLayoutEngineTests.cs
@@ -219,17 +219,17 @@ public class ProxyLayoutEngineTests
 		// Given
 		Mock<ILayoutEngine> innerLayoutEngine = new();
 		innerLayoutEngine.Setup(
-			x => x.MoveWindowEdgesInDirection(It.IsAny<Direction>(), It.IsAny<IPoint<int>>(), It.IsAny<IWindow>())
+			x => x.MoveWindowEdgesInDirection(It.IsAny<Direction>(), It.IsAny<IPoint<double>>(), It.IsAny<IWindow>())
 		);
 
 		ProxyLayoutEngine proxyLayoutEngine = new(innerLayoutEngine.Object);
 
 		// When
-		proxyLayoutEngine.MoveWindowEdgesInDirection(Direction.Left, new Point<int>(), new Mock<IWindow>().Object);
+		proxyLayoutEngine.MoveWindowEdgesInDirection(Direction.Left, new Point<double>(), new Mock<IWindow>().Object);
 
 		// Then
 		innerLayoutEngine.Verify(
-			x => x.MoveWindowEdgesInDirection(It.IsAny<Direction>(), It.IsAny<IPoint<int>>(), It.IsAny<IWindow>()),
+			x => x.MoveWindowEdgesInDirection(It.IsAny<Direction>(), It.IsAny<IPoint<double>>(), It.IsAny<IWindow>()),
 			Times.Once
 		);
 	}

--- a/src/Whim.Tests/Layout/ProxyLayoutEngineTests.cs
+++ b/src/Whim.Tests/Layout/ProxyLayoutEngineTests.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Xunit;
 
-namespace Whim;
+namespace Whim.Tests;
 
 public class ProxyLayoutEngineTests
 {

--- a/src/Whim.Tests/Monitor/MonitorHelpersTests.cs
+++ b/src/Whim.Tests/Monitor/MonitorHelpersTests.cs
@@ -81,6 +81,82 @@ public class MonitorHelpersTests
 		Assert.Equal(expected.Y, actual.Y);
 	}
 
+	public static IEnumerable<object[]> IntToUnitSquareRespectSignData()
+	{
+		yield return new object[]
+		{
+			new Location<int>() { Width = 1920, Height = 1080 },
+			new Point<int>() { X = -192, Y = 108 },
+			new Point<double>() { X = -0.1, Y = 0.1 }
+		};
+		yield return new object[]
+		{
+			new Location<int>() { Width = 1920, Height = 1080 },
+			new Point<int>() { X = 960, Y = -270 },
+			new Point<double>() { X = 0.5, Y = -0.25 }
+		};
+		yield return new object[]
+		{
+			new Location<int>()
+			{
+				X = 100,
+				Y = 100,
+				Width = 1920,
+				Height = 1080
+			},
+			new Point<int>() { X = -192, Y = -108 },
+			new Point<double>() { X = -0.1, Y = -0.1 }
+		};
+		yield return new object[]
+		{
+			new Location<int>()
+			{
+				X = 100,
+				Y = 100,
+				Width = 1920,
+				Height = 1080
+			},
+			new Point<int>() { X = -960, Y = 270 },
+			new Point<double>() { X = -0.5, Y = 0.25 }
+		};
+		yield return new object[]
+		{
+			new Location<int>()
+			{
+				X = -100,
+				Y = 100,
+				Width = 1920,
+				Height = 1080
+			},
+			new Point<int>() { X = 192, Y = -108 },
+			new Point<double>() { X = 0.1, Y = -0.1 }
+		};
+		yield return new object[]
+		{
+			new Location<int>()
+			{
+				X = -100,
+				Y = 100,
+				Width = 1920,
+				Height = 1080
+			},
+			new Point<int>() { X = -960, Y = -270 },
+			new Point<double>() { X = -0.5, Y = -0.25 }
+		};
+	}
+
+	[Theory]
+	[MemberData(nameof(IntToUnitSquareRespectSignData))]
+	public void ToUnitSquarePointRespectSignTheory(ILocation<int> monitor, IPoint<int> point, IPoint<double> expected)
+	{
+		// When
+		IPoint<double> actual = monitor.ToUnitSquare(point, respectSign: true);
+
+		// Then
+		Assert.Equal(expected.X, actual.X);
+		Assert.Equal(expected.Y, actual.Y);
+	}
+
 	public static IEnumerable<object[]> DoubleToUnitSquareData()
 	{
 		yield return new object[]

--- a/src/Whim.Tests/Window/WindowManagerTests.cs
+++ b/src/Whim.Tests/Window/WindowManagerTests.cs
@@ -718,7 +718,7 @@ public class WindowManagerTests
 		// Then
 		wrapper.NativeManager.Verify(nm => nm.DwmGetWindowLocation(It.IsAny<HWND>()), Times.Once);
 		workspace.Verify(
-			w => w.MoveWindowEdgesInDirection(It.IsAny<Direction>(), It.IsAny<ILocation<int>>(), It.IsAny<IWindow>()),
+			w => w.MoveWindowEdgesInDirection(It.IsAny<Direction>(), It.IsAny<IPoint<double>>(), It.IsAny<IWindow>()),
 			Times.Never()
 		);
 	}
@@ -841,7 +841,7 @@ public class WindowManagerTests
 		);
 
 		// Then
-		workspace.Verify(w => w.MoveWindowEdgesInDirection(direction, pixelsDelta, It.IsAny<IWindow>()));
+		wrapper.WorkspaceManager.Verify(w => w.MoveWindowEdgesInDirection(direction, pixelsDelta, It.IsAny<IWindow>()));
 	}
 
 	[Fact]

--- a/src/Whim.Tests/Workspace/WorkspaceManagerTests.cs
+++ b/src/Whim.Tests/Workspace/WorkspaceManagerTests.cs
@@ -1590,4 +1590,115 @@ public class WorkspaceManagerTests
 		// Then the workspace is returned
 		Assert.Equal(workspaces[1].Object, activeWorkspace);
 	}
+
+	[Fact]
+	public void MoveWindowEdgesInDirection_NoWindow()
+	{
+		// Given
+		Mock<IWorkspace>[] workspaces = new[] { new Mock<IWorkspace>(), new Mock<IWorkspace>() };
+
+		Wrapper wrapper = new(workspaces);
+		wrapper.WorkspaceManager.Initialize();
+
+		// When moving the window edges in a direction
+		wrapper.WorkspaceManager.MoveWindowEdgesInDirection(Direction.Left, new Point<int>());
+
+		// Then nothing happens
+		workspaces[0].Verify(
+			w => w.MoveWindowEdgesInDirection(It.IsAny<Direction>(), It.IsAny<IPoint<double>>(), It.IsAny<IWindow?>()),
+			Times.Never()
+		);
+		workspaces[1].Verify(
+			w => w.MoveWindowEdgesInDirection(It.IsAny<Direction>(), It.IsAny<IPoint<double>>(), It.IsAny<IWindow?>()),
+			Times.Never()
+		);
+	}
+
+	[Fact]
+	public void MoveWindowEdgesInDirection_NoContainingWorkspace()
+	{
+		// Given
+		Mock<IWorkspace>[] workspaces = new[] { new Mock<IWorkspace>(), new Mock<IWorkspace>() };
+
+		Wrapper wrapper = new(workspaces);
+
+		Mock<IWindow> window = new();
+		workspaces[1].Setup(w => w.Windows).Returns(new[] { window.Object });
+		workspaces[1].Setup(w => w.LastFocusedWindow).Returns(window.Object);
+
+		wrapper.WorkspaceManager.Initialize();
+		wrapper.MonitorManager.Setup(m => m.ActiveMonitor).Returns(wrapper.Monitors[1].Object);
+
+		// When moving the window edges in a direction
+		wrapper.WorkspaceManager.MoveWindowEdgesInDirection(Direction.Left, new Point<int>());
+
+		// Then nothing happens
+		workspaces[0].Verify(
+			w => w.MoveWindowEdgesInDirection(It.IsAny<Direction>(), It.IsAny<IPoint<double>>(), It.IsAny<IWindow?>()),
+			Times.Never()
+		);
+		workspaces[1].Verify(
+			w => w.MoveWindowEdgesInDirection(It.IsAny<Direction>(), It.IsAny<IPoint<double>>(), It.IsAny<IWindow?>()),
+			Times.Never()
+		);
+	}
+
+	[Fact]
+	public void MoveWindowEdgesInDirection_NoContainingMonitor()
+	{
+		// Given
+		Mock<IWorkspace>[] workspaces = new[] { new Mock<IWorkspace>(), new Mock<IWorkspace>() };
+
+		Wrapper wrapper = new(workspaces);
+
+		Mock<IWindow> window = new();
+		workspaces[1].Setup(w => w.Windows).Returns(new[] { window.Object });
+		workspaces[1].Setup(w => w.LastFocusedWindow).Returns(window.Object);
+
+		wrapper.WorkspaceManager.Initialize();
+		wrapper.WorkspaceManager.WindowAdded(window.Object);
+
+		// When moving the window edges in a direction
+		wrapper.WorkspaceManager.MoveWindowEdgesInDirection(Direction.Left, new Point<int>());
+
+		// Then nothing happens
+		workspaces[0].Verify(
+			w => w.MoveWindowEdgesInDirection(It.IsAny<Direction>(), It.IsAny<IPoint<double>>(), It.IsAny<IWindow?>()),
+			Times.Never()
+		);
+		workspaces[1].Verify(
+			w => w.MoveWindowEdgesInDirection(It.IsAny<Direction>(), It.IsAny<IPoint<double>>(), It.IsAny<IWindow?>()),
+			Times.Never()
+		);
+	}
+
+	[Fact]
+	public void MoveWindowEdgesInDirection_Success()
+	{
+		// Given
+		Mock<IWorkspace>[] workspaces = new[] { new Mock<IWorkspace>(), new Mock<IWorkspace>() };
+
+		Wrapper wrapper = new(workspaces);
+
+		Mock<IWindow> window = new();
+		workspaces[0].Setup(w => w.Windows).Returns(new[] { window.Object });
+		workspaces[0].Setup(w => w.LastFocusedWindow).Returns(window.Object);
+		wrapper.MonitorManager.Setup(m => m.ActiveMonitor).Returns(wrapper.Monitors[0].Object);
+
+		wrapper.WorkspaceManager.Initialize();
+		wrapper.WorkspaceManager.WindowAdded(window.Object);
+
+		// When moving the window edges in a direction
+		wrapper.WorkspaceManager.MoveWindowEdgesInDirection(Direction.Left, new Point<int>());
+
+		// Then the window edges are moved
+		workspaces[0].Verify(
+			w => w.MoveWindowEdgesInDirection(Direction.Left, It.IsAny<IPoint<double>>(), window.Object),
+			Times.Once()
+		);
+		workspaces[1].Verify(
+			w => w.MoveWindowEdgesInDirection(It.IsAny<Direction>(), It.IsAny<IPoint<double>>(), It.IsAny<IWindow?>()),
+			Times.Never()
+		);
+	}
 }

--- a/src/Whim.Tests/Workspace/WorkspaceManagerTests.cs
+++ b/src/Whim.Tests/Workspace/WorkspaceManagerTests.cs
@@ -1648,18 +1648,19 @@ public class WorkspaceManagerTests
 	{
 		// Given
 		Mock<IWorkspace>[] workspaces = new[] { new Mock<IWorkspace>(), new Mock<IWorkspace>() };
+		Mock<IMonitor>[] monitors = new[] { new Mock<IMonitor>() };
 
-		Wrapper wrapper = new(workspaces);
+		Wrapper wrapper = new(workspaces, monitors);
 
 		Mock<IWindow> window = new();
 		workspaces[1].Setup(w => w.Windows).Returns(new[] { window.Object });
-		workspaces[1].Setup(w => w.LastFocusedWindow).Returns(window.Object);
+		wrapper.RouterManager.Setup(r => r.RouteWindow(window.Object)).Returns(workspaces[1].Object);
 
 		wrapper.WorkspaceManager.Initialize();
 		wrapper.WorkspaceManager.WindowAdded(window.Object);
 
 		// When moving the window edges in a direction
-		wrapper.WorkspaceManager.MoveWindowEdgesInDirection(Direction.Left, new Point<int>());
+		wrapper.WorkspaceManager.MoveWindowEdgesInDirection(Direction.Left, new Point<int>(), window.Object);
 
 		// Then nothing happens
 		workspaces[0].Verify(

--- a/src/Whim.Tests/Workspace/WorkspaceTests.cs
+++ b/src/Whim.Tests/Workspace/WorkspaceTests.cs
@@ -911,14 +911,14 @@ public class WorkspaceTests
 		MocksBuilder mocks = new();
 		Workspace workspace =
 			new(mocks.Context.Object, mocks.Triggers, "Workspace", new ILayoutEngine[] { mocks.LayoutEngine.Object });
-		IPoint<int> pixelDeltas = new Point<int>() { X = 3, Y = 0 };
+		IPoint<double> deltas = new Point<double>() { X = 0.3, Y = 0 };
 
 		// When MoveWindowEdgesInDirection is called
-		workspace.MoveWindowEdgesInDirection(Direction.Up, pixelDeltas, null);
+		workspace.MoveWindowEdgesInDirection(Direction.Up, deltas, null);
 
 		// Then the layout engine is not told to move the window
 		mocks.LayoutEngine.Verify(
-			l => l.MoveWindowEdgesInDirection(Direction.Up, pixelDeltas, It.IsAny<IWindow>()),
+			l => l.MoveWindowEdgesInDirection(Direction.Up, deltas, It.IsAny<IWindow>()),
 			Times.Never
 		);
 	}
@@ -931,16 +931,13 @@ public class WorkspaceTests
 		Mock<IWindow> window = new();
 		Workspace workspace =
 			new(mocks.Context.Object, mocks.Triggers, "Workspace", new ILayoutEngine[] { mocks.LayoutEngine.Object });
-		IPoint<int> pixelDeltas = new Point<int>() { X = 3, Y = 0 };
+		IPoint<double> deltas = new Point<double>() { X = 0.3, Y = 0 };
 
 		// When MoveWindowEdgesInDirection is called
-		workspace.MoveWindowEdgesInDirection(Direction.Up, pixelDeltas, window.Object);
+		workspace.MoveWindowEdgesInDirection(Direction.Up, deltas, window.Object);
 
 		// Then the layout engine is not told to move the window
-		mocks.LayoutEngine.Verify(
-			l => l.MoveWindowEdgesInDirection(Direction.Up, pixelDeltas, window.Object),
-			Times.Never
-		);
+		mocks.LayoutEngine.Verify(l => l.MoveWindowEdgesInDirection(Direction.Up, deltas, window.Object), Times.Never);
 	}
 
 	[Fact]
@@ -952,16 +949,13 @@ public class WorkspaceTests
 		Workspace workspace =
 			new(mocks.Context.Object, mocks.Triggers, "Workspace", new ILayoutEngine[] { mocks.LayoutEngine.Object });
 		workspace.AddWindow(window.Object);
-		IPoint<int> pixelDeltas = new Point<int>() { X = 3, Y = 0 };
+		IPoint<double> deltas = new Point<double>() { X = 0.3, Y = 0 };
 
 		// When MoveWindowEdgesInDirection is called
-		workspace.MoveWindowEdgesInDirection(Direction.Up, pixelDeltas, window.Object);
+		workspace.MoveWindowEdgesInDirection(Direction.Up, deltas, window.Object);
 
 		// Then the layout engine is told to move the window
-		mocks.LayoutEngine.Verify(
-			l => l.MoveWindowEdgesInDirection(Direction.Up, pixelDeltas, window.Object),
-			Times.Once
-		);
+		mocks.LayoutEngine.Verify(l => l.MoveWindowEdgesInDirection(Direction.Up, deltas, window.Object), Times.Once);
 	}
 
 	[Fact]

--- a/src/Whim.TreeLayout.Tests/TestAddWindow.cs
+++ b/src/Whim.TreeLayout.Tests/TestAddWindow.cs
@@ -76,7 +76,7 @@ public class TestAddWindow
 		workspaceManager.Setup(w => w.ActiveWorkspace.LastFocusedWindow).Returns(window1.Object);
 
 		// When
-		engine.MoveWindowEdgesInDirection(Direction.Right, new Point<int>() { X = 192, Y = 0 }, window1.Object);
+		engine.MoveWindowEdgesInDirection(Direction.Right, new Point<double>() { X = 0.1, Y = 0 }, window1.Object);
 
 		engine.Add(window3.Object);
 

--- a/src/Whim.TreeLayout.Tests/TestMoveWindowEdgeInDirection.cs
+++ b/src/Whim.TreeLayout.Tests/TestMoveWindowEdgeInDirection.cs
@@ -10,10 +10,10 @@ public class TestMoveWindowEdgesInDirection
 	{
 		// Given
 		TestTreeEngineMocks testEngine = new();
-		IPoint<int> pixelDeltas = new Point<int>() { X = 192, Y = 0 };
+		IPoint<double> pixelsDeltas = new Point<double>() { X = 0.1, Y = 0 };
 
 		// When
-		testEngine.Engine.MoveWindowEdgesInDirection(Direction.Left, pixelDeltas, new Mock<IWindow>().Object);
+		testEngine.Engine.MoveWindowEdgesInDirection(Direction.Left, pixelsDeltas, new Mock<IWindow>().Object);
 
 		// Then
 		Assert.Equal(0.5, testEngine.LeftNode.GetWeight());
@@ -25,10 +25,10 @@ public class TestMoveWindowEdgesInDirection
 	{
 		// Given
 		TestTreeEngineMocks testEngine = new();
-		IPoint<int> pixelDeltas = new Point<int>() { X = 192, Y = 0 };
+		IPoint<double> pixelsDeltas = new Point<double>() { X = 0.1, Y = 0 };
 
 		// When
-		testEngine.Engine.MoveWindowEdgesInDirection(Direction.Left, pixelDeltas, testEngine.LeftWindow.Object);
+		testEngine.Engine.MoveWindowEdgesInDirection(Direction.Left, pixelsDeltas, testEngine.LeftWindow.Object);
 
 		// Then
 		Assert.Equal(0.5, testEngine.LeftNode.GetWeight());
@@ -45,10 +45,10 @@ public class TestMoveWindowEdgesInDirection
 		TestTree tree = new();
 		TestTreeEngineMocks testEngine = new();
 		testEngine.Engine.DoLayout(new Location<int>() { Height = 1080, Width = 1920 }, new Mock<IMonitor>().Object);
-		IPoint<int> pixelDeltas = new Point<int>() { X = 192, Y = 0 };
+		IPoint<double> pixelsDeltas = new Point<double>() { X = 0.1, Y = 0 };
 
 		// When
-		testEngine.Engine.MoveWindowEdgesInDirection(Direction.Left, pixelDeltas, testEngine.LeftWindow.Object);
+		testEngine.Engine.MoveWindowEdgesInDirection(Direction.Left, pixelsDeltas, testEngine.LeftWindow.Object);
 
 		// Then
 		Assert.Equal(tree.Left.GetWeight(), testEngine.LeftNode.GetWeight());
@@ -64,10 +64,10 @@ public class TestMoveWindowEdgesInDirection
 		// Given
 		TestTreeEngineMocks testEngine = new();
 		testEngine.Engine.DoLayout(new Location<int>() { Height = 1080, Width = 1920 }, new Mock<IMonitor>().Object);
-		IPoint<int> pixelDeltas = new Point<int>() { X = 192, Y = 0 };
+		IPoint<double> pixelsDeltas = new Point<double>() { X = 0.1, Y = 0 };
 
 		// When
-		testEngine.Engine.MoveWindowEdgesInDirection(Direction.Right, pixelDeltas, testEngine.LeftWindow.Object);
+		testEngine.Engine.MoveWindowEdgesInDirection(Direction.Right, pixelsDeltas, testEngine.LeftWindow.Object);
 
 		// Then
 		Assert.Equal(0.5 + 0.1, testEngine.LeftNode.GetWeight());
@@ -85,12 +85,12 @@ public class TestMoveWindowEdgesInDirection
 		IWindowState[] _ = testEngine.Engine
 			.DoLayout(new Location<int>() { Height = 1080, Width = 1920 }, new Mock<IMonitor>().Object)
 			.ToArray();
-		IPoint<int> pixelDeltas = new Point<int>() { X = 192, Y = 0 };
+		IPoint<double> pixelsDeltas = new Point<double>() { X = 0.1, Y = 0 };
 
 		// When
 		testEngine.Engine.MoveWindowEdgesInDirection(
 			Direction.Left,
-			pixelDeltas,
+			pixelsDeltas,
 			testEngine.RightTopLeftBottomLeftWindow.Object
 		);
 
@@ -110,10 +110,10 @@ public class TestMoveWindowEdgesInDirection
 		IWindowState[] _ = testEngine.Engine
 			.DoLayout(new Location<int>() { Height = 1080, Width = 1920 }, new Mock<IMonitor>().Object)
 			.ToArray();
-		IPoint<int> pixelDeltas = new Point<int>() { X = 0, Y = 108 };
+		IPoint<double> pixelsDeltas = new Point<double>() { X = 0, Y = 0.1 };
 
 		// When
-		testEngine.Engine.MoveWindowEdgesInDirection(Direction.Up, pixelDeltas, testEngine.RightBottomWindow.Object);
+		testEngine.Engine.MoveWindowEdgesInDirection(Direction.Up, pixelsDeltas, testEngine.RightBottomWindow.Object);
 
 		// Then
 		Assert.Equal(0.5 + 0.1, testEngine.RightBottomNode.GetWeight());
@@ -129,12 +129,12 @@ public class TestMoveWindowEdgesInDirection
 		// Given
 		TestTreeEngineMocks testEngine = new();
 		testEngine.Engine.DoLayout(new Location<int>() { Height = 1080, Width = 1920 }, new Mock<IMonitor>().Object);
-		IPoint<int> pixelDeltas = new Point<int>() { X = 0, Y = 108 };
+		IPoint<double> pixelsDeltas = new Point<double>() { X = 0, Y = 0.1 };
 
 		// When
 		testEngine.Engine.MoveWindowEdgesInDirection(
 			Direction.Down,
-			pixelDeltas,
+			pixelsDeltas,
 			testEngine.RightTopRight3Window.Object
 		);
 

--- a/src/Whim.TreeLayout.Tests/TestTreeEngineMocks.cs
+++ b/src/Whim.TreeLayout.Tests/TestTreeEngineMocks.cs
@@ -132,7 +132,7 @@ internal class TestTreeEngineMocks
 
 		Engine.MoveWindowEdgesInDirection(
 			Direction.Down,
-			new Point<int>() { X = 0, Y = 54 },
+			new Point<double>() { X = 0, Y = 0.05 },
 			RightTopLeftBottomRightTopWindow.Object
 		);
 	}

--- a/src/Whim.TreeLayout/TreeLayoutEngine.cs
+++ b/src/Whim.TreeLayout/TreeLayoutEngine.cs
@@ -406,9 +406,9 @@ public partial class TreeLayoutEngine : ITreeLayoutEngine
 	IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
 	/// <inheritdoc />
-	public void MoveWindowEdgesInDirection(Direction edges, IPoint<int> pixelDeltas, IWindow window)
+	public void MoveWindowEdgesInDirection(Direction edges, IPoint<double> delta, IWindow window)
 	{
-		Logger.Debug($"Moving window {window} edges in direction {edges} by {pixelDeltas} in layout engine {Name}");
+		Logger.Debug($"Moving window {window} edges in direction {edges} by {delta} in layout engine {Name}");
 
 		if (!_windows.TryGetValue(window, out LeafNode? focusedNode))
 		{
@@ -446,8 +446,8 @@ public partial class TreeLayoutEngine : ITreeLayoutEngine
 
 		// For each adjacent node, move the window edge in the given direction.
 		Node[] focusedNodeLineage = focusedNode.Lineage.ToArray();
-		MoveSingleWindowEdgeInDirection(pixelDeltas.X, true, focusedNodeLineage, xAdjacentNode);
-		MoveSingleWindowEdgeInDirection(pixelDeltas.Y, false, focusedNodeLineage, yAdjacentNode);
+		MoveSingleWindowEdgeInDirection(delta.X, true, focusedNodeLineage, xAdjacentNode);
+		MoveSingleWindowEdgeInDirection(delta.Y, false, focusedNodeLineage, yAdjacentNode);
 	}
 
 	private void MoveSingleWindowEdgeInDirection(
@@ -485,10 +485,8 @@ public partial class TreeLayoutEngine : ITreeLayoutEngine
 		// First, we need to find the location of the parent node.
 		ILocation<double> parentLocation = GetNodeLocation(parentNode);
 
-		// Figure out what the relative delta of pixelDelta is, first given the unit square, then
-		// given the dimensions of the parent node.
-		double unitSquareDelta = delta / (isXAxis ? _location.Width : _location.Height);
-		double relativeDelta = unitSquareDelta / (isXAxis ? parentLocation.Width : parentLocation.Height);
+		// Figure out what the relative delta of pixelsDeltas is given the unit square.
+		double relativeDelta = delta / (isXAxis ? parentLocation.Width : parentLocation.Height);
 
 		// Now we can adjust the weights.
 		int parentDepth = parentNode.Depth;

--- a/src/Whim/Commands/CoreCommands.cs
+++ b/src/Whim/Commands/CoreCommands.cs
@@ -81,7 +81,7 @@ internal class CoreCommands : PluginCommands
 				identifier: "move_window_left_edge_left",
 				title: "Move the current window's left edge to the left",
 				callback: () =>
-					_context.WorkspaceManager.ActiveWorkspace.MoveWindowEdgesInDirection(
+					_context.WorkspaceManager.MoveWindowEdgesInDirection(
 						Direction.Left,
 						new Point<int>() { X = MoveWindowEdgeDelta, Y = 0 }
 					),
@@ -91,7 +91,7 @@ internal class CoreCommands : PluginCommands
 				identifier: "move_window_left_edge_right",
 				title: "Move the current window's left edge to the right",
 				callback: () =>
-					_context.WorkspaceManager.ActiveWorkspace.MoveWindowEdgesInDirection(
+					_context.WorkspaceManager.MoveWindowEdgesInDirection(
 						Direction.Left,
 						new Point<int>() { X = -MoveWindowEdgeDelta, Y = 0 }
 					),
@@ -101,7 +101,7 @@ internal class CoreCommands : PluginCommands
 				identifier: "move_window_right_edge_left",
 				title: "Move the current window's right edge to the left",
 				callback: () =>
-					_context.WorkspaceManager.ActiveWorkspace.MoveWindowEdgesInDirection(
+					_context.WorkspaceManager.MoveWindowEdgesInDirection(
 						Direction.Right,
 						new Point<int>() { X = -MoveWindowEdgeDelta, Y = 0 }
 					),
@@ -111,7 +111,7 @@ internal class CoreCommands : PluginCommands
 				identifier: "move_window_right_edge_right",
 				title: "Move the current window's right edge to the right",
 				callback: () =>
-					_context.WorkspaceManager.ActiveWorkspace.MoveWindowEdgesInDirection(
+					_context.WorkspaceManager.MoveWindowEdgesInDirection(
 						Direction.Right,
 						new Point<int>() { X = MoveWindowEdgeDelta, Y = 0 }
 					),
@@ -121,7 +121,7 @@ internal class CoreCommands : PluginCommands
 				identifier: "move_window_top_edge_up",
 				title: "Move the current window's top edge up",
 				callback: () =>
-					_context.WorkspaceManager.ActiveWorkspace.MoveWindowEdgesInDirection(
+					_context.WorkspaceManager.MoveWindowEdgesInDirection(
 						Direction.Up,
 						new Point<int>() { Y = MoveWindowEdgeDelta }
 					),
@@ -131,7 +131,7 @@ internal class CoreCommands : PluginCommands
 				identifier: "move_window_top_edge_down",
 				title: "Move the current window's top edge down",
 				callback: () =>
-					_context.WorkspaceManager.ActiveWorkspace.MoveWindowEdgesInDirection(
+					_context.WorkspaceManager.MoveWindowEdgesInDirection(
 						Direction.Up,
 						new Point<int>() { Y = -MoveWindowEdgeDelta }
 					),
@@ -141,7 +141,7 @@ internal class CoreCommands : PluginCommands
 				identifier: "move_window_bottom_edge_up",
 				title: "Move the current window's bottom edge up",
 				callback: () =>
-					_context.WorkspaceManager.ActiveWorkspace.MoveWindowEdgesInDirection(
+					_context.WorkspaceManager.MoveWindowEdgesInDirection(
 						Direction.Down,
 						new Point<int>() { Y = -MoveWindowEdgeDelta }
 					),
@@ -151,7 +151,7 @@ internal class CoreCommands : PluginCommands
 				identifier: "move_window_bottom_edge_down",
 				title: "Move the current window's bottom edge down",
 				callback: () =>
-					_context.WorkspaceManager.ActiveWorkspace.MoveWindowEdgesInDirection(
+					_context.WorkspaceManager.MoveWindowEdgesInDirection(
 						Direction.Down,
 						new Point<int>() { Y = MoveWindowEdgeDelta }
 					),

--- a/src/Whim/Layout/BaseProxyLayoutEngine.cs
+++ b/src/Whim/Layout/BaseProxyLayoutEngine.cs
@@ -73,8 +73,8 @@ public abstract class BaseProxyLayoutEngine : ILayoutEngine
 	IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
 	/// <inheritdoc/>
-	public virtual void MoveWindowEdgesInDirection(Direction edge, IPoint<int> pixelDeltas, IWindow window) =>
-		InnerLayoutEngine.MoveWindowEdgesInDirection(edge, pixelDeltas, window);
+	public virtual void MoveWindowEdgesInDirection(Direction edge, IPoint<double> deltas, IWindow window) =>
+		InnerLayoutEngine.MoveWindowEdgesInDirection(edge, deltas, window);
 
 	/// <inheritdoc/>
 	public abstract IEnumerable<IWindowState> DoLayout(ILocation<int> location, IMonitor monitor);

--- a/src/Whim/Layout/BaseStackLayoutEngine.cs
+++ b/src/Whim/Layout/BaseStackLayoutEngine.cs
@@ -81,7 +81,7 @@ public abstract class BaseStackLayoutEngine : ILayoutEngine
 	public abstract void SwapWindowInDirection(Direction direction, IWindow window);
 
 	/// <inheritdoc/>
-	public abstract void MoveWindowEdgesInDirection(Direction edge, IPoint<int> pixelDeltas, IWindow window);
+	public abstract void MoveWindowEdgesInDirection(Direction edge, IPoint<double> deltas, IWindow window);
 
 	/// <inheritdoc/>
 	public abstract void AddWindowAtPoint(IWindow window, IPoint<double> point);

--- a/src/Whim/Layout/ColumnLayoutEngine.cs
+++ b/src/Whim/Layout/ColumnLayoutEngine.cs
@@ -137,7 +137,7 @@ public class ColumnLayoutEngine : BaseStackLayoutEngine
 	}
 
 	/// <inheritdoc />
-	public override void MoveWindowEdgesInDirection(Direction edge, IPoint<int> pixelDelta, IWindow window)
+	public override void MoveWindowEdgesInDirection(Direction edge, IPoint<double> deltas, IWindow window)
 	{
 		// Not implemented.
 	}

--- a/src/Whim/Layout/ILayoutEngine.cs
+++ b/src/Whim/Layout/ILayoutEngine.cs
@@ -44,16 +44,16 @@ public interface ILayoutEngine : ICollection<IWindow>
 	void SwapWindowInDirection(Direction direction, IWindow window);
 
 	/// <summary>
-	/// Moves the focused window's edges by the specified <paramref name="pixelDeltas"/>.
+	/// Moves the focused window's edges by the specified <paramref name="deltas"/>.
 	/// </summary>
 	/// <param name="edges">The edges to change.</param>
-	/// <param name="pixelDeltas">
-	/// The number of pixels to change the edge by. The <paramref name="edges"/> directions are
-	/// associated with the <paramref name="pixelDeltas"/>.
-	/// When a value is positive, then the edge will move in the direction of the <paramref name="edges"/>.
+	/// <param name="deltas">
+	/// The deltas to change the given <paramref name="edges"/> by. When a value is positive, then
+	/// the edge will move in the direction of the <paramref name="edges"/>.
+	/// The <paramref name="deltas"/> are in the range [0, 1] for both x and y (the unit square).
 	/// </param>
 	/// <param name="window"></param>
-	void MoveWindowEdgesInDirection(Direction edges, IPoint<int> pixelDeltas, IWindow window);
+	void MoveWindowEdgesInDirection(Direction edges, IPoint<double> deltas, IWindow window);
 
 	/// <summary>
 	/// Hides all phantom windows belonging to the layout engine.

--- a/src/Whim/Monitor/IMonitor.cs
+++ b/src/Whim/Monitor/IMonitor.cs
@@ -65,12 +65,18 @@ public static class MonitorHelpers
 	/// </summary>
 	/// <param name="monitor"></param>
 	/// <param name="point">The point to translate.</param>
+	/// <param name="respectSign">
+	/// Whether to respect the sign. For example, values in [-infinity, 0] will become [-1, 0].
+	/// </param>
 	/// <returns>The converted point, where x and y are in the range [0, 1].</returns>
-	public static IPoint<double> ToUnitSquare(this ILocation<int> monitor, IPoint<int> point)
+	public static IPoint<double> ToUnitSquare(this ILocation<int> monitor, IPoint<int> point, bool respectSign = false)
 	{
-		double x = Math.Abs((double)point.X / monitor.Width);
-		double y = Math.Abs((double)point.Y / monitor.Height);
-		return new Point<double>() { X = x, Y = y };
+		double x = (double)point.X / monitor.Width;
+		double y = (double)point.Y / monitor.Height;
+
+		return respectSign
+			? new Point<double>() { X = x, Y = y }
+			: new Point<double>() { X = Math.Abs(x), Y = Math.Abs(y) };
 	}
 
 	/// <summary>

--- a/src/Whim/Window/WindowManager.cs
+++ b/src/Whim/Window/WindowManager.cs
@@ -450,7 +450,7 @@ internal class WindowManager : IWindowManager
 			return false;
 		}
 
-		workspace.MoveWindowEdgesInDirection(
+		_context.WorkspaceManager.MoveWindowEdgesInDirection(
 			movedEdge,
 			new Point<int>() { X = movedEdgeDeltaX, Y = movedEdgeDeltaY, },
 			window

--- a/src/Whim/Workspace/IWorkspace.cs
+++ b/src/Whim/Workspace/IWorkspace.cs
@@ -119,21 +119,24 @@ public interface IWorkspace : IDisposable
 
 	/// <summary>
 	/// Change the <paramref name="window"/>'s <paramref name="edges"/> direction by
-	/// the specified <paramref name="pixelDeltas"/>.
+	/// the specified <paramref name="deltas"/>.
 	/// </summary>
 	/// <param name="edges">The edges to change.</param>
-	/// <param name="pixelDeltas">
-	/// The number of pixels to change the edge by. The <paramref name="edges"/> directions are
-	/// associated with the <paramref name="pixelDeltas"/>.
+	/// <param name="deltas">
+	/// The deltas to change the given <paramref name="edges"/> by. When a value is positive, then
+	/// the edge will move in the direction of the <paramref name="edges"/>.
+	/// The <paramref name="deltas"/> have a coordinate space of [0, 1] for both x and y (the unit
+	/// square).
 	/// </param>
 	/// <param name="window">
 	/// The window to change the edge of. If null, the currently focused window is
 	/// used.
 	/// </param>
-	void MoveWindowEdgesInDirection(Direction edges, IPoint<int> pixelDeltas, IWindow? window = null);
+	void MoveWindowEdgesInDirection(Direction edges, IPoint<double> deltas, IWindow? window = null);
 
 	/// <summary>
 	/// Moves or adds the given <paramref name="window"/> to the given <paramref name="point"/>.
+	/// The point has a coordinate space of [0, 1] for both x and y (the unit square).
 	/// </summary>
 	/// <param name="window">The window to move.</param>
 	/// <param name="point">The point to move the window to.</param>

--- a/src/Whim/Workspace/IWorkspaceManager.cs
+++ b/src/Whim/Workspace/IWorkspaceManager.cs
@@ -12,63 +12,63 @@ public interface IWorkspaceManager : IEnumerable<IWorkspace>, IDisposable
 	/// <summary>
 	/// The active workspace.
 	/// </summary>
-	public IWorkspace ActiveWorkspace { get; }
+	IWorkspace ActiveWorkspace { get; }
 
 	/// <summary>
 	/// Creates the default layout engines to add to a workspace.
 	/// </summary>
-	public Func<IList<ILayoutEngine>> CreateLayoutEngines { get; set; }
+	Func<IList<ILayoutEngine>> CreateLayoutEngines { get; set; }
 
 	/// <summary>
 	/// Initialize the event listeners.
 	/// </summary>
-	public void Initialize();
+	void Initialize();
 
 	/// <summary>
 	/// Description of how an <see cref="IWindow"/> has been routed between workspaces.
 	/// </summary>
-	public event EventHandler<RouteEventArgs>? WindowRouted;
+	event EventHandler<RouteEventArgs>? WindowRouted;
 
 	/// <summary>
 	/// Event for when a workspace is added.
 	/// </summary>
-	public event EventHandler<WorkspaceEventArgs>? WorkspaceAdded;
+	event EventHandler<WorkspaceEventArgs>? WorkspaceAdded;
 
 	/// <summary>
 	/// Event for when a workspace is removed.
 	/// </summary>
-	public event EventHandler<WorkspaceEventArgs>? WorkspaceRemoved;
+	event EventHandler<WorkspaceEventArgs>? WorkspaceRemoved;
 
 	/// <summary>
 	/// Event for when <see cref="IWorkspace.DoLayout"/> has started.
 	/// </summary>
-	public event EventHandler<WorkspaceEventArgs>? WorkspaceLayoutStarted;
+	event EventHandler<WorkspaceEventArgs>? WorkspaceLayoutStarted;
 
 	/// <summary>
 	/// Event for when <see cref="IWorkspace.DoLayout"/> has completed.
 	/// </summary>
-	public event EventHandler<WorkspaceEventArgs>? WorkspaceLayoutCompleted;
+	event EventHandler<WorkspaceEventArgs>? WorkspaceLayoutCompleted;
 
 	/// <summary>
 	/// Event for when a monitor's workspace has changed.
 	/// </summary>
-	public event EventHandler<MonitorWorkspaceChangedEventArgs>? MonitorWorkspaceChanged;
+	event EventHandler<MonitorWorkspaceChangedEventArgs>? MonitorWorkspaceChanged;
 
 	/// <summary>
 	/// Event for when a workspace's active layout engine has changed.
 	/// </summary>
-	public event EventHandler<ActiveLayoutEngineChangedEventArgs>? ActiveLayoutEngineChanged;
+	event EventHandler<ActiveLayoutEngineChangedEventArgs>? ActiveLayoutEngineChanged;
 
 	/// <summary>
 	/// Event for when a workspace is renamed.
 	/// </summary>
-	public event EventHandler<WorkspaceRenamedEventArgs>? WorkspaceRenamed;
+	event EventHandler<WorkspaceRenamedEventArgs>? WorkspaceRenamed;
 
 	/// <summary>
 	/// Triggers all active workspaces to update their layout.
 	/// Active workspaces are those that are visible on a monitor.
 	/// </summary>
-	public void LayoutAllActiveWorkspaces();
+	void LayoutAllActiveWorkspaces();
 
 	/// <summary>
 	/// Add a new workspace.
@@ -81,32 +81,32 @@ public interface IWorkspaceManager : IEnumerable<IWorkspace>, IDisposable
 	/// The layout engines to add to the workspace. Defaults to <see langword="null"/>, which will
 	/// use the <see cref="CreateLayoutEngines"/> function.
 	/// </param>
-	public void Add(string? name = null, IEnumerable<ILayoutEngine>? layoutEngines = null);
+	void Add(string? name = null, IEnumerable<ILayoutEngine>? layoutEngines = null);
 
 	/// <summary>
 	/// Tries to remove the given workspace.
 	/// </summary>
 	/// <param name="workspace">The workspace to remove.</param>
-	public bool Remove(IWorkspace workspace);
+	bool Remove(IWorkspace workspace);
 
 	/// <summary>
 	/// Try remove a workspace, by the workspace name.
 	/// </summary>
 	/// <param name="workspaceName">The workspace name to try and remove.</param>
 	/// <returns><c>true</c> when the workspace has been removed.</returns>
-	public bool Remove(string workspaceName);
+	bool Remove(string workspaceName);
 
 	/// <summary>
 	/// Tries to get a workspace by the given name.
 	/// </summary>
 	/// <param name="workspaceName">The workspace name to try and get.</param>
-	public IWorkspace? TryGet(string workspaceName);
+	IWorkspace? TryGet(string workspaceName);
 
 	/// <summary>
 	/// Tries to get a workspace by the given name.
 	/// </summary>
 	/// <param name="workspaceName">The workspace name to try and get.</param>
-	public IWorkspace? this[string workspaceName] { get; }
+	IWorkspace? this[string workspaceName] { get; }
 
 	/// <summary>
 	/// Activates the given workspace in the active monitor, or the given monitor (if provided).
@@ -116,7 +116,7 @@ public interface IWorkspaceManager : IEnumerable<IWorkspace>, IDisposable
 	/// The monitor to activate the workspace in. If <see langword="null"/>, this will default to
 	/// the active monitor.
 	/// </param>
-	public void Activate(IWorkspace workspace, IMonitor? monitor = null);
+	void Activate(IWorkspace workspace, IMonitor? monitor = null);
 
 	/// <summary>
 	/// Activates the previous workspace in the given monitor, or the focused monitor (if provided).
@@ -125,7 +125,7 @@ public interface IWorkspaceManager : IEnumerable<IWorkspace>, IDisposable
 	/// The monitor to activate the workspace in. If <see langword="null"/>, this will default to
 	/// the focused monitor.
 	/// </param>
-	public void ActivatePrevious(IMonitor? monitor = null);
+	void ActivatePrevious(IMonitor? monitor = null);
 
 	/// <summary>
 	/// Activates the next workspace in the given monitor, or the focused monitor (if provided).
@@ -134,35 +134,35 @@ public interface IWorkspaceManager : IEnumerable<IWorkspace>, IDisposable
 	/// The monitor to activate the workspace in. If <see langword="null"/>, this will default to
 	/// the focused monitor.
 	/// </param>
-	public void ActivateNext(IMonitor? monitor = null);
+	void ActivateNext(IMonitor? monitor = null);
 
 	/// <summary>
 	/// Retrieves the monitor for the active workspace.
 	/// </summary>
 	/// <param name="workspace"></param>
 	/// <returns><see langword="null"/> if the workspace is not active.</returns>
-	public IMonitor? GetMonitorForWorkspace(IWorkspace workspace);
+	IMonitor? GetMonitorForWorkspace(IWorkspace workspace);
 
 	/// <summary>
 	/// Retrieves the active workspace for the given monitor.
 	/// </summary>
 	/// <param name="monitor"></param>
 	/// <returns><see langword="null"/> if the monitor is not active.</returns>
-	public IWorkspace? GetWorkspaceForMonitor(IMonitor monitor);
+	IWorkspace? GetWorkspaceForMonitor(IMonitor monitor);
 
 	/// <summary>
 	/// Retrieves the workspace for the given window.
 	/// </summary>
 	/// <param name="window"></param>
 	/// <returns><see langword="null"/> if the window is not in a workspace.</returns>
-	public IWorkspace? GetWorkspaceForWindow(IWindow window);
+	IWorkspace? GetWorkspaceForWindow(IWindow window);
 
 	/// <summary>
 	/// Retrieves the monitor for the given window.
 	/// </summary>
 	/// <param name="window"></param>
 	/// <returns><see langword="null"/> if the window is not in a workspace.</returns>
-	public IMonitor? GetMonitorForWindow(IWindow window);
+	IMonitor? GetMonitorForWindow(IWindow window);
 
 	/// <summary>
 	/// Adds a proxy layout engine to the workspace manager.
@@ -170,12 +170,12 @@ public interface IWorkspaceManager : IEnumerable<IWorkspace>, IDisposable
 	/// all workspaces.
 	/// </summary>
 	/// <param name="proxyLayoutEngine">The proxy layout engine to add.</param>
-	public void AddProxyLayoutEngine(ProxyLayoutEngine proxyLayoutEngine);
+	void AddProxyLayoutEngine(ProxyLayoutEngine proxyLayoutEngine);
 
 	/// <summary>
 	/// The proxy layout engines.
 	/// </summary>
-	public IEnumerable<ProxyLayoutEngine> ProxyLayoutEngines { get; }
+	IEnumerable<ProxyLayoutEngine> ProxyLayoutEngines { get; }
 
 	/// <summary>
 	/// Moves the given <paramref name="window"/> to the given <paramref name="workspace"/>.
@@ -185,7 +185,7 @@ public interface IWorkspaceManager : IEnumerable<IWorkspace>, IDisposable
 	/// The window to move. If <see langword="null"/>, this will default to
 	/// the focused/active window.
 	/// </param>
-	public void MoveWindowToWorkspace(IWorkspace workspace, IWindow? window = null);
+	void MoveWindowToWorkspace(IWorkspace workspace, IWindow? window = null);
 
 	/// <summary>
 	/// Moves the given <paramref name="window"/> to the given <paramref name="monitor"/>.
@@ -195,7 +195,7 @@ public interface IWorkspaceManager : IEnumerable<IWorkspace>, IDisposable
 	/// The window to move. If <see langword="null"/>, this will default to
 	/// the focused/active window.
 	/// </param>
-	public void MoveWindowToMonitor(IMonitor monitor, IWindow? window = null);
+	void MoveWindowToMonitor(IMonitor monitor, IWindow? window = null);
 
 	/// <summary>
 	/// Moves the given <paramref name="window"/> to the previous monitor.
@@ -204,7 +204,7 @@ public interface IWorkspaceManager : IEnumerable<IWorkspace>, IDisposable
 	/// The window to move. If <see langword="null"/>, this will default to
 	/// the focused/active window.
 	/// </param>
-	public void MoveWindowToPreviousMonitor(IWindow? window = null);
+	void MoveWindowToPreviousMonitor(IWindow? window = null);
 
 	/// <summary>
 	/// Moves the given <paramref name="window"/> to the next monitor.
@@ -213,14 +213,31 @@ public interface IWorkspaceManager : IEnumerable<IWorkspace>, IDisposable
 	/// The window to move. If <see langword="null"/>, this will default to
 	/// the focused/active window.
 	/// </param>
-	public void MoveWindowToNextMonitor(IWindow? window = null);
+	void MoveWindowToNextMonitor(IWindow? window = null);
 
 	/// <summary>
 	/// Moves the given <paramref name="window"/> to the given <paramref name="point"/>.
 	/// </summary>
 	/// <param name="window">The window to move.</param>
-	/// <param name="point">The point to move the window to.</param>
-	public void MoveWindowToPoint(IWindow window, IPoint<int> point);
+	/// <param name="point">
+	/// The point to move the window to. The point is in the coordinate space of the monitors,
+	/// not the unit square.
+	/// </param>
+	void MoveWindowToPoint(IWindow window, IPoint<int> point);
+
+	/// <summary>
+	/// Moves the given <paramref name="window"/> by the given <paramref name="pixelsDeltas"/>.
+	/// </summary>
+	/// <param name="edges">The edges to change.</param>
+	/// <param name="pixelsDeltas">
+	/// The deltas (in pixels) to change the given <paramref name="edges"/> by. When a value is
+	/// positive, then the edge will move in the direction of the <paramref name="edges"/>.
+	/// The <paramref name="pixelsDeltas"/> are in the coordinate space of the monitors, not the
+	/// unit square.
+	/// </param>
+	/// <param name="window"></param>
+	/// <returns>Whether the window's edges were moved.</returns>
+	bool MoveWindowEdgesInDirection(Direction edges, IPoint<int> pixelsDeltas, IWindow? window = null);
 
 	#region Phantom Windows
 	/// <summary>
@@ -228,11 +245,11 @@ public interface IWorkspaceManager : IEnumerable<IWorkspace>, IDisposable
 	/// </summary>
 	/// <param name="window">The phantom window to add.</param>
 	/// <param name="workspace">The workspace to add the window for.</param>
-	public void AddPhantomWindow(IWorkspace workspace, IWindow window);
+	void AddPhantomWindow(IWorkspace workspace, IWindow window);
 
 	/// <summary>
 	/// Remove the given phantom window.
 	/// </summary>
-	public void RemovePhantomWindow(IWindow window);
+	void RemovePhantomWindow(IWindow window);
 	#endregion
 }

--- a/src/Whim/Workspace/Workspace.cs
+++ b/src/Whim/Workspace/Workspace.cs
@@ -359,13 +359,13 @@ internal class Workspace : IWorkspace, IInternalWorkspace
 		}
 	}
 
-	public void MoveWindowEdgesInDirection(Direction edges, IPoint<int> pixelDeltas, IWindow? window = null)
+	public void MoveWindowEdgesInDirection(Direction edges, IPoint<double> deltas, IWindow? window = null)
 	{
-		Logger.Debug($"Moving window {window} in workspace {Name} in direction {edges} by {pixelDeltas}");
+		Logger.Debug($"Moving window {window} in workspace {Name} in direction {edges} by {deltas}");
 
 		if (GetValidVisibleWindow(window) is IWindow validWindow)
 		{
-			ActiveLayoutEngine.MoveWindowEdgesInDirection(edges, pixelDeltas, validWindow);
+			ActiveLayoutEngine.MoveWindowEdgesInDirection(edges, deltas, validWindow);
 			DoLayout();
 		}
 	}

--- a/src/Whim/Workspace/WorkspaceManager.cs
+++ b/src/Whim/Workspace/WorkspaceManager.cs
@@ -667,19 +667,19 @@ internal class WorkspaceManager : IInternalWorkspaceManager, IWorkspaceManager
 
 		Logger.Debug("Moving window {window} in direction {edges} by {pixelsDeltas}");
 
-		// Get the containing monitor.
-		IMonitor? monitor = GetMonitorForWindow(window);
-		if (monitor == null)
+		// Get the containing workspace.
+		IWorkspace? workspace = GetWorkspaceForWindow(window);
+		if (workspace == null)
 		{
-			Logger.Error($"Could not find a monitor for {window}");
+			Logger.Error($"Could not find workspace for window {window}");
 			return false;
 		}
 
-		// Get the containing workspace.
-		IWorkspace? workspace = GetWorkspaceForMonitor(monitor);
-		if (workspace == null)
+		// Get the containing monitor.
+		IMonitor? monitor = GetMonitorForWorkspace(workspace);
+		if (monitor == null)
 		{
-			Logger.Error($"Monitor {monitor} was not found to correspond to any workspace");
+			Logger.Error($"Could not find monitor for workspace {workspace}");
 			return false;
 		}
 


### PR DESCRIPTION
`MoveWindowEdgesInDirection` for `IWorkspace` and `ILayoutEngine` now take `IPoint<double>` instead of `IPoint<int>`, reflecting the updated coordinate space (monitor to unit square).

`IWorkspaceManager.MoveWindowEdgesInDirection` was added. Like other `IWorkspaceManager` methods, this works in the monitor coordinate space.