### PR TITLE
Add `MoveWindowToPoint` for `ILayoutEngine`

### DIFF
--- a/src/Whim.Bar.Tests/BarLayoutEngineTests.cs
+++ b/src/Whim.Bar.Tests/BarLayoutEngineTests.cs
@@ -1,3 +1,4 @@
+using FluentAssertions;
 using Moq;
 using Xunit;
 
@@ -5,12 +6,16 @@ namespace Whim.Bar.Tests;
 
 public class BarLayoutEngineTests
 {
-	[Fact]
-	public void Update_Same()
+	private class Wrapper
 	{
-		// Given
-		BarConfig config =
-			new(
+		public Mock<ILayoutEngine> InnerLayoutEngine { get; } = new();
+		public Mock<IMonitor> Monitor { get; } = new();
+		public ILocation<int> Location { get; } = new Location<int>() { Width = 100, Height = 100 };
+		public BarConfig BarConfig { get; }
+
+		public Wrapper()
+		{
+			BarConfig = new(
 				leftComponents: new List<BarComponent>(),
 				centerComponents: new List<BarComponent>(),
 				rightComponents: new List<BarComponent>()
@@ -19,88 +24,337 @@ public class BarLayoutEngineTests
 				Height = 30
 			};
 
-		Mock<ILayoutEngine> innerLayoutEngine = new();
-		innerLayoutEngine.Setup(ile => ile.RemoveWindow(It.IsAny<IWindow>())).Returns(innerLayoutEngine.Object);
-
-		Mock<IMonitor> monitor = new();
-		monitor.SetupGet(m => m.ScaleFactor).Returns(100);
-
-		ILocation<int> location = new Location<int>() { Width = 1920, Height = 1080 };
-
-		BarLayoutEngine engine = new(config, innerLayoutEngine.Object);
-
-		// When
-		ILayoutEngine newEngine = engine.RemoveWindow(new Mock<IWindow>().Object);
-
-		// Then
-		Assert.Same(engine, newEngine);
-		Assert.IsType<BarLayoutEngine>(newEngine);
+			Monitor.SetupGet(m => m.ScaleFactor).Returns(100);
+		}
 	}
 
 	[Fact]
-	public void Update_Different()
+	public void Count()
 	{
 		// Given
-		BarConfig config =
-			new(
-				leftComponents: new List<BarComponent>(),
-				centerComponents: new List<BarComponent>(),
-				rightComponents: new List<BarComponent>()
-			)
-			{
-				Height = 30
-			};
+		Wrapper wrapper = new();
+		BarLayoutEngine engine = new(wrapper.BarConfig, wrapper.InnerLayoutEngine.Object);
 
-		Mock<ILayoutEngine> innerLayoutEngine = new();
-
-		Mock<IMonitor> monitor = new();
-		monitor.SetupGet(m => m.ScaleFactor).Returns(100);
-
-		ILocation<int> location = new Location<int>() { Width = 1920, Height = 1080 };
-
-		BarLayoutEngine engine = new(config, innerLayoutEngine.Object);
+		wrapper.InnerLayoutEngine.SetupGet(ile => ile.Count).Returns(5);
 
 		// When
-		ILayoutEngine newEngine = engine.AddWindow(new Mock<IWindow>().Object);
+		int count = engine.Count;
+
+		// Then
+		Assert.Equal(5, count);
+	}
+
+	[Fact]
+	public void AddWindow()
+	{
+		// Given
+		Wrapper wrapper = new();
+		BarLayoutEngine engine = new(wrapper.BarConfig, wrapper.InnerLayoutEngine.Object);
+
+		IWindow window = new Mock<IWindow>().Object;
+
+		Mock<ILayoutEngine> addWindowResult = new();
+		wrapper.InnerLayoutEngine.Setup(ile => ile.AddWindow(window)).Returns(addWindowResult.Object);
+		addWindowResult.Setup(ile => ile.AddWindow(window)).Returns(addWindowResult.Object);
+
+		// When
+		ILayoutEngine newEngine = engine.AddWindow(window);
+		ILayoutEngine newEngine2 = newEngine.AddWindow(window);
 
 		// Then
 		Assert.NotSame(engine, newEngine);
-		Assert.IsType<BarLayoutEngine>(newEngine);
+		Assert.Same(newEngine, newEngine2);
 	}
 
 	[Fact]
-	public void GetLayout()
+	public void ContainsWindow()
 	{
 		// Given
-		BarConfig config =
-			new(
-				leftComponents: new List<BarComponent>(),
-				centerComponents: new List<BarComponent>(),
-				rightComponents: new List<BarComponent>()
-			)
-			{
-				Height = 30
-			};
+		Wrapper wrapper = new();
+		BarLayoutEngine engine = new(wrapper.BarConfig, wrapper.InnerLayoutEngine.Object);
 
-		Mock<ILayoutEngine> innerLayoutEngine = new();
-		Mock<IMonitor> monitor = new();
-		monitor.SetupGet(m => m.ScaleFactor).Returns(100);
+		IWindow window = new Mock<IWindow>().Object;
 
-		ILocation<int> location = new Location<int>() { Width = 1920, Height = 1080 };
-
-		BarLayoutEngine engine = new(config, innerLayoutEngine.Object);
+		wrapper.InnerLayoutEngine.Setup(ile => ile.ContainsWindow(window)).Returns(true);
 
 		// When
-		IEnumerable<IWindowState> layout = engine.DoLayout(location, monitor.Object);
+		bool contains = engine.ContainsWindow(window);
 
 		// Then
-		ILocation<int> expectedLocation = new Location<int>()
+		Assert.True(contains);
+	}
+
+	[Fact]
+	public void FocusWindowInDirection()
+	{
+		// Given
+		Wrapper wrapper = new();
+		BarLayoutEngine engine = new(wrapper.BarConfig, wrapper.InnerLayoutEngine.Object);
+
+		IWindow window = new Mock<IWindow>().Object;
+		Direction direction = Direction.Left;
+
+		// When
+		engine.FocusWindowInDirection(direction, window);
+
+		// Then
+		wrapper.InnerLayoutEngine.Verify(ile => ile.FocusWindowInDirection(direction, window), Times.Once);
+	}
+
+	[Fact]
+	public void GetFirstWindow()
+	{
+		// Given
+		Wrapper wrapper = new();
+		BarLayoutEngine engine = new(wrapper.BarConfig, wrapper.InnerLayoutEngine.Object);
+
+		IWindow window = new Mock<IWindow>().Object;
+
+		wrapper.InnerLayoutEngine.Setup(ile => ile.GetFirstWindow()).Returns(window);
+
+		// When
+		IWindow? firstWindow = engine.GetFirstWindow();
+
+		// Then
+		Assert.Same(window, firstWindow);
+	}
+
+	[Fact]
+	public void HidePhantomWindows()
+	{
+		// Given
+		Wrapper wrapper = new();
+		BarLayoutEngine engine = new(wrapper.BarConfig, wrapper.InnerLayoutEngine.Object);
+
+		// When
+		engine.HidePhantomWindows();
+
+		// Then
+		wrapper.InnerLayoutEngine.Verify(ile => ile.HidePhantomWindows(), Times.Once);
+	}
+
+	[Fact]
+	public void MoveWindowEdgesInDirection_NotSame()
+	{
+		// Given
+		Wrapper wrapper = new();
+		BarLayoutEngine engine = new(wrapper.BarConfig, wrapper.InnerLayoutEngine.Object);
+
+		IWindow window = new Mock<IWindow>().Object;
+		Direction direction = Direction.Left;
+		IPoint<double> deltas = new Point<double>();
+
+		Mock<ILayoutEngine> moveWindowEdgesInDirectionResult = new();
+		wrapper.InnerLayoutEngine
+			.Setup(ile => ile.MoveWindowEdgesInDirection(direction, deltas, window))
+			.Returns(moveWindowEdgesInDirectionResult.Object);
+
+		// When
+		ILayoutEngine newEngine = engine.MoveWindowEdgesInDirection(direction, deltas, window);
+
+		// Then
+		Assert.NotSame(engine, newEngine);
+	}
+
+	[Fact]
+	public void MoveWindowEdgesInDirection_Same()
+	{
+		// Given
+		Wrapper wrapper = new();
+		BarLayoutEngine engine = new(wrapper.BarConfig, wrapper.InnerLayoutEngine.Object);
+
+		IWindow window = new Mock<IWindow>().Object;
+		Direction direction = Direction.Left;
+		IPoint<double> deltas = new Point<double>();
+
+		wrapper.InnerLayoutEngine
+			.Setup(ile => ile.MoveWindowEdgesInDirection(direction, deltas, window))
+			.Returns(wrapper.InnerLayoutEngine.Object);
+
+		// When
+		ILayoutEngine newEngine = engine.MoveWindowEdgesInDirection(direction, deltas, window);
+
+		// Then
+		Assert.Same(engine, newEngine);
+	}
+
+	[Fact]
+	public void MoveWindowToPoint_NotSame()
+	{
+		// Given
+		Wrapper wrapper = new();
+		BarLayoutEngine engine = new(wrapper.BarConfig, wrapper.InnerLayoutEngine.Object);
+
+		IWindow window = new Mock<IWindow>().Object;
+		IPoint<double> point = new Point<double>();
+
+		Mock<ILayoutEngine> moveWindowToPointResult = new();
+		wrapper.InnerLayoutEngine
+			.Setup(ile => ile.MoveWindowToPoint(window, point))
+			.Returns(moveWindowToPointResult.Object);
+
+		// When
+		ILayoutEngine newEngine = engine.MoveWindowToPoint(window, point);
+
+		// Then
+		Assert.NotSame(engine, newEngine);
+	}
+
+	[Fact]
+	public void MoveWindowToPoint_Same()
+	{
+		// Given
+		Wrapper wrapper = new();
+		BarLayoutEngine engine = new(wrapper.BarConfig, wrapper.InnerLayoutEngine.Object);
+
+		IWindow window = new Mock<IWindow>().Object;
+		IPoint<double> point = new Point<double>();
+
+		wrapper.InnerLayoutEngine
+			.Setup(ile => ile.MoveWindowToPoint(window, point))
+			.Returns(wrapper.InnerLayoutEngine.Object);
+
+		// When
+		ILayoutEngine newEngine = engine.MoveWindowToPoint(window, point);
+
+		// Then
+		Assert.Same(engine, newEngine);
+	}
+
+	[Fact]
+	public void RemoveWindow_NotSame()
+	{
+		// Given
+		Wrapper wrapper = new();
+		BarLayoutEngine engine = new(wrapper.BarConfig, wrapper.InnerLayoutEngine.Object);
+
+		IWindow window = new Mock<IWindow>().Object;
+
+		Mock<ILayoutEngine> removeWindowResult = new();
+		wrapper.InnerLayoutEngine.Setup(ile => ile.RemoveWindow(window)).Returns(removeWindowResult.Object);
+
+		// When
+		ILayoutEngine newEngine = engine.RemoveWindow(window);
+
+		// Then
+		Assert.NotSame(engine, newEngine);
+	}
+
+	[Fact]
+	public void RemoveWindow_Same()
+	{
+		// Given
+		Wrapper wrapper = new();
+		BarLayoutEngine engine = new(wrapper.BarConfig, wrapper.InnerLayoutEngine.Object);
+
+		IWindow window = new Mock<IWindow>().Object;
+
+		wrapper.InnerLayoutEngine.Setup(ile => ile.RemoveWindow(window)).Returns(wrapper.InnerLayoutEngine.Object);
+
+		// When
+		ILayoutEngine newEngine = engine.RemoveWindow(window);
+
+		// Then
+		Assert.Same(engine, newEngine);
+	}
+
+	[Fact]
+	public void SwapWindowInDirection_NotSame()
+	{
+		// Given
+		Wrapper wrapper = new();
+		BarLayoutEngine engine = new(wrapper.BarConfig, wrapper.InnerLayoutEngine.Object);
+		IWindow window = new Mock<IWindow>().Object;
+		Direction direction = Direction.Left;
+
+		Mock<ILayoutEngine> swapWindowInDirectionResult = new();
+		wrapper.InnerLayoutEngine
+			.Setup(ile => ile.SwapWindowInDirection(direction, window))
+			.Returns(swapWindowInDirectionResult.Object);
+
+		// When
+		ILayoutEngine newEngine = engine.SwapWindowInDirection(direction, window);
+
+		// Then
+		Assert.NotSame(engine, newEngine);
+	}
+
+	[Fact]
+	public void SwapWindowInDirection_Same()
+	{
+		// Given
+		Wrapper wrapper = new();
+		BarLayoutEngine engine = new(wrapper.BarConfig, wrapper.InnerLayoutEngine.Object);
+		IWindow window = new Mock<IWindow>().Object;
+		Direction direction = Direction.Left;
+
+		wrapper.InnerLayoutEngine
+			.Setup(ile => ile.SwapWindowInDirection(direction, window))
+			.Returns(wrapper.InnerLayoutEngine.Object);
+
+		// When
+		ILayoutEngine newEngine = engine.SwapWindowInDirection(direction, window);
+
+		// Then
+		Assert.Same(engine, newEngine);
+	}
+
+	[Fact]
+	public void DoLayout()
+	{
+		// Given
+		Wrapper wrapper = new();
+		BarLayoutEngine engine = new(wrapper.BarConfig, wrapper.InnerLayoutEngine.Object);
+		IWindow window1 = new Mock<IWindow>().Object;
+		IWindow window2 = new Mock<IWindow>().Object;
+
+		IWindowState[] expectedWindowStates = new[]
 		{
-			X = 0,
-			Y = 30,
-			Width = 1920,
-			Height = 1050
+			new WindowState()
+			{
+				Window = window1,
+				Location = new Location<int>()
+				{
+					Y = 30,
+					Width = 50,
+					Height = 70
+				},
+				WindowSize = WindowSize.Normal
+			},
+			new WindowState()
+			{
+				Window = window2,
+				Location = new Location<int>()
+				{
+					X = 50,
+					Y = 30,
+					Width = 50,
+					Height = 70
+				},
+				WindowSize = WindowSize.Normal
+			}
 		};
-		innerLayoutEngine.Verify(m => m.DoLayout(expectedLocation, monitor.Object), Times.Once);
+
+		ILocation<int> expectedGivenLocation = new Location<int>()
+		{
+			Y = 30,
+			Width = 100,
+			Height = 70
+		};
+
+		wrapper.InnerLayoutEngine
+			.Setup(ile => ile.DoLayout(expectedGivenLocation, wrapper.Monitor.Object))
+			.Returns(expectedWindowStates);
+
+		// When
+		IWindowState[] layout = engine.DoLayout(wrapper.Location, wrapper.Monitor.Object).ToArray();
+
+		// Then
+		Assert.Equal(2, layout.Length);
+		wrapper.InnerLayoutEngine.Verify(
+			ile => ile.DoLayout(expectedGivenLocation, wrapper.Monitor.Object),
+			Times.Once
+		);
+		layout.Should().BeEquivalentTo(expectedWindowStates);
 	}
 }

--- a/src/Whim.Bar.Tests/BarLayoutEngineTests.cs
+++ b/src/Whim.Bar.Tests/BarLayoutEngineTests.cs
@@ -20,7 +20,7 @@ public class BarLayoutEngineTests
 			};
 
 		Mock<ILayoutEngine> innerLayoutEngine = new();
-		innerLayoutEngine.Setup(ile => ile.Remove(It.IsAny<IWindow>())).Returns(innerLayoutEngine.Object);
+		innerLayoutEngine.Setup(ile => ile.RemoveWindow(It.IsAny<IWindow>())).Returns(innerLayoutEngine.Object);
 
 		Mock<IMonitor> monitor = new();
 		monitor.SetupGet(m => m.ScaleFactor).Returns(100);
@@ -30,7 +30,7 @@ public class BarLayoutEngineTests
 		BarLayoutEngine engine = new(config, innerLayoutEngine.Object);
 
 		// When
-		ILayoutEngine newEngine = engine.Remove(new Mock<IWindow>().Object);
+		ILayoutEngine newEngine = engine.RemoveWindow(new Mock<IWindow>().Object);
 
 		// Then
 		Assert.Same(engine, newEngine);
@@ -61,7 +61,7 @@ public class BarLayoutEngineTests
 		BarLayoutEngine engine = new(config, innerLayoutEngine.Object);
 
 		// When
-		ILayoutEngine newEngine = engine.Add(new Mock<IWindow>().Object);
+		ILayoutEngine newEngine = engine.AddWindow(new Mock<IWindow>().Object);
 
 		// Then
 		Assert.NotSame(engine, newEngine);

--- a/src/Whim.Bar/BarLayoutEngine.cs
+++ b/src/Whim.Bar/BarLayoutEngine.cs
@@ -21,8 +21,14 @@ public class BarLayoutEngine : BaseProxyLayoutEngine
 	}
 
 	/// <inheritdoc />
-	protected override ILayoutEngine Update(ILayoutEngine newLayoutEngine) =>
-		newLayoutEngine == InnerLayoutEngine ? this : new BarLayoutEngine(_barConfig, newLayoutEngine);
+	public override int Count => InnerLayoutEngine.Count;
+
+	/// <inheritdoc />
+	public override ILayoutEngine AddWindow(IWindow window) =>
+		new BarLayoutEngine(_barConfig, InnerLayoutEngine.AddWindow(window));
+
+	/// <inheritdoc />
+	public override bool ContainsWindow(IWindow window) => InnerLayoutEngine.ContainsWindow(window);
 
 	/// <inheritdoc />
 	public override IEnumerable<IWindowState> DoLayout(ILocation<int> location, IMonitor monitor)
@@ -40,4 +46,30 @@ public class BarLayoutEngine : BaseProxyLayoutEngine
 			};
 		return InnerLayoutEngine.DoLayout(proxiedLocation, monitor);
 	}
+
+	/// <inheritdoc />
+	public override void FocusWindowInDirection(Direction direction, IWindow window) =>
+		InnerLayoutEngine.FocusWindowInDirection(direction, window);
+
+	/// <inheritdoc />
+	public override IWindow? GetFirstWindow() => InnerLayoutEngine.GetFirstWindow();
+
+	/// <inheritdoc />
+	public override void HidePhantomWindows() => InnerLayoutEngine.HidePhantomWindows();
+
+	/// <inheritdoc />
+	public override ILayoutEngine MoveWindowEdgesInDirection(Direction edge, IPoint<double> deltas, IWindow window) =>
+		new BarLayoutEngine(_barConfig, InnerLayoutEngine.MoveWindowEdgesInDirection(edge, deltas, window));
+
+	/// <inheritdoc />
+	public override ILayoutEngine MoveWindowToPoint(IWindow window, IPoint<double> point) =>
+		new BarLayoutEngine(_barConfig, InnerLayoutEngine.MoveWindowToPoint(window, point));
+
+	/// <inheritdoc />
+	public override ILayoutEngine RemoveWindow(IWindow window) =>
+		new BarLayoutEngine(_barConfig, InnerLayoutEngine.RemoveWindow(window));
+
+	/// <inheritdoc />
+	public override ILayoutEngine SwapWindowInDirection(Direction direction, IWindow window) =>
+		new BarLayoutEngine(_barConfig, InnerLayoutEngine.SwapWindowInDirection(direction, window));
 }

--- a/src/Whim.Bar/BarLayoutEngine.cs
+++ b/src/Whim.Bar/BarLayoutEngine.cs
@@ -20,12 +20,14 @@ public class BarLayoutEngine : BaseProxyLayoutEngine
 		_barConfig = barConfig;
 	}
 
+	private BarLayoutEngine UpdateInner(ILayoutEngine newInnerLayoutEngine) =>
+		InnerLayoutEngine == newInnerLayoutEngine ? this : new BarLayoutEngine(_barConfig, newInnerLayoutEngine);
+
 	/// <inheritdoc />
 	public override int Count => InnerLayoutEngine.Count;
 
 	/// <inheritdoc />
-	public override ILayoutEngine AddWindow(IWindow window) =>
-		new BarLayoutEngine(_barConfig, InnerLayoutEngine.AddWindow(window));
+	public override ILayoutEngine AddWindow(IWindow window) => UpdateInner(InnerLayoutEngine.AddWindow(window));
 
 	/// <inheritdoc />
 	public override bool ContainsWindow(IWindow window) => InnerLayoutEngine.ContainsWindow(window);
@@ -59,17 +61,16 @@ public class BarLayoutEngine : BaseProxyLayoutEngine
 
 	/// <inheritdoc />
 	public override ILayoutEngine MoveWindowEdgesInDirection(Direction edge, IPoint<double> deltas, IWindow window) =>
-		new BarLayoutEngine(_barConfig, InnerLayoutEngine.MoveWindowEdgesInDirection(edge, deltas, window));
+		UpdateInner(InnerLayoutEngine.MoveWindowEdgesInDirection(edge, deltas, window));
 
 	/// <inheritdoc />
 	public override ILayoutEngine MoveWindowToPoint(IWindow window, IPoint<double> point) =>
-		new BarLayoutEngine(_barConfig, InnerLayoutEngine.MoveWindowToPoint(window, point));
+		UpdateInner(InnerLayoutEngine.MoveWindowToPoint(window, point));
 
 	/// <inheritdoc />
-	public override ILayoutEngine RemoveWindow(IWindow window) =>
-		new BarLayoutEngine(_barConfig, InnerLayoutEngine.RemoveWindow(window));
+	public override ILayoutEngine RemoveWindow(IWindow window) => UpdateInner(InnerLayoutEngine.RemoveWindow(window));
 
 	/// <inheritdoc />
 	public override ILayoutEngine SwapWindowInDirection(Direction direction, IWindow window) =>
-		new BarLayoutEngine(_barConfig, InnerLayoutEngine.SwapWindowInDirection(direction, window));
+		UpdateInner(InnerLayoutEngine.SwapWindowInDirection(direction, window));
 }

--- a/src/Whim.CommandPalette.Tests/CommandPaletteCommandsTests.cs
+++ b/src/Whim.CommandPalette.Tests/CommandPaletteCommandsTests.cs
@@ -1,6 +1,6 @@
 using FluentAssertions;
 using Moq;
-using Whim.TestUtilities;
+using Whim.TestUtils;
 using Xunit;
 
 namespace Whim.CommandPalette.Tests;

--- a/src/Whim.FloatingLayout.Tests/FloatingLayoutCommandsTests.cs
+++ b/src/Whim.FloatingLayout.Tests/FloatingLayoutCommandsTests.cs
@@ -1,5 +1,5 @@
 using Moq;
-using Whim.TestUtilities;
+using Whim.TestUtils;
 using Xunit;
 
 namespace Whim.FloatingLayout.Tests;

--- a/src/Whim.FloatingLayout.Tests/FloatingLayoutEngineTests.cs
+++ b/src/Whim.FloatingLayout.Tests/FloatingLayoutEngineTests.cs
@@ -499,4 +499,60 @@ public class FloatingLayoutEngineTests
 		windowStates.Should().BeEquivalentTo(expected);
 	}
 	#endregion
+
+	#region GetFirstWindow
+	[Fact]
+	public void GetFirstWindow_NoInnerFirstWindow()
+	{
+		// Given
+		Wrapper wrapper = new();
+		FloatingLayoutEngine engine =
+			new(wrapper.Context.Object, wrapper.Plugin.Object, wrapper.InnerLayoutEngine.Object);
+
+		// When
+		IWindow? firstWindow = engine.GetFirstWindow();
+
+		// Then
+		Assert.Null(firstWindow);
+	}
+
+	[Fact]
+	public void GetFirstWindow_InnerFirstWindow()
+	{
+		// Given
+		Mock<IWindow> window = new();
+
+		Wrapper wrapper = new();
+		FloatingLayoutEngine engine =
+			new(wrapper.Context.Object, wrapper.Plugin.Object, wrapper.InnerLayoutEngine.Object);
+
+		wrapper.InnerLayoutEngine.Setup(ile => ile.GetFirstWindow()).Returns(window.Object);
+
+		// When
+		IWindow? firstWindow = engine.GetFirstWindow();
+
+		// Then
+		Assert.Same(window.Object, firstWindow);
+	}
+
+	[Fact]
+	public void GetFirstWindow_FloatingFirstWindow()
+	{
+		// Given
+		Mock<IWindow> window = new();
+		Mock<ILayoutEngine> newInnerLayoutEngine = new();
+
+		Wrapper wrapper = new Wrapper()
+			.MarkAsFloating(window.Object)
+			.Setup_RemoveWindow(window.Object, newInnerLayoutEngine);
+		FloatingLayoutEngine engine =
+			new(wrapper.Context.Object, wrapper.Plugin.Object, wrapper.InnerLayoutEngine.Object);
+
+		// When
+		IWindow? firstWindow = engine.AddWindow(window.Object).GetFirstWindow();
+
+		// Then
+		Assert.Same(window.Object, firstWindow);
+	}
+	#endregion
 }

--- a/src/Whim.FloatingLayout.Tests/FloatingLayoutEngineTests.cs
+++ b/src/Whim.FloatingLayout.Tests/FloatingLayoutEngineTests.cs
@@ -167,7 +167,7 @@ public class FloatingLayoutEngineTests
 	}
 
 	[Fact]
-	public void AddAtPoint()
+	public void MoveWindowToPoint()
 	{
 		// Given
 		Wrapper wrapper = new();
@@ -178,7 +178,7 @@ public class FloatingLayoutEngineTests
 		Mock<IWindow> window = new();
 
 		// When
-		ILayoutEngine result = engine.AddAtPoint(window.Object, new Point<double>());
+		ILayoutEngine result = engine.MoveWindowToPoint(window.Object, new Point<double>());
 
 		// Then
 		Assert.NotSame(engine, result);

--- a/src/Whim.FloatingLayout.Tests/FloatingLayoutEngineTests.cs
+++ b/src/Whim.FloatingLayout.Tests/FloatingLayoutEngineTests.cs
@@ -59,6 +59,30 @@ public class FloatingLayoutEngineTests
 
 			return this;
 		}
+
+		public Wrapper Setup_PluginTracksLocation(
+			Mock<IWorkspace> workspace,
+			Mock<IWindow> window,
+			ILayoutEngine engine
+		)
+		{
+			WorkspaceManager.Setup(x => x.GetWorkspaceForWindow(window.Object)).Returns(workspace.Object);
+			workspace
+				.Setup(w => w.TryGetWindowLocation(It.IsAny<IWindow>()))
+				.Returns(
+					new WindowState()
+					{
+						Location = new Location<int>(),
+						Window = window.Object,
+						WindowSize = WindowSize.Normal,
+					}
+				);
+			workspace.Setup(w => w.ActiveLayoutEngine).Returns(engine);
+			InnerLayoutEngine.Setup(ile => ile.ContainsWindow(window.Object)).Returns(false);
+			InnerLayoutEngine.Setup(ile => ile.RemoveWindow(window.Object)).Returns(InnerLayoutEngine.Object);
+
+			return this;
+		}
 	}
 
 	#region Add
@@ -86,29 +110,28 @@ public class FloatingLayoutEngineTests
 	{
 		// Given
 		Wrapper wrapper = new();
-
-		Mock<IWorkspace> workspace = new();
 		Mock<IWindow> window = new();
 
 		FloatingLayoutEngine engine =
 			new(wrapper.Context.Object, wrapper.FloatingLayoutPlugin, wrapper.InnerLayoutEngine.Object);
 
 		// When
+		wrapper.Setup_PluginTracksLocation(new Mock<IWorkspace>(), window, engine).Setup_GetMonitorAtPoint();
+		wrapper.FloatingLayoutPlugin.MarkWindowAsFloating(window.Object);
 		ILayoutEngine result = engine.AddWindow(window.Object);
 
 		// Then
 		Assert.Same(engine, result);
 		wrapper.NativeManager.Verify(nm => nm.DwmGetWindowLocation(It.IsAny<HWND>()), Times.Once);
-		wrapper.MonitorManager.Verify(mm => mm.GetMonitorAtPoint(It.IsAny<ILocation<int>>()), Times.Never);
+		wrapper.MonitorManager.Verify(mm => mm.GetMonitorAtPoint(It.IsAny<ILocation<int>>()), Times.Once);
 		wrapper.InnerLayoutEngine.Verify(x => x.AddWindow(window.Object), Times.Never);
 	}
 
 	[Fact]
-	public void Add_AlreadyTrackedByLayoutEngine_LocationHasNotChanged()
+	public void Add_AlreadyTrackedByFloatingLayoutEngine_LocationHasNotChanged()
 	{
 		// Given
 		Wrapper wrapper = new();
-
 		Mock<IWorkspace> workspace = new();
 		Mock<IWindow> window = new();
 
@@ -122,12 +145,14 @@ public class FloatingLayoutEngineTests
 					Height = 50
 				}
 			)
-			.Setup_GetMonitorAtPoint();
+			.Setup_GetMonitorAtPoint()
+			.Setup_PluginTracksLocation(workspace, window, wrapper.InnerLayoutEngine.Object);
 
 		FloatingLayoutEngine engine =
 			new(wrapper.Context.Object, wrapper.FloatingLayoutPlugin, wrapper.InnerLayoutEngine.Object);
 
 		// When
+		wrapper.FloatingLayoutPlugin.MarkWindowAsFloating(window.Object);
 		ILayoutEngine result = engine.AddWindow(window.Object);
 		ILayoutEngine result2 = result.AddWindow(window.Object);
 
@@ -136,11 +161,13 @@ public class FloatingLayoutEngineTests
 		Assert.Same(result, result2);
 
 		wrapper.NativeManager.Verify(nm => nm.DwmGetWindowLocation(It.IsAny<HWND>()), Times.Exactly(2));
-		wrapper.MonitorManager.Verify(mm => mm.GetMonitorAtPoint(It.IsAny<ILocation<int>>()), Times.Exactly(2));
+		wrapper.MonitorManager.Verify(mm => mm.GetMonitorAtPoint(It.IsAny<ILocation<int>>()), Times.Exactly(3));
 	}
+	#endregion
 
+	#region MoveWindowToPoint
 	[Fact]
