### PR TITLE
Create immutable core `ILayoutEngine` classes

### DIFF
--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -8,7 +8,6 @@ on:
       - ".github/workflows/pull_request_labels.yml"
       - ".github/pull_request_template.md"
   pull_request:
-    branches: [main]
     paths-ignore:
       - ".github/ISSUE_TEMPLATE/*"
       - ".github/workflows/pull_request_labels.yml"

--- a/src/Whim.Tests/Layout/IImmutableLayoutEngineTests.cs
+++ b/src/Whim.Tests/Layout/IImmutableLayoutEngineTests.cs
@@ -1,0 +1,140 @@
+using Moq;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Whim.Tests;
+
+public class IImmutableLayoutEngineTests
+{
+	private class ProxyLayoutEngine : ImmutableBaseProxyLayoutEngine
+	{
+		public ProxyLayoutEngine(IImmutableLayoutEngine innerLayoutEngine)
+			: base(innerLayoutEngine) { }
+
+		public override IEnumerable<IWindowState> DoLayout(ILocation<int> location, IMonitor monitor) =>
+			InnerLayoutEngine.DoLayout(location, monitor);
+	}
+
+	private class TestLayoutEngine : IImmutableLayoutEngine
+	{
+		public string Name => throw new System.NotImplementedException();
+
+		public int Count => throw new System.NotImplementedException();
+
+		public IImmutableLayoutEngine Add(IWindow window) => throw new System.NotImplementedException();
+
+		public IImmutableLayoutEngine AddAtPoint(IWindow window, IPoint<double> point) =>
+			throw new System.NotImplementedException();
+
+		public bool Contains(IWindow window) => throw new System.NotImplementedException();
+
+		public IEnumerable<IWindowState> DoLayout(ILocation<int> location, IMonitor monitor) =>
+			throw new System.NotImplementedException();
+
+		public void FocusWindowInDirection(Direction direction, IWindow window) =>
+			throw new System.NotImplementedException();
+
+		public IWindow? GetFirstWindow() => throw new System.NotImplementedException();
+
+		public IImmutableLayoutEngine HidePhantomWindows() => throw new System.NotImplementedException();
+
+		public IImmutableLayoutEngine MoveWindowEdgesInDirection(
+			Direction edges,
+			IPoint<double> deltas,
+			IWindow window
+		) => throw new System.NotImplementedException();
+
+		public IImmutableLayoutEngine Remove(IWindow window) => throw new System.NotImplementedException();
+
+		public IImmutableLayoutEngine SwapWindowInDirection(Direction direction, IWindow window) =>
+			throw new System.NotImplementedException();
+	}
+
+	internal interface ITestLayoutEngine : IImmutableLayoutEngine { }
+
+	#region GetLayoutEngine
+	[Fact]
+	public void GetLayoutEngine_IsT()
+	{
+		// Given
+		IImmutableLayoutEngine engine = new TestLayoutEngine();
+
+		// When
+		IImmutableLayoutEngine? newEngine = engine.GetLayoutEngine<IImmutableLayoutEngine>();
+
+		// Then
+		Assert.Same(engine, newEngine);
+		Assert.NotNull(newEngine);
+	}
+
+	[Fact]
+	public void GetLayoutEngine_IsProxy()
+	{
+		// Given
+		TestLayoutEngine engine = new();
+		ProxyLayoutEngine proxy = new(engine);
+
+		// When
+		TestLayoutEngine? newEngine = proxy.GetLayoutEngine<TestLayoutEngine>();
+
+		// Then
+		Assert.Same(engine, newEngine);
+		Assert.NotNull(newEngine);
+	}
+
+	[Fact]
+	public void GetLayoutEngine_Null()
+	{
+		// Given
+		IImmutableLayoutEngine engine = new TestLayoutEngine();
+
+		// When
+		IImmutableLayoutEngine? newEngine = engine.GetLayoutEngine<ITestLayoutEngine>();
+
+		// Then
+		Assert.Null(newEngine);
+	}
+	#endregion
+
+	#region
+	[Fact]
+	public void ContainsEqual_IsT()
+	{
+		// Given
+		IImmutableLayoutEngine engine = new TestLayoutEngine();
+
+		// When
+		bool contains = engine.ContainsEqual(engine);
+
+		// Then
+		Assert.True(contains);
+	}
+
+	[Fact]
+	public void ContainsEqual_IsProxy()
+	{
+		// Given
+		TestLayoutEngine engine = new();
+		ProxyLayoutEngine proxy = new(engine);
+
+		// When
+		bool contains = proxy.ContainsEqual(engine);
+
+		// Then
+		Assert.True(contains);
+	}
+
+	[Fact]
+	public void ContainsEqual_Null()
+	{
+		// Given
+		IImmutableLayoutEngine engine = new TestLayoutEngine();
+
+		// When
+		bool contains = engine.ContainsEqual(new Mock<IImmutableLayoutEngine>().Object);
+
+		// Then
+		Assert.False(contains);
+	}
+	#endregion
+}

--- a/src/Whim.Tests/Layout/IImmutableLayoutEngineTests.cs
+++ b/src/Whim.Tests/Layout/IImmutableLayoutEngineTests.cs
@@ -72,10 +72,11 @@ public class IImmutableLayoutEngineTests
 	{
 		// Given
 		TestLayoutEngine engine = new();
-		ProxyLayoutEngine proxy = new(engine);
+		IImmutableLayoutEngine proxyInner = new ProxyLayoutEngine(engine);
+		IImmutableLayoutEngine proxyOuter = new ProxyLayoutEngine(proxyInner);
 
 		// When
-		TestLayoutEngine? newEngine = proxy.GetLayoutEngine<TestLayoutEngine>();
+		TestLayoutEngine? newEngine = proxyOuter.GetLayoutEngine<TestLayoutEngine>();
 
 		// Then
 		Assert.Same(engine, newEngine);
@@ -115,10 +116,11 @@ public class IImmutableLayoutEngineTests
 	{
 		// Given
 		TestLayoutEngine engine = new();
-		ProxyLayoutEngine proxy = new(engine);
+		IImmutableLayoutEngine proxyInner = new ProxyLayoutEngine(engine);
+		IImmutableLayoutEngine proxyOuter = new ProxyLayoutEngine(proxyInner);
 
 		// When
-		bool contains = proxy.ContainsEqual(engine);
+		bool contains = proxyOuter.ContainsEqual(engine);
 
 		// Then
 		Assert.True(contains);

--- a/src/Whim.Tests/Layout/ImmutableBaseProxyLayoutEngineTests.cs
+++ b/src/Whim.Tests/Layout/ImmutableBaseProxyLayoutEngineTests.cs
@@ -1,0 +1,239 @@
+using Moq;
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Whim.Tests;
+
+public class ImmutableBaseProxyLayoutEngineTests
+{
+	private class ProxyLayoutEngine : ImmutableBaseProxyLayoutEngine
+	{
+		public ProxyLayoutEngine(IImmutableLayoutEngine innerLayoutEngine)
+			: base(innerLayoutEngine) { }
+
+		public override IEnumerable<IWindowState> DoLayout(ILocation<int> location, IMonitor monitor) =>
+			InnerLayoutEngine.DoLayout(location, monitor);
+	}
+
+	[Fact]
+	public void Name()
+	{
+		// Given
+		Mock<IImmutableLayoutEngine> innerLayoutEngine = new();
+		innerLayoutEngine.Setup(x => x.Name).Returns("Inner Layout Engine");
+
+		ProxyLayoutEngine proxyLayoutEngine = new(innerLayoutEngine.Object);
+
+		// When
+		string name = proxyLayoutEngine.Name;
+
+		// Then
+		Assert.Equal("Inner Layout Engine", name);
+	}
+
+	[Fact]
+	public void Count()
+	{
+		// Given
+		Mock<IImmutableLayoutEngine> innerLayoutEngine = new();
+		innerLayoutEngine.Setup(x => x.Count).Returns(42);
+
+		ProxyLayoutEngine proxyLayoutEngine = new(innerLayoutEngine.Object);
+
+		// When
+		int count = proxyLayoutEngine.Count;
+
+		// Then
+		Assert.Equal(42, count);
+	}
+
+	[Fact]
+	public void Add()
+	{
+		// Given
+		Mock<IImmutableLayoutEngine> innerLayoutEngine = new();
+		innerLayoutEngine.Setup(x => x.Add(It.IsAny<IWindow>()));
+
+		ProxyLayoutEngine proxyLayoutEngine = new(innerLayoutEngine.Object);
+
+		// When
+		IImmutableLayoutEngine newEngine = proxyLayoutEngine.Add(new Mock<IWindow>().Object);
+
+		// Then
+		Assert.NotSame(proxyLayoutEngine, newEngine);
+		innerLayoutEngine.Verify(x => x.Add(It.IsAny<IWindow>()), Times.Once);
+	}
+
+	[Fact]
+	public void Remove()
+	{
+		// Given
+		Mock<IImmutableLayoutEngine> innerLayoutEngine = new();
+		innerLayoutEngine.Setup(x => x.Remove(It.IsAny<IWindow>()));
+
+		ProxyLayoutEngine proxyLayoutEngine = new(innerLayoutEngine.Object);
+
+		// When
+		IImmutableLayoutEngine newEngine = proxyLayoutEngine.Remove(new Mock<IWindow>().Object);
+
+		// Then
+		Assert.NotSame(proxyLayoutEngine, newEngine);
+		innerLayoutEngine.Verify(x => x.Remove(It.IsAny<IWindow>()), Times.Once);
+	}
+
+	[Fact]
+	public void GetFirstWindow()
+	{
+		// Given
+		Mock<IImmutableLayoutEngine> innerLayoutEngine = new();
+		innerLayoutEngine.Setup(x => x.GetFirstWindow()).Returns(new Mock<IWindow>().Object);
+
+		ProxyLayoutEngine proxyLayoutEngine = new(innerLayoutEngine.Object);
+
+		// When
+		IWindow? window = proxyLayoutEngine.GetFirstWindow();
+
+		// Then
+		Assert.NotNull(window);
+		innerLayoutEngine.Verify(x => x.GetFirstWindow(), Times.Once);
+	}
+
+	[Fact]
+	public void FocusWindowInDirection()
+	{
+		// Given
+		Mock<IImmutableLayoutEngine> innerLayoutEngine = new();
+		innerLayoutEngine.Setup(x => x.FocusWindowInDirection(It.IsAny<Direction>(), It.IsAny<IWindow>()));
+
+		ProxyLayoutEngine proxyLayoutEngine = new(innerLayoutEngine.Object);
+
+		// When
+		proxyLayoutEngine.FocusWindowInDirection(Direction.Left, new Mock<IWindow>().Object);
+
+		// Then
+		innerLayoutEngine.Verify(x => x.FocusWindowInDirection(It.IsAny<Direction>(), It.IsAny<IWindow>()), Times.Once);
+	}
+
+	[Fact]
+	public void SwapWindowInDirection()
+	{
+		// Given
+		Mock<IImmutableLayoutEngine> innerLayoutEngine = new();
+		innerLayoutEngine.Setup(x => x.SwapWindowInDirection(It.IsAny<Direction>(), It.IsAny<IWindow>()));
+
+		ProxyLayoutEngine proxyLayoutEngine = new(innerLayoutEngine.Object);
+
+		// When
+		IImmutableLayoutEngine newEngine = proxyLayoutEngine.SwapWindowInDirection(
+			Direction.Left,
+			new Mock<IWindow>().Object
+		);
+
+		// Then
+		Assert.NotSame(proxyLayoutEngine, newEngine);
+		innerLayoutEngine.Verify(x => x.SwapWindowInDirection(It.IsAny<Direction>(), It.IsAny<IWindow>()), Times.Once);
+	}
+
+	[Fact]
+	public void Contains()
+	{
+		// Given
+		Mock<IImmutableLayoutEngine> innerLayoutEngine = new();
+		innerLayoutEngine.Setup(x => x.Contains(It.IsAny<IWindow>())).Returns(true);
+
+		ProxyLayoutEngine proxyLayoutEngine = new(innerLayoutEngine.Object);
+
+		// When
+		bool contains = proxyLayoutEngine.Contains(new Mock<IWindow>().Object);
+
+		// Then
+		Assert.True(contains);
+		innerLayoutEngine.Verify(x => x.Contains(It.IsAny<IWindow>()), Times.Once);
+	}
+
+	[Fact]
+	public void MoveWindowEdgesInDirection()
+	{
+		// Given
+		Mock<IImmutableLayoutEngine> innerLayoutEngine = new();
+		innerLayoutEngine.Setup(
+			x => x.MoveWindowEdgesInDirection(It.IsAny<Direction>(), It.IsAny<IPoint<double>>(), It.IsAny<IWindow>())
+		);
+
+		ProxyLayoutEngine proxyLayoutEngine = new(innerLayoutEngine.Object);
+
+		// When
+		IImmutableLayoutEngine newEngine = proxyLayoutEngine.MoveWindowEdgesInDirection(
+			Direction.Left,
+			new Point<double>(),
+			new Mock<IWindow>().Object
+		);
+
+		// Then
+		Assert.NotSame(proxyLayoutEngine, newEngine);
+		innerLayoutEngine.Verify(
+			x => x.MoveWindowEdgesInDirection(It.IsAny<Direction>(), It.IsAny<IPoint<double>>(), It.IsAny<IWindow>()),
+			Times.Once
+		);
+	}
+
+	[Fact]
+	public void DoLayout()
+	{
+		// Given
+		Mock<IImmutableLayoutEngine> innerLayoutEngine = new();
+		innerLayoutEngine
+			.Setup(x => x.DoLayout(It.IsAny<ILocation<int>>(), It.IsAny<IMonitor>()))
+			.Returns(Array.Empty<IWindowState>());
+
+		ProxyLayoutEngine proxyLayoutEngine = new(innerLayoutEngine.Object);
+
+		// When
+		IEnumerable<IWindowState> windows = proxyLayoutEngine.DoLayout(
+			new Mock<ILocation<int>>().Object,
+			new Mock<IMonitor>().Object
+		);
+
+		// Then
+		Assert.Empty(windows);
+		innerLayoutEngine.Verify(x => x.DoLayout(It.IsAny<ILocation<int>>(), It.IsAny<IMonitor>()), Times.Once);
+	}
+
+	[Fact]
+	public void HidePhantomWindows()
+	{
+		// Given
+		Mock<IImmutableLayoutEngine> innerLayoutEngine = new();
+		innerLayoutEngine.Setup(x => x.HidePhantomWindows());
+
+		ProxyLayoutEngine proxyLayoutEngine = new(innerLayoutEngine.Object);
+
+		// When
+		IImmutableLayoutEngine newEngine = proxyLayoutEngine.HidePhantomWindows();
+
+		// Then
+		Assert.NotSame(proxyLayoutEngine, newEngine);
+		innerLayoutEngine.Verify(x => x.HidePhantomWindows(), Times.Once);
+	}
+
+	[Fact]
+	public void AddAtPoint()
+	{
+		// Given
+		Mock<IImmutableLayoutEngine> innerLayoutEngine = new();
+		innerLayoutEngine.Setup(x => x.AddAtPoint(It.IsAny<IWindow>(), It.IsAny<IPoint<double>>()));
+
+		ProxyLayoutEngine proxyLayoutEngine = new(innerLayoutEngine.Object);
+
+		// When
+		IImmutableLayoutEngine newEngine = proxyLayoutEngine.AddAtPoint(
+			new Mock<IWindow>().Object,
+			new Point<double>()
+		);
+
+		// Then
+		Assert.NotSame(proxyLayoutEngine, newEngine);
+		innerLayoutEngine.Verify(x => x.AddAtPoint(It.IsAny<IWindow>(), It.IsAny<IPoint<double>>()), Times.Once);
+	}
+}

--- a/src/Whim.Tests/Layout/ImmutableColumnLayoutEngineTests.cs
+++ b/src/Whim.Tests/Layout/ImmutableColumnLayoutEngineTests.cs
@@ -142,23 +142,6 @@ public class ImmutableColumnLayoutEngineTests
 		Assert.False(contains);
 	}
 
-	[Fact]
-	public void GetWindows()
-	{
-		// Given
-		Mock<IWindow> window = CreateMockWindow();
-		IImmutableLayoutEngine engine = new ImmutableColumnLayoutEngine().Add(window.Object);
-
-		// When
-		IEnumerator<IWindow> enumerator = engine.GetWindows();
-
-		// Then
-		Assert.NotNull(enumerator);
-		Assert.True(enumerator.MoveNext());
-		Assert.Same(window.Object, enumerator.Current);
-		Assert.False(enumerator.MoveNext());
-	}
-
 	#region DoLayout
 	[Fact]
 	public void DoLayout_Empty()

--- a/src/Whim.Tests/Layout/ImmutableColumnLayoutEngineTests.cs
+++ b/src/Whim.Tests/Layout/ImmutableColumnLayoutEngineTests.cs
@@ -912,7 +912,7 @@ public class ImmutableColumnLayoutEngineTests
 		IImmutableLayoutEngine engine = new ImmutableColumnLayoutEngine().Add(new Mock<IWindow>().Object);
 
 		// When
-		IImmutableLayoutEngine newEngine = engine.AddAtPoint(window.Object, new Point<double>() { X = -0.1 });
+		IImmutableLayoutEngine newEngine = engine.AddAtPoint(window.Object, new Point<double>() { X = -10 });
 		List<IWindowState> windows = newEngine
 			.DoLayout(new Location<int>() { Width = 1920, Height = 1080 }, new Mock<IMonitor>().Object)
 			.ToList();
@@ -931,7 +931,7 @@ public class ImmutableColumnLayoutEngineTests
 		IImmutableLayoutEngine engine = new ImmutableColumnLayoutEngine().Add(new Mock<IWindow>().Object);
 
 		// When
-		IImmutableLayoutEngine newEngine = engine.AddAtPoint(window.Object, new Point<double>() { X = 1.1 });
+		IImmutableLayoutEngine newEngine = engine.AddAtPoint(window.Object, new Point<double>() { X = 10 });
 		List<IWindowState> windows = newEngine
 			.DoLayout(new Location<int>() { Width = 1920, Height = 1080 }, new Mock<IMonitor>().Object)
 			.ToList();

--- a/src/Whim.Tests/Layout/ImmutableColumnLayoutEngineTests.cs
+++ b/src/Whim.Tests/Layout/ImmutableColumnLayoutEngineTests.cs
@@ -880,4 +880,25 @@ public class ImmutableColumnLayoutEngineTests
 		Assert.Equal(0, windows[1].Location.X);
 	}
 	#endregion
