### PR TITLE
Don't lose windows when switching between workspaces

### DIFF
--- a/src/Whim.Tests/Window/WindowManagerTests.cs
+++ b/src/Whim.Tests/Window/WindowManagerTests.cs
@@ -418,7 +418,7 @@ public class WindowManagerTests
 		wrapper.WinEventProc!.Invoke((HWINEVENTHOOK)0, PInvoke.EVENT_OBJECT_HIDE, hwnd, 0, 0, 0, 0);
 
 		// Then
-		wrapper.WorkspaceManager.Verify(wm => wm.GetWorkspaceForWindow(It.IsAny<IWindow>()), Times.Once);
+		wrapper.WorkspaceManager.Verify(wm => wm.GetMonitorForWindow(It.IsAny<IWindow>()), Times.Once);
 	}
 
 	[Fact]
@@ -430,8 +430,8 @@ public class WindowManagerTests
 		wrapper.AllowWindowCreation(hwnd);
 
 		wrapper.WorkspaceManager
-			.Setup(wm => wm.GetWorkspaceForWindow(It.IsAny<IWindow>()))
-			.Returns(new Mock<IWorkspace>().Object);
+			.Setup(wm => wm.GetMonitorForWindow(It.IsAny<IWindow>()))
+			.Returns(new Mock<IMonitor>().Object);
 
 		WindowManager windowManager = new(wrapper.Context.Object, wrapper.CoreNativeManager.Object);
 

--- a/src/Whim.Tests/Workspace/WorkspaceManagerTests.cs
+++ b/src/Whim.Tests/Workspace/WorkspaceManagerTests.cs
@@ -830,41 +830,6 @@ public class WorkspaceManagerTests
 		workspace2.Verify(w => w.AddWindow(window.Object), Times.Once());
 		window.Verify(w => w.Hide(), Times.Never());
 	}
-
-	[Fact]
-	public void MoveWindowToWorkspace_Success_WindowHidden()
-	{
-		// Given
-		Mock<IWindow> window = new();
-
-		// there are 3 workspaces
-		Mock<IWorkspace> workspace = new();
-		Mock<IWorkspace> workspace2 = new();
-		Mock<IWorkspace> workspace3 = new();
-
-		// and there are 3 monitors
-		Mock<IMonitor>[] monitors = new[] { new Mock<IMonitor>(), new Mock<IMonitor>(), new Mock<IMonitor>(), };
-
-		Wrapper wrapper = new(new[] { workspace, workspace2, workspace3 }, monitors);
-
-		wrapper.WorkspaceManager.Activate(workspace.Object, wrapper.Monitors[0].Object);
-		wrapper.WorkspaceManager.Activate(workspace.Object, wrapper.Monitors[1].Object);
-
-		// and the window is added
-		wrapper.WorkspaceManager.WindowAdded(window.Object);
-		workspace.Reset();
-		workspace2.Reset();
-		workspace3.Reset();
-		window.Reset();
-
-		// When a window in a workspace is moved to another workspace
-		wrapper.WorkspaceManager.MoveWindowToWorkspace(workspace2.Object, window.Object);
-
-		// Then the window is removed from the first workspace and added to the third
-		workspace.Verify(w => w.RemoveWindow(window.Object), Times.Once());
-		workspace2.Verify(w => w.AddWindow(window.Object), Times.Once());
-		window.Verify(w => w.Hide(), Times.Once());
-	}
 	#endregion
 
 	#region MoveWindowToMonitor

--- a/src/Whim/Window/WindowManager.cs
+++ b/src/Whim/Window/WindowManager.cs
@@ -323,9 +323,9 @@ internal class WindowManager : IWindowManager
 	{
 		Logger.Debug($"Window hidden: {window}");
 
-		if (_context.WorkspaceManager.GetWorkspaceForWindow(window) == null)
+		if (_context.WorkspaceManager.GetMonitorForWindow(window) == null)
 		{
-			Logger.Debug($"Window {window} is not on a workspace, ignoring event");
+			Logger.Debug($"Window {window} is not tracked in a monitor, ignoring event");
 			return;
 		}
 

--- a/src/Whim/Workspace/Workspace.cs
+++ b/src/Whim/Workspace/Workspace.cs
@@ -37,11 +37,7 @@ internal class Workspace : IWorkspace, IInternalWorkspace
 	private int _activeLayoutEngineIndex;
 	private bool _disposedValue;
 
-	public ILayoutEngine ActiveLayoutEngine
-	{
-		private set => _layoutEngines[_activeLayoutEngineIndex] = value;
-		get => _layoutEngines[_activeLayoutEngineIndex];
-	}
+	public ILayoutEngine ActiveLayoutEngine => _layoutEngines[_activeLayoutEngineIndex];
 
 	/// <summary>
 	/// All the windows in this workspace which are <see cref="WindowSize.Normal"/>.
@@ -303,7 +299,7 @@ internal class Workspace : IWorkspace, IInternalWorkspace
 
 		if (GetValidVisibleWindow(window) is IWindow validWindow)
 		{
-			ActiveLayoutEngine = ActiveLayoutEngine.SwapWindowInDirection(direction, validWindow);
+			_layoutEngines[_activeLayoutEngineIndex] = ActiveLayoutEngine.SwapWindowInDirection(direction, validWindow);
 			DoLayout();
 		}
 	}
@@ -314,7 +310,11 @@ internal class Workspace : IWorkspace, IInternalWorkspace
 
 		if (GetValidVisibleWindow(window) is IWindow validWindow)
 		{
-			ActiveLayoutEngine = ActiveLayoutEngine.MoveWindowEdgesInDirection(edges, deltas, validWindow);
+			_layoutEngines[_activeLayoutEngineIndex] = ActiveLayoutEngine.MoveWindowEdgesInDirection(
+				edges,
+				deltas,
+				validWindow
+			);
 			DoLayout();
 		}
 	}
@@ -326,7 +326,7 @@ internal class Workspace : IWorkspace, IInternalWorkspace
 		if (_normalWindows.Contains(window))
 		{
 			// The window is already in the workspace, so move it in just the active layout engine
-			ActiveLayoutEngine = ActiveLayoutEngine.MoveWindowToPoint(window, point);
+			_layoutEngines[_activeLayoutEngineIndex] = ActiveLayoutEngine.MoveWindowToPoint(window, point);
 		}
 		else
 		{

--- a/src/Whim/Workspace/WorkspaceManager.cs
+++ b/src/Whim/Workspace/WorkspaceManager.cs
@@ -556,11 +556,6 @@ internal class WorkspaceManager : IInternalWorkspaceManager, IWorkspaceManager
 		_windowWorkspaceMap[window] = workspace;
 		currentWorkspace.RemoveWindow(window);
 		workspace.AddWindow(window);
-
-		if (GetMonitorForWorkspace(workspace) is null)
-		{
-			window.Hide();
-		}
 	}
 
 	public void MoveWindowToMonitor(IMonitor monitor, IWindow? window = null)


### PR DESCRIPTION
Closes #461

Previously, `WindowManager.OnWindowHidden` would only ignore windows if they were in a workspace. However, we want to ignore already hidden windows from hidden workspaces.