-	public void MoveWindowToPoint()
+	public void MoveWindowToPoint_UseInner()
 	{
 		// Given
 		Wrapper wrapper = new();
@@ -155,7 +182,40 @@ public class FloatingLayoutEngineTests
 		// Then
 		Assert.NotSame(engine, result);
 		wrapper.NativeManager.Verify(nm => nm.DwmGetWindowLocation(It.IsAny<HWND>()), Times.Never);
-		wrapper.InnerLayoutEngine.Verify(x => x.AddWindow(window.Object), Times.Once);
+		wrapper.InnerLayoutEngine.Verify(
+			x => x.MoveWindowToPoint(window.Object, It.IsAny<IPoint<double>>()),
+			Times.Once
+		);
+	}
+
+	[Fact]
+	public void MoveWindowToPoint_UpdateLocation()
+	{
+		// Given
+		Wrapper wrapper = new Wrapper()
+			.Setup_GetMonitorAtPoint()
+			.Setup_DwmGetWindowLocation_NotNull(new Location<int>());
+
+		FloatingLayoutEngine engine =
+			new(wrapper.Context.Object, wrapper.FloatingLayoutPlugin, wrapper.InnerLayoutEngine.Object);
+
+		Mock<IWorkspace> workspace = new();
+		Mock<IWindow> window = new();
+
+		wrapper.Setup_PluginTracksLocation(workspace, window, engine);
+
+		// When
+		wrapper.FloatingLayoutPlugin.MarkWindowAsFloating(window.Object);
+		ILayoutEngine result = engine.MoveWindowToPoint(window.Object, new Point<double>());
+
+		// Then
+		Assert.NotSame(engine, result);
+		wrapper.NativeManager.Verify(nm => nm.DwmGetWindowLocation(It.IsAny<HWND>()), Times.Once);
+		wrapper.InnerLayoutEngine.Verify(
+			x => x.MoveWindowToPoint(window.Object, It.IsAny<IPoint<double>>()),
+			Times.Never
+		);
+		Assert.Single(wrapper.FloatingLayoutPlugin.FloatingWindows);
 	}
 	#endregion
 
@@ -180,11 +240,10 @@ public class FloatingLayoutEngineTests
 	}
 
 	[Fact]
-	public void Remove_TrackedByLayoutEngine()
+	public void Remove_TrackedByFloatingLayoutEngine()
 	{
 		// Given
 		Wrapper wrapper = new();
-
 		Mock<IWorkspace> workspace = new();
 		Mock<IWindow> window = new();
 
@@ -202,16 +261,19 @@ public class FloatingLayoutEngineTests
 
 		FloatingLayoutEngine engine =
 			new(wrapper.Context.Object, wrapper.FloatingLayoutPlugin, wrapper.InnerLayoutEngine.Object);
+		wrapper.Setup_PluginTracksLocation(workspace, window, engine);
 
 		// When
+		wrapper.FloatingLayoutPlugin.MarkWindowAsFloating(window.Object);
 		ILayoutEngine result = engine.AddWindow(window.Object).RemoveWindow(window.Object);
 
 		// Then
 		Assert.NotSame(engine, result);
 		wrapper.NativeManager.Verify(nm => nm.DwmGetWindowLocation(It.IsAny<HWND>()), Times.Once);
-		wrapper.MonitorManager.Verify(mm => mm.GetMonitorAtPoint(It.IsAny<ILocation<int>>()), Times.Once);
-		wrapper.InnerLayoutEngine.Verify(x => x.RemoveWindow(window.Object), Times.Never);
+		wrapper.MonitorManager.Verify(mm => mm.GetMonitorAtPoint(It.IsAny<ILocation<int>>()), Times.Exactly(2));
+		wrapper.InnerLayoutEngine.Verify(x => x.RemoveWindow(window.Object), Times.Once);
 		Assert.Empty(wrapper.FloatingLayoutPlugin.FloatingWindows);
+		Assert.False(result.ContainsWindow(window.Object));
 	}
 
 	#endregion
@@ -221,7 +283,6 @@ public class FloatingLayoutEngineTests
 	{
 		// Given
 		Wrapper wrapper = new();
-
 		Mock<IWindow> window = new();
 		Mock<IWindow> window2 = new();
 
@@ -243,6 +304,9 @@ public class FloatingLayoutEngineTests
 				wrapper.FloatingLayoutPlugin,
 				new ColumnLayoutEngine(new LayoutEngineIdentity())
 			);
+
+		wrapper.Setup_PluginTracksLocation(new Mock<IWorkspace>(), window, engine);
+		wrapper.FloatingLayoutPlugin.MarkWindowAsFloating(window.Object);
 
 		// When
 		ILayoutEngine result = engine.AddWindow(window.Object);
@@ -267,28 +331,5 @@ public class FloatingLayoutEngineTests
 			states[0].Location
 		);
 		Assert.Equal(new Location<int>() { Width = 100, Height = 100 }, states[1].Location);
-	}
-
-	[Fact]
-	public void SwapWindowInDirection()
-	{
-		// Given
-		Wrapper wrapper = new();
-
-		Mock<IWorkspace> workspace = new();
-		Mock<IWindow> window = new();
-
-		wrapper.InnerLayoutEngine
-			.Setup(x => x.SwapWindowInDirection(Direction.Left, window.Object))
-			.Returns(wrapper.InnerLayoutEngine.Object);
-
-		FloatingLayoutEngine engine =
-			new(wrapper.Context.Object, wrapper.FloatingLayoutPlugin, wrapper.InnerLayoutEngine.Object);
-
-		// When
-		ILayoutEngine result = engine.SwapWindowInDirection(Direction.Left, window.Object);
-
-		// Then
-		Assert.Same(engine, result);
 	}
 }

--- a/src/Whim.FloatingLayout.Tests/FloatingLayoutEngineTests.cs
+++ b/src/Whim.FloatingLayout.Tests/FloatingLayoutEngineTests.cs
@@ -88,6 +88,26 @@ public class FloatingLayoutEngineTests
 	}
 
 	[Fact]
+	public void AddWindow_UseInner_SameInner()
+	{
+		// Given
+		Mock<IWindow> window = new();
+
+		Wrapper wrapper = new();
+		FloatingLayoutEngine engine =
+			new(wrapper.Context.Object, wrapper.Plugin.Object, wrapper.InnerLayoutEngine.Object);
+
+		wrapper.InnerLayoutEngine.Setup(ile => ile.AddWindow(window.Object)).Returns(wrapper.InnerLayoutEngine.Object);
+
+		// When
+		ILayoutEngine newEngine = engine.AddWindow(window.Object);
+
+		// Then
+		Assert.Same(engine, newEngine);
+		wrapper.InnerLayoutEngine.Verify(ile => ile.AddWindow(window.Object), Times.Once);
+	}
+
+	[Fact]
 	public void AddWindow_FloatingInPlugin_Succeed()
 	{
 		// Given
@@ -193,6 +213,28 @@ public class FloatingLayoutEngineTests
 	}
 
 	[Fact]
+	public void RemoveWindow_UseInner_SameInner()
+	{
+		// Given
+		Mock<IWindow> window = new();
+
+		Wrapper wrapper = new();
+		FloatingLayoutEngine engine =
+			new(wrapper.Context.Object, wrapper.Plugin.Object, wrapper.InnerLayoutEngine.Object);
+
+		wrapper.InnerLayoutEngine
+			.Setup(ile => ile.RemoveWindow(window.Object))
+			.Returns(wrapper.InnerLayoutEngine.Object);
+
+		// When
+		ILayoutEngine newEngine = engine.RemoveWindow(window.Object);
+
+		// Then
+		Assert.Same(engine, newEngine);
+		wrapper.InnerLayoutEngine.Verify(ile => ile.RemoveWindow(window.Object), Times.Once);
+	}
+
+	[Fact]
 	public void RemoveWindow_FloatingInPlugin()
 	{
 		// Given
@@ -237,6 +279,29 @@ public class FloatingLayoutEngineTests
 
 		// Then
 		Assert.NotSame(engine, newEngine);
+		wrapper.InnerLayoutEngine.Verify(ile => ile.MoveWindowToPoint(window.Object, location), Times.Once);
+	}
+
+	[Fact]
+	public void MoveWindowToPoint_UseInner_SameInner()
+	{
+		// Given
+		Mock<IWindow> window = new();
+		ILocation<double> location = new Location<double>();
+
+		Wrapper wrapper = new();
+		FloatingLayoutEngine engine =
+			new(wrapper.Context.Object, wrapper.Plugin.Object, wrapper.InnerLayoutEngine.Object);
+
+		wrapper.InnerLayoutEngine
+			.Setup(ile => ile.MoveWindowToPoint(window.Object, location))
+			.Returns(wrapper.InnerLayoutEngine.Object);
+
+		// When
+		ILayoutEngine newEngine = engine.MoveWindowToPoint(window.Object, location);
+
+		// Then
+		Assert.Same(engine, newEngine);
 		wrapper.InnerLayoutEngine.Verify(ile => ile.MoveWindowToPoint(window.Object, location), Times.Once);
 	}
 
@@ -327,6 +392,33 @@ public class FloatingLayoutEngineTests
 
 		// Then
 		Assert.NotSame(engine, newEngine);
+		wrapper.InnerLayoutEngine.Verify(
+			ile => ile.MoveWindowEdgesInDirection(direction, deltas, window.Object),
+			Times.Once
+		);
+	}
+
+	[Fact]
+	public void MoveWindowEdgesInDirection_UseInner_SameInner()
+	{
+		// Given
+		Mock<IWindow> window = new();
+		Direction direction = Direction.Left;
+		IPoint<double> deltas = new Point<double>();
+
+		Wrapper wrapper = new();
+		FloatingLayoutEngine engine =
+			new(wrapper.Context.Object, wrapper.Plugin.Object, wrapper.InnerLayoutEngine.Object);
+
+		wrapper.InnerLayoutEngine
+			.Setup(ile => ile.MoveWindowEdgesInDirection(direction, deltas, window.Object))
+			.Returns(wrapper.InnerLayoutEngine.Object);
+
+		// When
+		ILayoutEngine newEngine = engine.MoveWindowEdgesInDirection(direction, deltas, window.Object);
+
+		// Then
+		Assert.Same(engine, newEngine);
 		wrapper.InnerLayoutEngine.Verify(
 			ile => ile.MoveWindowEdgesInDirection(direction, deltas, window.Object),
 			Times.Once
@@ -576,6 +668,26 @@ public class FloatingLayoutEngineTests
 	}
 
 	[Fact]
+	public void FocusWindowInDirection_UseInner_SameInner()
+	{
+		// Given
+		Mock<IWindow> window = new();
+		Direction direction = Direction.Left;
+
+		Wrapper wrapper = new();
+		FloatingLayoutEngine engine =
+			new(wrapper.Context.Object, wrapper.Plugin.Object, wrapper.InnerLayoutEngine.Object);
+
+		wrapper.InnerLayoutEngine.Setup(ile => ile.FocusWindowInDirection(direction, window.Object));
+
+		// When
+		engine.FocusWindowInDirection(direction, window.Object);
+
+		// Then
+		wrapper.InnerLayoutEngine.Verify(ile => ile.FocusWindowInDirection(direction, window.Object), Times.Once);
+	}
+
+	[Fact]
 	public void FocusWindowInDirection_FloatingWindow()
 	{
 		// Given
@@ -608,6 +720,28 @@ public class FloatingLayoutEngineTests
 		Wrapper wrapper = new();
 		FloatingLayoutEngine engine =
 			new(wrapper.Context.Object, wrapper.Plugin.Object, wrapper.InnerLayoutEngine.Object);
+
+		// When
+		engine.SwapWindowInDirection(direction, window.Object);
+
+		// Then
+		wrapper.InnerLayoutEngine.Verify(ile => ile.SwapWindowInDirection(direction, window.Object), Times.Once);
+	}
+
+	[Fact]
+	public void SwapWindowInDirection_UseInner_SameInner()
+	{
+		// Given
+		Mock<IWindow> window = new();
+		Direction direction = Direction.Left;
+
+		Wrapper wrapper = new();
+		FloatingLayoutEngine engine =
+			new(wrapper.Context.Object, wrapper.Plugin.Object, wrapper.InnerLayoutEngine.Object);
+
+		wrapper.InnerLayoutEngine
+			.Setup(ile => ile.SwapWindowInDirection(direction, window.Object))
+			.Returns(wrapper.InnerLayoutEngine.Object);
 
 		// When
 		engine.SwapWindowInDirection(direction, window.Object);
@@ -654,6 +788,26 @@ public class FloatingLayoutEngineTests
 
 		// Then
 		Assert.False(containsWindow);
+		wrapper.InnerLayoutEngine.Verify(ile => ile.ContainsWindow(window.Object), Times.Once);
+	}
+
+	[Fact]
+	public void ContainsWindow_UseInner_SameInner()
+	{
+		// Given
+		Mock<IWindow> window = new();
+
+		Wrapper wrapper = new();
+		FloatingLayoutEngine engine =
+			new(wrapper.Context.Object, wrapper.Plugin.Object, wrapper.InnerLayoutEngine.Object);
+
+		wrapper.InnerLayoutEngine.Setup(ile => ile.ContainsWindow(window.Object)).Returns(true);
+
+		// When
+		bool containsWindow = engine.ContainsWindow(window.Object);
+
+		// Then
+		Assert.True(containsWindow);
 		wrapper.InnerLayoutEngine.Verify(ile => ile.ContainsWindow(window.Object), Times.Once);
 	}
 

--- a/src/Whim.FloatingLayout.Tests/FloatingLayoutEngineTests.cs
+++ b/src/Whim.FloatingLayout.Tests/FloatingLayoutEngineTests.cs
@@ -543,8 +543,8 @@ public class FloatingLayoutEngineTests
 			);
 
 		// When
-		IWindowState[] windowStates = engine
-			.AddWindow(floatingWindow.Object)
+		ILayoutEngine newEngine = engine.AddWindow(floatingWindow.Object);
+		IWindowState[] windowStates = newEngine
 			.DoLayout(
 				new Location<int>()
 				{
@@ -556,6 +556,7 @@ public class FloatingLayoutEngineTests
 				wrapper.Monitor.Object
 			)
 			.ToArray();
+		int count = newEngine.Count;
 
 		// Then
 		Assert.Equal(3, windowStates.Length);
@@ -589,6 +590,8 @@ public class FloatingLayoutEngineTests
 		};
 
 		windowStates.Should().BeEquivalentTo(expected);
+
+		Assert.Equal(3, count);
 	}
 	#endregion
 

--- a/src/Whim.FloatingLayout.Tests/FloatingLayoutEngineTests.cs
+++ b/src/Whim.FloatingLayout.Tests/FloatingLayoutEngineTests.cs
@@ -97,12 +97,12 @@ public class FloatingLayoutEngineTests
 		Mock<IWindow> window = new();
 
 		// When
-		ILayoutEngine result = engine.Add(window.Object);
+		ILayoutEngine result = engine.AddWindow(window.Object);
 
 		// Then
 		Assert.NotSame(engine, result);
 		wrapper.NativeManager.Verify(nm => nm.DwmGetWindowLocation(It.IsAny<HWND>()), Times.Never);
-		wrapper.InnerLayoutEngine.Verify(x => x.Add(window.Object), Times.Once);
+		wrapper.InnerLayoutEngine.Verify(x => x.AddWindow(window.Object), Times.Once);
 	}
 
 	[Fact]
@@ -120,13 +120,13 @@ public class FloatingLayoutEngineTests
 			new(wrapper.Context.Object, wrapper.FloatingLayoutPlugin.Object, wrapper.InnerLayoutEngine.Object);
 
 		// When
-		ILayoutEngine result = engine.Add(window.Object);
+		ILayoutEngine result = engine.AddWindow(window.Object);
 
 		// Then
 		Assert.Same(engine, result);
 		wrapper.NativeManager.Verify(nm => nm.DwmGetWindowLocation(It.IsAny<HWND>()), Times.Once);
 		wrapper.MonitorManager.Verify(mm => mm.GetMonitorAtPoint(It.IsAny<ILocation<int>>()), Times.Never);
-		wrapper.InnerLayoutEngine.Verify(x => x.Add(window.Object), Times.Never);
+		wrapper.InnerLayoutEngine.Verify(x => x.AddWindow(window.Object), Times.Never);
 	}
 
 	[Fact]
@@ -155,8 +155,8 @@ public class FloatingLayoutEngineTests
 			new(wrapper.Context.Object, wrapper.FloatingLayoutPlugin.Object, wrapper.InnerLayoutEngine.Object);
 
 		// When
-		ILayoutEngine result = engine.Add(window.Object);
-		ILayoutEngine result2 = result.Add(window.Object);
+		ILayoutEngine result = engine.AddWindow(window.Object);
+		ILayoutEngine result2 = result.AddWindow(window.Object);
 
 		// Then
 		Assert.NotSame(engine, result);
@@ -183,7 +183,7 @@ public class FloatingLayoutEngineTests
 		// Then
 		Assert.NotSame(engine, result);
 		wrapper.NativeManager.Verify(nm => nm.DwmGetWindowLocation(It.IsAny<HWND>()), Times.Never);
-		wrapper.InnerLayoutEngine.Verify(x => x.Add(window.Object), Times.Once);
+		wrapper.InnerLayoutEngine.Verify(x => x.AddWindow(window.Object), Times.Once);
 	}
 	#endregion
 
@@ -200,12 +200,12 @@ public class FloatingLayoutEngineTests
 		Mock<IWindow> window = new();
 
 		// When
-		ILayoutEngine result = engine.Remove(window.Object);
+		ILayoutEngine result = engine.RemoveWindow(window.Object);
 
 		// Then
 		Assert.NotSame(engine, result);
 		wrapper.NativeManager.Verify(nm => nm.DwmGetWindowLocation(It.IsAny<HWND>()), Times.Never);
-		wrapper.InnerLayoutEngine.Verify(x => x.Remove(window.Object), Times.Once);
+		wrapper.InnerLayoutEngine.Verify(x => x.RemoveWindow(window.Object), Times.Once);
 	}
 
 	[Fact]
@@ -234,13 +234,13 @@ public class FloatingLayoutEngineTests
 			new(wrapper.Context.Object, wrapper.FloatingLayoutPlugin.Object, wrapper.InnerLayoutEngine.Object);
 
 		// When
-		ILayoutEngine result = engine.Add(window.Object).Remove(window.Object);
+		ILayoutEngine result = engine.AddWindow(window.Object).RemoveWindow(window.Object);
 
 		// Then
 		Assert.NotSame(engine, result);
 		wrapper.NativeManager.Verify(nm => nm.DwmGetWindowLocation(It.IsAny<HWND>()), Times.Once);
 		wrapper.MonitorManager.Verify(mm => mm.GetMonitorAtPoint(It.IsAny<ILocation<int>>()), Times.Once);
-		wrapper.InnerLayoutEngine.Verify(x => x.Remove(window.Object), Times.Once);
+		wrapper.InnerLayoutEngine.Verify(x => x.RemoveWindow(window.Object), Times.Once);
 		wrapper.InternalFloatingLayoutPlugin?.Verify(
 			iflp => iflp.MutableFloatingWindows.Remove(window.Object),
 			Times.Never
@@ -273,13 +273,13 @@ public class FloatingLayoutEngineTests
 			new(wrapper.Context.Object, wrapper.FloatingLayoutPlugin.Object, wrapper.InnerLayoutEngine.Object);
 
 		// When
-		ILayoutEngine result = engine.Add(window.Object).Remove(window.Object);
+		ILayoutEngine result = engine.AddWindow(window.Object).RemoveWindow(window.Object);
 
 		// Then
 		Assert.NotSame(engine, result);
 		wrapper.NativeManager.Verify(nm => nm.DwmGetWindowLocation(It.IsAny<HWND>()), Times.Once);
 		wrapper.MonitorManager.Verify(mm => mm.GetMonitorAtPoint(It.IsAny<ILocation<int>>()), Times.Once);
-		wrapper.InnerLayoutEngine.Verify(x => x.Remove(window.Object), Times.Never);
+		wrapper.InnerLayoutEngine.Verify(x => x.RemoveWindow(window.Object), Times.Never);
 		wrapper.InternalFloatingLayoutPlugin?.Verify(
 			iflp => iflp.MutableFloatingWindows.Remove(window.Object),
 			Times.Once
@@ -318,8 +318,8 @@ public class FloatingLayoutEngineTests
 			);
 
 		// When
-		ILayoutEngine result = engine.Add(window.Object);
-		ILayoutEngine result2 = result.Add(window2.Object);
+		ILayoutEngine result = engine.AddWindow(window.Object);
+		ILayoutEngine result2 = result.AddWindow(window2.Object);
 		IWindowState[] states = result2
 			.DoLayout(new Location<int>() { Width = 100, Height = 100 }, new Mock<IMonitor>().Object)
 			.ToArray();

--- a/src/Whim.FloatingLayout.Tests/FloatingLayoutEngineTests.cs
+++ b/src/Whim.FloatingLayout.Tests/FloatingLayoutEngineTests.cs
@@ -555,4 +555,142 @@ public class FloatingLayoutEngineTests
 		Assert.Same(window.Object, firstWindow);
 	}
 	#endregion
+
+	#region FocusWindowInDirection
+	[Fact]
+	public void FocusWindowInDirection_UseInner()
+	{
+		// Given
+		Mock<IWindow> window = new();
+		Direction direction = Direction.Left;
+
+		Wrapper wrapper = new();
+		FloatingLayoutEngine engine =
+			new(wrapper.Context.Object, wrapper.Plugin.Object, wrapper.InnerLayoutEngine.Object);
+
+		// When
+		engine.FocusWindowInDirection(direction, window.Object);
+
+		// Then
+		wrapper.InnerLayoutEngine.Verify(ile => ile.FocusWindowInDirection(direction, window.Object), Times.Once);
+	}
+
+	[Fact]
+	public void FocusWindowInDirection_FloatingWindow()
+	{
+		// Given
+		Mock<IWindow> window = new();
+		Mock<ILayoutEngine> newInnerLayoutEngine = new();
+		Direction direction = Direction.Left;
+
+		Wrapper wrapper = new Wrapper()
+			.MarkAsFloating(window.Object)
+			.Setup_RemoveWindow(window.Object, newInnerLayoutEngine);
+		FloatingLayoutEngine engine =
+			new(wrapper.Context.Object, wrapper.Plugin.Object, wrapper.InnerLayoutEngine.Object);
+
+		// When
+		engine.AddWindow(window.Object).FocusWindowInDirection(direction, window.Object);
+
+		// Then
+		wrapper.InnerLayoutEngine.Verify(ile => ile.FocusWindowInDirection(direction, window.Object), Times.Never);
+	}
+	#endregion
+
+	#region SwapWindowInDirection
+	[Fact]
+	public void SwapWindowInDirection_UseInner()
+	{
+		// Given
+		Mock<IWindow> window = new();
+		Direction direction = Direction.Left;
+
+		Wrapper wrapper = new();
+		FloatingLayoutEngine engine =
+			new(wrapper.Context.Object, wrapper.Plugin.Object, wrapper.InnerLayoutEngine.Object);
+
+		// When
+		engine.SwapWindowInDirection(direction, window.Object);
+
+		// Then
+		wrapper.InnerLayoutEngine.Verify(ile => ile.SwapWindowInDirection(direction, window.Object), Times.Once);
+	}
+
+	[Fact]
+	public void SwapWindowInDirection_FloatingWindow()
+	{
+		// Given
+		Mock<IWindow> window = new();
+		Mock<ILayoutEngine> newInnerLayoutEngine = new();
+		Direction direction = Direction.Left;
+
+		Wrapper wrapper = new Wrapper()
+			.MarkAsFloating(window.Object)
+			.Setup_RemoveWindow(window.Object, newInnerLayoutEngine);
+		FloatingLayoutEngine engine =
+			new(wrapper.Context.Object, wrapper.Plugin.Object, wrapper.InnerLayoutEngine.Object);
+
+		// When
+		engine.AddWindow(window.Object).SwapWindowInDirection(direction, window.Object);
+
+		// Then
+		wrapper.InnerLayoutEngine.Verify(ile => ile.SwapWindowInDirection(direction, window.Object), Times.Never);
+	}
+	#endregion
+
+	#region ContainsWindow
+	[Fact]
+	public void ContainsWindow_UseInner()
+	{
+		// Given
+		Mock<IWindow> window = new();
+
+		Wrapper wrapper = new();
+		FloatingLayoutEngine engine =
+			new(wrapper.Context.Object, wrapper.Plugin.Object, wrapper.InnerLayoutEngine.Object);
+
+		// When
+		bool containsWindow = engine.ContainsWindow(window.Object);
+
+		// Then
+		Assert.False(containsWindow);
+		wrapper.InnerLayoutEngine.Verify(ile => ile.ContainsWindow(window.Object), Times.Once);
+	}
+
+	[Fact]
+	public void ContainsWindow_FloatingWindow()
+	{
+		// Given
+		Mock<IWindow> window = new();
+		Mock<ILayoutEngine> newInnerLayoutEngine = new();
+
+		Wrapper wrapper = new Wrapper()
+			.MarkAsFloating(window.Object)
+			.Setup_RemoveWindow(window.Object, newInnerLayoutEngine);
+		FloatingLayoutEngine engine =
+			new(wrapper.Context.Object, wrapper.Plugin.Object, wrapper.InnerLayoutEngine.Object);
+
+		// When
+		bool containsWindow = engine.AddWindow(window.Object).ContainsWindow(window.Object);
+
+		// Then
+		Assert.True(containsWindow);
+		wrapper.InnerLayoutEngine.Verify(ile => ile.ContainsWindow(window.Object), Times.Never);
+	}
+	#endregion
+
+	[Fact]
+	public void HidePhantomWindows()
+	{
+		// Given
+		Wrapper wrapper = new();
+		FloatingLayoutEngine engine =
+			new(wrapper.Context.Object, wrapper.Plugin.Object, wrapper.InnerLayoutEngine.Object);
+
+		// When
+		engine.HidePhantomWindows();
+
+		// Then
+		wrapper.InnerLayoutEngine.Verify(ile => ile.HidePhantomWindows(), Times.Once);
+	}
 }

--- a/src/Whim.FloatingLayout.Tests/FloatingLayoutPluginTests.cs
+++ b/src/Whim.FloatingLayout.Tests/FloatingLayoutPluginTests.cs
@@ -203,7 +203,7 @@ public class FloatingLayoutPluginTests
 
 		// Then
 		Assert.Single(plugin.FloatingWindows);
-		Assert.Equal(window.Object, plugin.FloatingWindows.First());
+		Assert.Equal(window.Object, plugin.FloatingWindows.Keys.First());
 		wrapper.Workspace.Verify(w => w.MoveWindowToPoint(window.Object, It.IsAny<IPoint<double>>()), Times.Once);
 	}
 	#endregion
@@ -284,7 +284,7 @@ public class FloatingLayoutPluginTests
 
 		// Then
 		Assert.Single(plugin.FloatingWindows);
-		Assert.Equal(window.Object, plugin.FloatingWindows.First());
+		Assert.Equal(window.Object, plugin.FloatingWindows.Keys.First());
 	}
 
 	[Fact]

--- a/src/Whim.FloatingLayout.Tests/FloatingLayoutPluginTests.cs
+++ b/src/Whim.FloatingLayout.Tests/FloatingLayoutPluginTests.cs
@@ -41,6 +41,11 @@ public class FloatingLayoutPluginTests
 		public Wrapper Setup_TryGetWindowLocation(IWindow window, IWindowState? windowState)
 		{
 			Workspace.Setup(w => w.TryGetWindowLocation(window)).Returns(windowState);
+
+			if (windowState != null)
+			{
+				Workspace.Setup(w => w.ActiveLayoutEngine).Returns(FloatingLayoutEngine);
+			}
 			return this;
 		}
 

--- a/src/Whim.FloatingLayout.Tests/FloatingLayoutPluginTests.cs
+++ b/src/Whim.FloatingLayout.Tests/FloatingLayoutPluginTests.cs
@@ -113,6 +113,37 @@ public class FloatingLayoutPluginTests
 		wrapper.WorkspaceManager.Verify(x => x.AddProxyLayoutEngine(It.IsAny<CreateProxyLayoutEngine>()), Times.Never);
 	}
 
+	[Fact]
+	public void WindowManager_WindowRemoved()
+	{
+		// Given
+		Mock<IWindow> window = new();
+		Mock<IMonitor> monitor = new();
+		Location<int> location = new();
+		WindowState windowState =
+			new()
+			{
+				Window = window.Object,
+				Location = location,
+				WindowSize = WindowSize.Normal
+			};
+
+		Wrapper wrapper = new();
+		wrapper
+			.Setup_GetWorkspaceForWindow(window.Object, wrapper.Workspace.Object)
+			.Setup_TryGetWindowLocation(window.Object, windowState)
+			.Setup_GetMonitorAtPoint(location, monitor);
+		FloatingLayoutPlugin plugin = wrapper.Plugin;
+
+		// When
+		plugin.PreInitialize();
+		plugin.MarkWindowAsFloating(window.Object);
+		wrapper.WindowManager.Raise(x => x.WindowRemoved += null, new WindowEventArgs() { Window = window.Object });
+
+		// Then nothing
+		Assert.Empty(plugin.FloatingWindows);
+	}
+
 	#region MarkWindowAsFloating
 	[Fact]
 	public void MarkWindowAsFloating_NoWindow()
@@ -213,8 +244,25 @@ public class FloatingLayoutPluginTests
 	}
 	#endregion
 
+	#region MarkWindowAsDocked
 	[Fact]