+
+	[Fact]
+	public void MoveWindowEdgesInDirection()
+	{
+		// Given
+		Mock<IWindow> window = CreateMockWindow();
+
+		IImmutableLayoutEngine engine = new ImmutableColumnLayoutEngine()
+			.Add(window.Object)
+			.Add(new Mock<IWindow>().Object);
+
+		// When
+		IImmutableLayoutEngine newEngine = engine.MoveWindowEdgesInDirection(
+			Direction.Up,
+			new Point<double>() { X = 0.2 },
+			window.Object
+		);
+
+		// Then
+		Assert.Same(engine, newEngine);
+	}
 }

--- a/src/Whim.Tests/Layout/ImmutableColumnLayoutEngineTests.cs
+++ b/src/Whim.Tests/Layout/ImmutableColumnLayoutEngineTests.cs
@@ -1,6 +1,5 @@
 using Moq;
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using Xunit;
@@ -144,31 +143,14 @@ public class ImmutableColumnLayoutEngineTests
 	}
 
 	[Fact]
-	public void GetEnumerator_Generic()
+	public void GetWindows()
 	{
 		// Given
 		Mock<IWindow> window = CreateMockWindow();
 		IImmutableLayoutEngine engine = new ImmutableColumnLayoutEngine().Add(window.Object);
 
 		// When
-		IEnumerator<IWindow> enumerator = engine.GetEnumerator();
-
-		// Then
-		Assert.NotNull(enumerator);
-		Assert.True(enumerator.MoveNext());
-		Assert.Same(window.Object, enumerator.Current);
-		Assert.False(enumerator.MoveNext());
-	}
-
-	[Fact]
-	public void GetEnumerator_NonGeneric()
-	{
-		// Given
-		Mock<IWindow> window = CreateMockWindow();
-		IImmutableLayoutEngine engine = new ImmutableColumnLayoutEngine().Add(window.Object);
-
-		// When
-		IEnumerator enumerator = ((IEnumerable)engine).GetEnumerator();
+		IEnumerator<IWindow> enumerator = engine.GetWindows();
 
 		// Then
 		Assert.NotNull(enumerator);

--- a/src/Whim.Tests/Layout/ImmutableColumnLayoutEngineTests.cs
+++ b/src/Whim.Tests/Layout/ImmutableColumnLayoutEngineTests.cs
@@ -161,6 +161,21 @@ public class ImmutableColumnLayoutEngineTests
 
 	#region DoLayout
 	[Fact]
+	public void DoLayout_Empty()
+	{
+		// Given
+		IImmutableLayoutEngine engine = new ImmutableColumnLayoutEngine();
+
+		// When
+		IWindowState[] windowStates = engine
+			.DoLayout(new Location<int>() { Width = 1920, Height = 1080 }, new Mock<IMonitor>().Object)
+			.ToArray();
+
+		// Then
+		Assert.Empty(windowStates);
+	}
+
+	[Fact]
 	public void DoLayout_LeftToRight_SingleWindow()
 	{
 		// Given

--- a/src/Whim.Tests/Layout/ImmutableColumnLayoutEngineTests.cs
+++ b/src/Whim.Tests/Layout/ImmutableColumnLayoutEngineTests.cs
@@ -901,4 +901,103 @@ public class ImmutableColumnLayoutEngineTests
 		// Then
 		Assert.Same(engine, newEngine);
 	}
+
+	#region AddWindowAtPoint
+	[Fact]
+	public void AddWindowAtPoint_LessThan0()
+	{
+		// Given
+		Mock<IWindow> window = CreateMockWindow();
+
+		IImmutableLayoutEngine engine = new ImmutableColumnLayoutEngine().Add(new Mock<IWindow>().Object);
+
+		// When
+		IImmutableLayoutEngine newEngine = engine.AddAtPoint(window.Object, new Point<double>() { X = -0.1 });
+		List<IWindowState> windows = newEngine
+			.DoLayout(new Location<int>() { Width = 1920, Height = 1080 }, new Mock<IMonitor>().Object)
+			.ToList();
+
+		// Then
+		Assert.NotSame(engine, newEngine);
+		Assert.Equal(0, windows.FindIndex(w => w.Window == window.Object));
+	}
+
+	[Fact]
+	public void AddWindowAtPoint_GreaterThanAmountOfWindows()
+	{
+		// Given
+		Mock<IWindow> window = CreateMockWindow();
+
+		IImmutableLayoutEngine engine = new ImmutableColumnLayoutEngine().Add(new Mock<IWindow>().Object);
+
+		// When
+		IImmutableLayoutEngine newEngine = engine.AddAtPoint(window.Object, new Point<double>() { X = 1.1 });
+		List<IWindowState> windows = newEngine
+			.DoLayout(new Location<int>() { Width = 1920, Height = 1080 }, new Mock<IMonitor>().Object)
+			.ToList();
+
+		// Then
+		Assert.NotSame(engine, newEngine);
+		Assert.Equal(1, windows.FindIndex(w => w.Window == window.Object));
+	}
+
+	[Fact]
+	public void AddWindowAtPoint_LeftToRight_Middle()
+	{
+		// Given
+		Mock<IWindow> window = CreateMockWindow();
+
+		IImmutableLayoutEngine engine = new ImmutableColumnLayoutEngine()
+			.Add(new Mock<IWindow>().Object)
+			.Add(new Mock<IWindow>().Object);
+
+		// When
+		IImmutableLayoutEngine newEngine = engine.AddAtPoint(window.Object, new Point<double>() { X = 0.5 });
+		List<IWindowState> windows = newEngine
+			.DoLayout(new Location<int>() { Width = 1920, Height = 1080 }, new Mock<IMonitor>().Object)
+			.ToList();
+
+		// Then
+		Assert.NotSame(engine, newEngine);
+		Assert.Equal(1, windows.FindIndex(w => w.Window == window.Object));
+	}
+
+	[Fact]
+	public void AddWindowAtPoint_RightToLeft_Middle()
+	{
+		// Given
+		Mock<IWindow> window = CreateMockWindow();
+
+		IImmutableLayoutEngine engine = new ImmutableColumnLayoutEngine() { LeftToRight = false }
+			.Add(new Mock<IWindow>().Object)
+			.Add(new Mock<IWindow>().Object);
+
+		// When
+		IImmutableLayoutEngine newEngine = engine.AddAtPoint(window.Object, new Point<double>() { X = 0.5 });
+		List<IWindowState> windows = newEngine
+			.DoLayout(new Location<int>() { Width = 1920, Height = 1080 }, new Mock<IMonitor>().Object)
+			.ToList();
+
+		// Then
+		Assert.NotSame(engine, newEngine);
+		Assert.Equal(1, windows.FindIndex(w => w.Window == window.Object));
+	}
+	#endregion
+
+	[Fact]
+	public void HidePhantomWindows()
+	{
+		// Given
+		Mock<IWindow> window = CreateMockWindow();
+
+		IImmutableLayoutEngine engine = new ImmutableColumnLayoutEngine()
+			.Add(window.Object)
+			.Add(new Mock<IWindow>().Object);
+
+		// When
+		IImmutableLayoutEngine newEngine = engine.HidePhantomWindows();
+
+		// Then
+		Assert.Same(engine, newEngine);
+	}
 }