-	public void MarkWindowAsDocked()
+	public void MarkWindowAsDocked_WindowIsNotFloating()
+	{
+		// Given
+		Mock<IWindow> window = new();
+		Wrapper wrapper = new();
+		FloatingLayoutPlugin plugin = wrapper.Plugin;
+
+		// When
+		plugin.MarkWindowAsDocked(window.Object);
+
+		// Then
+		Assert.Empty(plugin.FloatingWindows);
+		wrapper.Workspace.Verify(w => w.MoveWindowToPoint(window.Object, It.IsAny<IPoint<double>>()), Times.Never);
+	}
+
+	[Fact]
+	public void MarkWindowAsDocked_WindowIsFloating()
 	{
 		// Given
 		Mock<IWindow> window = new();
@@ -244,6 +292,7 @@ public class FloatingLayoutPluginTests
 		Assert.Empty(plugin.FloatingWindows);
 		wrapper.Workspace.Verify(w => w.MoveWindowToPoint(window.Object, It.IsAny<IPoint<double>>()), Times.Exactly(2));
 	}
+	#endregion
 
 	#region ToggleWindowFloating
 	[Fact]

--- a/src/Whim.FloatingLayout/FloatingLayoutEngine.cs
+++ b/src/Whim.FloatingLayout/FloatingLayoutEngine.cs
@@ -101,7 +101,7 @@ public class FloatingLayoutEngine : BaseProxyLayoutEngine
 	}
 
 	/// <inheritdoc />
-	public override ILayoutEngine AddAtPoint(IWindow window, IPoint<double> point) => Add(window);
+	public override ILayoutEngine MoveWindowToPoint(IWindow window, IPoint<double> point) => Add(window);
 
 	/// <inheritdoc />
 	public override IEnumerable<IWindowState> DoLayout(ILocation<int> location, IMonitor monitor)

--- a/src/Whim.FloatingLayout/FloatingLayoutEngine.cs
+++ b/src/Whim.FloatingLayout/FloatingLayoutEngine.cs
@@ -48,6 +48,9 @@ public class FloatingLayoutEngine : BaseProxyLayoutEngine
 		_floatingWindowLocations = floatingWindowLocations;
 	}
 
+	private FloatingLayoutEngine UpdateInner(ILayoutEngine newInnerLayoutEngine) =>
+		InnerLayoutEngine == newInnerLayoutEngine ? this : new FloatingLayoutEngine(this, newInnerLayoutEngine);
+
 	/// <inheritdoc />
 	public override ILayoutEngine AddWindow(IWindow window)
 	{
@@ -58,7 +61,7 @@ public class FloatingLayoutEngine : BaseProxyLayoutEngine
 			return UpdateWindowLocation(window);
 		}
 
-		return new FloatingLayoutEngine(this, InnerLayoutEngine.AddWindow(window));
+		return UpdateInner(InnerLayoutEngine.AddWindow(window));
 	}
 
 	/// <inheritdoc />
@@ -72,7 +75,7 @@ public class FloatingLayoutEngine : BaseProxyLayoutEngine
 			return new FloatingLayoutEngine(this, InnerLayoutEngine, _floatingWindowLocations.Remove(window));
 		}
 
-		return new FloatingLayoutEngine(this, InnerLayoutEngine.RemoveWindow(window));
+		return UpdateInner(InnerLayoutEngine.RemoveWindow(window));
 	}
 
 	/// <inheritdoc />
@@ -84,7 +87,7 @@ public class FloatingLayoutEngine : BaseProxyLayoutEngine
 			return UpdateWindowLocation(window);
 		}
 
-		return new FloatingLayoutEngine(this, InnerLayoutEngine.MoveWindowToPoint(window, point));
+		return UpdateInner(InnerLayoutEngine.MoveWindowToPoint(window, point));
 	}
 
 	/// <inheritdoc />

--- a/src/Whim.FloatingLayout/FloatingLayoutEngine.cs
+++ b/src/Whim.FloatingLayout/FloatingLayoutEngine.cs
@@ -7,10 +7,10 @@ namespace Whim.FloatingLayout;
 /// <summary>
 /// A proxy layout engine to allow windows to be free-floating.
 /// </summary>
-public class FloatingLayoutEngine : BaseProxyLayoutEngine
+internal class FloatingLayoutEngine : BaseProxyLayoutEngine
 {
 	private readonly IContext _context;
-	private readonly FloatingLayoutPlugin _plugin;
+	private readonly IInternalFloatingLayoutPlugin _plugin;
 	private readonly ImmutableDictionary<IWindow, ILocation<double>> _floatingWindowLocations;
 
 	/// <inheritdoc />
@@ -22,7 +22,7 @@ public class FloatingLayoutEngine : BaseProxyLayoutEngine
 	/// <param name="context"></param>
 	/// <param name="plugin"></param>
 	/// <param name="innerLayoutEngine"></param>
-	public FloatingLayoutEngine(IContext context, FloatingLayoutPlugin plugin, ILayoutEngine innerLayoutEngine)
+	public FloatingLayoutEngine(IContext context, IInternalFloatingLayoutPlugin plugin, ILayoutEngine innerLayoutEngine)
 		: base(innerLayoutEngine)
 	{
 		_context = context;
@@ -58,7 +58,12 @@ public class FloatingLayoutEngine : BaseProxyLayoutEngine
 		// update the location and return.
 		if (IsWindowFloating(window))
 		{
-			return UpdateWindowLocation(window);
+			// return UpdateWindowLocation(window);
+			FloatingLayoutEngine newEngine = UpdateWindowLocation(window);
+			if (newEngine != this)
+			{
+				return newEngine;
+			}
 		}
 
 		return UpdateInner(InnerLayoutEngine.AddWindow(window));

--- a/src/Whim.FloatingLayout/FloatingLayoutEngine.cs
+++ b/src/Whim.FloatingLayout/FloatingLayoutEngine.cs
@@ -155,17 +155,9 @@ internal class FloatingLayoutEngine : BaseProxyLayoutEngine
 	/// <inheritdoc />
 	public override IEnumerable<IWindowState> DoLayout(ILocation<int> location, IMonitor monitor)
 	{
-		List<IWindow> windowsToRemove = new();
-
 		// Iterate over all windows in _windowToLocation.
 		foreach ((IWindow window, ILocation<double> loc) in _floatingWindowLocations)
 		{
-			if (!_plugin.FloatingWindows.ContainsKey(window))
-			{
-				windowsToRemove.Add(window);
-				continue;
-			}
-
 			yield return new WindowState()
 			{
 				Window = window,
@@ -178,12 +170,6 @@ internal class FloatingLayoutEngine : BaseProxyLayoutEngine
 		foreach (IWindowState windowLocation in InnerLayoutEngine.DoLayout(location, monitor))
 		{
 			yield return windowLocation;
-		}
-
-		// Remove all windows that are no longer floating.
-		foreach (IWindow window in windowsToRemove)
-		{
-			_floatingWindowLocations.Remove(window);
 		}
 	}
 

--- a/src/Whim.FloatingLayout/FloatingLayoutEngine.cs
+++ b/src/Whim.FloatingLayout/FloatingLayoutEngine.cs
@@ -49,12 +49,6 @@ public class FloatingLayoutEngine : BaseProxyLayoutEngine
 	}
 
 	/// <inheritdoc />
-	protected override ILayoutEngine Update(ILayoutEngine newInnerLayoutEngine) =>
-		newInnerLayoutEngine == InnerLayoutEngine
-			? this
-			: new FloatingLayoutEngine(_context, _plugin, newInnerLayoutEngine);
-
-	/// <inheritdoc />
 	public override ILayoutEngine AddWindow(IWindow window)
 	{
 		// If the window is already tracked by this layout engine, or is a new floating window,

--- a/src/Whim.FloatingLayout/FloatingLayoutEngine.cs
+++ b/src/Whim.FloatingLayout/FloatingLayoutEngine.cs
@@ -50,7 +50,7 @@ public class FloatingLayoutEngine : BaseProxyLayoutEngine
 		newInnerLayoutEngine == InnerLayoutEngine ? this : new FloatingLayoutEngine(this, newInnerLayoutEngine);
 
 	/// <inheritdoc />
-	public override ILayoutEngine Add(IWindow window)
+	public override ILayoutEngine AddWindow(IWindow window)
 	{
 		// If the window is already tracked by this layout engine, or is a new floating window,
 		// update the location and return.
@@ -62,7 +62,7 @@ public class FloatingLayoutEngine : BaseProxyLayoutEngine
 			return UpdateWindowLocation(window, location);
 		}
 
-		return base.Add(window);
+		return base.AddWindow(window);
 	}
 
 	private FloatingLayoutEngine UpdateWindowLocation(IWindow window, ILocation<double>? oldLocation)
@@ -87,7 +87,7 @@ public class FloatingLayoutEngine : BaseProxyLayoutEngine
 	}
 
 	/// <inheritdoc />
-	public override ILayoutEngine Remove(IWindow window)
+	public override ILayoutEngine RemoveWindow(IWindow window)
 	{
 		// If tracked by this layout engine, remove it.
 		// Otherwise, pass to the inner layout engine.
@@ -97,11 +97,11 @@ public class FloatingLayoutEngine : BaseProxyLayoutEngine
 			return new FloatingLayoutEngine(this, _floatingWindowLocations.Remove(window));
 		}
 
-		return base.Remove(window);
+		return base.RemoveWindow(window);
 	}
 
 	/// <inheritdoc />
-	public override ILayoutEngine MoveWindowToPoint(IWindow window, IPoint<double> point) => Add(window);
+	public override ILayoutEngine MoveWindowToPoint(IWindow window, IPoint<double> point) => AddWindow(window);
 
 	/// <inheritdoc />
 	public override IEnumerable<IWindowState> DoLayout(ILocation<int> location, IMonitor monitor)

--- a/src/Whim.FloatingLayout/FloatingLayoutPlugin.cs
+++ b/src/Whim.FloatingLayout/FloatingLayoutPlugin.cs
@@ -11,7 +11,11 @@ public class FloatingLayoutPlugin : IFloatingLayoutPlugin
 	/// <inheritdoc />
 	public string Name => "whim.floating_layout";
 
-	/// <inheritdoc />
+	/// <summary>
+	/// Mapping of floating windows to the layout engines that they are floating in.
+	/// This is not exposed outside of this namespace to prevent mutation of the dictionary and
+	/// sets.
+	/// </summary>
 	internal IDictionary<IWindow, ISet<LayoutEngineIdentity>> FloatingWindows { get; } =
 		new Dictionary<IWindow, ISet<LayoutEngineIdentity>>();
 

--- a/src/Whim.FloatingLayout/FloatingLayoutPlugin.cs
+++ b/src/Whim.FloatingLayout/FloatingLayoutPlugin.cs
@@ -4,19 +4,15 @@ using System.Text.Json;
 namespace Whim.FloatingLayout;
 
 /// <inheritdoc />
-public class FloatingLayoutPlugin : IFloatingLayoutPlugin
+public class FloatingLayoutPlugin : IFloatingLayoutPlugin, IInternalFloatingLayoutPlugin
 {
 	private readonly IContext _context;
 
 	/// <inheritdoc />
 	public string Name => "whim.floating_layout";
 
-	/// <summary>
-	/// Mapping of floating windows to the layout engines that they are floating in.
-	/// This is not exposed outside of this namespace to prevent mutation of the dictionary and
-	/// sets.
-	/// </summary>
-	internal IDictionary<IWindow, ISet<LayoutEngineIdentity>> FloatingWindows { get; } =
+	/// <inheritdoc/>
+	public IDictionary<IWindow, ISet<LayoutEngineIdentity>> FloatingWindows { get; } =
 		new Dictionary<IWindow, ISet<LayoutEngineIdentity>>();
 
 	/// <summary>

--- a/src/Whim.FloatingLayout/FloatingLayoutPlugin.cs
+++ b/src/Whim.FloatingLayout/FloatingLayoutPlugin.cs
@@ -95,6 +95,7 @@ public class FloatingLayoutPlugin : IFloatingLayoutPlugin
 		{
 			FloatingWindows.Remove(window);
 		}
+		else
 		{
 			FloatingWindows[window] = layoutEngines;
 		}

--- a/src/Whim.FloatingLayout/IFloatingLayoutPlugin.cs
+++ b/src/Whim.FloatingLayout/IFloatingLayoutPlugin.cs
@@ -1,5 +1,3 @@
-using System.Collections.Generic;
-
 namespace Whim.FloatingLayout;
 
 /// <summary>
@@ -7,11 +5,6 @@ namespace Whim.FloatingLayout;
 /// </summary>
 public interface IFloatingLayoutPlugin : IPlugin
 {
-	/// <summary>
-	/// All the floating windows.
-	/// </summary>
-	IReadOnlySet<IWindow> FloatingWindows { get; }
-
 	/// <summary>
 	/// Mark the given <paramref name="window"/> as a floating window
 	/// </summary>

--- a/src/Whim.FloatingLayout/IInternalFloatingLayoutPlugin.cs
+++ b/src/Whim.FloatingLayout/IInternalFloatingLayoutPlugin.cs
@@ -1,0 +1,13 @@
+using System.Collections.Generic;
+
+namespace Whim.FloatingLayout;
+
+internal interface IInternalFloatingLayoutPlugin
+{
+	/// <summary>
+	/// Mapping of floating windows to the layout engines that they are floating in.
+	/// This is not exposed outside of this namespace to prevent mutation of the dictionary and
+	/// sets.
+	/// </summary>
+	IDictionary<IWindow, ISet<LayoutEngineIdentity>> FloatingWindows { get; }
+}

--- a/src/Whim.FloatingLayout/IInternalFloatingLayoutPlugin.cs
+++ b/src/Whim.FloatingLayout/IInternalFloatingLayoutPlugin.cs
@@ -1,8 +1,0 @@
-using System.Collections.Generic;
-
-namespace Whim.FloatingLayout;
-
-internal interface IInternalFloatingLayoutPlugin
-{
-	ISet<IWindow> MutableFloatingWindows { get; }
-}

--- a/src/Whim.Gaps.Tests/GapsCommandsTests.cs
+++ b/src/Whim.Gaps.Tests/GapsCommandsTests.cs
@@ -1,5 +1,5 @@
 using Moq;
-using Whim.TestUtilities;
+using Whim.TestUtils;
 using Xunit;
 
 namespace Whim.Gaps.Tests;

--- a/src/Whim.Gaps.Tests/GapsLayoutEngineTests.cs
+++ b/src/Whim.Gaps.Tests/GapsLayoutEngineTests.cs
@@ -98,7 +98,7 @@ public class GapsLayoutEngineTests
 
 		for (int i = 0; i < windowsCount; i++)
 		{
-			innerLayoutEngine = innerLayoutEngine.Add(new Mock<IWindow>().Object);
+			innerLayoutEngine = innerLayoutEngine.AddWindow(new Mock<IWindow>().Object);
 		}
 
 		GapsLayoutEngine gapsLayoutEngine = new(gapsConfig, innerLayoutEngine);
@@ -131,7 +131,7 @@ public class GapsLayoutEngineTests
 		GapsLayoutEngine gapsLayoutEngine = new(gapsConfig, innerLayoutEngine);
 
 		// When
-		ILayoutEngine newEngine = gapsLayoutEngine.Remove(new Mock<IWindow>().Object);
+		ILayoutEngine newEngine = gapsLayoutEngine.RemoveWindow(new Mock<IWindow>().Object);
 
 		// Then
 		Assert.Same(newEngine, gapsLayoutEngine);
@@ -147,7 +147,7 @@ public class GapsLayoutEngineTests
 		GapsLayoutEngine gapsLayoutEngine = new(gapsConfig, innerLayoutEngine);
 
 		// When
-		ILayoutEngine newEngine = gapsLayoutEngine.Add(new Mock<IWindow>().Object);
+		ILayoutEngine newEngine = gapsLayoutEngine.AddWindow(new Mock<IWindow>().Object);
 
 		// Then
 		Assert.NotSame(newEngine, gapsLayoutEngine);

--- a/src/Whim.Gaps.Tests/GapsLayoutEngineTests.cs
+++ b/src/Whim.Gaps.Tests/GapsLayoutEngineTests.cs
@@ -123,34 +123,292 @@ public class GapsLayoutEngineTests
 	}
 
 	[Fact]
-	public void Update_Same()
+	public void Count()
 	{
 		// Given
 		GapsConfig gapsConfig = new() { OuterGap = 10, InnerGap = 5 };
-		ILayoutEngine innerLayoutEngine = new ColumnLayoutEngine(_identity);
-		GapsLayoutEngine gapsLayoutEngine = new(gapsConfig, innerLayoutEngine);
+		Mock<ILayoutEngine> innerLayoutEngine = new();
+		innerLayoutEngine.Setup(ile => ile.Count).Returns(5);
+
+		GapsLayoutEngine gapsLayoutEngine = new(gapsConfig, innerLayoutEngine.Object);
 
 		// When
-		ILayoutEngine newEngine = gapsLayoutEngine.RemoveWindow(new Mock<IWindow>().Object);
 
 		// Then
-		Assert.Same(newEngine, gapsLayoutEngine);
-		Assert.IsType<GapsLayoutEngine>(newEngine);
+		Assert.Equal(5, gapsLayoutEngine.Count);
+		innerLayoutEngine.Verify(ile => ile.Count, Times.Once);
 	}
 
 	[Fact]
-	public void Update_Different()
+	public void ContainsWindow()
+	{
+		// Given
+		Mock<IWindow> window = new();
+		GapsConfig gapsConfig = new() { OuterGap = 10, InnerGap = 5 };
+		Mock<ILayoutEngine> innerLayoutEngine = new();
+		innerLayoutEngine.Setup(ile => ile.ContainsWindow(It.IsAny<IWindow>())).Returns(true);
+
+		GapsLayoutEngine gapsLayoutEngine = new(gapsConfig, innerLayoutEngine.Object);
+
+		// When
+		bool containsWindow = gapsLayoutEngine.ContainsWindow(window.Object);
+
+		// Then
+		Assert.True(containsWindow);
+		innerLayoutEngine.Verify(ile => ile.ContainsWindow(window.Object), Times.Once);
+	}
+
+	[Fact]
+	public void FocusWindowInDirection()
+	{
+		// Given
+		Mock<IWindow> window = new();
+		Direction direction = Direction.Left;
+		GapsConfig gapsConfig = new() { OuterGap = 10, InnerGap = 5 };
+		Mock<ILayoutEngine> innerLayoutEngine = new();
+		innerLayoutEngine.Setup(ile => ile.FocusWindowInDirection(direction, window.Object));
+
+		GapsLayoutEngine gapsLayoutEngine = new(gapsConfig, innerLayoutEngine.Object);
+
+		// When
+		gapsLayoutEngine.FocusWindowInDirection(direction, window.Object);
+
+		// Then
+		innerLayoutEngine.Verify(ile => ile.FocusWindowInDirection(direction, window.Object), Times.Once);
+	}
+
+	[Fact]
+	public void HidePhantomWindows()
 	{
 		// Given
 		GapsConfig gapsConfig = new() { OuterGap = 10, InnerGap = 5 };
-		ILayoutEngine innerLayoutEngine = new ColumnLayoutEngine(_identity);
-		GapsLayoutEngine gapsLayoutEngine = new(gapsConfig, innerLayoutEngine);
+		Mock<ILayoutEngine> innerLayoutEngine = new();
+		innerLayoutEngine.Setup(ile => ile.HidePhantomWindows());
+
+		GapsLayoutEngine gapsLayoutEngine = new(gapsConfig, innerLayoutEngine.Object);
 
 		// When
-		ILayoutEngine newEngine = gapsLayoutEngine.AddWindow(new Mock<IWindow>().Object);
+		gapsLayoutEngine.HidePhantomWindows();
 
 		// Then
-		Assert.NotSame(newEngine, gapsLayoutEngine);
-		Assert.IsType<GapsLayoutEngine>(newEngine);
+		innerLayoutEngine.Verify(ile => ile.HidePhantomWindows(), Times.Once);
 	}
+
+	#region Add
+	[Fact]
+	public void Add_Same()
+	{
+		// Given
+		Mock<IWindow> window = new();
+		GapsConfig gapsConfig = new() { OuterGap = 10, InnerGap = 5 };
+		Mock<ILayoutEngine> innerLayoutEngine = new();
+		innerLayoutEngine.Setup(ile => ile.AddWindow(window.Object)).Returns(innerLayoutEngine.Object);
+
+		GapsLayoutEngine gapsLayoutEngine = new(gapsConfig, innerLayoutEngine.Object);
+
+		// When
+		ILayoutEngine newLayoutEngine = gapsLayoutEngine.AddWindow(window.Object);
+
+		// Then
+		Assert.Same(gapsLayoutEngine, newLayoutEngine);
+		innerLayoutEngine.Verify(ile => ile.AddWindow(window.Object), Times.Once);
+	}
+
+	[Fact]
+	public void Add_NotSame()
+	{
+		// Given
+		Mock<IWindow> window = new();
+		GapsConfig gapsConfig = new() { OuterGap = 10, InnerGap = 5 };
+		Mock<ILayoutEngine> innerLayoutEngine = new();
+		innerLayoutEngine.Setup(ile => ile.AddWindow(window.Object)).Returns(new Mock<ILayoutEngine>().Object);
+
+		GapsLayoutEngine gapsLayoutEngine = new(gapsConfig, innerLayoutEngine.Object);
+
+		// When
+		ILayoutEngine newLayoutEngine = gapsLayoutEngine.AddWindow(window.Object);
+
+		// Then
+		Assert.NotSame(gapsLayoutEngine, newLayoutEngine);
+		innerLayoutEngine.Verify(ile => ile.AddWindow(window.Object), Times.Once);
+	}
+	#endregion
+
+	#region Remove
+	[Fact]
+	public void Remove_Same()
+	{
+		// Given
+		Mock<IWindow> window = new();
+		GapsConfig gapsConfig = new() { OuterGap = 10, InnerGap = 5 };
+		Mock<ILayoutEngine> innerLayoutEngine = new();
+		innerLayoutEngine.Setup(ile => ile.RemoveWindow(window.Object)).Returns(innerLayoutEngine.Object);
+
+		GapsLayoutEngine gapsLayoutEngine = new(gapsConfig, innerLayoutEngine.Object);
+
+		// When
+		ILayoutEngine newLayoutEngine = gapsLayoutEngine.RemoveWindow(window.Object);
+
+		// Then
+		Assert.Same(gapsLayoutEngine, newLayoutEngine);
+		innerLayoutEngine.Verify(ile => ile.RemoveWindow(window.Object), Times.Once);
+	}
+
+	[Fact]
+	public void Remove_NotSame()
+	{
+		// Given
+		Mock<IWindow> window = new();
+		GapsConfig gapsConfig = new() { OuterGap = 10, InnerGap = 5 };
+		Mock<ILayoutEngine> innerLayoutEngine = new();
+		innerLayoutEngine.Setup(ile => ile.RemoveWindow(window.Object)).Returns(new Mock<ILayoutEngine>().Object);
+
+		GapsLayoutEngine gapsLayoutEngine = new(gapsConfig, innerLayoutEngine.Object);
+
+		// When
+		ILayoutEngine newLayoutEngine = gapsLayoutEngine.RemoveWindow(window.Object);
+
+		// Then
+		Assert.NotSame(gapsLayoutEngine, newLayoutEngine);
+		innerLayoutEngine.Verify(ile => ile.RemoveWindow(window.Object), Times.Once);
+	}
+	#endregion
+
+	#region MoveWindowEdgesInDirection
+	[Fact]
+	public void MoveWindowEdgesInDirection_Same()
+	{
+		// Given
+		Mock<IWindow> window = new();
+		Direction direction = Direction.Left;
+		IPoint<double> deltas = new Point<double>();
+		GapsConfig gapsConfig = new() { OuterGap = 10, InnerGap = 5 };
+		Mock<ILayoutEngine> innerLayoutEngine = new();
+		innerLayoutEngine
+			.Setup(ile => ile.MoveWindowEdgesInDirection(direction, deltas, window.Object))
+			.Returns(innerLayoutEngine.Object);
+
+		GapsLayoutEngine gapsLayoutEngine = new(gapsConfig, innerLayoutEngine.Object);
+
+		// When
+		ILayoutEngine newLayoutEngine = gapsLayoutEngine.MoveWindowEdgesInDirection(direction, deltas, window.Object);
+
+		// Then
+		Assert.Same(gapsLayoutEngine, newLayoutEngine);
+		innerLayoutEngine.Verify(ile => ile.MoveWindowEdgesInDirection(direction, deltas, window.Object), Times.Once);
+	}
+
+	[Fact]
+	public void MoveWindowEdgesInDirection_NotSame()
+	{
+		// Given
+		Mock<IWindow> window = new();
+		Direction direction = Direction.Left;
+		IPoint<double> deltas = new Point<double>();
+		GapsConfig gapsConfig = new() { OuterGap = 10, InnerGap = 5 };
+		Mock<ILayoutEngine> innerLayoutEngine = new();
+		innerLayoutEngine
+			.Setup(ile => ile.MoveWindowEdgesInDirection(direction, deltas, window.Object))
+			.Returns(new Mock<ILayoutEngine>().Object);
+
+		GapsLayoutEngine gapsLayoutEngine = new(gapsConfig, innerLayoutEngine.Object);
+
+		// When
+		ILayoutEngine newLayoutEngine = gapsLayoutEngine.MoveWindowEdgesInDirection(direction, deltas, window.Object);
+
+		// Then
+		Assert.NotSame(gapsLayoutEngine, newLayoutEngine);
+		innerLayoutEngine.Verify(ile => ile.MoveWindowEdgesInDirection(direction, deltas, window.Object), Times.Once);
+	}
+	#endregion
+
+	#region MoveWindowToPoint
+	[Fact]
+	public void MoveWindowToPoint_Same()
+	{
+		// Given
+		Mock<IWindow> window = new();
+		IPoint<double> point = new Point<double>();
+		GapsConfig gapsConfig = new() { OuterGap = 10, InnerGap = 5 };
+		Mock<ILayoutEngine> innerLayoutEngine = new();
+		innerLayoutEngine.Setup(ile => ile.MoveWindowToPoint(window.Object, point)).Returns(innerLayoutEngine.Object);
+
+		GapsLayoutEngine gapsLayoutEngine = new(gapsConfig, innerLayoutEngine.Object);
+
+		// When
+		ILayoutEngine newLayoutEngine = gapsLayoutEngine.MoveWindowToPoint(window.Object, point);
+
+		// Then
+		Assert.Same(gapsLayoutEngine, newLayoutEngine);
+		innerLayoutEngine.Verify(ile => ile.MoveWindowToPoint(window.Object, point), Times.Once);
+	}
+
+	[Fact]
+	public void MoveWindowToPoint_NotSame()
+	{
+		// Given
+		Mock<IWindow> window = new();
+		IPoint<double> point = new Point<double>();
+		GapsConfig gapsConfig = new() { OuterGap = 10, InnerGap = 5 };
+		Mock<ILayoutEngine> innerLayoutEngine = new();
+		innerLayoutEngine
+			.Setup(ile => ile.MoveWindowToPoint(window.Object, point))
+			.Returns(new Mock<ILayoutEngine>().Object);
+
+		GapsLayoutEngine gapsLayoutEngine = new(gapsConfig, innerLayoutEngine.Object);
+
+		// When
+		ILayoutEngine newLayoutEngine = gapsLayoutEngine.MoveWindowToPoint(window.Object, point);
+
+		// Then
+		Assert.NotSame(gapsLayoutEngine, newLayoutEngine);
+		innerLayoutEngine.Verify(ile => ile.MoveWindowToPoint(window.Object, point), Times.Once);
+	}
+	#endregion
+
+	#region SwapWindowInDirection
+	[Fact]
+	public void SwapWindowInDirection_Same()
+	{
+		// Given
+		Mock<IWindow> window = new();
+		Direction direction = Direction.Left;
+		GapsConfig gapsConfig = new() { OuterGap = 10, InnerGap = 5 };
+		Mock<ILayoutEngine> innerLayoutEngine = new();
+		innerLayoutEngine
+			.Setup(ile => ile.SwapWindowInDirection(direction, window.Object))
+			.Returns(innerLayoutEngine.Object);
+
+		GapsLayoutEngine gapsLayoutEngine = new(gapsConfig, innerLayoutEngine.Object);
+
+		// When
+		ILayoutEngine newLayoutEngine = gapsLayoutEngine.SwapWindowInDirection(direction, window.Object);
+
+		// Then
+		Assert.Same(gapsLayoutEngine, newLayoutEngine);
+		innerLayoutEngine.Verify(ile => ile.SwapWindowInDirection(direction, window.Object), Times.Once);
+	}
+
+	[Fact]
+	public void SwapWindowInDirection_NotSame()
+	{
+		// Given
+		Mock<IWindow> window = new();
+		Direction direction = Direction.Left;
+		GapsConfig gapsConfig = new() { OuterGap = 10, InnerGap = 5 };
+		Mock<ILayoutEngine> innerLayoutEngine = new();
+		innerLayoutEngine
+			.Setup(ile => ile.SwapWindowInDirection(direction, window.Object))
+			.Returns(new Mock<ILayoutEngine>().Object);
+
+		GapsLayoutEngine gapsLayoutEngine = new(gapsConfig, innerLayoutEngine.Object);
+
+		// When
+		ILayoutEngine newLayoutEngine = gapsLayoutEngine.SwapWindowInDirection(direction, window.Object);
+
+		// Then
+		Assert.NotSame(gapsLayoutEngine, newLayoutEngine);
+		innerLayoutEngine.Verify(ile => ile.SwapWindowInDirection(direction, window.Object), Times.Once);
+	}
+	#endregion
 }

--- a/src/Whim.Gaps.Tests/GapsLayoutEngineTests.cs
+++ b/src/Whim.Gaps.Tests/GapsLayoutEngineTests.cs
@@ -411,4 +411,23 @@ public class GapsLayoutEngineTests
 		innerLayoutEngine.Verify(ile => ile.SwapWindowInDirection(direction, window.Object), Times.Once);
 	}
 	#endregion
+
+	[Fact]
+	public void GetFirstWindow()
+	{
+		// Given
+		Mock<IWindow> window = new();
+		GapsConfig gapsConfig = new() { OuterGap = 10, InnerGap = 5 };
+		Mock<ILayoutEngine> innerLayoutEngine = new();
+		innerLayoutEngine.Setup(ile => ile.GetFirstWindow()).Returns(window.Object);
+
+		GapsLayoutEngine gapsLayoutEngine = new(gapsConfig, innerLayoutEngine.Object);
+
+		// When
+		IWindow? firstWindow = gapsLayoutEngine.GetFirstWindow();
+
+		// Then
+		Assert.Same(window.Object, firstWindow);
+		innerLayoutEngine.Verify(ile => ile.GetFirstWindow(), Times.Once);
+	}
 }

--- a/src/Whim.Gaps/GapsLayoutEngine.cs
+++ b/src/Whim.Gaps/GapsLayoutEngine.cs
@@ -26,12 +26,14 @@ public class GapsLayoutEngine : BaseProxyLayoutEngine
 		_gapsConfig = oldEngine._gapsConfig;
 	}
 
+	private GapsLayoutEngine UpdateInner(ILayoutEngine newInnerLayoutEngine) =>
+		InnerLayoutEngine == newInnerLayoutEngine ? this : new GapsLayoutEngine(this, newInnerLayoutEngine);
+
 	/// <inheritdoc />
 	public override int Count => InnerLayoutEngine.Count;
 
 	/// <inheritdoc />
-	public override ILayoutEngine AddWindow(IWindow window) =>
-		new GapsLayoutEngine(this, InnerLayoutEngine.AddWindow(window));
+	public override ILayoutEngine AddWindow(IWindow window) => UpdateInner(InnerLayoutEngine.AddWindow(window));
 
 	/// <inheritdoc />
 	public override bool ContainsWindow(IWindow window) => InnerLayoutEngine.ContainsWindow(window);
@@ -86,17 +88,16 @@ public class GapsLayoutEngine : BaseProxyLayoutEngine
 
 	/// <inheritdoc />
 	public override ILayoutEngine MoveWindowEdgesInDirection(Direction edge, IPoint<double> deltas, IWindow window) =>
-		new GapsLayoutEngine(this, InnerLayoutEngine.MoveWindowEdgesInDirection(edge, deltas, window));
+		UpdateInner(InnerLayoutEngine.MoveWindowEdgesInDirection(edge, deltas, window));
 
 	/// <inheritdoc />
 	public override ILayoutEngine MoveWindowToPoint(IWindow window, IPoint<double> point) =>
-		new GapsLayoutEngine(this, InnerLayoutEngine.MoveWindowToPoint(window, point));
+		UpdateInner(InnerLayoutEngine.MoveWindowToPoint(window, point));
 
 	/// <inheritdoc />
-	public override ILayoutEngine RemoveWindow(IWindow window) =>
-		new GapsLayoutEngine(this, InnerLayoutEngine.RemoveWindow(window));
+	public override ILayoutEngine RemoveWindow(IWindow window) => UpdateInner(InnerLayoutEngine.RemoveWindow(window));
 
 	/// <inheritdoc />
 	public override ILayoutEngine SwapWindowInDirection(Direction direction, IWindow window) =>
-		new GapsLayoutEngine(this, InnerLayoutEngine.SwapWindowInDirection(direction, window));
+		UpdateInner(InnerLayoutEngine.SwapWindowInDirection(direction, window));
 }

--- a/src/Whim.Gaps/GapsLayoutEngine.cs
+++ b/src/Whim.Gaps/GapsLayoutEngine.cs
@@ -20,9 +20,21 @@ public class GapsLayoutEngine : BaseProxyLayoutEngine
 		_gapsConfig = gapsConfig;
 	}
 
+	private GapsLayoutEngine(GapsLayoutEngine oldEngine, ILayoutEngine innerLayoutEngine)
+		: base(innerLayoutEngine)
+	{
+		_gapsConfig = oldEngine._gapsConfig;
+	}
+
 	/// <inheritdoc />
-	protected override ILayoutEngine Update(ILayoutEngine newLayoutEngine) =>
-		newLayoutEngine == InnerLayoutEngine ? this : new GapsLayoutEngine(_gapsConfig, newLayoutEngine);
+	public override int Count => InnerLayoutEngine.Count;
+
+	/// <inheritdoc />
+	public override ILayoutEngine AddWindow(IWindow window) =>
+		new GapsLayoutEngine(this, InnerLayoutEngine.AddWindow(window));
+
+	/// <inheritdoc />
+	public override bool ContainsWindow(IWindow window) => InnerLayoutEngine.ContainsWindow(window);
 
 	/// <inheritdoc />
 	public override IEnumerable<IWindowState> DoLayout(ILocation<int> location, IMonitor monitor)
@@ -61,4 +73,30 @@ public class GapsLayoutEngine : BaseProxyLayoutEngine
 			};
 		}
 	}
+
+	/// <inheritdoc />
+	public override void FocusWindowInDirection(Direction direction, IWindow window) =>
+		InnerLayoutEngine.FocusWindowInDirection(direction, window);
+
+	/// <inheritdoc />
+	public override IWindow? GetFirstWindow() => InnerLayoutEngine.GetFirstWindow();
+
+	/// <inheritdoc />
+	public override void HidePhantomWindows() => InnerLayoutEngine.HidePhantomWindows();
+
+	/// <inheritdoc />
+	public override ILayoutEngine MoveWindowEdgesInDirection(Direction edge, IPoint<double> deltas, IWindow window) =>
+		new GapsLayoutEngine(this, InnerLayoutEngine.MoveWindowEdgesInDirection(edge, deltas, window));
+
+	/// <inheritdoc />
+	public override ILayoutEngine MoveWindowToPoint(IWindow window, IPoint<double> point) =>
+		new GapsLayoutEngine(this, InnerLayoutEngine.MoveWindowToPoint(window, point));
+
+	/// <inheritdoc />
+	public override ILayoutEngine RemoveWindow(IWindow window) =>
+		new GapsLayoutEngine(this, InnerLayoutEngine.RemoveWindow(window));
+
+	/// <inheritdoc />
+	public override ILayoutEngine SwapWindowInDirection(Direction direction, IWindow window) =>
+		new GapsLayoutEngine(this, InnerLayoutEngine.SwapWindowInDirection(direction, window));
 }

--- a/src/Whim.TestUtils/ITestLayoutEngine.cs
+++ b/src/Whim.TestUtils/ITestLayoutEngine.cs
@@ -1,0 +1,6 @@
+namespace Whim.TestUtils;
+
+/// <summary>
+/// A layout engine interface that is used for testing.
+/// </summary>
+public interface ITestLayoutEngine : ILayoutEngine { }

--- a/src/Whim.TestUtils/PluginCommandsTestUtils.cs
+++ b/src/Whim.TestUtils/PluginCommandsTestUtils.cs
@@ -1,7 +1,7 @@
 using System.Linq;
 using Xunit;
 
-namespace Whim.TestUtilities;
+namespace Whim.TestUtils;
 
 /// <summary>
 /// Test utilities for <see cref="_pluginCommands"/>.

--- a/src/Whim.TestUtils/TestLayoutEngine.cs
+++ b/src/Whim.TestUtils/TestLayoutEngine.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Collections.Generic;
+
+namespace Whim.TestUtils;
+
+/// <summary>
+/// A test layout engine that does nothing.
+/// </summary>
+public class TestLayoutEngine : ILayoutEngine
+{
+	/// <inheritdoc/>
+	public string Name => "Test Layout Engine";
+
+	/// <inheritdoc/>
+	public int Count => 0;
+
+	/// <inheritdoc/>
+	public LayoutEngineIdentity Identity => new();
+
+	/// <inheritdoc/>
+	public ILayoutEngine AddWindow(IWindow window) => throw new NotImplementedException();
+
+	/// <inheritdoc/>
+	public ILayoutEngine MoveWindowToPoint(IWindow window, IPoint<double> point) => throw new NotImplementedException();
+
+	/// <inheritdoc/>
+	public bool ContainsWindow(IWindow window) => throw new NotImplementedException();
+
+	/// <inheritdoc/>
+	public IEnumerable<IWindowState> DoLayout(ILocation<int> location, IMonitor monitor) =>
+		throw new NotImplementedException();
+
+	/// <inheritdoc/>
+	public void FocusWindowInDirection(Direction direction, IWindow window) => throw new NotImplementedException();
+
+	/// <inheritdoc/>
+	public IWindow? GetFirstWindow() => throw new NotImplementedException();
+
+	/// <inheritdoc/>
+	public void HidePhantomWindows() => throw new NotImplementedException();
+
+	/// <inheritdoc/>
+	public ILayoutEngine MoveWindowEdgesInDirection(Direction edges, IPoint<double> deltas, IWindow window) =>
+		throw new NotImplementedException();
+
+	/// <inheritdoc/>
+	public ILayoutEngine RemoveWindow(IWindow window) => throw new NotImplementedException();
+
+	/// <inheritdoc/>
+	public ILayoutEngine SwapWindowInDirection(Direction direction, IWindow window) =>
+		throw new NotImplementedException();
+}

--- a/src/Whim.TestUtils/TestProxyLayoutEngine.cs
+++ b/src/Whim.TestUtils/TestProxyLayoutEngine.cs
@@ -32,7 +32,7 @@ public class TestProxyLayoutEngine : BaseProxyLayoutEngine
 		throw new NotImplementedException();
 
 	/// <inheritdoc/>
-	public override IWindow? GetFirstWindow() => throw new NotImplementedException();
+	public override IWindow? GetFirstWindow() => null;
 
 	/// <inheritdoc/>
 	public override void HidePhantomWindows() => throw new NotImplementedException();

--- a/src/Whim.TestUtils/TestProxyLayoutEngine.cs
+++ b/src/Whim.TestUtils/TestProxyLayoutEngine.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Collections.Generic;
+
+namespace Whim.TestUtils;
+
+/// <summary>
+/// A non-functional proxy layout engine that can be used for testing.
+/// </summary>
+public class TestProxyLayoutEngine : BaseProxyLayoutEngine
+{
+	/// <summary>
+	/// Creates a new <see cref="TestProxyLayoutEngine"/> with the given <paramref name="innerLayoutEngine"/>.
+	/// </summary>
+	public TestProxyLayoutEngine(ILayoutEngine innerLayoutEngine)
+		: base(innerLayoutEngine) { }
+
+	/// <inheritdoc/>
+	public override int Count => 0;
+
+	/// <inheritdoc/>
+	public override ILayoutEngine AddWindow(IWindow window) => throw new NotImplementedException();
+
+	/// <inheritdoc/>
+	public override bool ContainsWindow(IWindow window) => throw new NotImplementedException();
+
+	/// <inheritdoc/>
+	public override IEnumerable<IWindowState> DoLayout(ILocation<int> location, IMonitor monitor) =>
+		InnerLayoutEngine.DoLayout(location, monitor);
+
+	/// <inheritdoc/>
+	public override void FocusWindowInDirection(Direction direction, IWindow window) =>
+		throw new NotImplementedException();
+
+	/// <inheritdoc/>
+	public override IWindow? GetFirstWindow() => throw new NotImplementedException();
+
+	/// <inheritdoc/>
+	public override void HidePhantomWindows() => throw new NotImplementedException();
+
+	/// <inheritdoc/>
+	public override ILayoutEngine MoveWindowEdgesInDirection(Direction edge, IPoint<double> deltas, IWindow window) =>
+		throw new NotImplementedException();
+
+	/// <inheritdoc/>
+	public override ILayoutEngine MoveWindowToPoint(IWindow window, IPoint<double> point) =>
+		throw new NotImplementedException();
+
+	/// <inheritdoc/>
+	public override ILayoutEngine RemoveWindow(IWindow window) => throw new NotImplementedException();
+
+	/// <inheritdoc/>
+	public override ILayoutEngine SwapWindowInDirection(Direction direction, IWindow window) =>
+		throw new NotImplementedException();
+}

--- a/src/Whim.Tests/Commands/CoreCommandsTests.cs
+++ b/src/Whim.Tests/Commands/CoreCommandsTests.cs
@@ -1,5 +1,5 @@
 using Moq;
-using Whim.TestUtilities;
+using Whim.TestUtils;
 using Xunit;
 
 namespace Whim.Tests;

--- a/src/Whim.Tests/Layout/BaseProxyLayoutEngineTests.cs
+++ b/src/Whim.Tests/Layout/BaseProxyLayoutEngineTests.cs
@@ -74,17 +74,17 @@ public class BaseProxyLayoutEngineTests
 	{
 		// Given
 		Mock<ILayoutEngine> innerLayoutEngine = new();
-		innerLayoutEngine.Setup(x => x.Add(It.IsAny<IWindow>()));
+		innerLayoutEngine.Setup(x => x.AddWindow(It.IsAny<IWindow>()));
 
 		ProxyLayoutEngine proxyLayoutEngine = new(innerLayoutEngine.Object);
 
 		// When
-		ILayoutEngine newEngine = proxyLayoutEngine.Add(new Mock<IWindow>().Object);
+		ILayoutEngine newEngine = proxyLayoutEngine.AddWindow(new Mock<IWindow>().Object);
 
 		// Then
 		Assert.NotSame(proxyLayoutEngine, newEngine);
 		Assert.IsType<ProxyLayoutEngine>(newEngine);
-		innerLayoutEngine.Verify(x => x.Add(It.IsAny<IWindow>()), Times.Once);
+		innerLayoutEngine.Verify(x => x.AddWindow(It.IsAny<IWindow>()), Times.Once);
 	}
 
 	[Fact]
@@ -92,17 +92,17 @@ public class BaseProxyLayoutEngineTests
 	{
 		// Given
 		Mock<ILayoutEngine> innerLayoutEngine = new();
-		innerLayoutEngine.Setup(x => x.Remove(It.IsAny<IWindow>()));
+		innerLayoutEngine.Setup(x => x.RemoveWindow(It.IsAny<IWindow>()));
 
 		ProxyLayoutEngine proxyLayoutEngine = new(innerLayoutEngine.Object);
 
 		// When
-		ILayoutEngine newEngine = proxyLayoutEngine.Remove(new Mock<IWindow>().Object);
+		ILayoutEngine newEngine = proxyLayoutEngine.RemoveWindow(new Mock<IWindow>().Object);
 
 		// Then
 		Assert.NotSame(proxyLayoutEngine, newEngine);
 		Assert.IsType<ProxyLayoutEngine>(newEngine);
-		innerLayoutEngine.Verify(x => x.Remove(It.IsAny<IWindow>()), Times.Once);
+		innerLayoutEngine.Verify(x => x.RemoveWindow(It.IsAny<IWindow>()), Times.Once);
 	}
 
 	[Fact]
@@ -161,16 +161,16 @@ public class BaseProxyLayoutEngineTests
 	{
 		// Given
 		Mock<ILayoutEngine> innerLayoutEngine = new();
-		innerLayoutEngine.Setup(x => x.Contains(It.IsAny<IWindow>())).Returns(true);
+		innerLayoutEngine.Setup(x => x.ContainsWindow(It.IsAny<IWindow>())).Returns(true);
 
 		ProxyLayoutEngine proxyLayoutEngine = new(innerLayoutEngine.Object);
 
 		// When
-		bool contains = proxyLayoutEngine.Contains(new Mock<IWindow>().Object);
+		bool contains = proxyLayoutEngine.ContainsWindow(new Mock<IWindow>().Object);
 
 		// Then
 		Assert.True(contains);
-		innerLayoutEngine.Verify(x => x.Contains(It.IsAny<IWindow>()), Times.Once);
+		innerLayoutEngine.Verify(x => x.ContainsWindow(It.IsAny<IWindow>()), Times.Once);
 	}
 
 	[Fact]

--- a/src/Whim.Tests/Layout/BaseProxyLayoutEngineTests.cs
+++ b/src/Whim.Tests/Layout/BaseProxyLayoutEngineTests.cs
@@ -239,21 +239,21 @@ public class BaseProxyLayoutEngineTests
 	}
 
 	[Fact]
-	public void AddAtPoint()
+	public void MoveWindowToPoint()
 	{
 		// Given
 		Mock<ILayoutEngine> innerLayoutEngine = new();
-		innerLayoutEngine.Setup(x => x.AddAtPoint(It.IsAny<IWindow>(), It.IsAny<IPoint<double>>()));
+		innerLayoutEngine.Setup(x => x.MoveWindowToPoint(It.IsAny<IWindow>(), It.IsAny<IPoint<double>>()));
 
 		ProxyLayoutEngine proxyLayoutEngine = new(innerLayoutEngine.Object);
 
 		// When
-		ILayoutEngine newEngine = proxyLayoutEngine.AddAtPoint(new Mock<IWindow>().Object, new Point<double>());
+		ILayoutEngine newEngine = proxyLayoutEngine.MoveWindowToPoint(new Mock<IWindow>().Object, new Point<double>());
 
 		// Then
 		Assert.NotSame(proxyLayoutEngine, newEngine);
 		Assert.IsType<ProxyLayoutEngine>(newEngine);
-		innerLayoutEngine.Verify(x => x.AddAtPoint(It.IsAny<IWindow>(), It.IsAny<IPoint<double>>()), Times.Once);
+		innerLayoutEngine.Verify(x => x.MoveWindowToPoint(It.IsAny<IWindow>(), It.IsAny<IPoint<double>>()), Times.Once);
 	}
 
 	#region GetLayoutEngine

--- a/src/Whim.Tests/Layout/BaseProxyLayoutEngineTests.cs
+++ b/src/Whim.Tests/Layout/BaseProxyLayoutEngineTests.cs
@@ -1,275 +1,25 @@
 using Moq;