--- a/src/Whim.Tests/Layout/ImmutableColumnLayoutEngineTests.cs
+++ b/src/Whim.Tests/Layout/ImmutableColumnLayoutEngineTests.cs
@@ -1,0 +1,886 @@
+using Moq;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace Whim.Tests;
+
+public class ImmutableColumnLayoutEngineTests
+{
+	private static readonly Random rnd = new();
+
+	private static Mock<IWindow> CreateMockWindow()
+	{
+		Mock<IWindow> window = new();
+		window.Setup(w => w.Handle).Returns(new Windows.Win32.Foundation.HWND(rnd.Next()));
+		return window;
+	}
+
+	private static IWindow CreateWindow() => CreateMockWindow().Object;
+
+	[Fact]
+	public void Name_Default()
+	{
+		// Given
+		ImmutableColumnLayoutEngine engine = new();
+
+		// When
+		string name = engine.Name;
+
+		// Then
+		Assert.Equal("Column", name);
+	}
+
+	[Fact]
+	public void Name_Custom()
+	{
+		// Given
+		ImmutableColumnLayoutEngine engine = new() { Name = "Custom" };
+
+		// When
+		string name = engine.Name;
+
+		// Then
+		Assert.Equal("Custom", name);
+	}
+
+	[Fact]
+	public void LeftToRight_Default()
+	{
+		// Given
+		ImmutableColumnLayoutEngine engine = new();
+
+		// When
+		bool leftToRight = engine.LeftToRight;
+
+		// Then
+		Assert.True(leftToRight);
+	}
+
+	[Fact]
+	public void LeftToRight_Custom()
+	{
+		// Given
+		ImmutableColumnLayoutEngine engine = new() { LeftToRight = false };
+
+		// When
+		bool leftToRight = engine.LeftToRight;
+
+		// Then
+		Assert.False(leftToRight);
+	}
+
+	[Fact]
+	public void Add()
+	{
+		// Given
+		ImmutableColumnLayoutEngine engine = new();
+
+		// When
+		IImmutableLayoutEngine newLayoutEngine = engine.Add(CreateWindow());
+
+		// Then
+		Assert.NotSame(engine, newLayoutEngine);
+		Assert.Equal(1, newLayoutEngine.Count);
+	}
+
+	[Fact]
+	public void Remove()
+	{
+		// Given
+		Mock<IWindow> window = CreateMockWindow();
+		IImmutableLayoutEngine engine = new ImmutableColumnLayoutEngine().Add(window.Object);
+
+		// When
+		IImmutableLayoutEngine newLayoutEngine = engine.Remove(window.Object);
+
+		// Then
+		Assert.NotSame(engine, newLayoutEngine);
+		Assert.Equal(0, newLayoutEngine.Count);
+	}
+
+	[Fact]
+	public void Remove_NoChanges()
+	{
+		// Given
+		IImmutableLayoutEngine engine = new ImmutableColumnLayoutEngine().Add(CreateWindow());
+
+		// When
+		IImmutableLayoutEngine newLayoutEngine = engine.Remove(new Mock<IWindow>().Object);
+
+		// Then
+		Assert.Same(engine, newLayoutEngine);
+		Assert.Equal(1, newLayoutEngine.Count);
+	}
+
+	[Fact]
+	public void Contains()
+	{
+		// Given
+		Mock<IWindow> window = CreateMockWindow();
+		IImmutableLayoutEngine engine = new ImmutableColumnLayoutEngine().Add(window.Object);
+
+		// When
+		bool contains = engine.Contains(window.Object);
+
+		// Then
+		Assert.True(contains);
+	}
+
+	[Fact]
+	public void Contains_False()
+	{
+		// Given
+		Mock<IWindow> window = CreateMockWindow();
+		IImmutableLayoutEngine engine = new ImmutableColumnLayoutEngine().Add(window.Object);
+
+		// When
+		bool contains = engine.Contains(new Mock<IWindow>().Object);
+
+		// Then
+		Assert.False(contains);
+	}
+
+	[Fact]
+	public void GetEnumerator_Generic()
+	{
+		// Given
+		Mock<IWindow> window = CreateMockWindow();
+		IImmutableLayoutEngine engine = new ImmutableColumnLayoutEngine().Add(window.Object);
+
+		// When
+		IEnumerator<IWindow> enumerator = engine.GetEnumerator();
+
+		// Then
+		Assert.NotNull(enumerator);
+		Assert.True(enumerator.MoveNext());
+		Assert.Same(window.Object, enumerator.Current);
+		Assert.False(enumerator.MoveNext());
+	}
+
+	[Fact]
+	public void GetEnumerator_NonGeneric()
+	{
+		// Given
+		Mock<IWindow> window = CreateMockWindow();
+		IImmutableLayoutEngine engine = new ImmutableColumnLayoutEngine().Add(window.Object);
+
+		// When
+		IEnumerator enumerator = ((IEnumerable)engine).GetEnumerator();
+
+		// Then
+		Assert.NotNull(enumerator);
+		Assert.True(enumerator.MoveNext());
+		Assert.Same(window.Object, enumerator.Current);
+		Assert.False(enumerator.MoveNext());
+	}
+
+	#region DoLayout
+	[Fact]
+	public void DoLayout_LeftToRight_SingleWindow()
+	{
+		// Given
+		Mock<IWindow> window = CreateMockWindow();
+		IImmutableLayoutEngine engine = new ImmutableColumnLayoutEngine().Add(window.Object);
+
+		// When
+		IWindowState[] windowStates = engine
+			.DoLayout(new Location<int>() { Width = 1920, Height = 1080 }, new Mock<IMonitor>().Object)
+			.ToArray();
+
+		// Then
+		Assert.Single(windowStates);
+		Assert.Equal(
+			new WindowState()
+			{
+				Location = new Location<int>()
+				{
+					X = 0,
+					Y = 0,
+					Width = 1920,
+					Height = 1080
+				},
+				Window = window.Object,
+				WindowSize = WindowSize.Normal
+			},
+			windowStates[0]
+		);
+	}
+
+	[Fact]
+	public void DoLayout_LeftToRight_MultipleWindows()
+	{
+		// Given
+		IWindow window = CreateWindow();
+		IWindow window2 = CreateWindow();
+		IWindow window3 = CreateWindow();
+
+		IImmutableLayoutEngine engine = new ImmutableColumnLayoutEngine().Add(window).Add(window2).Add(window3);
+
+		Location<int> location = new() { Width = 1920, Height = 1080 };
+
+		// When
+		IWindowState[] result = engine.DoLayout(location, new Mock<IMonitor>().Object).ToArray();
+
+		// Then
+		Assert.Equal(3, result.Length);
+
+		Assert.Equal(
+			new WindowState()
+			{
+				Location = new Location<int>()
+				{
+					X = 0,
+					Y = 0,
+					Width = 640,
+					Height = 1080
+				},
+				Window = window,
+				WindowSize = WindowSize.Normal
+			},
+			result[0]
+		);
+
+		Assert.Equal(
+			new WindowState()
+			{
+				Location = new Location<int>()
+				{
+					X = 640,
+					Y = 0,
+					Width = 640,
+					Height = 1080
+				},
+				Window = window2,
+				WindowSize = WindowSize.Normal
+			},
+			result[1]
+		);
+
+		Assert.Equal(
+			new WindowState()
+			{
+				Location = new Location<int>()
+				{
+					X = 1280,
+					Y = 0,
+					Width = 640,
+					Height = 1080
+				},
+				Window = window3,
+				WindowSize = WindowSize.Normal
+			},
+			result[2]
+		);
+	}
+
+	[Fact]
+	public void DoLayout_RightToLeft_SingleWindow()
+	{
+		// Given
+		IWindow window = CreateWindow();
+		IImmutableLayoutEngine engine = new ImmutableColumnLayoutEngine() { LeftToRight = false }.Add(window);
+
+		Location<int> location = new() { Width = 1920, Height = 1080 };
+
+		// When
+		IWindowState[] result = engine.DoLayout(location, new Mock<IMonitor>().Object).ToArray();
+
+		// Then
+		Assert.Single(result);
+		Assert.Equal(
+			new WindowState()
+			{
+				Location = new Location<int>()
+				{
+					X = 0,
+					Y = 0,
+					Width = 1920,
+					Height = 1080
+				},
+				Window = window,
+				WindowSize = WindowSize.Normal
+			},
+			result[0]
+		);
+	}
+
+	[Fact]
+	public void DoLayout_RightToLeft_MultipleWindows()
+	{
+		// Given
+		IWindow window = CreateWindow();
+		IWindow window2 = CreateWindow();
+		IWindow window3 = CreateWindow();
+
+		IImmutableLayoutEngine engine = new ImmutableColumnLayoutEngine() { LeftToRight = false }
+			.Add(window)
+			.Add(window2)
+			.Add(window3);
+
+		Location<int> location = new() { Width = 1920, Height = 1080 };
+
+		// When
+		IWindowState[] result = engine.DoLayout(location, new Mock<IMonitor>().Object).ToArray();
+
+		// Then
+		Assert.Equal(3, result.Length);
+
+		Assert.Equal(
+			new WindowState()
+			{
+				Location = new Location<int>()
+				{
+					X = 1280,
+					Y = 0,
+					Width = 640,
+					Height = 1080
+				},
+				Window = window,
+				WindowSize = WindowSize.Normal
+			},
+			result[0]
+		);
+
+		Assert.Equal(
+			new WindowState()
+			{
+				Location = new Location<int>()
+				{
+					X = 640,
+					Y = 0,
+					Width = 640,
+					Height = 1080
+				},
+				Window = window2,
+				WindowSize = WindowSize.Normal
+			},
+			result[1]
+		);
+
+		Assert.Equal(
+			new WindowState()
+			{
+				Location = new Location<int>()
+				{
+					X = 0,
+					Y = 0,
+					Width = 640,
+					Height = 1080
+				},
+				Window = window3,
+				WindowSize = WindowSize.Normal
+			},
+			result[2]
+		);
+	}
+	#endregion
+
+	[Fact]
+	public void GetFirstWindow_Null()
+	{
+		// Given
+		IImmutableLayoutEngine engine = new ImmutableColumnLayoutEngine();
+
+		// When
+		IWindow? result = engine.GetFirstWindow();
+
+		// Then
+		Assert.Null(result);
+	}
+
+	[Fact]
+	public void GetFirstWindow_SingleWindow()
+	{
+		// Given
+		IWindow window = CreateWindow();
+		IImmutableLayoutEngine engine = new ImmutableColumnLayoutEngine().Add(window);
+
+		// When
+		IWindow? result = engine.GetFirstWindow();
+
+		// Then
+		Assert.Same(window, result);
+	}
+
+	#region FocusWindowInDirection
+	[Fact]
+	public void FocusWindowInDirection_IgnoreIllegalDirection()
+	{
+		// Given
+		Mock<IWindow> leftWindow = CreateMockWindow();
+		Mock<IWindow> rightWindow = CreateMockWindow();
+
+		IImmutableLayoutEngine engine = new ImmutableColumnLayoutEngine()
+			.Add(leftWindow.Object)
+			.Add(rightWindow.Object);
+
+		// When
+		engine.FocusWindowInDirection(Direction.Up, leftWindow.Object);
+
+		// Then
+		leftWindow.Verify(w => w.Focus(), Times.Never);
+		rightWindow.Verify(w => w.Focus(), Times.Never);
+	}
+
+	[Fact]
+	public void FocusWindowInDirection_WindowNotFound()
+	{
+		// Given
+		Mock<IWindow> leftWindow = CreateMockWindow();
+		Mock<IWindow> rightWindow = CreateMockWindow();
+		Mock<IWindow> otherWindow = CreateMockWindow();
+
+		IImmutableLayoutEngine engine = new ImmutableColumnLayoutEngine()
+			.Add(leftWindow.Object)
+			.Add(rightWindow.Object);
+
+		// When
+		engine.FocusWindowInDirection(Direction.Left, otherWindow.Object);
+
+		// Then
+		leftWindow.Verify(w => w.Focus(), Times.Never);
+		rightWindow.Verify(w => w.Focus(), Times.Never);
+	}
+
+	[Fact]
+	public void FocusWindowInDirection_LeftToRight_FocusRight()
+	{
+		// Given
+		Mock<IWindow> leftWindow = CreateMockWindow();
+		Mock<IWindow> rightWindow = CreateMockWindow();
+
+		IImmutableLayoutEngine engine = new ImmutableColumnLayoutEngine()
+			.Add(leftWindow.Object)
+			.Add(rightWindow.Object);
+
+		// When
+		engine.FocusWindowInDirection(Direction.Right, leftWindow.Object);
+
+		// Then
+		leftWindow.Verify(w => w.Focus(), Times.Never);
+		rightWindow.Verify(w => w.Focus(), Times.Once);
+	}
+
+	[Fact]
+	public void FocusWindowInDirection_LeftToRight_FocusRightWrapAround()
+	{
+		// Given
+		Mock<IWindow> leftWindow = CreateMockWindow();
+		Mock<IWindow> rightWindow = CreateMockWindow();
+
+		IImmutableLayoutEngine engine = new ImmutableColumnLayoutEngine()
+			.Add(leftWindow.Object)
+			.Add(rightWindow.Object);
+
+		// When
+		engine.FocusWindowInDirection(Direction.Right, rightWindow.Object);
+
+		// Then
+		leftWindow.Verify(w => w.Focus(), Times.Once);
+	}
+
+	[Fact]
+	public void FocusWindowInDirection_LeftToRight_FocusLeft()
+	{
+		// Given
+		Mock<IWindow> leftWindow = CreateMockWindow();
+		Mock<IWindow> rightWindow = CreateMockWindow();
+
+		IImmutableLayoutEngine engine = new ImmutableColumnLayoutEngine()
+			.Add(leftWindow.Object)
+			.Add(rightWindow.Object);
+
+		// When
+		engine.FocusWindowInDirection(Direction.Left, rightWindow.Object);
+
+		// Then
+		leftWindow.Verify(w => w.Focus(), Times.Once);
+	}
+
+	[Fact]
+	public void FocusWindowInDirection_LeftToRight_FocusLeftWrapAround()
+	{
+		// Given
+		Mock<IWindow> leftWindow = CreateMockWindow();
+		Mock<IWindow> rightWindow = CreateMockWindow();
+
+		IImmutableLayoutEngine engine = new ImmutableColumnLayoutEngine()
+			.Add(leftWindow.Object)
+			.Add(rightWindow.Object);
+
+		// When
+		engine.FocusWindowInDirection(Direction.Left, leftWindow.Object);
+
+		// Then
+		rightWindow.Verify(w => w.Focus(), Times.Once);
+	}
+
+	[Fact]
+	public void FocusWindowInDirection_RightToLeft_FocusLeft()
+	{
+		// Given
+		Mock<IWindow> leftWindow = CreateMockWindow();
+		Mock<IWindow> rightWindow = CreateMockWindow();
+
+		IImmutableLayoutEngine engine = new ImmutableColumnLayoutEngine() { LeftToRight = false }
+			.Add(leftWindow.Object)
+			.Add(rightWindow.Object);
+
+		// When
+		engine.FocusWindowInDirection(Direction.Left, leftWindow.Object);
+
+		// Then
+		rightWindow.Verify(w => w.Focus(), Times.Once);
+	}
+
+	[Fact]
+	public void FocusWindowInDirection_RightToLeft_FocusLeftWrapAround()
+	{
+		// Given
+		Mock<IWindow> leftWindow = CreateMockWindow();
+		Mock<IWindow> rightWindow = CreateMockWindow();
+
+		IImmutableLayoutEngine engine = new ImmutableColumnLayoutEngine() { LeftToRight = false }
+			.Add(leftWindow.Object)
+			.Add(rightWindow.Object);
+
+		// When
+		engine.FocusWindowInDirection(Direction.Left, rightWindow.Object);
+
+		// Then
+		leftWindow.Verify(w => w.Focus(), Times.Once);
+	}
+
+	[Fact]
+	public void FocusWindowInDirection_RightToLeft_FocusRight()
+	{
+		// Given
+		Mock<IWindow> leftWindow = CreateMockWindow();
+		Mock<IWindow> rightWindow = CreateMockWindow();
+
+		IImmutableLayoutEngine engine = new ImmutableColumnLayoutEngine() { LeftToRight = false }
+			.Add(leftWindow.Object)
+			.Add(rightWindow.Object);
+
+		// When
+		engine.FocusWindowInDirection(Direction.Right, rightWindow.Object);
+
+		// Then
+		leftWindow.Verify(w => w.Focus(), Times.Once);
+	}
+
+	[Fact]
+	public void FocusWindowInDirection_RightToLeft_FocusRightWrapAround()
+	{
+		// Given
+		Mock<IWindow> leftWindow = CreateMockWindow();
+		Mock<IWindow> rightWindow = CreateMockWindow();
+
+		IImmutableLayoutEngine engine = new ImmutableColumnLayoutEngine() { LeftToRight = false }
+			.Add(leftWindow.Object)
+			.Add(rightWindow.Object);
+
+		// When
+		engine.FocusWindowInDirection(Direction.Right, leftWindow.Object);
+
+		// Then
+		rightWindow.Verify(w => w.Focus(), Times.Once);
+	}
+	#endregion
+
+	#region SwapWindowInDirection
+	[Fact]
+	public void SwapWindowInDirection_IgnoreIllegalDirection()
+	{
+		// Given
+		Mock<IWindow> leftWindow = CreateMockWindow();
+		Mock<IWindow> rightWindow = CreateMockWindow();
+
+		IImmutableLayoutEngine engine = new ImmutableColumnLayoutEngine()
+			.Add(leftWindow.Object)
+			.Add(rightWindow.Object);
+
+		// When
+		IImmutableLayoutEngine newEngine = engine.SwapWindowInDirection(Direction.Up, leftWindow.Object);
+
+		// Then
+		IWindowState[] windows = newEngine
+			.DoLayout(new Location<int>() { Width = 1920, Height = 1080 }, new Mock<IMonitor>().Object)
+			.ToArray();
+
+		Assert.Same(engine, newEngine);
+		Assert.Equal(2, windows.Length);
+
+		Assert.Equal(leftWindow.Object, windows[0].Window);
+		Assert.Equal(0, windows[0].Location.X);
+
+		Assert.Equal(rightWindow.Object, windows[1].Window);
+		Assert.Equal(960, windows[1].Location.X);
+	}
+
+	[Fact]
+	public void SwapWindowInDirection_WindowNotFound()
+	{
+		// Given
+		Mock<IWindow> leftWindow = CreateMockWindow();
+		Mock<IWindow> rightWindow = CreateMockWindow();
+		Mock<IWindow> notFoundWindow = CreateMockWindow();
+
+		IImmutableLayoutEngine engine = new ImmutableColumnLayoutEngine()
+			.Add(leftWindow.Object)
+			.Add(rightWindow.Object);
+
+		// When
+		IImmutableLayoutEngine newEngine = engine.SwapWindowInDirection(Direction.Left, notFoundWindow.Object);
+
+		// Then
+		IWindowState[] windows = newEngine
+			.DoLayout(new Location<int>() { Width = 1920, Height = 1080 }, new Mock<IMonitor>().Object)
+			.ToArray();
+
+		Assert.Same(engine, newEngine);
+		Assert.Equal(2, windows.Length);
+
+		Assert.Equal(leftWindow.Object, windows[0].Window);
+		Assert.Equal(0, windows[0].Location.X);
+
+		Assert.Equal(rightWindow.Object, windows[1].Window);
+		Assert.Equal(960, windows[1].Location.X);
+	}
+
+	[Fact]
+	public void SwapWindowInDirection_LeftToRight_SwapRight()
+	{
+		// Given
+		Mock<IWindow> leftWindow = CreateMockWindow();
+		Mock<IWindow> rightWindow = CreateMockWindow();
+
+		IImmutableLayoutEngine engine = new ImmutableColumnLayoutEngine()
+			.Add(leftWindow.Object)
+			.Add(rightWindow.Object);
+
+		// When
+		IImmutableLayoutEngine newEngine = engine.SwapWindowInDirection(Direction.Right, leftWindow.Object);
+
+		// Then
+		IWindowState[] windows = newEngine
+			.DoLayout(new Location<int>() { Width = 1920, Height = 1080 }, new Mock<IMonitor>().Object)
+			.ToArray();
+
+		Assert.Equal(2, windows.Length);
+		Assert.NotSame(engine, newEngine);
+
+		Assert.Equal(rightWindow.Object, windows[0].Window);
+		Assert.Equal(0, windows[0].Location.X);
+
+		Assert.Equal(leftWindow.Object, windows[1].Window);
+		Assert.Equal(960, windows[1].Location.X);
+	}
+
+	[Fact]
+	public void SwapWindowInDirection_LeftToRight_SwapRightWrapAround()
+	{
+		// Given
+		Mock<IWindow> leftWindow = CreateMockWindow();
+		Mock<IWindow> rightWindow = CreateMockWindow();
+
+		IImmutableLayoutEngine engine = new ImmutableColumnLayoutEngine()
+			.Add(leftWindow.Object)
+			.Add(rightWindow.Object);
+
+		// When
+		IImmutableLayoutEngine newEngine = engine.SwapWindowInDirection(Direction.Right, rightWindow.Object);
+
+		// Then
+		IWindowState[] windows = newEngine
+			.DoLayout(new Location<int>() { Width = 1920, Height = 1080 }, new Mock<IMonitor>().Object)
+			.ToArray();
+
+		Assert.Equal(2, windows.Length);
+		Assert.NotSame(engine, newEngine);
+
+		Assert.Equal(rightWindow.Object, windows[0].Window);
+		Assert.Equal(0, windows[0].Location.X);
+
+		Assert.Equal(leftWindow.Object, windows[1].Window);
+		Assert.Equal(960, windows[1].Location.X);
+	}
+
+	[Fact]
+	public void SwapWindowInDirection_LeftToRight_SwapLeft()
+	{
+		// Given
+		Mock<IWindow> leftWindow = CreateMockWindow();
+		Mock<IWindow> rightWindow = CreateMockWindow();
+
+		IImmutableLayoutEngine engine = new ImmutableColumnLayoutEngine()
+			.Add(leftWindow.Object)
+			.Add(rightWindow.Object);
+
+		// When
+		IImmutableLayoutEngine newEngine = engine.SwapWindowInDirection(Direction.Left, rightWindow.Object);
+
+		// Then
+		IWindowState[] windows = newEngine
+			.DoLayout(new Location<int>() { Width = 1920, Height = 1080 }, new Mock<IMonitor>().Object)
+			.ToArray();
+
+		Assert.Equal(2, windows.Length);
+		Assert.NotSame(engine, newEngine);
+
+		Assert.Equal(rightWindow.Object, windows[0].Window);
+		Assert.Equal(0, windows[0].Location.X);
+
+		Assert.Equal(leftWindow.Object, windows[1].Window);
+		Assert.Equal(960, windows[1].Location.X);
+	}
+
+	[Fact]
+	public void SwapWindowInDirection_LeftToRight_SwapLeftWrapAround()
+	{
+		// Given
+		Mock<IWindow> leftWindow = CreateMockWindow();
+		Mock<IWindow> rightWindow = CreateMockWindow();
+
+		IImmutableLayoutEngine engine = new ImmutableColumnLayoutEngine()
+			.Add(leftWindow.Object)
+			.Add(rightWindow.Object);
+
+		// When
+		IImmutableLayoutEngine newEngine = engine.SwapWindowInDirection(Direction.Left, leftWindow.Object);
+
+		// Then
+		IWindowState[] windows = newEngine
+			.DoLayout(new Location<int>() { Width = 1920, Height = 1080 }, new Mock<IMonitor>().Object)
+			.ToArray();
+
+		Assert.Equal(2, windows.Length);
+		Assert.NotSame(engine, newEngine);
+
+		Assert.Equal(rightWindow.Object, windows[0].Window);
+		Assert.Equal(0, windows[0].Location.X);
+
+		Assert.Equal(leftWindow.Object, windows[1].Window);
+		Assert.Equal(960, windows[1].Location.X);
+	}
+
+	[Fact]
+	public void SwapWindowInDirection_RightToLeft_SwapLeft()
+	{
+		// Given
+		Mock<IWindow> rightWindow = CreateMockWindow();
+		Mock<IWindow> leftWindow = CreateMockWindow();
+
+		IImmutableLayoutEngine engine = new ImmutableColumnLayoutEngine() { LeftToRight = false }
+			.Add(rightWindow.Object)
+			.Add(leftWindow.Object);
+
+		// When
+		IImmutableLayoutEngine newEngine = engine.SwapWindowInDirection(Direction.Left, leftWindow.Object);
+
+		// Then
+		IWindowState[] windows = newEngine
+			.DoLayout(new Location<int>() { Width = 1920, Height = 1080 }, new Mock<IMonitor>().Object)
+			.ToArray();
+
+		Assert.Equal(2, windows.Length);
+		Assert.NotSame(engine, newEngine);
+
+		Assert.Equal(leftWindow.Object, windows[0].Window);
+		Assert.Equal(960, windows[0].Location.X);
+
+		Assert.Equal(rightWindow.Object, windows[1].Window);
+		Assert.Equal(0, windows[1].Location.X);
+	}
+
+	[Fact]
+	public void SwapWindowInDirection_RightToLeft_SwapLeftWrapAround()
+	{
+		// Given
+		Mock<IWindow> rightWindow = CreateMockWindow();
+		Mock<IWindow> leftWindow = CreateMockWindow();
+
+		IImmutableLayoutEngine engine = new ImmutableColumnLayoutEngine() { LeftToRight = false }
+			.Add(rightWindow.Object)
+			.Add(leftWindow.Object);
+
+		// When
+		IImmutableLayoutEngine newEngine = engine.SwapWindowInDirection(Direction.Left, rightWindow.Object);
+
+		// Then
+		IWindowState[] windows = newEngine
+			.DoLayout(new Location<int>() { Width = 1920, Height = 1080 }, new Mock<IMonitor>().Object)
+			.ToArray();
+
+		Assert.Equal(2, windows.Length);
+		Assert.NotSame(engine, newEngine);
+
+		Assert.Equal(leftWindow.Object, windows[0].Window);
+		Assert.Equal(960, windows[0].Location.X);
+
+		Assert.Equal(rightWindow.Object, windows[1].Window);
+		Assert.Equal(0, windows[1].Location.X);
+	}
+
+	[Fact]
+	public void SwapWindowInDirection_RightToLeft_SwapRight()
+	{
+		// Given
+		Mock<IWindow> rightWindow = CreateMockWindow();
+		Mock<IWindow> leftWindow = CreateMockWindow();
+
+		IImmutableLayoutEngine engine = new ImmutableColumnLayoutEngine() { LeftToRight = false }
+			.Add(rightWindow.Object)
+			.Add(leftWindow.Object);
+
+		// When
+		IImmutableLayoutEngine newEngine = engine.SwapWindowInDirection(Direction.Right, rightWindow.Object);
+
+		// Then
+		IWindowState[] windows = newEngine
+			.DoLayout(new Location<int>() { Width = 1920, Height = 1080 }, new Mock<IMonitor>().Object)
+			.ToArray();
+
+		Assert.Equal(2, windows.Length);
+		Assert.NotSame(engine, newEngine);
+
+		Assert.Equal(leftWindow.Object, windows[0].Window);
+		Assert.Equal(960, windows[0].Location.X);
+
+		Assert.Equal(rightWindow.Object, windows[1].Window);
+		Assert.Equal(0, windows[1].Location.X);
+	}
+
+	[Fact]
+	public void SwapWindowInDirection_RightToLeft_SwapRightWrapAround()
+	{
+		// Given
+		Mock<IWindow> rightWindow = CreateMockWindow();
+		Mock<IWindow> leftWindow = CreateMockWindow();
+
+		IImmutableLayoutEngine engine = new ImmutableColumnLayoutEngine() { LeftToRight = false }
+			.Add(rightWindow.Object)
+			.Add(leftWindow.Object);
+
+		// When
+		IImmutableLayoutEngine newEngine = engine.SwapWindowInDirection(Direction.Right, leftWindow.Object);
+
+		// Then
+		IWindowState[] windows = newEngine
+			.DoLayout(new Location<int>() { Width = 1920, Height = 1080 }, new Mock<IMonitor>().Object)
+			.ToArray();
+
+		Assert.Equal(2, windows.Length);
+		Assert.NotSame(engine, newEngine);
+
+		Assert.Equal(leftWindow.Object, windows[0].Window);
+		Assert.Equal(960, windows[0].Location.X);
+
+		Assert.Equal(rightWindow.Object, windows[1].Window);
+		Assert.Equal(0, windows[1].Location.X);
+	}
+	#endregion
+}