-using System;
-using System.Collections.Generic;
+using Whim.TestUtils;
 using Xunit;
 
 namespace Whim.Tests;
 
 public class BaseProxyLayoutEngineTests
 {
-	private class ProxyLayoutEngine : BaseProxyLayoutEngine
-	{
-		public ProxyLayoutEngine(ILayoutEngine innerLayoutEngine)
-			: base(innerLayoutEngine) { }
-
-		protected override ILayoutEngine Update(ILayoutEngine newLayoutEngine) =>
-			newLayoutEngine == InnerLayoutEngine ? this : new ProxyLayoutEngine(newLayoutEngine);
-
-		public override IEnumerable<IWindowState> DoLayout(ILocation<int> location, IMonitor monitor) =>
-			InnerLayoutEngine.DoLayout(location, monitor);
-	}
-
-	internal interface ITestLayoutEngine : ILayoutEngine { }
-
-	[Fact]
-	public void Name()
-	{
-		// Given
-		Mock<ILayoutEngine> innerLayoutEngine = new();
-		innerLayoutEngine.Setup(x => x.Name).Returns("Inner Layout Engine");
-
-		ProxyLayoutEngine proxyLayoutEngine = new(innerLayoutEngine.Object);
-
-		// When
-		string name = proxyLayoutEngine.Name;
-
-		// Then
-		Assert.Equal("Inner Layout Engine", name);
-	}
-
-	[Fact]
-	public void Identity()
-	{
-		// Given
-		Mock<ILayoutEngine> innerLayoutEngine = new();
-		innerLayoutEngine.Setup(x => x.Identity).Returns(new LayoutEngineIdentity());
-
-		ProxyLayoutEngine proxyLayoutEngine = new(innerLayoutEngine.Object);
-
-		// When
-		LayoutEngineIdentity identity = proxyLayoutEngine.Identity;
-
-		// Then
-		Assert.Same(innerLayoutEngine.Object.Identity, identity);
-	}
-
-	[Fact]
-	public void Count()
-	{
-		// Given
-		Mock<ILayoutEngine> innerLayoutEngine = new();
-		innerLayoutEngine.Setup(x => x.Count).Returns(42);
-
-		ProxyLayoutEngine proxyLayoutEngine = new(innerLayoutEngine.Object);
-
-		// When
-		int count = proxyLayoutEngine.Count;
-
-		// Then
-		Assert.Equal(42, count);
-	}
-
-	[Fact]
-	public void Add()
-	{
-		// Given
-		Mock<ILayoutEngine> innerLayoutEngine = new();
-		innerLayoutEngine.Setup(x => x.AddWindow(It.IsAny<IWindow>()));
-
-		ProxyLayoutEngine proxyLayoutEngine = new(innerLayoutEngine.Object);
-
-		// When
-		ILayoutEngine newEngine = proxyLayoutEngine.AddWindow(new Mock<IWindow>().Object);
-
-		// Then
-		Assert.NotSame(proxyLayoutEngine, newEngine);
-		Assert.IsType<ProxyLayoutEngine>(newEngine);
-		innerLayoutEngine.Verify(x => x.AddWindow(It.IsAny<IWindow>()), Times.Once);
-	}
-
-	[Fact]
-	public void Remove()
-	{
-		// Given
-		Mock<ILayoutEngine> innerLayoutEngine = new();
-		innerLayoutEngine.Setup(x => x.RemoveWindow(It.IsAny<IWindow>()));
-
-		ProxyLayoutEngine proxyLayoutEngine = new(innerLayoutEngine.Object);
-
-		// When
-		ILayoutEngine newEngine = proxyLayoutEngine.RemoveWindow(new Mock<IWindow>().Object);
-
-		// Then
-		Assert.NotSame(proxyLayoutEngine, newEngine);
-		Assert.IsType<ProxyLayoutEngine>(newEngine);
-		innerLayoutEngine.Verify(x => x.RemoveWindow(It.IsAny<IWindow>()), Times.Once);
-	}
-
-	[Fact]
-	public void GetFirstWindow()
-	{
-		// Given
-		Mock<ILayoutEngine> innerLayoutEngine = new();
-		innerLayoutEngine.Setup(x => x.GetFirstWindow()).Returns(new Mock<IWindow>().Object);
-
-		ProxyLayoutEngine proxyLayoutEngine = new(innerLayoutEngine.Object);
-
-		// When
-		IWindow? window = proxyLayoutEngine.GetFirstWindow();
-
-		// Then
-		Assert.NotNull(window);
-		innerLayoutEngine.Verify(x => x.GetFirstWindow(), Times.Once);
-	}
-
-	[Fact]
-	public void FocusWindowInDirection()
-	{
-		// Given
-		Mock<ILayoutEngine> innerLayoutEngine = new();
-		innerLayoutEngine.Setup(x => x.FocusWindowInDirection(It.IsAny<Direction>(), It.IsAny<IWindow>()));
-
-		ProxyLayoutEngine proxyLayoutEngine = new(innerLayoutEngine.Object);
-
-		// When
-		proxyLayoutEngine.FocusWindowInDirection(Direction.Left, new Mock<IWindow>().Object);
-
-		// Then
-		innerLayoutEngine.Verify(x => x.FocusWindowInDirection(It.IsAny<Direction>(), It.IsAny<IWindow>()), Times.Once);
-	}
-
-	[Fact]
-	public void SwapWindowInDirection()
-	{
-		// Given
-		Mock<ILayoutEngine> innerLayoutEngine = new();
-		innerLayoutEngine.Setup(x => x.SwapWindowInDirection(It.IsAny<Direction>(), It.IsAny<IWindow>()));
-
-		ProxyLayoutEngine proxyLayoutEngine = new(innerLayoutEngine.Object);
-
-		// When
-		ILayoutEngine newEngine = proxyLayoutEngine.SwapWindowInDirection(Direction.Left, new Mock<IWindow>().Object);
-
-		// Then
-		Assert.NotSame(proxyLayoutEngine, newEngine);
-		Assert.IsType<ProxyLayoutEngine>(newEngine);
-		innerLayoutEngine.Verify(x => x.SwapWindowInDirection(It.IsAny<Direction>(), It.IsAny<IWindow>()), Times.Once);
-	}
-
-	[Fact]
-	public void Contains()
-	{
-		// Given
-		Mock<ILayoutEngine> innerLayoutEngine = new();
-		innerLayoutEngine.Setup(x => x.ContainsWindow(It.IsAny<IWindow>())).Returns(true);
-
-		ProxyLayoutEngine proxyLayoutEngine = new(innerLayoutEngine.Object);
-
-		// When
-		bool contains = proxyLayoutEngine.ContainsWindow(new Mock<IWindow>().Object);
-
-		// Then
-		Assert.True(contains);
-		innerLayoutEngine.Verify(x => x.ContainsWindow(It.IsAny<IWindow>()), Times.Once);
-	}
-
-	[Fact]
-	public void MoveWindowEdgesInDirection()
-	{
-		// Given
-		Mock<ILayoutEngine> innerLayoutEngine = new();
-		innerLayoutEngine.Setup(
-			x => x.MoveWindowEdgesInDirection(It.IsAny<Direction>(), It.IsAny<IPoint<double>>(), It.IsAny<IWindow>())
-		);
-
-		ProxyLayoutEngine proxyLayoutEngine = new(innerLayoutEngine.Object);
-
-		// When
-		ILayoutEngine newEngine = proxyLayoutEngine.MoveWindowEdgesInDirection(
-			Direction.Left,
-			new Point<double>(),
-			new Mock<IWindow>().Object
-		);
-
-		// Then
-		Assert.NotSame(proxyLayoutEngine, newEngine);
-		Assert.IsType<ProxyLayoutEngine>(newEngine);
-		innerLayoutEngine.Verify(
-			x => x.MoveWindowEdgesInDirection(It.IsAny<Direction>(), It.IsAny<IPoint<double>>(), It.IsAny<IWindow>()),
-			Times.Once
-		);
-	}
-
-	[Fact]
-	public void DoLayout()
-	{
-		// Given
-		Mock<ILayoutEngine> innerLayoutEngine = new();
-		innerLayoutEngine
-			.Setup(x => x.DoLayout(It.IsAny<ILocation<int>>(), It.IsAny<IMonitor>()))
-			.Returns(Array.Empty<IWindowState>());
-
-		ProxyLayoutEngine proxyLayoutEngine = new(innerLayoutEngine.Object);
-
-		// When
-		IEnumerable<IWindowState> windows = proxyLayoutEngine.DoLayout(
-			new Mock<ILocation<int>>().Object,
-			new Mock<IMonitor>().Object
-		);
-
-		// Then
-		Assert.Empty(windows);
-		innerLayoutEngine.Verify(x => x.DoLayout(It.IsAny<ILocation<int>>(), It.IsAny<IMonitor>()), Times.Once);
-	}
-
-	[Fact]
-	public void HidePhantomWindows()
-	{
-		// Given
-		Mock<ILayoutEngine> innerLayoutEngine = new();
-		innerLayoutEngine.Setup(x => x.HidePhantomWindows());
-
-		ProxyLayoutEngine proxyLayoutEngine = new(innerLayoutEngine.Object);
-
-		// When
-		proxyLayoutEngine.HidePhantomWindows();
-
-		// Then
-		innerLayoutEngine.Verify(x => x.HidePhantomWindows(), Times.Once);
-	}
-
-	[Fact]
-	public void MoveWindowToPoint()
-	{
-		// Given
-		Mock<ILayoutEngine> innerLayoutEngine = new();
-		innerLayoutEngine.Setup(x => x.MoveWindowToPoint(It.IsAny<IWindow>(), It.IsAny<IPoint<double>>()));
-
-		ProxyLayoutEngine proxyLayoutEngine = new(innerLayoutEngine.Object);
-
-		// When
-		ILayoutEngine newEngine = proxyLayoutEngine.MoveWindowToPoint(new Mock<IWindow>().Object, new Point<double>());
-
-		// Then
-		Assert.NotSame(proxyLayoutEngine, newEngine);
-		Assert.IsType<ProxyLayoutEngine>(newEngine);
-		innerLayoutEngine.Verify(x => x.MoveWindowToPoint(It.IsAny<IWindow>(), It.IsAny<IPoint<double>>()), Times.Once);
-	}
-
 	#region GetLayoutEngine
 	[Fact]
 	public void GetLayoutEngine_IsT()
 	{
 		// Given
 		Mock<ILayoutEngine> innerLayoutEngine = new();
-		ProxyLayoutEngine proxyLayoutEngine = new(innerLayoutEngine.Object);
+		TestProxyLayoutEngine proxyLayoutEngine = new(innerLayoutEngine.Object);
 
 		// When
-		ProxyLayoutEngine? newEngine = proxyLayoutEngine.GetLayoutEngine<ProxyLayoutEngine>();
+		TestProxyLayoutEngine? newEngine = proxyLayoutEngine.GetLayoutEngine<TestProxyLayoutEngine>();
 
 		// Then
 		Assert.Same(proxyLayoutEngine, newEngine);
-		Assert.IsType<ProxyLayoutEngine>(newEngine);
+		Assert.IsType<TestProxyLayoutEngine>(newEngine);
 	}
 
 	[Fact]
@@ -278,7 +28,7 @@ public class BaseProxyLayoutEngineTests
 		// Given
 		Mock<ITestLayoutEngine> innerLayoutEngine = new();
 		innerLayoutEngine.Setup(x => x.GetLayoutEngine<ITestLayoutEngine>()).Returns(innerLayoutEngine.Object);
-		ProxyLayoutEngine proxyLayoutEngine = new(innerLayoutEngine.Object);
+		TestProxyLayoutEngine proxyLayoutEngine = new(innerLayoutEngine.Object);
 
 		// When
 		ITestLayoutEngine? newEngine = proxyLayoutEngine.GetLayoutEngine<ITestLayoutEngine>();
@@ -293,7 +43,7 @@ public class BaseProxyLayoutEngineTests
 	{
 		// Given
 		Mock<ILayoutEngine> innerLayoutEngine = new();
-		ProxyLayoutEngine proxyLayoutEngine = new(innerLayoutEngine.Object);
+		TestProxyLayoutEngine proxyLayoutEngine = new(innerLayoutEngine.Object);
 
 		// When
 		ITestLayoutEngine? newEngine = proxyLayoutEngine.GetLayoutEngine<ITestLayoutEngine>();
@@ -309,7 +59,7 @@ public class BaseProxyLayoutEngineTests
 	{
 		// Given
 		Mock<ILayoutEngine> innerLayoutEngine = new();
-		ProxyLayoutEngine proxyLayoutEngine = new(innerLayoutEngine.Object);
+		TestProxyLayoutEngine proxyLayoutEngine = new(innerLayoutEngine.Object);
 
 		// When
 		bool contains = proxyLayoutEngine.ContainsEqual(proxyLayoutEngine);
@@ -324,7 +74,7 @@ public class BaseProxyLayoutEngineTests
 		// Given
 		Mock<ITestLayoutEngine> innerLayoutEngine = new();
 		innerLayoutEngine.Setup(x => x.ContainsEqual(innerLayoutEngine.Object)).Returns(true);
-		ProxyLayoutEngine proxyLayoutEngine = new(innerLayoutEngine.Object);
+		TestProxyLayoutEngine proxyLayoutEngine = new(innerLayoutEngine.Object);
 
 		// When
 		bool contains = proxyLayoutEngine.ContainsEqual(innerLayoutEngine.Object);
@@ -339,7 +89,7 @@ public class BaseProxyLayoutEngineTests
 	{
 		// Given
 		Mock<ILayoutEngine> innerLayoutEngine = new();
-		ProxyLayoutEngine proxyLayoutEngine = new(innerLayoutEngine.Object);
+		TestProxyLayoutEngine proxyLayoutEngine = new(innerLayoutEngine.Object);
 
 		// When
 		bool contains = proxyLayoutEngine.ContainsEqual(new Mock<ILayoutEngine>().Object);

--- a/src/Whim.Tests/Layout/ColumnLayoutEngineTests.cs
+++ b/src/Whim.Tests/Layout/ColumnLayoutEngineTests.cs
@@ -79,7 +79,7 @@ public class ColumnLayoutEngineTests
 		ColumnLayoutEngine engine = new(identity);
 
 		// When
-		ILayoutEngine newLayoutEngine = engine.Add(CreateWindow());
+		ILayoutEngine newLayoutEngine = engine.AddWindow(CreateWindow());
 
 		// Then
 		Assert.NotSame(engine, newLayoutEngine);
@@ -91,10 +91,10 @@ public class ColumnLayoutEngineTests
 	{
 		// Given
 		Mock<IWindow> window = CreateMockWindow();
-		ILayoutEngine engine = new ColumnLayoutEngine(identity).Add(window.Object);
+		ILayoutEngine engine = new ColumnLayoutEngine(identity).AddWindow(window.Object);
 
 		// When
-		ILayoutEngine newLayoutEngine = engine.Remove(window.Object);
+		ILayoutEngine newLayoutEngine = engine.RemoveWindow(window.Object);
 
 		// Then
 		Assert.NotSame(engine, newLayoutEngine);
@@ -105,10 +105,10 @@ public class ColumnLayoutEngineTests
 	public void Remove_NoChanges()
 	{
 		// Given
-		ILayoutEngine engine = new ColumnLayoutEngine(identity).Add(CreateWindow());
+		ILayoutEngine engine = new ColumnLayoutEngine(identity).AddWindow(CreateWindow());
 
 		// When
-		ILayoutEngine newLayoutEngine = engine.Remove(new Mock<IWindow>().Object);
+		ILayoutEngine newLayoutEngine = engine.RemoveWindow(new Mock<IWindow>().Object);
 
 		// Then
 		Assert.Same(engine, newLayoutEngine);
@@ -120,10 +120,10 @@ public class ColumnLayoutEngineTests
 	{
 		// Given
 		Mock<IWindow> window = CreateMockWindow();
-		ILayoutEngine engine = new ColumnLayoutEngine(identity).Add(window.Object);
+		ILayoutEngine engine = new ColumnLayoutEngine(identity).AddWindow(window.Object);
 
 		// When
-		bool contains = engine.Contains(window.Object);
+		bool contains = engine.ContainsWindow(window.Object);
 
 		// Then
 		Assert.True(contains);
@@ -134,10 +134,10 @@ public class ColumnLayoutEngineTests
 	{
 		// Given
 		Mock<IWindow> window = CreateMockWindow();
-		ILayoutEngine engine = new ColumnLayoutEngine(identity).Add(window.Object);
+		ILayoutEngine engine = new ColumnLayoutEngine(identity).AddWindow(window.Object);
 
 		// When
-		bool contains = engine.Contains(new Mock<IWindow>().Object);
+		bool contains = engine.ContainsWindow(new Mock<IWindow>().Object);
 
 		// Then
 		Assert.False(contains);
@@ -164,7 +164,7 @@ public class ColumnLayoutEngineTests
 	{
 		// Given
 		Mock<IWindow> window = CreateMockWindow();
-		ILayoutEngine engine = new ColumnLayoutEngine(identity).Add(window.Object);
+		ILayoutEngine engine = new ColumnLayoutEngine(identity).AddWindow(window.Object);
 
 		// When
 		IWindowState[] windowStates = engine
@@ -198,7 +198,7 @@ public class ColumnLayoutEngineTests
 		IWindow window2 = CreateWindow();
 		IWindow window3 = CreateWindow();
 
-		ILayoutEngine engine = new ColumnLayoutEngine(identity).Add(window).Add(window2).Add(window3);
+		ILayoutEngine engine = new ColumnLayoutEngine(identity).AddWindow(window).AddWindow(window2).AddWindow(window3);
 
 		Location<int> location = new() { Width = 1920, Height = 1080 };
 
@@ -262,7 +262,7 @@ public class ColumnLayoutEngineTests
 	{
 		// Given
 		IWindow window = CreateWindow();
-		ILayoutEngine engine = new ColumnLayoutEngine(identity) { LeftToRight = false }.Add(window);
+		ILayoutEngine engine = new ColumnLayoutEngine(identity) { LeftToRight = false }.AddWindow(window);
 
 		Location<int> location = new() { Width = 1920, Height = 1080 };
 
@@ -297,9 +297,9 @@ public class ColumnLayoutEngineTests
 		IWindow window3 = CreateWindow();
 
 		ILayoutEngine engine = new ColumnLayoutEngine(identity) { LeftToRight = false }
-			.Add(window)
-			.Add(window2)
-			.Add(window3);
+			.AddWindow(window)
+			.AddWindow(window2)
+			.AddWindow(window3);
 
 		Location<int> location = new() { Width = 1920, Height = 1080 };
 
@@ -377,7 +377,7 @@ public class ColumnLayoutEngineTests
 	{
 		// Given
 		IWindow window = CreateWindow();
-		ILayoutEngine engine = new ColumnLayoutEngine(identity).Add(window);
+		ILayoutEngine engine = new ColumnLayoutEngine(identity).AddWindow(window);
 
 		// When
 		IWindow? result = engine.GetFirstWindow();
@@ -394,7 +394,9 @@ public class ColumnLayoutEngineTests
 		Mock<IWindow> leftWindow = CreateMockWindow();
 		Mock<IWindow> rightWindow = CreateMockWindow();
 
-		ILayoutEngine engine = new ColumnLayoutEngine(identity).Add(leftWindow.Object).Add(rightWindow.Object);
+		ILayoutEngine engine = new ColumnLayoutEngine(identity)
+			.AddWindow(leftWindow.Object)
+			.AddWindow(rightWindow.Object);
 
 		// When
 		engine.FocusWindowInDirection(Direction.Up, leftWindow.Object);
@@ -412,7 +414,9 @@ public class ColumnLayoutEngineTests
 		Mock<IWindow> rightWindow = CreateMockWindow();
 		Mock<IWindow> otherWindow = CreateMockWindow();
 
-		ILayoutEngine engine = new ColumnLayoutEngine(identity).Add(leftWindow.Object).Add(rightWindow.Object);
+		ILayoutEngine engine = new ColumnLayoutEngine(identity)
+			.AddWindow(leftWindow.Object)
+			.AddWindow(rightWindow.Object);
 
 		// When
 		engine.FocusWindowInDirection(Direction.Left, otherWindow.Object);
@@ -429,7 +433,9 @@ public class ColumnLayoutEngineTests
 		Mock<IWindow> leftWindow = CreateMockWindow();
 		Mock<IWindow> rightWindow = CreateMockWindow();
 
-		ILayoutEngine engine = new ColumnLayoutEngine(identity).Add(leftWindow.Object).Add(rightWindow.Object);
+		ILayoutEngine engine = new ColumnLayoutEngine(identity)
+			.AddWindow(leftWindow.Object)
+			.AddWindow(rightWindow.Object);
 
 		// When
 		engine.FocusWindowInDirection(Direction.Right, leftWindow.Object);
@@ -446,7 +452,9 @@ public class ColumnLayoutEngineTests
 		Mock<IWindow> leftWindow = CreateMockWindow();
 		Mock<IWindow> rightWindow = CreateMockWindow();
 
-		ILayoutEngine engine = new ColumnLayoutEngine(identity).Add(leftWindow.Object).Add(rightWindow.Object);
+		ILayoutEngine engine = new ColumnLayoutEngine(identity)
+			.AddWindow(leftWindow.Object)
+			.AddWindow(rightWindow.Object);
 
 		// When
 		engine.FocusWindowInDirection(Direction.Right, rightWindow.Object);
@@ -462,7 +470,9 @@ public class ColumnLayoutEngineTests
 		Mock<IWindow> leftWindow = CreateMockWindow();
 		Mock<IWindow> rightWindow = CreateMockWindow();
 
-		ILayoutEngine engine = new ColumnLayoutEngine(identity).Add(leftWindow.Object).Add(rightWindow.Object);
+		ILayoutEngine engine = new ColumnLayoutEngine(identity)
+			.AddWindow(leftWindow.Object)
+			.AddWindow(rightWindow.Object);
 
 		// When
 		engine.FocusWindowInDirection(Direction.Left, rightWindow.Object);
@@ -478,7 +488,9 @@ public class ColumnLayoutEngineTests
 		Mock<IWindow> leftWindow = CreateMockWindow();
 		Mock<IWindow> rightWindow = CreateMockWindow();
 
-		ILayoutEngine engine = new ColumnLayoutEngine(identity).Add(leftWindow.Object).Add(rightWindow.Object);
+		ILayoutEngine engine = new ColumnLayoutEngine(identity)
+			.AddWindow(leftWindow.Object)
+			.AddWindow(rightWindow.Object);
 
 		// When
 		engine.FocusWindowInDirection(Direction.Left, leftWindow.Object);
@@ -495,8 +507,8 @@ public class ColumnLayoutEngineTests
 		Mock<IWindow> rightWindow = CreateMockWindow();
 
 		ILayoutEngine engine = new ColumnLayoutEngine(identity) { LeftToRight = false }
-			.Add(leftWindow.Object)
-			.Add(rightWindow.Object);
+			.AddWindow(leftWindow.Object)
+			.AddWindow(rightWindow.Object);
 
 		// When
 		engine.FocusWindowInDirection(Direction.Left, leftWindow.Object);
@@ -513,8 +525,8 @@ public class ColumnLayoutEngineTests
 		Mock<IWindow> rightWindow = CreateMockWindow();
 
 		ILayoutEngine engine = new ColumnLayoutEngine(identity) { LeftToRight = false }
-			.Add(leftWindow.Object)
-			.Add(rightWindow.Object);
+			.AddWindow(leftWindow.Object)
+			.AddWindow(rightWindow.Object);
 
 		// When
 		engine.FocusWindowInDirection(Direction.Left, rightWindow.Object);
@@ -531,8 +543,8 @@ public class ColumnLayoutEngineTests
 		Mock<IWindow> rightWindow = CreateMockWindow();
 
 		ILayoutEngine engine = new ColumnLayoutEngine(identity) { LeftToRight = false }
-			.Add(leftWindow.Object)
-			.Add(rightWindow.Object);
+			.AddWindow(leftWindow.Object)
+			.AddWindow(rightWindow.Object);
 
 		// When
 		engine.FocusWindowInDirection(Direction.Right, rightWindow.Object);
@@ -549,8 +561,8 @@ public class ColumnLayoutEngineTests
 		Mock<IWindow> rightWindow = CreateMockWindow();
 
 		ILayoutEngine engine = new ColumnLayoutEngine(identity) { LeftToRight = false }
-			.Add(leftWindow.Object)
-			.Add(rightWindow.Object);
+			.AddWindow(leftWindow.Object)
+			.AddWindow(rightWindow.Object);
 
 		// When
 		engine.FocusWindowInDirection(Direction.Right, leftWindow.Object);
@@ -568,7 +580,9 @@ public class ColumnLayoutEngineTests
 		Mock<IWindow> leftWindow = CreateMockWindow();
 		Mock<IWindow> rightWindow = CreateMockWindow();
 
-		ILayoutEngine engine = new ColumnLayoutEngine(identity).Add(leftWindow.Object).Add(rightWindow.Object);
+		ILayoutEngine engine = new ColumnLayoutEngine(identity)
+			.AddWindow(leftWindow.Object)
+			.AddWindow(rightWindow.Object);
 
 		// When
 		ILayoutEngine newEngine = engine.SwapWindowInDirection(Direction.Up, leftWindow.Object);
@@ -596,7 +610,9 @@ public class ColumnLayoutEngineTests
 		Mock<IWindow> rightWindow = CreateMockWindow();
 		Mock<IWindow> notFoundWindow = CreateMockWindow();
 
-		ILayoutEngine engine = new ColumnLayoutEngine(identity).Add(leftWindow.Object).Add(rightWindow.Object);
+		ILayoutEngine engine = new ColumnLayoutEngine(identity)
+			.AddWindow(leftWindow.Object)
+			.AddWindow(rightWindow.Object);
 
 		// When
 		ILayoutEngine newEngine = engine.SwapWindowInDirection(Direction.Left, notFoundWindow.Object);
@@ -623,7 +639,9 @@ public class ColumnLayoutEngineTests
 		Mock<IWindow> leftWindow = CreateMockWindow();
 		Mock<IWindow> rightWindow = CreateMockWindow();
 
-		ILayoutEngine engine = new ColumnLayoutEngine(identity).Add(leftWindow.Object).Add(rightWindow.Object);
+		ILayoutEngine engine = new ColumnLayoutEngine(identity)
+			.AddWindow(leftWindow.Object)
+			.AddWindow(rightWindow.Object);
 
 		// When
 		ILayoutEngine newEngine = engine.SwapWindowInDirection(Direction.Right, leftWindow.Object);
@@ -650,7 +668,9 @@ public class ColumnLayoutEngineTests
 		Mock<IWindow> leftWindow = CreateMockWindow();
 		Mock<IWindow> rightWindow = CreateMockWindow();
 
-		ILayoutEngine engine = new ColumnLayoutEngine(identity).Add(leftWindow.Object).Add(rightWindow.Object);
+		ILayoutEngine engine = new ColumnLayoutEngine(identity)
+			.AddWindow(leftWindow.Object)
+			.AddWindow(rightWindow.Object);
 
 		// When
 		ILayoutEngine newEngine = engine.SwapWindowInDirection(Direction.Right, rightWindow.Object);
@@ -677,7 +697,9 @@ public class ColumnLayoutEngineTests
 		Mock<IWindow> leftWindow = CreateMockWindow();
 		Mock<IWindow> rightWindow = CreateMockWindow();
 
-		ILayoutEngine engine = new ColumnLayoutEngine(identity).Add(leftWindow.Object).Add(rightWindow.Object);
+		ILayoutEngine engine = new ColumnLayoutEngine(identity)
+			.AddWindow(leftWindow.Object)
+			.AddWindow(rightWindow.Object);
 
 		// When
 		ILayoutEngine newEngine = engine.SwapWindowInDirection(Direction.Left, rightWindow.Object);
@@ -704,7 +726,9 @@ public class ColumnLayoutEngineTests
 		Mock<IWindow> leftWindow = CreateMockWindow();
 		Mock<IWindow> rightWindow = CreateMockWindow();
 
-		ILayoutEngine engine = new ColumnLayoutEngine(identity).Add(leftWindow.Object).Add(rightWindow.Object);
+		ILayoutEngine engine = new ColumnLayoutEngine(identity)
+			.AddWindow(leftWindow.Object)
+			.AddWindow(rightWindow.Object);
 
 		// When
 		ILayoutEngine newEngine = engine.SwapWindowInDirection(Direction.Left, leftWindow.Object);
@@ -732,8 +756,8 @@ public class ColumnLayoutEngineTests
 		Mock<IWindow> leftWindow = CreateMockWindow();
 
 		ILayoutEngine engine = new ColumnLayoutEngine(identity) { LeftToRight = false }
-			.Add(rightWindow.Object)
-			.Add(leftWindow.Object);
+			.AddWindow(rightWindow.Object)
+			.AddWindow(leftWindow.Object);
 
 		// When
 		ILayoutEngine newEngine = engine.SwapWindowInDirection(Direction.Left, leftWindow.Object);
@@ -761,8 +785,8 @@ public class ColumnLayoutEngineTests
 		Mock<IWindow> leftWindow = CreateMockWindow();
 
 		ILayoutEngine engine = new ColumnLayoutEngine(identity) { LeftToRight = false }
-			.Add(rightWindow.Object)
-			.Add(leftWindow.Object);
+			.AddWindow(rightWindow.Object)
+			.AddWindow(leftWindow.Object);
 
 		// When
 		ILayoutEngine newEngine = engine.SwapWindowInDirection(Direction.Left, rightWindow.Object);
@@ -790,8 +814,8 @@ public class ColumnLayoutEngineTests
 		Mock<IWindow> leftWindow = CreateMockWindow();
 
 		ILayoutEngine engine = new ColumnLayoutEngine(identity) { LeftToRight = false }
-			.Add(rightWindow.Object)
-			.Add(leftWindow.Object);
+			.AddWindow(rightWindow.Object)
+			.AddWindow(leftWindow.Object);
 
 		// When
 		ILayoutEngine newEngine = engine.SwapWindowInDirection(Direction.Right, rightWindow.Object);
@@ -819,8 +843,8 @@ public class ColumnLayoutEngineTests
 		Mock<IWindow> leftWindow = CreateMockWindow();
 
 		ILayoutEngine engine = new ColumnLayoutEngine(identity) { LeftToRight = false }
-			.Add(rightWindow.Object)
-			.Add(leftWindow.Object);
+			.AddWindow(rightWindow.Object)
+			.AddWindow(leftWindow.Object);
 
 		// When
 		ILayoutEngine newEngine = engine.SwapWindowInDirection(Direction.Right, leftWindow.Object);
@@ -847,7 +871,9 @@ public class ColumnLayoutEngineTests
 		// Given
 		Mock<IWindow> window = CreateMockWindow();
 
-		ILayoutEngine engine = new ColumnLayoutEngine(identity).Add(window.Object).Add(new Mock<IWindow>().Object);
+		ILayoutEngine engine = new ColumnLayoutEngine(identity)
+			.AddWindow(window.Object)
+			.AddWindow(new Mock<IWindow>().Object);
 
 		// When
 		ILayoutEngine newEngine = engine.MoveWindowEdgesInDirection(
@@ -867,7 +893,7 @@ public class ColumnLayoutEngineTests
 		// Given
 		Mock<IWindow> window = CreateMockWindow();
 
-		ILayoutEngine engine = new ColumnLayoutEngine(identity).Add(new Mock<IWindow>().Object);
+		ILayoutEngine engine = new ColumnLayoutEngine(identity).AddWindow(new Mock<IWindow>().Object);
 
 		// When
 		ILayoutEngine newEngine = engine.AddAtPoint(window.Object, new Point<double>() { X = -10 });
@@ -886,7 +912,7 @@ public class ColumnLayoutEngineTests
 		// Given
 		Mock<IWindow> window = CreateMockWindow();
 
-		ILayoutEngine engine = new ColumnLayoutEngine(identity).Add(new Mock<IWindow>().Object);
+		ILayoutEngine engine = new ColumnLayoutEngine(identity).AddWindow(new Mock<IWindow>().Object);
 
 		// When
 		ILayoutEngine newEngine = engine.AddAtPoint(window.Object, new Point<double>() { X = 10 });
@@ -906,8 +932,8 @@ public class ColumnLayoutEngineTests
 		Mock<IWindow> window = CreateMockWindow();
 
 		ILayoutEngine engine = new ColumnLayoutEngine(identity)
-			.Add(new Mock<IWindow>().Object)
-			.Add(new Mock<IWindow>().Object);
+			.AddWindow(new Mock<IWindow>().Object)
+			.AddWindow(new Mock<IWindow>().Object);
 
 		// When
 		ILayoutEngine newEngine = engine.AddAtPoint(window.Object, new Point<double>() { X = 0.5 });
@@ -927,8 +953,8 @@ public class ColumnLayoutEngineTests
 		Mock<IWindow> window = CreateMockWindow();
 
 		ILayoutEngine engine = new ColumnLayoutEngine(identity) { LeftToRight = false }
-			.Add(new Mock<IWindow>().Object)
-			.Add(new Mock<IWindow>().Object);
+			.AddWindow(new Mock<IWindow>().Object)
+			.AddWindow(new Mock<IWindow>().Object);
 
 		// When
 		ILayoutEngine newEngine = engine.AddAtPoint(window.Object, new Point<double>() { X = 0.5 });
@@ -948,7 +974,9 @@ public class ColumnLayoutEngineTests
 		// Given
 		Mock<IWindow> window = CreateMockWindow();
 
-		ILayoutEngine engine = new ColumnLayoutEngine(identity).Add(window.Object).Add(new Mock<IWindow>().Object);
+		ILayoutEngine engine = new ColumnLayoutEngine(identity)
+			.AddWindow(window.Object)
+			.AddWindow(new Mock<IWindow>().Object);
 
 		// When
 		engine.HidePhantomWindows();

--- a/src/Whim.Tests/Layout/ColumnLayoutEngineTests.cs
+++ b/src/Whim.Tests/Layout/ColumnLayoutEngineTests.cs
@@ -896,7 +896,7 @@ public class ColumnLayoutEngineTests
 		ILayoutEngine engine = new ColumnLayoutEngine(identity).AddWindow(new Mock<IWindow>().Object);
 
 		// When
-		ILayoutEngine newEngine = engine.AddAtPoint(window.Object, new Point<double>() { X = -10 });
+		ILayoutEngine newEngine = engine.MoveWindowToPoint(window.Object, new Point<double>() { X = -10 });
 		List<IWindowState> windows = newEngine
 			.DoLayout(new Location<int>() { Width = 1920, Height = 1080 }, new Mock<IMonitor>().Object)
 			.ToList();
@@ -915,7 +915,7 @@ public class ColumnLayoutEngineTests
 		ILayoutEngine engine = new ColumnLayoutEngine(identity).AddWindow(new Mock<IWindow>().Object);
 
 		// When
-		ILayoutEngine newEngine = engine.AddAtPoint(window.Object, new Point<double>() { X = 10 });
+		ILayoutEngine newEngine = engine.MoveWindowToPoint(window.Object, new Point<double>() { X = 10 });
 		List<IWindowState> windows = newEngine
 			.DoLayout(new Location<int>() { Width = 1920, Height = 1080 }, new Mock<IMonitor>().Object)
 			.ToList();
@@ -936,7 +936,7 @@ public class ColumnLayoutEngineTests
 			.AddWindow(new Mock<IWindow>().Object);
 
 		// When
-		ILayoutEngine newEngine = engine.AddAtPoint(window.Object, new Point<double>() { X = 0.5 });
+		ILayoutEngine newEngine = engine.MoveWindowToPoint(window.Object, new Point<double>() { X = 0.5 });
 		List<IWindowState> windows = newEngine
 			.DoLayout(new Location<int>() { Width = 1920, Height = 1080 }, new Mock<IMonitor>().Object)
 			.ToList();
@@ -957,7 +957,7 @@ public class ColumnLayoutEngineTests
 			.AddWindow(new Mock<IWindow>().Object);
 
 		// When
-		ILayoutEngine newEngine = engine.AddAtPoint(window.Object, new Point<double>() { X = 0.5 });
+		ILayoutEngine newEngine = engine.MoveWindowToPoint(window.Object, new Point<double>() { X = 0.5 });
 		List<IWindowState> windows = newEngine
 			.DoLayout(new Location<int>() { Width = 1920, Height = 1080 }, new Mock<IMonitor>().Object)
 			.ToList();

--- a/src/Whim.Tests/Layout/LayoutEngineTests.cs
+++ b/src/Whim.Tests/Layout/LayoutEngineTests.cs
@@ -1,23 +1,12 @@
 using Moq;
 using System.Collections.Generic;
+using Whim.TestUtils;
 using Xunit;
 
 namespace Whim.Tests;
 
 public class LayoutEngineTests
 {
-	private class ProxyLayoutEngine : BaseProxyLayoutEngine
-	{
-		public ProxyLayoutEngine(ILayoutEngine innerLayoutEngine)
-			: base(innerLayoutEngine) { }
-
-		protected override ILayoutEngine Update(ILayoutEngine newLayoutEngine) =>
-			newLayoutEngine == InnerLayoutEngine ? this : new ProxyLayoutEngine(newLayoutEngine);
-
-		public override IEnumerable<IWindowState> DoLayout(ILocation<int> location, IMonitor monitor) =>
-			InnerLayoutEngine.DoLayout(location, monitor);
-	}
-
 	private class TestLayoutEngine : ILayoutEngine
 	{
 		public LayoutEngineIdentity Identity => throw new System.NotImplementedException();
@@ -73,8 +62,8 @@ public class LayoutEngineTests
 	{
 		// Given
 		TestLayoutEngine engine = new();
-		ILayoutEngine proxyInner = new ProxyLayoutEngine(engine);
-		ILayoutEngine proxyOuter = new ProxyLayoutEngine(proxyInner);
+		ILayoutEngine proxyInner = new TestProxyLayoutEngine(engine);
+		ILayoutEngine proxyOuter = new TestProxyLayoutEngine(proxyInner);
 
 		// When
 		TestLayoutEngine? newEngine = proxyOuter.GetLayoutEngine<TestLayoutEngine>();
@@ -117,8 +106,8 @@ public class LayoutEngineTests
 	{
 		// Given
 		TestLayoutEngine engine = new();
-		ILayoutEngine proxyInner = new ProxyLayoutEngine(engine);
-		ILayoutEngine proxyOuter = new ProxyLayoutEngine(proxyInner);
+		ILayoutEngine proxyInner = new TestProxyLayoutEngine(engine);
+		ILayoutEngine proxyOuter = new TestProxyLayoutEngine(proxyInner);
 
 		// When
 		bool contains = proxyOuter.ContainsEqual(engine);

--- a/src/Whim.Tests/Layout/LayoutEngineTests.cs
+++ b/src/Whim.Tests/Layout/LayoutEngineTests.cs
@@ -27,7 +27,7 @@ public class LayoutEngineTests
 
 		public ILayoutEngine AddWindow(IWindow window) => throw new System.NotImplementedException();
 
-		public ILayoutEngine AddAtPoint(IWindow window, IPoint<double> point) =>
+		public ILayoutEngine MoveWindowToPoint(IWindow window, IPoint<double> point) =>
 			throw new System.NotImplementedException();
 
 		public bool ContainsWindow(IWindow window) => throw new System.NotImplementedException();

--- a/src/Whim.Tests/Layout/LayoutEngineTests.cs
+++ b/src/Whim.Tests/Layout/LayoutEngineTests.cs
@@ -25,12 +25,12 @@ public class LayoutEngineTests
 
 		public int Count => throw new System.NotImplementedException();
 
-		public ILayoutEngine Add(IWindow window) => throw new System.NotImplementedException();
+		public ILayoutEngine AddWindow(IWindow window) => throw new System.NotImplementedException();
 
 		public ILayoutEngine AddAtPoint(IWindow window, IPoint<double> point) =>
 			throw new System.NotImplementedException();
 
-		public bool Contains(IWindow window) => throw new System.NotImplementedException();
+		public bool ContainsWindow(IWindow window) => throw new System.NotImplementedException();
 
 		public IEnumerable<IWindowState> DoLayout(ILocation<int> location, IMonitor monitor) =>
 			throw new System.NotImplementedException();
@@ -45,7 +45,7 @@ public class LayoutEngineTests
 		public ILayoutEngine MoveWindowEdgesInDirection(Direction edges, IPoint<double> deltas, IWindow window) =>
 			throw new System.NotImplementedException();
 
-		public ILayoutEngine Remove(IWindow window) => throw new System.NotImplementedException();
+		public ILayoutEngine RemoveWindow(IWindow window) => throw new System.NotImplementedException();
 
 		public ILayoutEngine SwapWindowInDirection(Direction direction, IWindow window) =>
 			throw new System.NotImplementedException();

--- a/src/Whim.Tests/Workspace/WorkspaceManagerTests.cs
+++ b/src/Whim.Tests/Workspace/WorkspaceManagerTests.cs
@@ -27,11 +27,11 @@ public class WorkspaceManagerTests
 
 		public LayoutEngineIdentity Identity => throw new NotImplementedException();
 
-		public ILayoutEngine Add(IWindow window) => throw new NotImplementedException();
+		public ILayoutEngine AddWindow(IWindow window) => throw new NotImplementedException();
 
 		public ILayoutEngine AddAtPoint(IWindow window, IPoint<double> point) => throw new NotImplementedException();
 
-		public bool Contains(IWindow window) => throw new NotImplementedException();
+		public bool ContainsWindow(IWindow window) => throw new NotImplementedException();
 
 		public IEnumerable<IWindowState> DoLayout(ILocation<int> location, IMonitor monitor) =>
 			throw new NotImplementedException();
@@ -45,7 +45,7 @@ public class WorkspaceManagerTests
 		public ILayoutEngine MoveWindowEdgesInDirection(Direction edges, IPoint<double> deltas, IWindow window) =>
 			throw new NotImplementedException();
 
-		public ILayoutEngine Remove(IWindow window) => throw new NotImplementedException();
+		public ILayoutEngine RemoveWindow(IWindow window) => throw new NotImplementedException();
 
 		public ILayoutEngine SwapWindowInDirection(Direction direction, IWindow window) =>
 			throw new NotImplementedException();

--- a/src/Whim.Tests/Workspace/WorkspaceManagerTests.cs
+++ b/src/Whim.Tests/Workspace/WorkspaceManagerTests.cs
@@ -29,7 +29,8 @@ public class WorkspaceManagerTests
 
 		public ILayoutEngine AddWindow(IWindow window) => throw new NotImplementedException();
 
-		public ILayoutEngine MoveWindowToPoint(IWindow window, IPoint<double> point) => throw new NotImplementedException();
+		public ILayoutEngine MoveWindowToPoint(IWindow window, IPoint<double> point) =>
+			throw new NotImplementedException();
 
 		public bool ContainsWindow(IWindow window) => throw new NotImplementedException();
 

--- a/src/Whim.Tests/Workspace/WorkspaceManagerTests.cs
+++ b/src/Whim.Tests/Workspace/WorkspaceManagerTests.cs
@@ -29,7 +29,7 @@ public class WorkspaceManagerTests
 
 		public ILayoutEngine AddWindow(IWindow window) => throw new NotImplementedException();
 
-		public ILayoutEngine AddAtPoint(IWindow window, IPoint<double> point) => throw new NotImplementedException();
+		public ILayoutEngine MoveWindowToPoint(IWindow window, IPoint<double> point) => throw new NotImplementedException();
 
 		public bool ContainsWindow(IWindow window) => throw new NotImplementedException();
 

--- a/src/Whim.Tests/Workspace/WorkspaceManagerTests.cs
+++ b/src/Whim.Tests/Workspace/WorkspaceManagerTests.cs
@@ -1,7 +1,7 @@
 using Moq;
 using System;
-using System.Collections.Generic;
 using System.Linq;
+using Whim.TestUtils;
 using Xunit;
 
 namespace Whim.Tests;
@@ -17,52 +17,6 @@ public class WorkspaceManagerTests
 			: base(context) { }
 
 		public void Add(IWorkspace workspace) => _workspaces.Add(workspace);
-	}
-
-	private class TestLayoutEngine : ILayoutEngine
-	{
-		public string Name => throw new NotImplementedException();
-
-		public int Count => throw new NotImplementedException();
-
-		public LayoutEngineIdentity Identity => throw new NotImplementedException();
-
-		public ILayoutEngine AddWindow(IWindow window) => throw new NotImplementedException();
-
-		public ILayoutEngine MoveWindowToPoint(IWindow window, IPoint<double> point) =>
-			throw new NotImplementedException();
-
-		public bool ContainsWindow(IWindow window) => throw new NotImplementedException();
-
-		public IEnumerable<IWindowState> DoLayout(ILocation<int> location, IMonitor monitor) =>
-			throw new NotImplementedException();
-
-		public void FocusWindowInDirection(Direction direction, IWindow window) => throw new NotImplementedException();
-
-		public IWindow? GetFirstWindow() => throw new NotImplementedException();
-
-		public void HidePhantomWindows() => throw new NotImplementedException();
-
-		public ILayoutEngine MoveWindowEdgesInDirection(Direction edges, IPoint<double> deltas, IWindow window) =>
-			throw new NotImplementedException();
-
-		public ILayoutEngine RemoveWindow(IWindow window) => throw new NotImplementedException();
-
-		public ILayoutEngine SwapWindowInDirection(Direction direction, IWindow window) =>
-			throw new NotImplementedException();
-	}
-
-	private class TestProxyLayoutEngine : BaseProxyLayoutEngine
-	{
-		public TestProxyLayoutEngine(ILayoutEngine innerLayoutEngine)
-			: base(innerLayoutEngine) { }
-
-		public override IEnumerable<IWindowState> DoLayout(ILocation<int> location, IMonitor monitor)
-		{
-			yield break;
-		}
-
-		protected override ILayoutEngine Update(ILayoutEngine newLayoutEngine) => throw new NotImplementedException();
 	}
 
 	private class Wrapper

--- a/src/Whim.Tests/Workspace/WorkspaceTests.cs
+++ b/src/Whim.Tests/Workspace/WorkspaceTests.cs
@@ -38,8 +38,8 @@ public class WorkspaceTests
 			LayoutEngine.Setup(l => l.Name).Returns("Layout");
 
 			// This isn't strictly correct, but it's good enough for testing
-			LayoutEngine.Setup(l => l.Add(It.IsAny<IWindow>())).Returns(LayoutEngine.Object);
-			LayoutEngine.Setup(l => l.Remove(It.IsAny<IWindow>())).Returns(LayoutEngine.Object);
+			LayoutEngine.Setup(l => l.AddWindow(It.IsAny<IWindow>())).Returns(LayoutEngine.Object);
+			LayoutEngine.Setup(l => l.RemoveWindow(It.IsAny<IWindow>())).Returns(LayoutEngine.Object);
 			LayoutEngine
 				.Setup(
 					l =>
@@ -565,7 +565,7 @@ public class WorkspaceTests
 		workspace.AddWindow(window.Object);
 
 		// Then the window is added to the layout engine
-		mocks.LayoutEngine.Verify(l => l.Add(window.Object), Times.Never);
+		mocks.LayoutEngine.Verify(l => l.AddWindow(window.Object), Times.Never);
 		mocks.WorkspaceManager.Verify(wm => wm.GetMonitorForWorkspace(workspace), Times.Never);
 	}
 
@@ -583,7 +583,7 @@ public class WorkspaceTests
 		workspace.AddWindow(window.Object);
 
 		// Then the window is added to the layout engine
-		mocks.LayoutEngine.Verify(l => l.Add(window.Object), Times.Once);
+		mocks.LayoutEngine.Verify(l => l.AddWindow(window.Object), Times.Once);
 		mocks.WorkspaceManager.Verify(wm => wm.GetMonitorForWorkspace(workspace), Times.Once);
 	}
 
@@ -600,7 +600,7 @@ public class WorkspaceTests
 		workspace.AddWindow(window.Object);
 
 		// Then the window is added to the layout engine
-		mocks.LayoutEngine.Verify(l => l.Add(window.Object), Times.Once);
+		mocks.LayoutEngine.Verify(l => l.AddWindow(window.Object), Times.Once);
 		mocks.WorkspaceManager.Verify(wm => wm.GetMonitorForWorkspace(workspace), Times.Once);
 	}
 
@@ -619,7 +619,7 @@ public class WorkspaceTests
 
 		// Then the window is removed from the layout engine
 		Assert.False(result);
-		mocks.LayoutEngine.Verify(l => l.Remove(window.Object), Times.Never);
+		mocks.LayoutEngine.Verify(l => l.RemoveWindow(window.Object), Times.Never);
 		mocks.WorkspaceManager.Verify(wm => wm.GetMonitorForWorkspace(workspace), Times.Never);
 	}
 
@@ -636,7 +636,7 @@ public class WorkspaceTests
 		bool result = workspace.RemoveWindow(window.Object);
 
 		// Then the window is removed from the layout engine
-		mocks.LayoutEngine.Verify(l => l.Remove(window.Object), Times.Never);
+		mocks.LayoutEngine.Verify(l => l.RemoveWindow(window.Object), Times.Never);
 		mocks.WorkspaceManager.Verify(wm => wm.GetMonitorForWorkspace(workspace), Times.Never);
 	}
 
@@ -652,14 +652,14 @@ public class WorkspaceTests
 		// Phantom window is added
 		workspace.AddPhantomWindow(mocks.LayoutEngine.Object, window.Object);
 		mocks.WorkspaceManager.Invocations.Clear();
-		mocks.LayoutEngine.Setup(l => l.Remove(window.Object)).Returns(mocks.LayoutEngine.Object);
+		mocks.LayoutEngine.Setup(l => l.RemoveWindow(window.Object)).Returns(mocks.LayoutEngine.Object);
 
 		// When RemoveWindow is called
 		bool result = workspace.RemoveWindow(window.Object);
 
 		// Then the window is removed from the layout engine
 		Assert.False(result);
-		mocks.LayoutEngine.Verify(l => l.Remove(window.Object), Times.Once);
+		mocks.LayoutEngine.Verify(l => l.RemoveWindow(window.Object), Times.Once);
 		mocks.WorkspaceManager.Verify(wm => wm.GetMonitorForWorkspace(workspace), Times.Never);
 	}
 
@@ -674,19 +674,19 @@ public class WorkspaceTests
 
 		Mock<ILayoutEngine> resultingEngine = new();
 		resultingEngine.Setup(l => l.Name).Returns("Resulting engine");
-		mocks.LayoutEngine.Setup(l => l.Remove(window.Object)).Returns(resultingEngine.Object);
+		mocks.LayoutEngine.Setup(l => l.RemoveWindow(window.Object)).Returns(resultingEngine.Object);
 
 		// Phantom window is added
 		workspace.AddPhantomWindow(mocks.LayoutEngine.Object, window.Object);
 		mocks.WorkspaceManager.Invocations.Clear();
-		mocks.LayoutEngine.Setup(l => l.Remove(window.Object)).Returns(new Mock<ILayoutEngine>().Object);
+		mocks.LayoutEngine.Setup(l => l.RemoveWindow(window.Object)).Returns(new Mock<ILayoutEngine>().Object);
 
 		// When RemoveWindow is called
 		bool result = workspace.RemoveWindow(window.Object);
 
 		// Then the window is removed from the layout engine
 		Assert.True(result);
-		mocks.LayoutEngine.Verify(l => l.Remove(window.Object), Times.Once);
+		mocks.LayoutEngine.Verify(l => l.RemoveWindow(window.Object), Times.Once);
 		mocks.WorkspaceManager.Verify(wm => wm.GetMonitorForWorkspace(workspace), Times.Once);
 	}
 
@@ -706,7 +706,7 @@ public class WorkspaceTests
 
 		// Then the window is removed from the layout engine
 		Assert.False(result);
-		mocks.LayoutEngine.Verify(l => l.Remove(window.Object), Times.Once);
+		mocks.LayoutEngine.Verify(l => l.RemoveWindow(window.Object), Times.Once);
 		mocks.WorkspaceManager.Verify(wm => wm.GetMonitorForWorkspace(workspace), Times.Never);
 	}
 
@@ -721,14 +721,14 @@ public class WorkspaceTests
 		workspace.AddWindow(window.Object);
 		workspace.WindowFocused(window.Object);
 		mocks.WorkspaceManager.Invocations.Clear();
-		mocks.LayoutEngine.Setup(l => l.Remove(window.Object)).Returns(new Mock<ILayoutEngine>().Object);
+		mocks.LayoutEngine.Setup(l => l.RemoveWindow(window.Object)).Returns(new Mock<ILayoutEngine>().Object);
 
 		// When RemoveWindow is called
 		bool result = workspace.RemoveWindow(window.Object);
 
 		// Then the window is removed from the layout engine
 		Assert.True(result);
-		mocks.LayoutEngine.Verify(l => l.Remove(window.Object), Times.Once);
+		mocks.LayoutEngine.Verify(l => l.RemoveWindow(window.Object), Times.Once);
 		mocks.WorkspaceManager.Verify(wm => wm.GetMonitorForWorkspace(workspace), Times.Once);
 	}
 
@@ -752,7 +752,7 @@ public class WorkspaceTests
 
 		// Then the window is not removed from the layout engine
 		Assert.True(result);
-		mocks.LayoutEngine.Verify(l => l.Remove(window.Object), Times.Never);
+		mocks.LayoutEngine.Verify(l => l.RemoveWindow(window.Object), Times.Never);
 		mocks.WorkspaceManager.Verify(wm => wm.GetMonitorForWorkspace(workspace), Times.Once);
 	}
 
@@ -926,7 +926,7 @@ public class WorkspaceTests
 
 		// Then the layout engine is told to move the window
 		mocks.LayoutEngine.Verify(l => l.AddAtPoint(phantomWindow.Object, point), Times.Never);
-		mocks.LayoutEngine.Verify(l => l.Remove(phantomWindow.Object), Times.Never);
+		mocks.LayoutEngine.Verify(l => l.RemoveWindow(phantomWindow.Object), Times.Never);
 	}
 
 	[Fact]
@@ -949,7 +949,7 @@ public class WorkspaceTests
 
 		// Then the layout engine is told to move the window
 		mocks.LayoutEngine.Verify(l => l.AddAtPoint(window.Object, point), Times.Once);
-		mocks.LayoutEngine.Verify(l => l.Remove(window.Object), Times.Never);
+		mocks.LayoutEngine.Verify(l => l.RemoveWindow(window.Object), Times.Never);
 	}
 
 	[Fact]
@@ -977,7 +977,7 @@ public class WorkspaceTests
 
 		// Then the layout engine is told to move the window
 		mocks.LayoutEngine.Verify(l => l.AddAtPoint(window.Object, point), Times.Once);
-		mocks.LayoutEngine.Verify(l => l.Remove(window.Object), Times.Never);
+		mocks.LayoutEngine.Verify(l => l.RemoveWindow(window.Object), Times.Never);
 	}
 
 	[Fact]
@@ -999,7 +999,7 @@ public class WorkspaceTests
 		Mock<ILayoutEngine> removeResult = new();
 		Mock<ILayoutEngine> addAtPointResult = new();
 
-		mocks.LayoutEngine.Setup(l => l.Remove(It.IsAny<IWindow>())).Returns(removeResult.Object);
+		mocks.LayoutEngine.Setup(l => l.RemoveWindow(It.IsAny<IWindow>())).Returns(removeResult.Object);
 		removeResult.Setup(l => l.AddAtPoint(window.Object, point)).Returns(addAtPointResult.Object);
 		removeResult.Setup(l => l.Name).Returns("Remove result");
 
@@ -1007,7 +1007,7 @@ public class WorkspaceTests
 		workspace.MoveWindowToPoint(window.Object, point);
 
 		// Then the layout engine is told to remove and add the window
-		mocks.LayoutEngine.Verify(l => l.Remove(window.Object), Times.Once);
+		mocks.LayoutEngine.Verify(l => l.RemoveWindow(window.Object), Times.Once);
 		removeResult.Verify(l => l.AddAtPoint(window.Object, point), Times.Once);
 	}
 
@@ -1267,7 +1267,7 @@ public class WorkspaceTests
 		workspace.WindowMinimizeStart(window.Object);
 
 		// Then
-		mocks.LayoutEngine.Verify(e => e.Remove(window.Object), Times.Once);
+		mocks.LayoutEngine.Verify(e => e.RemoveWindow(window.Object), Times.Once);
 	}
 
 	[Fact]
@@ -1285,7 +1285,7 @@ public class WorkspaceTests
 		workspace.WindowMinimizeStart(window.Object);
 
 		// Then the window is only removed the first time
-		mocks.LayoutEngine.Verify(e => e.Remove(window.Object), Times.Once);
+		mocks.LayoutEngine.Verify(e => e.RemoveWindow(window.Object), Times.Once);
 	}
 
 	[Fact]