--- a/src/Whim.Tests/Whim.Tests.csproj
+++ b/src/Whim.Tests/Whim.Tests.csproj
@@ -52,4 +52,8 @@
 		<ProjectReference Include="..\Whim.TestUtils\Whim.TestUtils.csproj" />
 	</ItemGroup>
 
+	<ItemGroup>
+		<InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
+	</ItemGroup>
+
 </Project>

--- a/src/Whim/GlobalSuppressions.cs
+++ b/src/Whim/GlobalSuppressions.cs
@@ -15,6 +15,13 @@ using System.Diagnostics.CodeAnalysis;
 [assembly: SuppressMessage(
 	"Naming",
 	"CA1710:Identifiers should have correct suffix",
+	Justification = "IImmutableLayoutEngine's primary purpose is not as a collection",
+	Scope = "type",
+	Target = "~T:Whim.IImmutableLayoutEngine"
+)]
+[assembly: SuppressMessage(
+	"Naming",
+	"CA1710:Identifiers should have correct suffix",
 	Scope = "type",
 	Target = "~T:Whim.ICommandManager"
 )]

--- a/src/Whim/Layout/IImmutableLayoutEngine.cs
+++ b/src/Whim/Layout/IImmutableLayoutEngine.cs
@@ -20,6 +20,22 @@ public interface IImmutableLayoutEngine : IReadOnlyCollection<IWindow>
 	IImmutableLayoutEngine Add(IWindow window);
 
 	/// <summary>