@@ -1304,7 +1304,7 @@ public class WorkspaceTests
 		workspace.WindowMinimizeEnd(window.Object);
 
 		// Then
-		mocks.LayoutEngine.Verify(e => e.Add(window.Object), Times.Once);
+		mocks.LayoutEngine.Verify(e => e.AddWindow(window.Object), Times.Once);
 	}
 
 	[Fact]
@@ -1322,6 +1322,6 @@ public class WorkspaceTests
 		workspace.WindowMinimizeEnd(window.Object);
 
 		// Then
-		mocks.LayoutEngine.Verify(e => e.Add(window.Object), Times.Never);
+		mocks.LayoutEngine.Verify(e => e.AddWindow(window.Object), Times.Never);
 	}
 }

--- a/src/Whim.Tests/Workspace/WorkspaceTests.cs
+++ b/src/Whim.Tests/Workspace/WorkspaceTests.cs
@@ -925,7 +925,7 @@ public class WorkspaceTests
 		workspace.MoveWindowToPoint(phantomWindow.Object, point);
 
 		// Then the layout engine is told to move the window
-		mocks.LayoutEngine.Verify(l => l.AddAtPoint(phantomWindow.Object, point), Times.Never);
+		mocks.LayoutEngine.Verify(l => l.MoveWindowToPoint(phantomWindow.Object, point), Times.Never);
 		mocks.LayoutEngine.Verify(l => l.RemoveWindow(phantomWindow.Object), Times.Never);
 	}
 
@@ -939,16 +939,16 @@ public class WorkspaceTests
 			new(mocks.Context.Object, mocks.Triggers, "Workspace", new ILayoutEngine[] { mocks.LayoutEngine.Object });
 		IPoint<double> point = new Point<double>() { X = 0.3, Y = 0.3 };
 
-		// Set up AddAtPoint to return a new layout engine.
+		// Set up MoveWindowToPoint to return a new layout engine.
 		Mock<ILayoutEngine> resultingEngine = new();
 		resultingEngine.Setup(l => l.Name).Returns("Resulting engine");
-		mocks.LayoutEngine.Setup(l => l.AddAtPoint(window.Object, point)).Returns(resultingEngine.Object);
+		mocks.LayoutEngine.Setup(l => l.MoveWindowToPoint(window.Object, point)).Returns(resultingEngine.Object);
 
 		// When MoveWindowToPoint is called
 		workspace.MoveWindowToPoint(window.Object, point);
 
 		// Then the layout engine is told to move the window
-		mocks.LayoutEngine.Verify(l => l.AddAtPoint(window.Object, point), Times.Once);
+		mocks.LayoutEngine.Verify(l => l.MoveWindowToPoint(window.Object, point), Times.Once);
 		mocks.LayoutEngine.Verify(l => l.RemoveWindow(window.Object), Times.Never);
 	}
 
@@ -962,10 +962,10 @@ public class WorkspaceTests
 			new(mocks.Context.Object, mocks.Triggers, "Workspace", new ILayoutEngine[] { mocks.LayoutEngine.Object });
 		IPoint<double> point = new Point<double>() { X = 0.3, Y = 0.3 };
 
-		// Set up AddAtPoint to return a new layout engine.
+		// Set up MoveWindowToPoint to return a new layout engine.
 		Mock<ILayoutEngine> resultingEngine = new();
 		resultingEngine.Setup(l => l.Name).Returns("Resulting engine");
-		mocks.LayoutEngine.Setup(l => l.AddAtPoint(window.Object, point)).Returns(resultingEngine.Object);
+		mocks.LayoutEngine.Setup(l => l.MoveWindowToPoint(window.Object, point)).Returns(resultingEngine.Object);
 
 		workspace.AddWindow(window.Object);
 		workspace.WindowMinimizeStart(window.Object);
@@ -976,7 +976,7 @@ public class WorkspaceTests
 		workspace.MoveWindowToPoint(window.Object, point);
 
 		// Then the layout engine is told to move the window
-		mocks.LayoutEngine.Verify(l => l.AddAtPoint(window.Object, point), Times.Once);
+		mocks.LayoutEngine.Verify(l => l.MoveWindowToPoint(window.Object, point), Times.Once);
 		mocks.LayoutEngine.Verify(l => l.RemoveWindow(window.Object), Times.Never);
 	}
 
@@ -995,20 +995,19 @@ public class WorkspaceTests
 
 		mocks.LayoutEngine.Reset();
 
-		// Set up AddAtPoint to return a new layout engine.
-		Mock<ILayoutEngine> removeResult = new();
-		Mock<ILayoutEngine> addAtPointResult = new();
+		// Set up MoveWindowToPoint to return a new layout engine.
+		Mock<ILayoutEngine> moveWindowToPointResult = new();
+		moveWindowToPointResult.Setup(l => l.Name).Returns("Move window to result");
 
-		mocks.LayoutEngine.Setup(l => l.RemoveWindow(It.IsAny<IWindow>())).Returns(removeResult.Object);
-		removeResult.Setup(l => l.AddAtPoint(window.Object, point)).Returns(addAtPointResult.Object);
-		removeResult.Setup(l => l.Name).Returns("Remove result");
+		mocks.LayoutEngine
+			.Setup(l => l.MoveWindowToPoint(It.IsAny<IWindow>(), point))
+			.Returns(moveWindowToPointResult.Object);
 
 		// When MoveWindowToPoint is called
 		workspace.MoveWindowToPoint(window.Object, point);
 
 		// Then the layout engine is told to remove and add the window
-		mocks.LayoutEngine.Verify(l => l.RemoveWindow(window.Object), Times.Once);
-		removeResult.Verify(l => l.AddAtPoint(window.Object, point), Times.Once);
+		mocks.LayoutEngine.Verify(l => l.MoveWindowToPoint(window.Object, point), Times.Once);
 	}
 
 	[Fact]

--- a/src/Whim.TreeLayout.CommandPalette.Tests/TreeLayoutCommandPaletteCommandsTests.cs
+++ b/src/Whim.TreeLayout.CommandPalette.Tests/TreeLayoutCommandPaletteCommandsTests.cs
@@ -1,6 +1,6 @@
 using Moq;
 using Whim.CommandPalette;
-using Whim.TestUtilities;
+using Whim.TestUtils;
 using Xunit;
 
 namespace Whim.TreeLayout.CommandPalette.Tests;

--- a/src/Whim.TreeLayout.Tests/LayoutEngine/AddAtPointTests.cs
+++ b/src/Whim.TreeLayout.Tests/LayoutEngine/AddAtPointTests.cs
@@ -4,10 +4,10 @@ using Xunit;
 
 namespace Whim.TreeLayout.Tests;
 
-public class AddAtPointTests
+public class MoveWindowToPointTests
 {
 	[Fact]
-	public void AddAtPoint_RootIsNull()
+	public void MoveWindowToPoint_RootIsNull()
 	{
 		// Given
 		LayoutEngineWrapper wrapper = new();
@@ -16,7 +16,7 @@ public class AddAtPointTests
 		IPoint<double> point = new Point<double>() { X = 0.5, Y = 0.5 };
 
 		// When
-		ILayoutEngine result = engine.AddAtPoint(window.Object, point);
+		ILayoutEngine result = engine.MoveWindowToPoint(window.Object, point);
 
 		// Then
 		Assert.NotSame(engine, result);
@@ -25,7 +25,7 @@ public class AddAtPointTests
 	}
 
 	[Fact]
-	public void AddAtPoint_RootIsNull_AddPhantom()
+	public void MoveWindowToPoint_RootIsNull_AddPhantom()
 	{
 		// Given
 		Mock<IWindow> window = new();
@@ -34,7 +34,7 @@ public class AddAtPointTests
 		IPoint<double> point = new Point<double>() { X = 0.5, Y = 0.5 };
 
 		// When
-		ILayoutEngine result = engine.AddAtPoint(window.Object, point);
+		ILayoutEngine result = engine.MoveWindowToPoint(window.Object, point);
 
 		// Then
 		Assert.NotSame(engine, result);
@@ -43,7 +43,7 @@ public class AddAtPointTests
 	}
 
 	[Fact]
-	public void AddAtPoint_RootIsPhantomNode()
+	public void MoveWindowToPoint_RootIsPhantomNode()
 	{
 		// Given
 		Mock<IWindow> phantomWindow = new();
@@ -58,7 +58,7 @@ public class AddAtPointTests
 		IPoint<double> point = new Point<double>() { X = 0.5, Y = 0.5 };
 
 		// When
-		ILayoutEngine result = engine.AddAtPoint(window.Object, point);
+		ILayoutEngine result = engine.MoveWindowToPoint(window.Object, point);
 
 		// Then
 		Assert.NotSame(engine, result);
@@ -67,7 +67,7 @@ public class AddAtPointTests
 	}
 
 	[Fact]
-	public void AddAtPoint_RootIsWindowNode_Right()
+	public void MoveWindowToPoint_RootIsWindowNode_Right()
 	{
 		// Given
 		Mock<IWindow> window1 = new();
@@ -86,7 +86,7 @@ public class AddAtPointTests
 		Mock<IMonitor> monitor = new();
 
 		// When
-		ILayoutEngine result = engine.AddAtPoint(window2.Object, point);
+		ILayoutEngine result = engine.MoveWindowToPoint(window2.Object, point);
 		IWindowState[] windowStates = result.DoLayout(location, monitor.Object).ToArray();
 
 		// Then
@@ -129,7 +129,7 @@ public class AddAtPointTests
 	}
 
 	[Fact]
-	public void AddAtPoint_RootIsWindowNode_Down()
+	public void MoveWindowToPoint_RootIsWindowNode_Down()
 	{
 		// Given
 		Mock<IWindow> window1 = new();
@@ -148,7 +148,7 @@ public class AddAtPointTests
 		Mock<IMonitor> monitor = new();
 
 		// When
-		ILayoutEngine result = engine.AddAtPoint(window2.Object, point);
+		ILayoutEngine result = engine.MoveWindowToPoint(window2.Object, point);
 		IWindowState[] windowStates = result.DoLayout(location, monitor.Object).ToArray();
 
 		// Then
@@ -191,7 +191,7 @@ public class AddAtPointTests
 	}
 
 	[Fact]
-	public void AddAtPoint_RootIsWindowNode_Left()
+	public void MoveWindowToPoint_RootIsWindowNode_Left()
 	{
 		// Given
 		Mock<IWindow> window1 = new();
@@ -210,7 +210,7 @@ public class AddAtPointTests
 		Mock<IMonitor> monitor = new();
 
 		// When
-		ILayoutEngine result = engine.AddAtPoint(window2.Object, point);
+		ILayoutEngine result = engine.MoveWindowToPoint(window2.Object, point);
 		IWindowState[] windowStates = result.DoLayout(location, monitor.Object).ToArray();
 
 		// Then
@@ -253,7 +253,7 @@ public class AddAtPointTests
 	}
 
 	[Fact]
-	public void AddAtPoint_RootIsWindowNode_Up()
+	public void MoveWindowToPoint_RootIsWindowNode_Up()
 	{
 		// Given
 		Mock<IWindow> window1 = new();
@@ -272,7 +272,7 @@ public class AddAtPointTests
 		Mock<IMonitor> monitor = new();
 
 		// When
-		ILayoutEngine result = engine.AddAtPoint(window2.Object, point);
+		ILayoutEngine result = engine.MoveWindowToPoint(window2.Object, point);
 		IWindowState[] windowStates = result.DoLayout(location, monitor.Object).ToArray();
 
 		// Then
@@ -315,7 +315,7 @@ public class AddAtPointTests
 	}
 
 	[Fact]
-	public void AddAtPoint_RootIsSplitNode_DoesNotContainPoint()
+	public void MoveWindowToPoint_RootIsSplitNode_DoesNotContainPoint()
 	{
 		// Given
 		Mock<IWindow> window1 = new();
@@ -330,7 +330,7 @@ public class AddAtPointTests
 		IPoint<double> point = new Point<double>() { X = 1.7, Y = 0.5 };
 
 		// When
-		ILayoutEngine result = engine.AddAtPoint(window3.Object, point);
+		ILayoutEngine result = engine.MoveWindowToPoint(window3.Object, point);
 
 		// Then
 		Assert.Same(engine, result);
@@ -341,7 +341,7 @@ public class AddAtPointTests
 	}
 
 	[Fact]
-	public void AddAtPoint_RootIsSplitNode_AddInDirection()
+	public void MoveWindowToPoint_RootIsSplitNode_AddInDirection()
 	{
 		// Given
 		Mock<IWindow> window1 = new();
@@ -359,7 +359,7 @@ public class AddAtPointTests
 		Mock<IMonitor> monitor = new();
 
 		// When
-		ILayoutEngine result = engine.AddAtPoint(window3.Object, point);
+		ILayoutEngine result = engine.MoveWindowToPoint(window3.Object, point);
 		IWindowState[] windowStates = result.DoLayout(location, monitor.Object).ToArray();
 
 		// Then
@@ -415,7 +415,7 @@ public class AddAtPointTests
 	}
 
 	[Fact]
-	public void AddAtPoint_RootIsSplitNode_AddInDifferentDirection()
+	public void MoveWindowToPoint_RootIsSplitNode_AddInDifferentDirection()
 	{
 		// Given
 		Mock<IWindow> window1 = new();
@@ -433,7 +433,7 @@ public class AddAtPointTests
 		Mock<IMonitor> monitor = new();
 
 		// When
-		ILayoutEngine result = engine.AddAtPoint(window3.Object, point);
+		ILayoutEngine result = engine.MoveWindowToPoint(window3.Object, point);
 		IWindowState[] windowStates = result.DoLayout(location, monitor.Object).ToArray();
 
 		// Then

--- a/src/Whim.TreeLayout.Tests/LayoutEngine/AddAtPointTests.cs
+++ b/src/Whim.TreeLayout.Tests/LayoutEngine/AddAtPointTests.cs
@@ -20,7 +20,7 @@ public class AddAtPointTests
 
 		// Then
 		Assert.NotSame(engine, result);
-		Assert.True(result.Contains(window.Object));
+		Assert.True(result.ContainsWindow(window.Object));
 		Assert.Equal(1, result.Count);
 	}
 
@@ -38,7 +38,7 @@ public class AddAtPointTests
 
 		// Then
 		Assert.NotSame(engine, result);
-		Assert.True(result.Contains(window.Object));
+		Assert.True(result.ContainsWindow(window.Object));
 		Assert.Equal(1, result.Count);
 	}
 
@@ -54,7 +54,7 @@ public class AddAtPointTests
 			wrapper.Context.Object,
 			wrapper.Plugin.Object,
 			wrapper.Identity
-		).Add(phantomWindow.Object);
+		).AddWindow(phantomWindow.Object);
 		IPoint<double> point = new Point<double>() { X = 0.5, Y = 0.5 };
 
 		// When
@@ -62,7 +62,7 @@ public class AddAtPointTests
 
 		// Then
 		Assert.NotSame(engine, result);
-		Assert.True(result.Contains(window.Object));
+		Assert.True(result.ContainsWindow(window.Object));
 		Assert.Equal(1, result.Count);
 	}
 
@@ -78,7 +78,7 @@ public class AddAtPointTests
 			wrapper.Context.Object,
 			wrapper.Plugin.Object,
 			wrapper.Identity
-		).Add(window1.Object);
+		).AddWindow(window1.Object);
 
 		IPoint<double> point = new Point<double>() { X = 0.7, Y = 0.5 };
 
@@ -91,8 +91,8 @@ public class AddAtPointTests
 
 		// Then
 		Assert.NotSame(engine, result);
-		Assert.True(result.Contains(window1.Object));
-		Assert.True(result.Contains(window2.Object));
+		Assert.True(result.ContainsWindow(window1.Object));
+		Assert.True(result.ContainsWindow(window2.Object));
 		Assert.Equal(2, result.Count);
 
 		windowStates