+	/// REmoves a <paramref name="window"/> from the layout engine.
+	/// </summary>
+	/// <param name="window"></param>
+	/// <returns>The new <see cref="IImmutableLayoutEngine"/> after the remove.</returns>
+	IImmutableLayoutEngine Remove(IWindow window);
+
+	/// <summary>
+	/// Determines whether the layout engine contains the <paramref name="window"/>.
+	/// </summary>
+	/// <param name="window"></param>
+	/// <returns>
+	/// True if the layout engine contains the <paramref name="window"/>, otherwise false.
+	/// </returns>
+	bool Contains(IWindow window);
+
+	/// <summary>
 	/// Performs a layout inside the available <paramref name="location"/>.
 	/// </summary>
 	/// <remarks>

--- a/src/Whim/Layout/IImmutableLayoutEngine.cs
+++ b/src/Whim/Layout/IImmutableLayoutEngine.cs
@@ -105,7 +105,7 @@ public interface IImmutableLayoutEngine
 	IImmutableLayoutEngine HidePhantomWindows();
 
 	/// <summary>
-	/// Checks to see if this <see cref="ILayoutEngine"/> or a child layout engine is type
+	/// Checks to see if this <see cref="IImmutableLayoutEngine"/> or a child layout engine is type
 	/// <typeparamref name="T"/>.
 	/// </summary>
 	/// <typeparam name="T">The type of layout engine to check for.</typeparam>
@@ -113,14 +113,14 @@ public interface IImmutableLayoutEngine
 	/// The layout engine with type <typeparamref name="T"/>, or null if none is found.
 	/// </returns>
 	T? GetLayoutEngine<T>()
-		where T : ILayoutEngine
+		where T : IImmutableLayoutEngine
 	{
 		if (this is T layoutEngine)
 		{
 			return layoutEngine;
 		}
 
-		if (this is BaseProxyLayoutEngine proxy)
+		if (this is ImmutableBaseProxyLayoutEngine proxy)
 		{
 			return proxy.GetLayoutEngine<T>();
 		}
@@ -129,21 +129,21 @@ public interface IImmutableLayoutEngine
 	}
 
 	/// <summary>
-	/// Checks to see if this <see cref="ILayoutEngine"/> or a child layout engine is
+	/// Checks to see if this <see cref="IImmutableLayoutEngine"/> or a child layout engine is
 	/// <paramref name="layoutEngine"/>.
 	/// </summary>
 	/// <param name="layoutEngine">The layout engine to check for.</param>
 	/// <returns>
 	/// <cref name="true"/> if the layout engine is found, <cref name="false"/> otherwise.
 	/// </returns>
-	bool ContainsEqual(ILayoutEngine layoutEngine)
+	bool ContainsEqual(IImmutableLayoutEngine layoutEngine)
 	{
 		if (this == layoutEngine)
 		{
 			return true;
 		}
 
-		if (this is BaseProxyLayoutEngine proxy)
+		if (this is ImmutableBaseProxyLayoutEngine proxy)
 		{
 			return proxy.ContainsEqual(layoutEngine);
 		}

--- a/src/Whim/Layout/IImmutableLayoutEngine.cs
+++ b/src/Whim/Layout/IImmutableLayoutEngine.cs
@@ -25,6 +25,15 @@ public interface IImmutableLayoutEngine
 	IImmutableLayoutEngine Add(IWindow window);
 
 	/// <summary>
+	/// Move the <paramref name="window"/> to the <paramref name="point"/>.
+	/// The point has a coordinate space of [0, 1] for both x and y.
+	/// </summary>
+	/// <param name="window">The window to move.</param>
+	/// <param name="point">The point to move the window to.</param>
+	/// <returns>The new <see cref="IImmutableLayoutEngine"/> after the move.</returns>
+	IImmutableLayoutEngine AddAtPoint(IWindow window, IPoint<double> point);
+
+	/// <summary>
 	/// REmoves a <paramref name="window"/> from the layout engine.
 	/// </summary>
 	/// <param name="window"></param>
@@ -100,15 +109,6 @@ public interface IImmutableLayoutEngine
 	/// </summary>
 	/// <returns>The new <see cref="IImmutableLayoutEngine"/> after the hide.</returns>
 	IImmutableLayoutEngine HidePhantomWindows();
-
-	/// <summary>
-	/// Move the <paramref name="window"/> to the <paramref name="point"/>.
-	/// The point has a coordinate space of [0, 1] for both x and y.
-	/// </summary>
-	/// <param name="window">The window to move.</param>
-	/// <param name="point">The point to move the window to.</param>
-	/// <returns>The new <see cref="IImmutableLayoutEngine"/> after the move.</returns>
-	IImmutableLayoutEngine AddWindowAtPoint(IWindow window, IPoint<double> point);
 
 	/// <summary>
 	/// Checks to see if this <see cref="ILayoutEngine"/> or a child layout engine is type

--- a/src/Whim/Layout/IImmutableLayoutEngine.cs
+++ b/src/Whim/Layout/IImmutableLayoutEngine.cs
@@ -5,12 +5,19 @@ namespace Whim;
 /// <summary>
 /// Layout engines dictate how windows are laid out.
 /// </summary>
-public interface IImmutableLayoutEngine
+public interface IImmutableLayoutEngine : IReadOnlyCollection<IWindow>
 {
 	/// <summary>
 	/// The name of the layout engine.
 	/// </summary>
 	string Name { get; }
+
+	/// <summary>
+	/// Adds a <paramref name="window"/> to the layout engine.
+	/// </summary>
+	/// <param name="window"></param>
+	/// <returns>The new <see cref="IImmutableLayoutEngine"/> after the add.</returns>
+	IImmutableLayoutEngine Add(IWindow window);
 
 	/// <summary>
 	/// Performs a layout inside the available <paramref name="location"/>.
@@ -21,7 +28,7 @@ public interface IImmutableLayoutEngine
 	/// </remarks>
 	/// <param name="location">The available area to do a layout inside.</param>
 	/// <param name="monitor">The monitor which the layout is being done for.</param>
-	/// <returns></returns>
+	/// <returns>The layout result.</returns>
 	IEnumerable<IWindowState> DoLayout(ILocation<int> location, IMonitor monitor);
 
 	/// <summary>

--- a/src/Whim/Layout/IImmutableLayoutEngine.cs
+++ b/src/Whim/Layout/IImmutableLayoutEngine.cs
@@ -113,20 +113,7 @@ public interface IImmutableLayoutEngine
 	/// The layout engine with type <typeparamref name="T"/>, or null if none is found.
 	/// </returns>
 	T? GetLayoutEngine<T>()
-		where T : IImmutableLayoutEngine
-	{
-		if (this is T layoutEngine)
-		{
-			return layoutEngine;
-		}
-
-		if (this is ImmutableBaseProxyLayoutEngine proxy)
-		{
-			return proxy.GetLayoutEngine<T>();
-		}
-
-		return default;
-	}
+		where T : IImmutableLayoutEngine => this is T layoutEngine ? layoutEngine : default;
 
 	/// <summary>
 	/// Checks to see if this <see cref="IImmutableLayoutEngine"/> or a child layout engine is
@@ -136,18 +123,5 @@ public interface IImmutableLayoutEngine
 	/// <returns>
 	/// <cref name="true"/> if the layout engine is found, <cref name="false"/> otherwise.
 	/// </returns>
-	bool ContainsEqual(IImmutableLayoutEngine layoutEngine)
-	{
-		if (this == layoutEngine)
-		{
-			return true;
-		}
-
-		if (this is ImmutableBaseProxyLayoutEngine proxy)
-		{
-			return proxy.ContainsEqual(layoutEngine);
-		}
-
-		return false;
-	}
+	bool ContainsEqual(IImmutableLayoutEngine layoutEngine) => this == layoutEngine;
 }

--- a/src/Whim/Layout/IImmutableLayoutEngine.cs
+++ b/src/Whim/Layout/IImmutableLayoutEngine.cs
@@ -1,0 +1,125 @@
+using System.Collections.Generic;
+
+namespace Whim;
+
+/// <summary>
+/// Layout engines dictate how windows are laid out.
+/// </summary>
+public interface IImmutableLayoutEngine
+{
+	/// <summary>
+	/// The name of the layout engine.
+	/// </summary>
+	string Name { get; }
+
+	/// <summary>
+	/// Performs a layout inside the available <paramref name="location"/>.
+	/// </summary>
+	/// <remarks>
+	/// For a given <paramref name="location"/>, the layout engine should return the same
+	/// result every time.
+	/// </remarks>
+	/// <param name="location">The available area to do a layout inside.</param>
+	/// <param name="monitor">The monitor which the layout is being done for.</param>
+	/// <returns></returns>
+	IEnumerable<IWindowState> DoLayout(ILocation<int> location, IMonitor monitor);
+
+	/// <summary>
+	/// Retrieves the first window in the layout engine.
+	/// </summary>
+	IWindow? GetFirstWindow();
+
+	/// <summary>
+	/// Focuses the <paramref name="window"/> in the <paramref name="direction"/>.
+	/// It's recommended that this method is not called directly, but rather
+	/// through the <see cref="IWorkspace.FocusWindowInDirection"/> method.
+	/// </summary>
+	/// <param name="direction">The direction to focus in.</param>
+	/// <param name="window">The origin window</param>
+	void FocusWindowInDirection(Direction direction, IWindow window);
+
+	/// <summary>
+	/// Swaps the <paramref name="window"/> in the <paramref name="direction"/>.
+	/// It's recommended that this method is not called directly, but rather
+	/// through <see cref="IWorkspace.SwapWindowInDirection"/>.
+	/// </summary>
+	/// <param name="direction">The direction to swap the window in.</param>
+	/// <param name="window">The window to swap.</param>
+	/// <returns>The new <see cref="IImmutableLayoutEngine"/> after the swap.</returns>
+	IImmutableLayoutEngine SwapWindowInDirection(Direction direction, IWindow window);
+
+	/// <summary>
+	/// Moves the focused window's edges by the specified <paramref name="deltas"/>.
+	/// </summary>
+	/// <param name="edges">The edges to change.</param>
+	/// <param name="deltas">
+	/// The deltas to change the given <paramref name="edges"/> by. When a value is positive, then
+	/// the edge will move in the direction of the <paramref name="edges"/>.
+	/// The <paramref name="deltas"/> are in the range [0, 1] for both x and y (the unit square).
+	/// </param>
+	/// <param name="window"></param>
+	/// <returns>The new <see cref="IImmutableLayoutEngine"/> after the move.</returns>
+	IImmutableLayoutEngine MoveWindowEdgesInDirection(Direction edges, IPoint<double> deltas, IWindow window);
+
+	/// <summary>
+	/// Hides all phantom windows belonging to the layout engine.
+	/// </summary>
+	/// <returns>The new <see cref="IImmutableLayoutEngine"/> after the hide.</returns>
+	IImmutableLayoutEngine HidePhantomWindows();
+
+	/// <summary>
+	/// Move the <paramref name="window"/> to the <paramref name="point"/>.
+	/// The point has a coordinate space of [0, 1] for both x and y.
+	/// </summary>
+	/// <param name="window">The window to move.</param>
+	/// <param name="point">The point to move the window to.</param>
+	/// <returns>The new <see cref="IImmutableLayoutEngine"/> after the move.</returns>
+	IImmutableLayoutEngine AddWindowAtPoint(IWindow window, IPoint<double> point);
+
+	/// <summary>
+	/// Checks to see if this <see cref="ILayoutEngine"/> or a child layout engine is type
+	/// <typeparamref name="T"/>.
+	/// </summary>
+	/// <typeparam name="T">The type of layout engine to check for.</typeparam>
+	/// <returns>
+	/// The layout engine with type <typeparamref name="T"/>, or null if none is found.
+	/// </returns>
+	T? GetLayoutEngine<T>()
+		where T : ILayoutEngine
+	{
+		if (this is T layoutEngine)
+		{
+			return layoutEngine;
+		}
+
+		if (this is BaseProxyLayoutEngine proxy)
+		{
+			return proxy.GetLayoutEngine<T>();
+		}
+
+		return default;
+	}
+
+	/// <summary>
+	/// Checks to see if this <see cref="ILayoutEngine"/> or a child layout engine is
+	/// <paramref name="layoutEngine"/>.
+	/// </summary>
+	/// <param name="layoutEngine">The layout engine to check for.</param>
+	/// <returns>
+	/// <cref name="true"/> if the layout engine is found, <cref name="false"/> otherwise.
+	/// </returns>
+	bool ContainsEqual(ILayoutEngine layoutEngine)
+	{
+		if (this == layoutEngine)
+		{
+			return true;
+		}
+
+		if (this is BaseProxyLayoutEngine proxy)
+		{
+			return proxy.ContainsEqual(layoutEngine);
+		}
+
+		return false;
+	}
+}

--- a/src/Whim/Layout/IImmutableLayoutEngine.cs
+++ b/src/Whim/Layout/IImmutableLayoutEngine.cs
@@ -5,12 +5,17 @@ namespace Whim;
 /// <summary>
 /// Layout engines dictate how windows are laid out.
 /// </summary>
-public interface IImmutableLayoutEngine : IReadOnlyCollection<IWindow>
+public interface IImmutableLayoutEngine
 {
 	/// <summary>
 	/// The name of the layout engine.
 	/// </summary>
 	string Name { get; }
+
+	/// <summary>
+	/// The number of windows in the layout engine.
+	/// </summary>
+	int Count { get; }
 
 	/// <summary>
 	/// Adds a <paramref name="window"/> to the layout engine.
@@ -34,6 +39,12 @@ public interface IImmutableLayoutEngine : IReadOnlyCollection<IWindow>
 	/// True if the layout engine contains the <paramref name="window"/>, otherwise false.
 	/// </returns>
 	bool Contains(IWindow window);
+
+	/// <summary>
+	/// Gets an <see cref="IEnumerator{T}"/> of the windows in the layout engine.
+	/// </summary>
+	/// <returns>An <see cref="IEnumerator{T}"/> of the windows in the layout engine.</returns>
+	IEnumerator<IWindow> GetWindows();
 
 	/// <summary>
 	/// Performs a layout inside the available <paramref name="location"/>.

--- a/src/Whim/Layout/IImmutableLayoutEngine.cs
+++ b/src/Whim/Layout/IImmutableLayoutEngine.cs
@@ -34,7 +34,7 @@ public interface IImmutableLayoutEngine
 	IImmutableLayoutEngine AddAtPoint(IWindow window, IPoint<double> point);
 
 	/// <summary>
-	/// REmoves a <paramref name="window"/> from the layout engine.
+	/// Removes a <paramref name="window"/> from the layout engine.
 	/// </summary>
 	/// <param name="window"></param>
 	/// <returns>The new <see cref="IImmutableLayoutEngine"/> after the remove.</returns>
@@ -48,12 +48,6 @@ public interface IImmutableLayoutEngine
 	/// True if the layout engine contains the <paramref name="window"/>, otherwise false.
 	/// </returns>
 	bool Contains(IWindow window);
-
-	/// <summary>
-	/// Gets an <see cref="IEnumerator{T}"/> of the windows in the layout engine.
-	/// </summary>
-	/// <returns>An <see cref="IEnumerator{T}"/> of the windows in the layout engine.</returns>
-	IEnumerator<IWindow> GetWindows();
 
 	/// <summary>
 	/// Performs a layout inside the available <paramref name="location"/>.

--- a/src/Whim/Layout/ImmutableBaseProxyLayoutEngine.cs
+++ b/src/Whim/Layout/ImmutableBaseProxyLayoutEngine.cs
@@ -7,7 +7,7 @@ namespace Whim;
 /// The wrapper layout engine provides additional functionality, but still utilises the underlying
 /// layout engine.
 /// </summary>
-public delegate IImmutableLayoutEngine ImmutableProxyLayoutEngine(ILayoutEngine engine);
+public delegate IImmutableLayoutEngine ImmutableProxyLayoutEngine(IImmutableLayoutEngine engine);
 
 /// <summary>
 /// Abstract layout engine, which proxy layout engines should inherit from.
@@ -75,7 +75,7 @@ public abstract class ImmutableBaseProxyLayoutEngine : IImmutableLayoutEngine
 	public virtual IImmutableLayoutEngine HidePhantomWindows() => InnerLayoutEngine.HidePhantomWindows();
 
 	/// <summary>
-	/// Checks to see if this <cref name="ILayoutEngine"/>
+	/// Checks to see if this <cref name="IImmutableLayoutEngine"/>
 	/// or a child layout engine is type <typeparamref name="T"/>.
 	/// </summary>
 	/// <typeparam name="T">The type of layout engine to check for.</typeparam>
@@ -83,7 +83,7 @@ public abstract class ImmutableBaseProxyLayoutEngine : IImmutableLayoutEngine
 	/// The layout engine with type <typeparamref name="T"/>, or null if none is found.
 	/// </returns>
 	public T? GetLayoutEngine<T>()
-		where T : ILayoutEngine
+		where T : IImmutableLayoutEngine
 	{
 		if (this is T t)
 		{
@@ -99,14 +99,14 @@ public abstract class ImmutableBaseProxyLayoutEngine : IImmutableLayoutEngine
 	}
 
 	/// <summary>
-	/// Checks to see if this <cref name="ILayoutEngine"/>
+	/// Checks to see if this <cref name="IImmutableLayoutEngine"/>
 	/// or a child layout engine is equal to <paramref name="layoutEngine"/>.
 	/// </summary>
 	/// <param name="layoutEngine">The layout engine to check for.</param>
 	/// <returns>
 	/// <cref name="true"/> if the layout engine is found, <cref name="false"/> otherwise.
 	/// </returns>
-	public bool ContainsEqual(ILayoutEngine layoutEngine)
+	public bool ContainsEqual(IImmutableLayoutEngine layoutEngine)
 	{
 		if (this == layoutEngine)
 		{

--- a/src/Whim/Layout/ImmutableBaseProxyLayoutEngine.cs
+++ b/src/Whim/Layout/ImmutableBaseProxyLayoutEngine.cs
@@ -1,4 +1,3 @@
-using System.Collections;
 using System.Collections.Generic;
 
 namespace Whim;
@@ -59,9 +58,7 @@ public abstract class ImmutableBaseProxyLayoutEngine : IImmutableLayoutEngine
 	public virtual bool Contains(IWindow window) => InnerLayoutEngine.Contains(window);
 
 	/// <inheritdoc/>
-	public virtual IEnumerator<IWindow> GetEnumerator() => InnerLayoutEngine.GetEnumerator();
-
-	IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+	public virtual IEnumerator<IWindow> GetWindows() => InnerLayoutEngine.GetWindows();
 
 	/// <inheritdoc/>
 	public virtual IImmutableLayoutEngine MoveWindowEdgesInDirection(

--- a/src/Whim/Layout/ImmutableBaseProxyLayoutEngine.cs
+++ b/src/Whim/Layout/ImmutableBaseProxyLayoutEngine.cs
@@ -90,12 +90,7 @@ public abstract class ImmutableBaseProxyLayoutEngine : IImmutableLayoutEngine
 			return t;
 		}
 
-		if (InnerLayoutEngine != null)
-		{
-			return InnerLayoutEngine.GetLayoutEngine<T>();
-		}
-
-		return default;
+		return InnerLayoutEngine.GetLayoutEngine<T>();
 	}
 
 	/// <summary>
@@ -113,11 +108,6 @@ public abstract class ImmutableBaseProxyLayoutEngine : IImmutableLayoutEngine
 			return true;
 		}
 
-		if (InnerLayoutEngine != null)
-		{
-			return InnerLayoutEngine.ContainsEqual(layoutEngine);
-		}
-
-		return false;
+		return InnerLayoutEngine.ContainsEqual(layoutEngine);
 	}
 }

--- a/src/Whim/Layout/ImmutableBaseProxyLayoutEngine.cs
+++ b/src/Whim/Layout/ImmutableBaseProxyLayoutEngine.cs
@@ -41,6 +41,10 @@ public abstract class ImmutableBaseProxyLayoutEngine : IImmutableLayoutEngine
 	public virtual IImmutableLayoutEngine Add(IWindow window) => InnerLayoutEngine.Add(window);
 
 	/// <inheritdoc/>
+	public virtual IImmutableLayoutEngine AddAtPoint(IWindow window, IPoint<double> point) =>
+		InnerLayoutEngine.AddAtPoint(window, point);
+
+	/// <inheritdoc/>
 	public virtual IImmutableLayoutEngine Remove(IWindow window) => InnerLayoutEngine.Remove(window);
 
 	/// <inheritdoc/>
@@ -58,9 +62,6 @@ public abstract class ImmutableBaseProxyLayoutEngine : IImmutableLayoutEngine
 	public virtual bool Contains(IWindow window) => InnerLayoutEngine.Contains(window);
 
 	/// <inheritdoc/>
-	public virtual IEnumerator<IWindow> GetWindows() => InnerLayoutEngine.GetWindows();
-
-	/// <inheritdoc/>
 	public virtual IImmutableLayoutEngine MoveWindowEdgesInDirection(
 		Direction edge,
 		IPoint<double> deltas,
@@ -72,10 +73,6 @@ public abstract class ImmutableBaseProxyLayoutEngine : IImmutableLayoutEngine
 
 	/// <inheritdoc/>
 	public virtual IImmutableLayoutEngine HidePhantomWindows() => InnerLayoutEngine.HidePhantomWindows();
-
-	/// <inheritdoc/>
-	public virtual IImmutableLayoutEngine AddAtPoint(IWindow window, IPoint<double> point) =>
-		InnerLayoutEngine.AddAtPoint(window, point);
 
 	/// <summary>
 	/// Checks to see if this <cref name="ILayoutEngine"/>

--- a/src/Whim/Layout/ImmutableBaseProxyLayoutEngine.cs
+++ b/src/Whim/Layout/ImmutableBaseProxyLayoutEngine.cs
@@ -74,8 +74,8 @@ public abstract class ImmutableBaseProxyLayoutEngine : IImmutableLayoutEngine
 	public virtual IImmutableLayoutEngine HidePhantomWindows() => InnerLayoutEngine.HidePhantomWindows();
 
 	/// <inheritdoc/>
-	public virtual IImmutableLayoutEngine AddWindowAtPoint(IWindow window, IPoint<double> point) =>
-		InnerLayoutEngine.AddWindowAtPoint(window, point);
+	public virtual IImmutableLayoutEngine AddAtPoint(IWindow window, IPoint<double> point) =>
+		InnerLayoutEngine.AddAtPoint(window, point);
 
 	/// <summary>
 	/// Checks to see if this <cref name="ILayoutEngine"/>

--- a/src/Whim/Layout/ImmutableBaseProxyLayoutEngine.cs
+++ b/src/Whim/Layout/ImmutableBaseProxyLayoutEngine.cs
@@ -1,0 +1,129 @@
+using System.Collections;
+using System.Collections.Generic;
+
+namespace Whim;
+
+/// <summary>
+/// This delegate takes an in a layout engine and returns it with a wrapper layout engine.
+/// The wrapper layout engine provides additional functionality, but still utilises the underlying
+/// layout engine.
+/// </summary>
+public delegate IImmutableLayoutEngine ImmutableProxyLayoutEngine(ILayoutEngine engine);
+
+/// <summary>
+/// Abstract layout engine, which proxy layout engines should inherit from.
+/// </summary>
+public abstract class ImmutableBaseProxyLayoutEngine : IImmutableLayoutEngine
+{
+	/// <summary>
+	/// The proxied layout engine.
+	/// </summary>
+	protected IImmutableLayoutEngine InnerLayoutEngine { get; }
+
+	/// <summary>
+	/// Constructs a new proxy layout engine.
+	/// </summary>
+	/// <param name="innerLayoutEngine">The proxied layout engine.</param>
+	protected ImmutableBaseProxyLayoutEngine(IImmutableLayoutEngine innerLayoutEngine)
+	{
+		InnerLayoutEngine = innerLayoutEngine;
+	}
+
+	/// <summary>
+	/// The name is only really important for the user, so we can use the name of the proxied layout engine.
+	/// </summary>
+	/// <inheritdoc/>
+	public virtual string Name => InnerLayoutEngine.Name;
+
+	/// <inheritdoc/>
+	public virtual int Count => InnerLayoutEngine.Count;
+
+	/// <inheritdoc/>
+	public virtual IImmutableLayoutEngine Add(IWindow window) => InnerLayoutEngine.Add(window);
+
+	/// <inheritdoc/>
+	public virtual IImmutableLayoutEngine Remove(IWindow window) => InnerLayoutEngine.Remove(window);
+
+	/// <inheritdoc/>
+	public virtual IWindow? GetFirstWindow() => InnerLayoutEngine.GetFirstWindow();
+
+	/// <inheritdoc/>
+	public virtual void FocusWindowInDirection(Direction direction, IWindow window) =>
+		InnerLayoutEngine.FocusWindowInDirection(direction, window);
+
+	/// <inheritdoc/>
+	public virtual IImmutableLayoutEngine SwapWindowInDirection(Direction direction, IWindow window) =>
+		InnerLayoutEngine.SwapWindowInDirection(direction, window);
+
+	/// <inheritdoc/>
+	public virtual bool Contains(IWindow window) => InnerLayoutEngine.Contains(window);
+
+	/// <inheritdoc/>
+	public virtual IEnumerator<IWindow> GetEnumerator() => InnerLayoutEngine.GetEnumerator();
+
+	IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+	/// <inheritdoc/>
+	public virtual IImmutableLayoutEngine MoveWindowEdgesInDirection(
+		Direction edge,
+		IPoint<double> deltas,
+		IWindow window
+	) => InnerLayoutEngine.MoveWindowEdgesInDirection(edge, deltas, window);
+
+	/// <inheritdoc/>
+	public abstract IEnumerable<IWindowState> DoLayout(ILocation<int> location, IMonitor monitor);
+
+	/// <inheritdoc/>
+	public virtual IImmutableLayoutEngine HidePhantomWindows() => InnerLayoutEngine.HidePhantomWindows();
+
+	/// <inheritdoc/>
+	public virtual IImmutableLayoutEngine AddWindowAtPoint(IWindow window, IPoint<double> point) =>
+		InnerLayoutEngine.AddWindowAtPoint(window, point);
+
+	/// <summary>
+	/// Checks to see if this <cref name="ILayoutEngine"/>
+	/// or a child layout engine is type <typeparamref name="T"/>.
+	/// </summary>
+	/// <typeparam name="T">The type of layout engine to check for.</typeparam>
+	/// <returns>
+	/// The layout engine with type <typeparamref name="T"/>, or null if none is found.
+	/// </returns>
+	public T? GetLayoutEngine<T>()
+		where T : ILayoutEngine
+	{
+		if (this is T t)
+		{
+			return t;
+		}
+
+		if (InnerLayoutEngine != null)
+		{
+			return InnerLayoutEngine.GetLayoutEngine<T>();
+		}
+
+		return default;
+	}
+
+	/// <summary>
+	/// Checks to see if this <cref name="ILayoutEngine"/>
+	/// or a child layout engine is equal to <paramref name="layoutEngine"/>.
+	/// </summary>
+	/// <param name="layoutEngine">The layout engine to check for.</param>
+	/// <returns>
+	/// <cref name="true"/> if the layout engine is found, <cref name="false"/> otherwise.
+	/// </returns>
+	public bool ContainsEqual(ILayoutEngine layoutEngine)
+	{
+		if (this == layoutEngine)
+		{
+			return true;
+		}
+
+		if (InnerLayoutEngine != null)
+		{
+			return InnerLayoutEngine.ContainsEqual(layoutEngine);
+		}
+
+		return false;
+	}
+}

--- a/src/Whim/Layout/ImmutableColumnLayoutEngine.cs
+++ b/src/Whim/Layout/ImmutableColumnLayoutEngine.cs
@@ -7,7 +7,7 @@ using System.Linq;
 namespace Whim;
 
 /// <summary>
-/// Abstract layout engine with a stack data structure.
+/// Column layout engine with a stack data structure.
 /// </summary>
 public class ImmutableColumnLayoutEngine : IImmutableLayoutEngine
 {
@@ -17,12 +17,12 @@ public class ImmutableColumnLayoutEngine : IImmutableLayoutEngine
 	private readonly ImmutableList<IWindow> _stack;
 
 	/// <inheritdoc/>
-	public string Name { get; }
+	public string Name { get; init; } = "Column";
 
 	/// <summary>
-	/// Indicates the direction of the layout.
+	/// Indicates the direction of the layout. Defaults to <see langword="false"/>.
 	/// </summary>
-	public bool LeftToRight { get; }
+	public bool LeftToRight { get; init; } = true;
 
 	/// <inheritdoc/>
 	public int Count => _stack.Count;
@@ -30,12 +30,8 @@ public class ImmutableColumnLayoutEngine : IImmutableLayoutEngine
 	/// <summary>
 	/// Creates a new instance of the <see cref="ImmutableColumnLayoutEngine"/> class.
 	/// </summary>
-	/// <param name="name">The name of the layout engine.</param>
-	/// <param name="leftToRight">Indicates the direction of the layout.</param>
-	public ImmutableColumnLayoutEngine(string name = "Column", bool leftToRight = false)
+	public ImmutableColumnLayoutEngine()
 	{
-		Name = name;
-		LeftToRight = leftToRight;
 		_stack = ImmutableList<IWindow>.Empty;
 	}
 
@@ -50,7 +46,6 @@ public class ImmutableColumnLayoutEngine : IImmutableLayoutEngine
 	public IImmutableLayoutEngine Add(IWindow window)
 	{
 		Logger.Debug($"Adding window {window} to layout engine {Name}");
-
 		return new ImmutableColumnLayoutEngine(this, _stack.Add(window));
 	}
 

--- a/src/Whim/Layout/ImmutableColumnLayoutEngine.cs
+++ b/src/Whim/Layout/ImmutableColumnLayoutEngine.cs
@@ -78,10 +78,10 @@ public class ImmutableColumnLayoutEngine : IImmutableLayoutEngine
 			yield break;
 		}
 
-		int x,
-			y,
-			width,
-			height;
+		int x;
+		int y;
+		int width;
+		int height;
 
 		if (LeftToRight)
 		{
@@ -163,7 +163,7 @@ public class ImmutableColumnLayoutEngine : IImmutableLayoutEngine
 		}
 
 		// Find the index of the window in the stack.
-		int windowIndex = _stack.FindIndex(x => x.Handle == window?.Handle);
+		int windowIndex = _stack.FindIndex(x => x.Handle == window.Handle);
 		if (windowIndex == -1)
 		{
 			Logger.Error($"Window {window} not found in layout engine {Name}");

--- a/src/Whim/Layout/ImmutableColumnLayoutEngine.cs
+++ b/src/Whim/Layout/ImmutableColumnLayoutEngine.cs
@@ -184,12 +184,12 @@ public class ImmutableColumnLayoutEngine : IImmutableLayoutEngine
 		this;
 
 	/// <inheritdoc/>
-	public IImmutableLayoutEngine AddWindowAtPoint(IWindow window, IPoint<double> point)
+	public IImmutableLayoutEngine AddAtPoint(IWindow window, IPoint<double> point)
 	{
 		Logger.Debug($"Adding window {window} to layout engine {Name} at point {point}");
 
 		// Calculate the index of the window in the stack.
-		int idx = (int)Math.Round(point.X / _stack.Count, MidpointRounding.AwayFromZero);
+		int idx = (int)Math.Round(point.X * _stack.Count, MidpointRounding.AwayFromZero);
 
 		// Bound idx.
 		if (idx < 0)

--- a/src/Whim/Layout/ImmutableColumnLayoutEngine.cs
+++ b/src/Whim/Layout/ImmutableColumnLayoutEngine.cs
@@ -65,9 +65,6 @@ public class ImmutableColumnLayoutEngine : IImmutableLayoutEngine
 	}
 
 	/// <inheritdoc/>
-	public IEnumerator<IWindow> GetWindows() => _stack.GetEnumerator();
-
-	/// <inheritdoc/>
 	public IEnumerable<IWindowState> DoLayout(ILocation<int> location, IMonitor _)
 	{
 		string direction = LeftToRight ? "left to right" : "right to left";

--- a/src/Whim/Layout/ImmutableColumnLayoutEngine.cs
+++ b/src/Whim/Layout/ImmutableColumnLayoutEngine.cs
@@ -1,0 +1,239 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+
+namespace Whim;
+
+/// <summary>
+/// Abstract layout engine with a stack data structure.
+/// </summary>
+public class ImmutableColumnLayoutEngine : IImmutableLayoutEngine
+{
+	/// <summary>
+	/// The stack of windows in the engine.
+	/// </summary>
+	private readonly ImmutableList<IWindow> _stack;
+
+	/// <inheritdoc/>
+	public string Name { get; }
+
+	/// <summary>
+	/// Indicates the direction of the layout.
+	/// </summary>
+	public bool LeftToRight { get; }
+
+	/// <inheritdoc/>
+	public int Count => _stack.Count;
+
+	/// <summary>
+	/// Creates a new instance of the <see cref="ImmutableColumnLayoutEngine"/> class.
+	/// </summary>
+	/// <param name="name">The name of the layout engine.</param>
+	/// <param name="leftToRight">Indicates the direction of the layout.</param>
+	public ImmutableColumnLayoutEngine(string name = "Column", bool leftToRight = false)
+	{
+		Name = name;
+		LeftToRight = leftToRight;
+		_stack = ImmutableList<IWindow>.Empty;
+	}
+
+	private ImmutableColumnLayoutEngine(ImmutableColumnLayoutEngine layoutEngine, ImmutableList<IWindow> stack)
+	{
+		Name = layoutEngine.Name;
+		LeftToRight = layoutEngine.LeftToRight;
+		_stack = stack;
+	}
+
+	/// <summary>
+	/// Gets the delta to determine whether we want to move towards 0 or not.
+	/// </summary>
+	/// <param name="leftToRight">Whether we are moving left to right or right to left.</param>
+	/// <param name="direction">The window direction to move.</param>
+	private static int GetDelta(bool leftToRight, Direction direction)
+	{
+		if (leftToRight)
+		{
+			return direction == Direction.Left ? -1 : 1;
+		}
+		else
+		{
+			return direction == Direction.Left ? 1 : -1;
+		}
+	}
+
+	/// <inheritdoc/>
+	public IImmutableLayoutEngine Add(IWindow window)
+	{
+		Logger.Debug($"Adding window {window} to layout engine {Name}");
+
+		return new ImmutableColumnLayoutEngine(this, _stack.Add(window));
+	}
+
+	/// <inheritdoc/>
+	public ImmutableColumnLayoutEngine Remove(IWindow window)
+	{
+		Logger.Debug($"Removing window {window} from layout engine {Name}");
+
+		ImmutableList<IWindow> newStack = _stack.Remove(window);
+		return newStack == _stack ? this : new ImmutableColumnLayoutEngine(this, newStack);
+	}
+
+	/// <inheritdoc/>
+	public bool Contains(IWindow window)
+	{
+		Logger.Debug($"Checking if layout engine {Name} contains window {window}");
+		return _stack.Any(x => x.Handle == window.Handle);
+	}
+
+	/// <inheritdoc/>
+	public IEnumerator<IWindow> GetEnumerator() => _stack.GetEnumerator();
+
+	IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+	/// <inheritdoc/>
+	public IEnumerable<IWindowState> DoLayout(ILocation<int> location, IMonitor monitor)
+	{
+		string direction = LeftToRight ? "left to right" : "right to left";
+		Logger.Debug($"Performing a column layout {direction}");
+
+		if (_stack.Count == 0)
+		{
+			yield break;
+		}
+
+		int x,
+			y,
+			width,
+			height;
+
+		if (LeftToRight)
+		{
+			width = location.Width / _stack.Count;
+			height = location.Height;
+			x = location.X;
+			y = location.Y;
+		}
+		else
+		{
+			width = location.Width / _stack.Count;
+			height = location.Height;
+			x = location.X + location.Width - width;
+			y = location.Y;
+		}
+
+		foreach (IWindow window in _stack)
+		{
+			yield return new WindowState()
+			{
+				Window = window,
+				Location = new Location<int>()
+				{
+					X = x,
+					Y = y,
+					Width = width,
+					Height = height
+				},
+				WindowSize = WindowSize.Normal
+			};
+
+			if (LeftToRight)
+			{
+				x += width;
+			}
+			else
+			{
+				x -= width;
+			}
+		}
+	}
+
+	/// <inheritdoc/>
+	public IWindow? GetFirstWindow() => _stack.FirstOrDefault();
+
+	/// <inheritdoc/>
+	public void FocusWindowInDirection(Direction direction, IWindow window)
+	{
+		Logger.Debug($"Focusing window {window} in layout engine {Name}");
+
+		if (direction != Direction.Left && direction != Direction.Right)
+		{
+			return;
+		}
+
+		// Find the index of the window in the stack
+		int windowIndex = _stack.FindIndex(x => x.Handle == window.Handle);
+		if (windowIndex == -1)
+		{
+			Logger.Error($"Window {window} not found in layout engine {Name}");
+			return;
+		}
+
+		int delta = GetDelta(LeftToRight, direction);
+		int adjIndex = (windowIndex + delta).Mod(_stack.Count);
+
+		IWindow adjWindow = _stack[adjIndex];
+		adjWindow.Focus();
+	}
+
+	/// <inheritdoc/>
+	public IImmutableLayoutEngine SwapWindowInDirection(Direction direction, IWindow window)
+	{
+		Logger.Debug($"Swapping window {window} in layout engine {Name} in direction {direction}");
+
+		if (direction != Direction.Left && direction != Direction.Right)
+		{
+			return this;
+		}
+
+		// Find the index of the window in the stack.
+		int windowIndex = _stack.FindIndex(x => x.Handle == window?.Handle);
+		if (windowIndex == -1)
+		{
+			Logger.Error($"Window {window} not found in layout engine {Name}");
+			return this;
+		}
+
+		int delta = GetDelta(LeftToRight, direction);
+		int adjIndex = (windowIndex + delta).Mod(_stack.Count);
+
+		// Swap window
+		IWindow adjWindow = _stack[adjIndex];
+		ImmutableList<IWindow> newStack = _stack.SetItem(windowIndex, adjWindow).SetItem(adjIndex, window);
+		return new ImmutableColumnLayoutEngine(this, newStack);
+	}
+
+	/// <inheritdoc/>
+	public IImmutableLayoutEngine MoveWindowEdgesInDirection(Direction edge, IPoint<double> deltas, IWindow window) =>
+		this;
+
+	/// <inheritdoc/>
+	public IImmutableLayoutEngine AddWindowAtPoint(IWindow window, IPoint<double> point)
+	{
+		Logger.Debug($"Adding window {window} to layout engine {Name} at point {point}");
+
+		// Calculate the index of the window in the stack.
+		int idx = (int)Math.Round(point.X / _stack.Count, MidpointRounding.AwayFromZero);
+
+		// Bound idx.
+		if (idx < 0)
+		{
+			idx = 0;
+		}
+		else if (idx > _stack.Count)
+		{
+			idx = _stack.Count;
+		}
+
+		if (!LeftToRight)
+		{
+			idx = _stack.Count - idx;
+		}
+
+		return new ImmutableColumnLayoutEngine(this, _stack.Insert(idx, window));
+	}
+
+	/// <inheritdoc/>
+	public IImmutableLayoutEngine HidePhantomWindows() => this;
+}

--- a/src/Whim/Layout/ImmutableColumnLayoutEngine.cs
+++ b/src/Whim/Layout/ImmutableColumnLayoutEngine.cs
@@ -46,23 +46,6 @@ public class ImmutableColumnLayoutEngine : IImmutableLayoutEngine
 		_stack = stack;
 	}
 
-	/// <summary>
-	/// Gets the delta to determine whether we want to move towards 0 or not.
-	/// </summary>
-	/// <param name="leftToRight">Whether we are moving left to right or right to left.</param>
-	/// <param name="direction">The window direction to move.</param>
-	private static int GetDelta(bool leftToRight, Direction direction)
-	{
-		if (leftToRight)
-		{
-			return direction == Direction.Left ? -1 : 1;
-		}
-		else
-		{
-			return direction == Direction.Left ? 1 : -1;
-		}
-	}
-
 	/// <inheritdoc/>
 	public IImmutableLayoutEngine Add(IWindow window)
 	{
@@ -72,7 +55,7 @@ public class ImmutableColumnLayoutEngine : IImmutableLayoutEngine
 	}
 
 	/// <inheritdoc/>
-	public ImmutableColumnLayoutEngine Remove(IWindow window)
+	public IImmutableLayoutEngine Remove(IWindow window)
 	{
 		Logger.Debug($"Removing window {window} from layout engine {Name}");
 
@@ -236,4 +219,21 @@ public class ImmutableColumnLayoutEngine : IImmutableLayoutEngine
 
 	/// <inheritdoc/>
 	public IImmutableLayoutEngine HidePhantomWindows() => this;
+
+	/// <summary>
+	/// Gets the delta to determine whether we want to move towards 0 or not.
+	/// </summary>
+	/// <param name="leftToRight">Whether we are moving left to right or right to left.</param>
+	/// <param name="direction">The window direction to move.</param>
+	private static int GetDelta(bool leftToRight, Direction direction)
+	{
+		if (leftToRight)
+		{
+			return direction == Direction.Left ? -1 : 1;
+		}
+		else
+		{
+			return direction == Direction.Left ? 1 : -1;
+		}
+	}
 }

--- a/src/Whim/Layout/ImmutableColumnLayoutEngine.cs
+++ b/src/Whim/Layout/ImmutableColumnLayoutEngine.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
@@ -66,12 +65,10 @@ public class ImmutableColumnLayoutEngine : IImmutableLayoutEngine
 	}
 
 	/// <inheritdoc/>
-	public IEnumerator<IWindow> GetEnumerator() => _stack.GetEnumerator();
-
-	IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+	public IEnumerator<IWindow> GetWindows() => _stack.GetEnumerator();
 
 	/// <inheritdoc/>
-	public IEnumerable<IWindowState> DoLayout(ILocation<int> location, IMonitor monitor)
+	public IEnumerable<IWindowState> DoLayout(ILocation<int> location, IMonitor _)
 	{
 		string direction = LeftToRight ? "left to right" : "right to left";
 		Logger.Debug($"Performing a column layout {direction}");


### PR DESCRIPTION
Created the `IImmutableLayoutEngine` interface and core immutable layout engine classes.

`IEnumerable` is no longer implemented for `IImmutableLayoutEngine`, as the collection initialization syntax doesn't call the returned instance from `IImmutableLayoutEngine Add(IWindow window)`.