@@ -140,7 +140,7 @@ public class AddAtPointTests
 			wrapper.Context.Object,
 			wrapper.Plugin.Object,
 			wrapper.Identity
-		).Add(window1.Object);
+		).AddWindow(window1.Object);
 
 		IPoint<double> point = new Point<double>() { X = 0.5, Y = 0.7 };
 
@@ -153,8 +153,8 @@ public class AddAtPointTests
 
 		// Then
 		Assert.NotSame(engine, result);
-		Assert.True(result.Contains(window1.Object));
-		Assert.True(result.Contains(window2.Object));
+		Assert.True(result.ContainsWindow(window1.Object));
+		Assert.True(result.ContainsWindow(window2.Object));
 		Assert.Equal(2, result.Count);
 
 		windowStates
@@ -202,7 +202,7 @@ public class AddAtPointTests
 			wrapper.Context.Object,
 			wrapper.Plugin.Object,
 			wrapper.Identity
-		).Add(window1.Object);
+		).AddWindow(window1.Object);
 
 		IPoint<double> point = new Point<double>() { X = 0.3, Y = 0.5 };
 
@@ -215,8 +215,8 @@ public class AddAtPointTests
 
 		// Then
 		Assert.NotSame(engine, result);
-		Assert.True(result.Contains(window1.Object));
-		Assert.True(result.Contains(window2.Object));
+		Assert.True(result.ContainsWindow(window1.Object));
+		Assert.True(result.ContainsWindow(window2.Object));
 		Assert.Equal(2, result.Count);
 
 		windowStates
@@ -264,7 +264,7 @@ public class AddAtPointTests
 			wrapper.Context.Object,
 			wrapper.Plugin.Object,
 			wrapper.Identity
-		).Add(window1.Object);
+		).AddWindow(window1.Object);
 
 		IPoint<double> point = new Point<double>() { X = 0.5, Y = 0.3 };
 
@@ -277,8 +277,8 @@ public class AddAtPointTests
 
 		// Then
 		Assert.NotSame(engine, result);
-		Assert.True(result.Contains(window1.Object));
-		Assert.True(result.Contains(window2.Object));
+		Assert.True(result.ContainsWindow(window1.Object));
+		Assert.True(result.ContainsWindow(window2.Object));
 		Assert.Equal(2, result.Count);
 
 		windowStates
@@ -324,8 +324,8 @@ public class AddAtPointTests
 
 		LayoutEngineWrapper wrapper = new LayoutEngineWrapper().SetAsLastFocusedWindow(window1.Object);
 		ILayoutEngine engine = new TreeLayoutEngine(wrapper.Context.Object, wrapper.Plugin.Object, wrapper.Identity)
-			.Add(window1.Object)
-			.Add(window2.Object);
+			.AddWindow(window1.Object)
+			.AddWindow(window2.Object);
 
 		IPoint<double> point = new Point<double>() { X = 1.7, Y = 0.5 };
 
@@ -334,9 +334,9 @@ public class AddAtPointTests
 
 		// Then
 		Assert.Same(engine, result);
-		Assert.True(result.Contains(window1.Object));
-		Assert.True(result.Contains(window2.Object));
-		Assert.False(result.Contains(window3.Object));
+		Assert.True(result.ContainsWindow(window1.Object));
+		Assert.True(result.ContainsWindow(window2.Object));
+		Assert.False(result.ContainsWindow(window3.Object));
 		Assert.Equal(2, result.Count);
 	}
 
@@ -350,8 +350,8 @@ public class AddAtPointTests
 
 		LayoutEngineWrapper wrapper = new LayoutEngineWrapper().SetAsLastFocusedWindow(window1.Object);
 		ILayoutEngine engine = new TreeLayoutEngine(wrapper.Context.Object, wrapper.Plugin.Object, wrapper.Identity)
-			.Add(window1.Object)
-			.Add(window2.Object);
+			.AddWindow(window1.Object)
+			.AddWindow(window2.Object);
 
 		IPoint<double> point = new Point<double>() { X = 0.7, Y = 0.5 };
 
@@ -364,9 +364,9 @@ public class AddAtPointTests
 
 		// Then
 		Assert.NotSame(engine, result);
-		Assert.True(result.Contains(window1.Object));
-		Assert.True(result.Contains(window2.Object));
-		Assert.True(result.Contains(window3.Object));
+		Assert.True(result.ContainsWindow(window1.Object));
+		Assert.True(result.ContainsWindow(window2.Object));
+		Assert.True(result.ContainsWindow(window3.Object));
 		Assert.Equal(3, result.Count);
 
 		windowStates
@@ -424,8 +424,8 @@ public class AddAtPointTests
 
 		LayoutEngineWrapper wrapper = new LayoutEngineWrapper().SetAsLastFocusedWindow(window1.Object);
 		ILayoutEngine engine = new TreeLayoutEngine(wrapper.Context.Object, wrapper.Plugin.Object, wrapper.Identity)
-			.Add(window1.Object)
-			.Add(window2.Object);
+			.AddWindow(window1.Object)
+			.AddWindow(window2.Object);
 
 		IPoint<double> point = new Point<double>() { X = 0.75, Y = 0.8 };
 
@@ -438,9 +438,9 @@ public class AddAtPointTests
 
 		// Then
 		Assert.NotSame(engine, result);
-		Assert.True(result.Contains(window1.Object));
-		Assert.True(result.Contains(window2.Object));
-		Assert.True(result.Contains(window3.Object));
+		Assert.True(result.ContainsWindow(window1.Object));
+		Assert.True(result.ContainsWindow(window2.Object));
+		Assert.True(result.ContainsWindow(window3.Object));
 		Assert.Equal(3, result.Count);
 
 		windowStates

--- a/src/Whim.TreeLayout.Tests/LayoutEngine/AddAtPointTests.cs
+++ b/src/Whim.TreeLayout.Tests/LayoutEngine/AddAtPointTests.cs
@@ -487,4 +487,51 @@ public class MoveWindowToPointTests
 				}
 			);
 	}
+
+	[Fact]
+	public void MoveWindowToPoint_AlreadyContainsWindow()
+	{
+		// Given
+		Mock<IWindow> window = new();
+		LayoutEngineWrapper wrapper = new LayoutEngineWrapper().SetAsLastFocusedWindow(window.Object);
+		ILayoutEngine engine = new TreeLayoutEngine(
+			wrapper.Context.Object,
+			wrapper.Plugin.Object,
+			wrapper.Identity
+		).AddWindow(window.Object);
+
+		IPoint<double> point = new Point<double>() { X = 0.5, Y = 0.5 };
+
+		ILocation<int> location = new Location<int>() { Width = 100, Height = 100 };
+		Mock<IMonitor> monitor = new();
+
+		// When
+		ILayoutEngine result = engine.MoveWindowToPoint(window.Object, point);
+		IWindowState[] windowStates = result.DoLayout(location, monitor.Object).ToArray();
+
+		// Then
+		Assert.NotSame(engine, result);
+		Assert.True(result.ContainsWindow(window.Object));
+		Assert.Single(windowStates);
+
+		windowStates
+			.Should()
+			.BeEquivalentTo(
+				new IWindowState[]
+				{
+					new WindowState()
+					{
+						Window = window.Object,
+						Location = new Location<int>()
+						{
+							X = 0,
+							Y = 0,
+							Width = 100,
+							Height = 100
+						},
+						WindowSize = WindowSize.Normal
+					}
+				}
+			);
+	}
 }

--- a/src/Whim.TreeLayout.Tests/LayoutEngine/AddTests.cs
+++ b/src/Whim.TreeLayout.Tests/LayoutEngine/AddTests.cs
@@ -15,11 +15,11 @@ public class AddTests
 		TreeLayoutEngine engine = new(wrapper.Context.Object, wrapper.Plugin.Object, wrapper.Identity);
 
 		// When
-		ILayoutEngine result = engine.Add(window.Object);
+		ILayoutEngine result = engine.AddWindow(window.Object);
 
 		// Then
 		Assert.NotSame(engine, result);
-		Assert.True(result.Contains(window.Object));
+		Assert.True(result.ContainsWindow(window.Object));
 		Assert.Equal(1, result.Count);
 	}
 
@@ -32,11 +32,11 @@ public class AddTests
 		TreeLayoutEngine engine = new(wrapper.Context.Object, wrapper.Plugin.Object, wrapper.Identity);
 
 		// When
-		ILayoutEngine result = engine.Add(window.Object);
+		ILayoutEngine result = engine.AddWindow(window.Object);
 
 		// Then
 		Assert.NotSame(engine, result);
-		Assert.True(result.Contains(window.Object));
+		Assert.True(result.ContainsWindow(window.Object));
 		Assert.Equal(1, result.Count);
 	}
 
@@ -50,17 +50,17 @@ public class AddTests
 			wrapper.Context.Object,
 			wrapper.Plugin.Object,
 			wrapper.Identity
-		).Add(phantomWindow.Object);
+		).AddWindow(phantomWindow.Object);
 
 		Mock<IWindow> window = new();
 
 		// When
-		ILayoutEngine result = engine.Add(window.Object);
+		ILayoutEngine result = engine.AddWindow(window.Object);
 
 		// Then
 		Assert.NotSame(engine, result);
-		Assert.False(result.Contains(phantomWindow.Object));
-		Assert.True(result.Contains(window.Object));
+		Assert.False(result.ContainsWindow(phantomWindow.Object));
+		Assert.True(result.ContainsWindow(window.Object));
 		Assert.Equal(1, result.Count);
 	}
 
@@ -75,18 +75,18 @@ public class AddTests
 			wrapper.Context.Object,
 			wrapper.Plugin.Object,
 			wrapper.Identity
-		).Add(window1.Object);
+		).AddWindow(window1.Object);
 		ILocation<int> location = new Location<int>() { Width = 100, Height = 100 };
 		Mock<IMonitor> monitor = new();
 
 		// When
-		ILayoutEngine result = engine.Add(window2.Object);
+		ILayoutEngine result = engine.AddWindow(window2.Object);
 		IWindowState[] windowStates = result.DoLayout(location, monitor.Object).ToArray();
 
 		// Then
 		Assert.NotSame(engine, result);
-		Assert.True(result.Contains(window1.Object));
-		Assert.True(result.Contains(window2.Object));
+		Assert.True(result.ContainsWindow(window1.Object));
+		Assert.True(result.ContainsWindow(window2.Object));
 		Assert.Equal(2, result.Count);
 
 		windowStates
@@ -133,19 +133,19 @@ public class AddTests
 		LayoutEngineWrapper wrapper = new LayoutEngineWrapper().SetAsLastFocusedWindow(null);
 
 		ILayoutEngine engine = new TreeLayoutEngine(wrapper.Context.Object, wrapper.Plugin.Object, wrapper.Identity)
-			.Add(window1.Object)
-			.Add(window2.Object);
+			.AddWindow(window1.Object)
+			.AddWindow(window2.Object);
 
 		ILocation<int> location = new Location<int>() { Width = 100, Height = 100 };
 		Mock<IMonitor> monitor = new();
 
 		// When
-		ILayoutEngine result = engine.Add(window3.Object);
+		ILayoutEngine result = engine.AddWindow(window3.Object);
 		IWindowState[] windowStates = result.DoLayout(location, monitor.Object).ToArray();
 
 		// Then
 		Assert.NotSame(engine, result);
-		Assert.True(result.Contains(window3.Object));
+		Assert.True(result.ContainsWindow(window3.Object));
 		Assert.Equal(3, result.Count);
 
 		windowStates
@@ -204,19 +204,19 @@ public class AddTests
 		LayoutEngineWrapper wrapper = new LayoutEngineWrapper().SetAsLastFocusedWindow(window3.Object);
 
 		ILayoutEngine engine = new TreeLayoutEngine(wrapper.Context.Object, wrapper.Plugin.Object, wrapper.Identity)
-			.Add(window1.Object)
-			.Add(window2.Object);
+			.AddWindow(window1.Object)
+			.AddWindow(window2.Object);
 
 		ILocation<int> location = new Location<int>() { Width = 100, Height = 100 };
 		Mock<IMonitor> monitor = new();
 
 		// When
-		ILayoutEngine result = engine.Add(window3.Object);
+		ILayoutEngine result = engine.AddWindow(window3.Object);
 		IWindowState[] windowStates = result.DoLayout(location, monitor.Object).ToArray();
 
 		// Then
 		Assert.NotSame(engine, result);
-		Assert.True(result.Contains(window3.Object));
+		Assert.True(result.ContainsWindow(window3.Object));
 		Assert.Equal(3, result.Count);
 
 		windowStates
@@ -275,8 +275,8 @@ public class AddTests
 		LayoutEngineWrapper wrapper = new();
 
 		ILayoutEngine engine = new TreeLayoutEngine(wrapper.Context.Object, wrapper.Plugin.Object, wrapper.Identity)
-			.Add(window1.Object)
-			.Add(window2.Object);
+			.AddWindow(window1.Object)
+			.AddWindow(window2.Object);
 
 		wrapper.SetAsLastFocusedWindow(window1.Object);
 
@@ -284,12 +284,12 @@ public class AddTests
 		Mock<IMonitor> monitor = new();
 
 		// When
-		ILayoutEngine result = engine.Add(window3.Object);
+		ILayoutEngine result = engine.AddWindow(window3.Object);
 		IWindowState[] windowStates = result.DoLayout(location, monitor.Object).ToArray();
 
 		// Then
 		Assert.NotSame(engine, result);
-		Assert.True(result.Contains(window3.Object));
+		Assert.True(result.ContainsWindow(window3.Object));
 		Assert.Equal(3, result.Count);
 
 		windowStates
@@ -348,8 +348,8 @@ public class AddTests
 		LayoutEngineWrapper wrapper = new();
 
 		ILayoutEngine engine = new TreeLayoutEngine(wrapper.Context.Object, wrapper.Plugin.Object, wrapper.Identity)
-			.Add(window1.Object)
-			.Add(window2.Object);
+			.AddWindow(window1.Object)
+			.AddWindow(window2.Object);
 
 		wrapper.SetAddWindowDirection(Direction.Down);
 
@@ -357,12 +357,12 @@ public class AddTests
 		Mock<IMonitor> monitor = new();
 
 		// When
-		ILayoutEngine result = engine.Add(window3.Object);
+		ILayoutEngine result = engine.AddWindow(window3.Object);
 		IWindowState[] windowStates = result.DoLayout(location, monitor.Object).ToArray();
 
 		// Then
 		Assert.NotSame(engine, result);
-		Assert.True(result.Contains(window3.Object));
+		Assert.True(result.ContainsWindow(window3.Object));
 		Assert.Equal(3, result.Count);
 
 		windowStates

--- a/src/Whim.TreeLayout.Tests/LayoutEngine/FocusWindowInDirectionTests.cs
+++ b/src/Whim.TreeLayout.Tests/LayoutEngine/FocusWindowInDirectionTests.cs
@@ -34,7 +34,7 @@ public class FocusWindowInDirectionTests
 			wrapper.Context.Object,
 			wrapper.Plugin.Object,
 			wrapper.Identity
-		).Add(window1.Object);
+		).AddWindow(window1.Object);
 
 		// When
 		engine.FocusWindowInDirection(Direction.Left, focusWindow.Object);
@@ -54,8 +54,8 @@ public class FocusWindowInDirectionTests
 		LayoutEngineWrapper wrapper = new();
 
 		ILayoutEngine engine = new TreeLayoutEngine(wrapper.Context.Object, wrapper.Plugin.Object, wrapper.Identity)
-			.Add(window1.Object)
-			.Add(window2.Object);
+			.AddWindow(window1.Object)
+			.AddWindow(window2.Object);
 
 		// When
 		engine.FocusWindowInDirection(Direction.Left, window1.Object);
@@ -75,8 +75,8 @@ public class FocusWindowInDirectionTests
 		LayoutEngineWrapper wrapper = new();
 
 		ILayoutEngine engine = new TreeLayoutEngine(wrapper.Context.Object, wrapper.Plugin.Object, wrapper.Identity)
-			.Add(window1.Object)
-			.Add(window2.Object);
+			.AddWindow(window1.Object)
+			.AddWindow(window2.Object);
 
 		// When
 		engine.FocusWindowInDirection(Direction.Right, window1.Object);

--- a/src/Whim.TreeLayout.Tests/LayoutEngine/GetFirstWindowTests.cs
+++ b/src/Whim.TreeLayout.Tests/LayoutEngine/GetFirstWindowTests.cs
@@ -31,7 +31,7 @@ public class GetFirstWindowTests
 			wrapper.Context.Object,
 			wrapper.Plugin.Object,
 			wrapper.Identity
-		).Add(window.Object);
+		).AddWindow(window.Object);
 
 		// When
 		IWindow? result = engine.GetFirstWindow();
@@ -53,7 +53,7 @@ public class GetFirstWindowTests
 			wrapper.Context.Object,
 			wrapper.Plugin.Object,
 			wrapper.Identity
-		).Add(window.Object);
+		).AddWindow(window.Object);
 
 		// When
 		IWindow? result = engine.GetFirstWindow();
@@ -73,9 +73,9 @@ public class GetFirstWindowTests
 		LayoutEngineWrapper wrapper = new LayoutEngineWrapper().SetAsLastFocusedWindow(null);
 
 		ILayoutEngine engine = new TreeLayoutEngine(wrapper.Context.Object, wrapper.Plugin.Object, wrapper.Identity)
-			.Add(window1.Object)
-			.Add(window2.Object)
-			.Add(window3.Object);
+			.AddWindow(window1.Object)
+			.AddWindow(window2.Object)
+			.AddWindow(window3.Object);
 
 		// When
 		IWindow? result = engine.GetFirstWindow();

--- a/src/Whim.TreeLayout.Tests/LayoutEngine/HidePhantomWindowsTests.cs
+++ b/src/Whim.TreeLayout.Tests/LayoutEngine/HidePhantomWindowsTests.cs
@@ -19,10 +19,10 @@ public class HidePhantomWindowsTests
 			.SetAsPhantom(phantomWindow1.Object, phantomWindow2.Object);
 
 		ILayoutEngine engine = new TreeLayoutEngine(wrapper.Context.Object, wrapper.Plugin.Object, wrapper.Identity)
-			.Add(window1.Object)
-			.Add(window2.Object)
-			.Add(phantomWindow1.Object)
-			.Add(phantomWindow2.Object);
+			.AddWindow(window1.Object)
+			.AddWindow(window2.Object)
+			.AddWindow(phantomWindow1.Object)
+			.AddWindow(phantomWindow2.Object);
 
 		// When
 		engine.HidePhantomWindows();

--- a/src/Whim.TreeLayout.Tests/LayoutEngine/MoveWindowEdgesInDirectionTests.cs
+++ b/src/Whim.TreeLayout.Tests/LayoutEngine/MoveWindowEdgesInDirectionTests.cs
@@ -39,8 +39,8 @@ public class MoveSingleWindowEdgeInDirectionTests
 		IPoint<double> pixelsDeltas = new Point<double>() { X = 0.1, Y = 0.1 };
 
 		ILayoutEngine engine = new TreeLayoutEngine(wrapper.Context.Object, wrapper.Plugin.Object, wrapper.Identity)
-			.Add(window1.Object)
-			.Add(window2.Object);
+			.AddWindow(window1.Object)
+			.AddWindow(window2.Object);
 
 		// When
 		ILayoutEngine result = engine.MoveWindowEdgesInDirection(
@@ -67,7 +67,7 @@ public class MoveSingleWindowEdgeInDirectionTests
 			wrapper.Context.Object,
 			wrapper.Plugin.Object,
 			wrapper.Identity
-		).Add(window1.Object);
+		).AddWindow(window1.Object);
 
 		// When
 		ILayoutEngine result = engine.MoveWindowEdgesInDirection(Direction.Left, pixelsDeltas, window1.Object);
@@ -89,9 +89,9 @@ public class MoveSingleWindowEdgeInDirectionTests
 		IPoint<double> pixelsDeltas = new Point<double>() { X = -0.4 };
 
 		ILayoutEngine engine = new TreeLayoutEngine(wrapper.Context.Object, wrapper.Plugin.Object, wrapper.Identity)
-			.Add(window1.Object)
-			.Add(window2.Object)
-			.Add(window3.Object);
+			.AddWindow(window1.Object)
+			.AddWindow(window2.Object)
+			.AddWindow(window3.Object);
 
 		// When
 		ILayoutEngine result = engine.MoveWindowEdgesInDirection(Direction.Left, pixelsDeltas, window2.Object);
@@ -113,9 +113,9 @@ public class MoveSingleWindowEdgeInDirectionTests
 		IPoint<double> pixelsDeltas = new Point<double>() { X = 0.4 };
 
 		ILayoutEngine engine = new TreeLayoutEngine(wrapper.Context.Object, wrapper.Plugin.Object, wrapper.Identity)
-			.Add(window1.Object)
-			.Add(window2.Object)
-			.Add(window3.Object);
+			.AddWindow(window1.Object)
+			.AddWindow(window2.Object)
+			.AddWindow(window3.Object);
 
 		// When
 		ILayoutEngine result = engine.MoveWindowEdgesInDirection(Direction.Left, pixelsDeltas, window2.Object);
@@ -327,9 +327,9 @@ public class MoveSingleWindowEdgeInDirectionTests
 		LayoutEngineWrapper wrapper = new();
 
 		ILayoutEngine engine = new TreeLayoutEngine(wrapper.Context.Object, wrapper.Plugin.Object, wrapper.Identity)
-			.Add(window1.Object)
-			.Add(window2.Object)
-			.Add(window3.Object);
+			.AddWindow(window1.Object)
+			.AddWindow(window2.Object)
+			.AddWindow(window3.Object);
 
 		Mock<IMonitor> monitor = new();
 
@@ -532,9 +532,9 @@ public class MoveSingleWindowEdgeInDirectionTests
 		LayoutEngineWrapper wrapper = new LayoutEngineWrapper().SetAddWindowDirection(Direction.Down);
 
 		ILayoutEngine engine = new TreeLayoutEngine(wrapper.Context.Object, wrapper.Plugin.Object, wrapper.Identity)
-			.Add(window1.Object)
-			.Add(window2.Object)
-			.Add(window3.Object);
+			.AddWindow(window1.Object)
+			.AddWindow(window2.Object)
+			.AddWindow(window3.Object);
 
 		Mock<IMonitor> monitor = new();
 
@@ -988,8 +988,8 @@ public class MoveSingleWindowEdgeInDirectionTests
 		LayoutEngineWrapper wrapper = new();
 
 		ILayoutEngine engine = new TreeLayoutEngine(wrapper.Context.Object, wrapper.Plugin.Object, wrapper.Identity)
-			.Add(topLeft.Object)
-			.Add(topRight.Object)
+			.AddWindow(topLeft.Object)
+			.AddWindow(topRight.Object)
 			.AddAtPoint(bottomLeft.Object, new Point<double>() { X = 0.25, Y = 0.9 })
 			.AddAtPoint(bottomRight.Object, new Point<double>() { X = 0.75, Y = 0.9 });
 
@@ -1019,9 +1019,9 @@ public class MoveSingleWindowEdgeInDirectionTests
 		IPoint<double> pixelsDeltas = new Point<double>() { X = 0.1, Y = 0.1 };
 
 		ILayoutEngine engine = new TreeLayoutEngine(wrapper.Context.Object, wrapper.Plugin.Object, wrapper.Identity)
-			.Add(window1.Object)
-			.Add(window2.Object)
-			.Add(window3.Object);
+			.AddWindow(window1.Object)
+			.AddWindow(window2.Object)
+			.AddWindow(window3.Object);
 
 		// When
 		ILayoutEngine result = engine.MoveWindowEdgesInDirection((Direction)128, pixelsDeltas, window2.Object);

--- a/src/Whim.TreeLayout.Tests/LayoutEngine/MoveWindowEdgesInDirectionTests.cs
+++ b/src/Whim.TreeLayout.Tests/LayoutEngine/MoveWindowEdgesInDirectionTests.cs
@@ -990,8 +990,8 @@ public class MoveSingleWindowEdgeInDirectionTests
 		ILayoutEngine engine = new TreeLayoutEngine(wrapper.Context.Object, wrapper.Plugin.Object, wrapper.Identity)
 			.AddWindow(topLeft.Object)
 			.AddWindow(topRight.Object)
-			.AddAtPoint(bottomLeft.Object, new Point<double>() { X = 0.25, Y = 0.9 })
-			.AddAtPoint(bottomRight.Object, new Point<double>() { X = 0.75, Y = 0.9 });
+			.MoveWindowToPoint(bottomLeft.Object, new Point<double>() { X = 0.25, Y = 0.9 })
+			.MoveWindowToPoint(bottomRight.Object, new Point<double>() { X = 0.75, Y = 0.9 });
 
 		Mock<IMonitor> monitor = new();
 

--- a/src/Whim.TreeLayout.Tests/LayoutEngine/RemoveTests.cs
+++ b/src/Whim.TreeLayout.Tests/LayoutEngine/RemoveTests.cs
@@ -14,7 +14,7 @@ public class RemoveTests
 		TreeLayoutEngine engine = new(wrapper.Context.Object, wrapper.Plugin.Object, wrapper.Identity);
 
 		// When
-		ILayoutEngine result = engine.Remove(window.Object);
+		ILayoutEngine result = engine.RemoveWindow(window.Object);
 
 		// Then
 		Assert.Same(engine, result);
@@ -30,14 +30,14 @@ public class RemoveTests
 			wrapper.Context.Object,
 			wrapper.Plugin.Object,
 			wrapper.Identity
-		).Add(window.Object);
+		).AddWindow(window.Object);
 
 		// When
-		ILayoutEngine result = engine.Remove(window.Object);
+		ILayoutEngine result = engine.RemoveWindow(window.Object);
 
 		// Then
 		Assert.NotSame(engine, result);
-		Assert.False(result.Contains(window.Object));
+		Assert.False(result.ContainsWindow(window.Object));
 		Assert.Equal(0, result.Count);
 	}
 
@@ -51,16 +51,16 @@ public class RemoveTests
 			wrapper.Context.Object,
 			wrapper.Plugin.Object,
 			wrapper.Identity
-		).Add(window.Object);
+		).AddWindow(window.Object);
 
 		Mock<IWindow> wrongWindow = new();
 
 		// When
-		ILayoutEngine result = engine.Remove(wrongWindow.Object);
+		ILayoutEngine result = engine.RemoveWindow(wrongWindow.Object);
 
 		// Then
 		Assert.Same(engine, result);
-		Assert.True(result.Contains(window.Object));
+		Assert.True(result.ContainsWindow(window.Object));
 		Assert.Equal(1, result.Count);
 	}
 
@@ -72,18 +72,18 @@ public class RemoveTests
 		Mock<IWindow> window2 = new();
 		LayoutEngineWrapper wrapper = new();
 		ILayoutEngine engine = new TreeLayoutEngine(wrapper.Context.Object, wrapper.Plugin.Object, wrapper.Identity)
-			.Add(window1.Object)
-			.Add(window2.Object);
+			.AddWindow(window1.Object)
+			.AddWindow(window2.Object);
 
 		Mock<IWindow> wrongWindow = new();
 
 		// When
-		ILayoutEngine result = engine.Remove(wrongWindow.Object);
+		ILayoutEngine result = engine.RemoveWindow(wrongWindow.Object);
 
 		// Then
 		Assert.Same(engine, result);
-		Assert.True(result.Contains(window1.Object));
-		Assert.True(result.Contains(window2.Object));
+		Assert.True(result.ContainsWindow(window1.Object));
+		Assert.True(result.ContainsWindow(window2.Object));
 		Assert.Equal(2, result.Count);
 	}
 
@@ -95,16 +95,16 @@ public class RemoveTests
 		Mock<IWindow> window2 = new();
 		LayoutEngineWrapper wrapper = new();
 		ILayoutEngine engine = new TreeLayoutEngine(wrapper.Context.Object, wrapper.Plugin.Object, wrapper.Identity)
-			.Add(window1.Object)
-			.Add(window2.Object);
+			.AddWindow(window1.Object)
+			.AddWindow(window2.Object);
 
 		// When
-		ILayoutEngine result = engine.Remove(window1.Object);
+		ILayoutEngine result = engine.RemoveWindow(window1.Object);
 
 		// Then
 		Assert.NotSame(engine, result);
-		Assert.False(result.Contains(window1.Object));
-		Assert.True(result.Contains(window2.Object));
+		Assert.False(result.ContainsWindow(window1.Object));
+		Assert.True(result.ContainsWindow(window2.Object));
 		Assert.Equal(1, result.Count);
 	}
 
@@ -117,18 +117,18 @@ public class RemoveTests
 		Mock<IWindow> window3 = new();
 		LayoutEngineWrapper wrapper = new();
 		ILayoutEngine engine = new TreeLayoutEngine(wrapper.Context.Object, wrapper.Plugin.Object, wrapper.Identity)
-			.Add(window1.Object)
-			.Add(window2.Object)
+			.AddWindow(window1.Object)
+			.AddWindow(window2.Object)
 			.AddAtPoint(window3.Object, new Point<double>() { X = 0.75, Y = 0.75 });
 
 		// When
-		ILayoutEngine result = engine.Remove(window3.Object);
+		ILayoutEngine result = engine.RemoveWindow(window3.Object);
 
 		// Then
 		Assert.NotSame(engine, result);
-		Assert.True(result.Contains(window1.Object));
-		Assert.True(result.Contains(window2.Object));
-		Assert.False(result.Contains(window3.Object));
+		Assert.True(result.ContainsWindow(window1.Object));
+		Assert.True(result.ContainsWindow(window2.Object));
+		Assert.False(result.ContainsWindow(window3.Object));
 		Assert.Equal(2, result.Count);
 	}
 
@@ -141,18 +141,18 @@ public class RemoveTests
 		Mock<IWindow> window3 = new();
 		LayoutEngineWrapper wrapper = new();
 		ILayoutEngine engine = new TreeLayoutEngine(wrapper.Context.Object, wrapper.Plugin.Object, wrapper.Identity)
-			.Add(window1.Object)
-			.Add(window2.Object)
+			.AddWindow(window1.Object)
+			.AddWindow(window2.Object)
 			.AddAtPoint(window3.Object, new Point<double>() { X = 0.75, Y = 0.75 });
 
 		// When
-		ILayoutEngine result = engine.Remove(window1.Object);
+		ILayoutEngine result = engine.RemoveWindow(window1.Object);
 
 		// Then
 		Assert.NotSame(engine, result);
-		Assert.False(result.Contains(window1.Object));
-		Assert.True(result.Contains(window2.Object));
-		Assert.True(result.Contains(window3.Object));
+		Assert.False(result.ContainsWindow(window1.Object));
+		Assert.True(result.ContainsWindow(window2.Object));
+		Assert.True(result.ContainsWindow(window3.Object));
 		Assert.Equal(2, result.Count);
 	}
 
@@ -165,18 +165,18 @@ public class RemoveTests
 		Mock<IWindow> window3 = new();
 		LayoutEngineWrapper wrapper = new();
 		ILayoutEngine engine = new TreeLayoutEngine(wrapper.Context.Object, wrapper.Plugin.Object, wrapper.Identity)
-			.Add(window1.Object)
-			.Add(window2.Object)
-			.Add(window3.Object);
+			.AddWindow(window1.Object)
+			.AddWindow(window2.Object)
+			.AddWindow(window3.Object);
 
 		// When
-		ILayoutEngine result = engine.Remove(window2.Object);
+		ILayoutEngine result = engine.RemoveWindow(window2.Object);
 
 		// Then
 		Assert.NotSame(engine, result);
-		Assert.True(result.Contains(window1.Object));
-		Assert.False(result.Contains(window2.Object));
-		Assert.True(result.Contains(window3.Object));
+		Assert.True(result.ContainsWindow(window1.Object));
+		Assert.False(result.ContainsWindow(window2.Object));
+		Assert.True(result.ContainsWindow(window3.Object));
 		Assert.Equal(2, result.Count);
 	}
 }

--- a/src/Whim.TreeLayout.Tests/LayoutEngine/RemoveTests.cs
+++ b/src/Whim.TreeLayout.Tests/LayoutEngine/RemoveTests.cs
@@ -119,7 +119,7 @@ public class RemoveTests
 		ILayoutEngine engine = new TreeLayoutEngine(wrapper.Context.Object, wrapper.Plugin.Object, wrapper.Identity)
 			.AddWindow(window1.Object)
 			.AddWindow(window2.Object)
-			.AddAtPoint(window3.Object, new Point<double>() { X = 0.75, Y = 0.75 });
+			.MoveWindowToPoint(window3.Object, new Point<double>() { X = 0.75, Y = 0.75 });
 
 		// When
 		ILayoutEngine result = engine.RemoveWindow(window3.Object);
@@ -143,7 +143,7 @@ public class RemoveTests
 		ILayoutEngine engine = new TreeLayoutEngine(wrapper.Context.Object, wrapper.Plugin.Object, wrapper.Identity)
 			.AddWindow(window1.Object)
 			.AddWindow(window2.Object)
-			.AddAtPoint(window3.Object, new Point<double>() { X = 0.75, Y = 0.75 });
+			.MoveWindowToPoint(window3.Object, new Point<double>() { X = 0.75, Y = 0.75 });
 
 		// When
 		ILayoutEngine result = engine.RemoveWindow(window1.Object);

--- a/src/Whim.TreeLayout.Tests/LayoutEngine/SwapWindowInDirectionTests.cs
+++ b/src/Whim.TreeLayout.Tests/LayoutEngine/SwapWindowInDirectionTests.cs
@@ -138,7 +138,7 @@ public class SwapWindowInDirectionTests
 		ILayoutEngine engine = new TreeLayoutEngine(wrapper.Context.Object, wrapper.Plugin.Object, wrapper.Identity)
 			.AddWindow(window1.Object)
 			.AddWindow(window2.Object)
-			.AddAtPoint(window3.Object, new Point<double>() { X = 0.75, Y = 0.75 });
+			.MoveWindowToPoint(window3.Object, new Point<double>() { X = 0.75, Y = 0.75 });
 
 		Mock<IMonitor> monitor = new();
 		ILocation<int> location = new Location<int>() { Width = 100, Height = 100 };
@@ -201,8 +201,8 @@ public class SwapWindowInDirectionTests
 		ILayoutEngine engine = new TreeLayoutEngine(wrapper.Context.Object, wrapper.Plugin.Object, wrapper.Identity)
 			.AddWindow(topLeft.Object)
 			.AddWindow(topRight.Object)
-			.AddAtPoint(bottomLeft.Object, new Point<double>() { X = 0.25, Y = 0.9 })
-			.AddAtPoint(bottomRight.Object, new Point<double>() { X = 0.75, Y = 0.9 });
+			.MoveWindowToPoint(bottomLeft.Object, new Point<double>() { X = 0.25, Y = 0.9 })
+			.MoveWindowToPoint(bottomRight.Object, new Point<double>() { X = 0.75, Y = 0.9 });
 
 		Mock<IMonitor> monitor = new();
 		ILocation<int> location = new Location<int>() { Width = 100, Height = 100 };

--- a/src/Whim.TreeLayout.Tests/LayoutEngine/SwapWindowInDirectionTests.cs
+++ b/src/Whim.TreeLayout.Tests/LayoutEngine/SwapWindowInDirectionTests.cs
@@ -19,7 +19,7 @@ public class SwapWindowInDirectionTests
 
 		// Then
 		Assert.Same(engine, result);
-		Assert.False(result.Contains(window.Object));
+		Assert.False(result.ContainsWindow(window.Object));
 		Assert.Equal(0, result.Count);
 	}
 
@@ -31,8 +31,8 @@ public class SwapWindowInDirectionTests
 		Mock<IWindow> window2 = new();
 		LayoutEngineWrapper wrapper = new();
 		ILayoutEngine engine = new TreeLayoutEngine(wrapper.Context.Object, wrapper.Plugin.Object, wrapper.Identity)
-			.Add(window1.Object)
-			.Add(window2.Object);
+			.AddWindow(window1.Object)
+			.AddWindow(window2.Object);
 
 		Mock<IMonitor> monitor = new();
 		ILocation<int> location = new Location<int>() { Width = 100, Height = 100 };
@@ -83,8 +83,8 @@ public class SwapWindowInDirectionTests
 		Mock<IWindow> window2 = new();
 		LayoutEngineWrapper wrapper = new();
 		ILayoutEngine engine = new TreeLayoutEngine(wrapper.Context.Object, wrapper.Plugin.Object, wrapper.Identity)
-			.Add(window1.Object)
-			.Add(window2.Object);
+			.AddWindow(window1.Object)
+			.AddWindow(window2.Object);
 
 		Mock<IMonitor> monitor = new();
 		ILocation<int> location = new Location<int>() { Width = 100, Height = 100 };
@@ -136,8 +136,8 @@ public class SwapWindowInDirectionTests
 		Mock<IWindow> window3 = new();
 		LayoutEngineWrapper wrapper = new();
 		ILayoutEngine engine = new TreeLayoutEngine(wrapper.Context.Object, wrapper.Plugin.Object, wrapper.Identity)
-			.Add(window1.Object)
-			.Add(window2.Object)
+			.AddWindow(window1.Object)
+			.AddWindow(window2.Object)
 			.AddAtPoint(window3.Object, new Point<double>() { X = 0.75, Y = 0.75 });
 
 		Mock<IMonitor> monitor = new();
@@ -199,8 +199,8 @@ public class SwapWindowInDirectionTests
 		LayoutEngineWrapper wrapper = new();
 
 		ILayoutEngine engine = new TreeLayoutEngine(wrapper.Context.Object, wrapper.Plugin.Object, wrapper.Identity)
-			.Add(topLeft.Object)
-			.Add(topRight.Object)
+			.AddWindow(topLeft.Object)
+			.AddWindow(topRight.Object)
 			.AddAtPoint(bottomLeft.Object, new Point<double>() { X = 0.25, Y = 0.9 })
 			.AddAtPoint(bottomRight.Object, new Point<double>() { X = 0.75, Y = 0.9 });
 

--- a/src/Whim.TreeLayout/TreeLayoutEngine.cs
+++ b/src/Whim.TreeLayout/TreeLayoutEngine.cs
@@ -307,17 +307,14 @@ public class TreeLayoutEngine : ILayoutEngine
 			yield break;
 		}
 
-		foreach (LeafNodeWindowLocationState? item in _root.GetWindowLocations(location))
+		foreach (LeafNodeWindowLocationState item in _root.GetWindowLocations(location))
 		{
-			if (item.LeafNode is LeafNode leafNode)
+			yield return new WindowState()
 			{
-				yield return new WindowState()
-				{
-					Window = leafNode.Window,
-					Location = item.Location,
-					WindowSize = item.WindowSize
-				};
-			}
+				Window = item.LeafNode.Window,
+				Location = item.Location,
+				WindowSize = item.WindowSize
+			};
 		}
 	}
 

--- a/src/Whim.TreeLayout/TreeLayoutEngine.cs
+++ b/src/Whim.TreeLayout/TreeLayoutEngine.cs
@@ -127,7 +127,7 @@ public class TreeLayoutEngine : ILayoutEngine
 	}
 
 	/// <inheritdoc/>
-	public ILayoutEngine Add(IWindow window)
+	public ILayoutEngine AddWindow(IWindow window)
 	{
 		Logger.Debug($"Adding window {window} to layout engine {Name}");
 
@@ -208,7 +208,7 @@ public class TreeLayoutEngine : ILayoutEngine
 
 		if (_windows.ContainsKey(window))
 		{
-			treeLayoutEngine = (TreeLayoutEngine)treeLayoutEngine.Remove(window);
+			treeLayoutEngine = (TreeLayoutEngine)treeLayoutEngine.RemoveWindow(window);
 		}
 
 		return treeLayoutEngine.AddWindowAtPoint(window, point);
@@ -290,7 +290,7 @@ public class TreeLayoutEngine : ILayoutEngine
 	}
 
 	/// <inheritdoc />
-	public bool Contains(IWindow window)
+	public bool ContainsWindow(IWindow window)
 	{
 		Logger.Debug($"Checking if layout engine {Name} contains window {window}");
 
@@ -552,7 +552,7 @@ public class TreeLayoutEngine : ILayoutEngine
 	}
 
 	/// <inheritdoc />
-	public ILayoutEngine Remove(IWindow window)
+	public ILayoutEngine RemoveWindow(IWindow window)
 	{
 		Logger.Debug($"Removing window {window} from layout engine {Name}");
 

--- a/src/Whim.TreeLayout/TreeLayoutEngine.cs
+++ b/src/Whim.TreeLayout/TreeLayoutEngine.cs
@@ -246,14 +246,14 @@ public class TreeLayoutEngine : ILayoutEngine
 
 		if (_root is ISplitNode splitNode)
 		{
-			return AddAtPointSplitNode(point, newLeafNode, splitNode);
+			return MoveWindowToPointSplitNode(point, newLeafNode, splitNode);
 		}
 
 		Logger.Debug($"Root is null, creating new window node");
 		return new TreeLayoutEngine(this, newLeafNode, CreateRootNodeDict(window));
 	}
 
-	private ILayoutEngine AddAtPointSplitNode(IPoint<double> point, LeafNode newLeafNode, ISplitNode rootNode)
+	private ILayoutEngine MoveWindowToPointSplitNode(IPoint<double> point, LeafNode newLeafNode, ISplitNode rootNode)
 	{
 		LeafNodeStateAtPoint? result = rootNode.GetNodeContainingPoint(point);
 		if (result is null)

--- a/src/Whim.TreeLayout/TreeLayoutEngine.cs
+++ b/src/Whim.TreeLayout/TreeLayoutEngine.cs
@@ -200,10 +200,22 @@ public class TreeLayoutEngine : ILayoutEngine
 	}
 
 	/// <inheritdoc />
-	public ILayoutEngine AddAtPoint(IWindow window, IPoint<double> point)
+	public ILayoutEngine MoveWindowToPoint(IWindow window, IPoint<double> point)
 	{
 		Logger.Debug($"Adding window {window} to layout engine {Name}");
 
+		TreeLayoutEngine treeLayoutEngine = this;
+
+		if (_windows.ContainsKey(window))
+		{
+			treeLayoutEngine = (TreeLayoutEngine)treeLayoutEngine.Remove(window);
+		}
+
+		return treeLayoutEngine.AddWindowAtPoint(window, point);
+	}
+
+	private ILayoutEngine AddWindowAtPoint(IWindow window, IPoint<double> point)
+	{
 		// Create the new leaf node.
 		LeafNode newLeafNode = _plugin.PhantomWindows.Contains(window)
 			? new PhantomNode(window)

--- a/src/Whim/Layout/BaseProxyLayoutEngine.cs
+++ b/src/Whim/Layout/BaseProxyLayoutEngine.cs
@@ -61,8 +61,8 @@ public abstract class BaseProxyLayoutEngine : ILayoutEngine
 	public virtual ILayoutEngine Add(IWindow window) => Update(InnerLayoutEngine.Add(window));
 
 	/// <inheritdoc/>
-	public virtual ILayoutEngine AddAtPoint(IWindow window, IPoint<double> point) =>
-		Update(InnerLayoutEngine.AddAtPoint(window, point));
+	public virtual ILayoutEngine MoveWindowToPoint(IWindow window, IPoint<double> point) =>
+		Update(InnerLayoutEngine.MoveWindowToPoint(window, point));
 
 	/// <inheritdoc/>
 	public virtual ILayoutEngine Remove(IWindow window) => Update(InnerLayoutEngine.Remove(window));

--- a/src/Whim/Layout/BaseProxyLayoutEngine.cs
+++ b/src/Whim/Layout/BaseProxyLayoutEngine.cs
@@ -19,17 +19,17 @@ public abstract class BaseProxyLayoutEngine : ILayoutEngine
 	/// </summary>
 	protected ILayoutEngine InnerLayoutEngine { get; }
 
-	/// <inheritdoc/>
-	public LayoutEngineIdentity Identity => InnerLayoutEngine.Identity;
-
 	/// <summary>
-	/// Constructs a new proxy layout engine.
+	/// Creates a new <cref name="BaseProxyLayoutEngine"/> with the given <paramref name="innerLayoutEngine"/>.
 	/// </summary>
-	/// <param name="innerLayoutEngine">The proxied layout engine.</param>
+	/// <param name="innerLayoutEngine"></param>
 	protected BaseProxyLayoutEngine(ILayoutEngine innerLayoutEngine)
 	{
 		InnerLayoutEngine = innerLayoutEngine;
 	}
+
+	/// <inheritdoc/>
+	public LayoutEngineIdentity Identity => InnerLayoutEngine.Identity;
 
 	/// <summary>
 	/// Updates the layout engine with the new proxied layout engine.
@@ -52,44 +52,40 @@ public abstract class BaseProxyLayoutEngine : ILayoutEngine
 	/// The name is only really important for the user, so we can use the name of the proxied layout engine.
 	/// </summary>
 	/// <inheritdoc/>
-	public virtual string Name => InnerLayoutEngine.Name;
+	public string Name => InnerLayoutEngine.Name;
 
 	/// <inheritdoc/>
-	public virtual int Count => InnerLayoutEngine.Count;
+	public abstract int Count { get; }
 
 	/// <inheritdoc/>
-	public virtual ILayoutEngine AddWindow(IWindow window) => Update(InnerLayoutEngine.AddWindow(window));
+	public abstract ILayoutEngine AddWindow(IWindow window);
 
 	/// <inheritdoc/>
-	public virtual ILayoutEngine MoveWindowToPoint(IWindow window, IPoint<double> point) =>
-		Update(InnerLayoutEngine.MoveWindowToPoint(window, point));
+	public abstract ILayoutEngine MoveWindowToPoint(IWindow window, IPoint<double> point);
 
 	/// <inheritdoc/>
-	public virtual ILayoutEngine RemoveWindow(IWindow window) => Update(InnerLayoutEngine.RemoveWindow(window));
+	public abstract ILayoutEngine RemoveWindow(IWindow window);
 
 	/// <inheritdoc/>
-	public virtual IWindow? GetFirstWindow() => InnerLayoutEngine.GetFirstWindow();
+	public abstract IWindow? GetFirstWindow();
 
 	/// <inheritdoc/>
-	public virtual void FocusWindowInDirection(Direction direction, IWindow window) =>
-		InnerLayoutEngine.FocusWindowInDirection(direction, window);
+	public abstract void FocusWindowInDirection(Direction direction, IWindow window);
 
 	/// <inheritdoc/>
-	public virtual ILayoutEngine SwapWindowInDirection(Direction direction, IWindow window) =>
-		Update(InnerLayoutEngine.SwapWindowInDirection(direction, window));
+	public abstract ILayoutEngine SwapWindowInDirection(Direction direction, IWindow window);
 
 	/// <inheritdoc/>
-	public virtual bool ContainsWindow(IWindow window) => InnerLayoutEngine.ContainsWindow(window);
+	public abstract bool ContainsWindow(IWindow window);
 
 	/// <inheritdoc/>
-	public virtual ILayoutEngine MoveWindowEdgesInDirection(Direction edge, IPoint<double> deltas, IWindow window) =>
-		Update(InnerLayoutEngine.MoveWindowEdgesInDirection(edge, deltas, window));
+	public abstract ILayoutEngine MoveWindowEdgesInDirection(Direction edge, IPoint<double> deltas, IWindow window);
 
 	/// <inheritdoc/>
 	public abstract IEnumerable<IWindowState> DoLayout(ILocation<int> location, IMonitor monitor);
 
 	/// <inheritdoc/>
-	public virtual void HidePhantomWindows() => InnerLayoutEngine.HidePhantomWindows();
+	public abstract void HidePhantomWindows();
 
 	/// <summary>
 	/// Checks to see if this <cref name="IImmutableLayoutEngine"/>

--- a/src/Whim/Layout/BaseProxyLayoutEngine.cs
+++ b/src/Whim/Layout/BaseProxyLayoutEngine.cs
@@ -32,23 +32,6 @@ public abstract class BaseProxyLayoutEngine : ILayoutEngine
 	public LayoutEngineIdentity Identity => InnerLayoutEngine.Identity;
 
 	/// <summary>
-	/// Updates the layout engine with the new proxied layout engine.
-	/// </summary>
-	/// <param name="newLayoutEngine"></param>
-	/// <returns>
-	/// The proxy layout engine with the new proxied layout engine, if the new layout engine is different.
-	/// </returns>
-	/// <example>
-	/// <code>
-	/// public override IImmutableLayoutEngine Update(IImmutableLayoutEngine newLayoutEngine) =>
-	/// 	newLayoutEngine == InnerLayoutEngine
-	/// 		? this
-	/// 		: new MyProxyLayoutEngine(newLayoutEngine);
-	/// </code>
-	/// </example>
-	protected abstract ILayoutEngine Update(ILayoutEngine newLayoutEngine);
-
-	/// <summary>
 	/// The name is only really important for the user, so we can use the name of the proxied layout engine.
 	/// </summary>
 	/// <inheritdoc/>

--- a/src/Whim/Layout/BaseProxyLayoutEngine.cs
+++ b/src/Whim/Layout/BaseProxyLayoutEngine.cs
@@ -58,14 +58,14 @@ public abstract class BaseProxyLayoutEngine : ILayoutEngine
 	public virtual int Count => InnerLayoutEngine.Count;
 
 	/// <inheritdoc/>
-	public virtual ILayoutEngine Add(IWindow window) => Update(InnerLayoutEngine.Add(window));
+	public virtual ILayoutEngine AddWindow(IWindow window) => Update(InnerLayoutEngine.AddWindow(window));
 
 	/// <inheritdoc/>
 	public virtual ILayoutEngine MoveWindowToPoint(IWindow window, IPoint<double> point) =>
 		Update(InnerLayoutEngine.MoveWindowToPoint(window, point));
 
 	/// <inheritdoc/>
-	public virtual ILayoutEngine Remove(IWindow window) => Update(InnerLayoutEngine.Remove(window));
+	public virtual ILayoutEngine RemoveWindow(IWindow window) => Update(InnerLayoutEngine.RemoveWindow(window));
 
 	/// <inheritdoc/>
 	public virtual IWindow? GetFirstWindow() => InnerLayoutEngine.GetFirstWindow();
@@ -79,7 +79,7 @@ public abstract class BaseProxyLayoutEngine : ILayoutEngine
 		Update(InnerLayoutEngine.SwapWindowInDirection(direction, window));
 
 	/// <inheritdoc/>
-	public virtual bool Contains(IWindow window) => InnerLayoutEngine.Contains(window);
+	public virtual bool ContainsWindow(IWindow window) => InnerLayoutEngine.ContainsWindow(window);
 
 	/// <inheritdoc/>
 	public virtual ILayoutEngine MoveWindowEdgesInDirection(Direction edge, IPoint<double> deltas, IWindow window) =>

--- a/src/Whim/Layout/ColumnLayoutEngine.cs
+++ b/src/Whim/Layout/ColumnLayoutEngine.cs
@@ -48,14 +48,14 @@ public class ColumnLayoutEngine : ILayoutEngine
 	}
 
 	/// <inheritdoc/>
-	public ILayoutEngine Add(IWindow window)
+	public ILayoutEngine AddWindow(IWindow window)
 	{
 		Logger.Debug($"Adding window {window} to layout engine {Name}");
 		return new ColumnLayoutEngine(this, _stack.Add(window));
 	}
 
 	/// <inheritdoc/>
-	public ILayoutEngine Remove(IWindow window)
+	public ILayoutEngine RemoveWindow(IWindow window)
 	{
 		Logger.Debug($"Removing window {window} from layout engine {Name}");
 
@@ -64,7 +64,7 @@ public class ColumnLayoutEngine : ILayoutEngine
 	}
 
 	/// <inheritdoc/>
-	public bool Contains(IWindow window)
+	public bool ContainsWindow(IWindow window)
 	{
 		Logger.Debug($"Checking if layout engine {Name} contains window {window}");
 		return _stack.Any(x => x.Handle == window.Handle);

--- a/src/Whim/Layout/ColumnLayoutEngine.cs
+++ b/src/Whim/Layout/ColumnLayoutEngine.cs
@@ -186,29 +186,30 @@ public class ColumnLayoutEngine : ILayoutEngine
 	public ILayoutEngine MoveWindowEdgesInDirection(Direction edge, IPoint<double> deltas, IWindow window) => this;
 
 	/// <inheritdoc/>
-	public ILayoutEngine AddAtPoint(IWindow window, IPoint<double> point)
+	public ILayoutEngine MoveWindowToPoint(IWindow window, IPoint<double> point)
 	{
 		Logger.Debug($"Adding window {window} to layout engine {Name} at point {point}");
 
+		ImmutableList<IWindow> newStack = _stack.Remove(window);
 		// Calculate the index of the window in the stack.
-		int idx = (int)Math.Round(point.X * _stack.Count, MidpointRounding.AwayFromZero);
+		int idx = (int)Math.Round(point.X * newStack.Count, MidpointRounding.AwayFromZero);
 
 		// Bound idx.
 		if (idx < 0)
 		{
 			idx = 0;
 		}
-		else if (idx > _stack.Count)
+		else if (idx > newStack.Count)
 		{
-			idx = _stack.Count;
+			idx = newStack.Count;
 		}
 
 		if (!LeftToRight)
 		{
-			idx = _stack.Count - idx;
+			idx = newStack.Count - idx;
 		}
 
-		return new ColumnLayoutEngine(this, _stack.Insert(idx, window));
+		return new ColumnLayoutEngine(this, newStack.Insert(idx, window));
 	}
 
 	/// <inheritdoc/>

--- a/src/Whim/Layout/ILayoutEngine.cs
+++ b/src/Whim/Layout/ILayoutEngine.cs
@@ -43,7 +43,7 @@ public interface ILayoutEngine
 	/// <param name="window">The window to move.</param>
 	/// <param name="point">The point to move the window to.</param>
 	/// <returns>The new <see cref="ILayoutEngine"/> after the move.</returns>
-	ILayoutEngine AddAtPoint(IWindow window, IPoint<double> point);
+	ILayoutEngine MoveWindowToPoint(IWindow window, IPoint<double> point);
 
 	/// <summary>
 	/// Removes a <paramref name="window"/> from the layout engine.

--- a/src/Whim/Layout/ILayoutEngine.cs
+++ b/src/Whim/Layout/ILayoutEngine.cs
@@ -34,7 +34,7 @@ public interface ILayoutEngine
 	/// </summary>
 	/// <param name="window"></param>
 	/// <returns>The new <see cref="ILayoutEngine"/> after the add.</returns>
-	ILayoutEngine Add(IWindow window);
+	ILayoutEngine AddWindow(IWindow window);
 
 	/// <summary>
 	/// Move the <paramref name="window"/> to the <paramref name="point"/>.
@@ -50,7 +50,7 @@ public interface ILayoutEngine
 	/// </summary>
 	/// <param name="window"></param>
 	/// <returns>The new <see cref="ILayoutEngine"/> after the remove.</returns>
-	ILayoutEngine Remove(IWindow window);
+	ILayoutEngine RemoveWindow(IWindow window);
 
 	/// <summary>
 	/// Determines whether the layout engine contains the <paramref name="window"/>.
@@ -59,7 +59,7 @@ public interface ILayoutEngine
 	/// <returns>
 	/// True if the layout engine contains the <paramref name="window"/>, otherwise false.
 	/// </returns>
-	bool Contains(IWindow window);
+	bool ContainsWindow(IWindow window);
 
 	/// <summary>
 	/// Performs a layout inside the available <paramref name="location"/>.

--- a/src/Whim/Whim.csproj
+++ b/src/Whim/Whim.csproj
@@ -44,11 +44,12 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<InternalsVisibleTo Include="Whim.Tests" />
-		<InternalsVisibleTo Include="Whim.Gaps.Tests" />
-		<InternalsVisibleTo Include="Whim.FloatingLayout.Tests" />
-		<InternalsVisibleTo Include="Whim.TreeLayout.Tests" />
 		<InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
+		<InternalsVisibleTo Include="Whim.FloatingLayout.Tests" />
+		<InternalsVisibleTo Include="Whim.Gaps.Tests" />
+		<InternalsVisibleTo Include="Whim.Tests" />
+		<InternalsVisibleTo Include="Whim.TestUtils" />
+		<InternalsVisibleTo Include="Whim.TreeLayout.Tests" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Whim/Workspace/Workspace.cs
+++ b/src/Whim/Workspace/Workspace.cs
@@ -376,7 +376,7 @@ internal class Workspace : IWorkspace, IInternalWorkspace
 		if (_normalWindows.Contains(window))
 		{
 			// The window is already in the workspace, so move it in just the active layout engine
-			ActiveLayoutEngine = ActiveLayoutEngine.Remove(window).AddAtPoint(window, point);
+			ActiveLayoutEngine = ActiveLayoutEngine.MoveWindowToPoint(window, point);
 		}
 		else
 		{
@@ -391,7 +391,7 @@ internal class Workspace : IWorkspace, IInternalWorkspace
 
 			for (int idx = 0; idx < _layoutEngines.Length; idx++)
 			{
-				_layoutEngines[idx] = _layoutEngines[idx].AddAtPoint(window, point);
+				_layoutEngines[idx] = _layoutEngines[idx].MoveWindowToPoint(window, point);
 			}
 		}
 

--- a/src/Whim/Workspace/Workspace.cs
+++ b/src/Whim/Workspace/Workspace.cs
@@ -117,7 +117,7 @@ internal class Workspace : IWorkspace, IInternalWorkspace
 
 		for (int i = 0; i < _layoutEngines.Length; i++)
 		{
-			_layoutEngines[i] = _layoutEngines[i].Remove(window);
+			_layoutEngines[i] = _layoutEngines[i].RemoveWindow(window);
 		}
 
 		DoLayout();
@@ -227,7 +227,7 @@ internal class Workspace : IWorkspace, IInternalWorkspace
 		_normalWindows.Add(window);
 		for (int i = 0; i < _layoutEngines.Length; i++)
 		{
-			_layoutEngines[i] = _layoutEngines[i].Add(window);
+			_layoutEngines[i] = _layoutEngines[i].AddWindow(window);
 		}
 		DoLayout();
 		window.Focus();
@@ -244,7 +244,7 @@ internal class Workspace : IWorkspace, IInternalWorkspace
 
 		if (_phantomWindows.TryGetValue(window, out ILayoutEngine? phantomLayoutEngine))
 		{
-			ILayoutEngine newEngine = phantomLayoutEngine.Remove(window);
+			ILayoutEngine newEngine = phantomLayoutEngine.RemoveWindow(window);
 
 			bool removePhantomSuccess = newEngine != phantomLayoutEngine;
 			if (removePhantomSuccess)
@@ -271,7 +271,7 @@ internal class Workspace : IWorkspace, IInternalWorkspace
 			for (int idx = 0; idx < _layoutEngines.Length; idx++)
 			{
 				ILayoutEngine oldEngine = _layoutEngines[idx];
-				ILayoutEngine newEngine = oldEngine.Remove(window);
+				ILayoutEngine newEngine = oldEngine.RemoveWindow(window);
 
 				if (newEngine == oldEngine)
 				{


### PR DESCRIPTION
1. `ILayoutEngine.AddAtPoint` is now `ILayoutEngine.MoveWindowToPoint`. This means that we can move windows to a `ILayoutEngine` without having to add them first.
2. `ILayoutEngine` methods now include "`Window`" in their names.
3. Most `BaseProxyLayoutEngine` methods are now `abstract` instead of `virtual`. This forces layout engines to implement them, preventing unexpected behavior due to the developer missing a method. All proxy layout engines have been updated with this change.
4. Renamed `Whim.TestUtilities` to `Whim.TestUtils` to match the project name.
5. `FloatingLayoutEngine` now removes windows from inner layout engines when a window has been detected as floating.0
6. `FloatingLayoutEngine` is now internal-only. This makes testing easier (it can accept `IInternalFloatingLayoutPlugin`), and is beneficial since there is no reason to use it outside of `Whim.FloatingLayout`.
