### PR TITLE
Lock `ILayoutEngine` method calls in `Workspace`

### DIFF
--- a/src/Whim.Tests/Workspace/WorkspaceManagerTests.cs
+++ b/src/Whim.Tests/Workspace/WorkspaceManagerTests.cs
@@ -1180,7 +1180,10 @@ public class WorkspaceManagerTests
 	public void WindowFocused_ActivateWorkspace()
 	{
 		// Given
-		Mock<IWorkspace>[] workspaces = new[] { new Mock<IWorkspace>(), new Mock<IWorkspace>() };
+		Mock<IInternalWorkspace> workspace1 = new();
+		Mock<IInternalWorkspace> workspace2 = new();
+		Mock<IWorkspace>[] workspaces = new[] { workspace1.As<IWorkspace>(), workspace2.As<IWorkspace>() };
+
 		Mock<IMonitor> monitor = new();
 		Wrapper wrapper = new(workspaces, new Mock<IMonitor>[] { monitor });
 

--- a/src/Whim/Workspace/Workspace.cs
+++ b/src/Whim/Workspace/Workspace.cs
@@ -419,6 +419,7 @@ internal class Workspace : IWorkspace, IInternalWorkspace
 					deltas,
 					validWindow
 				);
+				success = true;
 			}
 		}
 

--- a/src/Whim/Workspace/WorkspaceManager.cs
+++ b/src/Whim/Workspace/WorkspaceManager.cs
@@ -415,10 +415,7 @@ internal class WorkspaceManager : IInternalWorkspaceManager, IWorkspaceManager
 
 		foreach (IWorkspace workspace in _workspaces)
 		{
-			if (workspace is IInternalWorkspace ws)
-			{
-				ws.WindowFocused(window);
-			}
+			((IInternalWorkspace)workspace).WindowFocused(window);
 		}
 
 		_windowWorkspaceMap.TryGetValue(window, out IWorkspace? workspaceFocused);
@@ -438,10 +435,7 @@ internal class WorkspaceManager : IInternalWorkspaceManager, IWorkspaceManager
 			return;
 		}
 
-		if (workspace is IInternalWorkspace ws)
-		{
-			ws.WindowMinimizeStart(window);
-		}
+		((IInternalWorkspace)workspace).WindowMinimizeStart(window);
 	}
 
 	public void WindowMinimizeEnd(IWindow window)
@@ -454,10 +448,7 @@ internal class WorkspaceManager : IInternalWorkspaceManager, IWorkspaceManager
 			return;
 		}
 
-		if (workspace is IInternalWorkspace ws)
-		{
-			ws.WindowMinimizeEnd(window);
-		}
+		((IInternalWorkspace)workspace).WindowMinimizeEnd(window);
 	}
 	#endregion
 

--- a/src/Whim/Workspace/WorkspaceManager.cs
+++ b/src/Whim/Workspace/WorkspaceManager.cs
@@ -40,7 +40,8 @@ internal class WorkspaceManager : IInternalWorkspaceManager, IWorkspaceManager
 	/// Stores the workspaces to create, when <see cref="Initialize"/> is called.
 	/// The workspaces will have been created prior to <see cref="Initialize"/>.
 	/// </summary>
-	private readonly List<(string Name, IEnumerable<CreateLeafLayoutEngine> LayoutEngines)> _workspacesToCreate = new();
+	private readonly List<(string Name, IEnumerable<CreateLeafLayoutEngine>? LayoutEngines)> _workspacesToCreate =
+		new();
 
 	/// <summary>
 	/// Maps monitors to their active workspace.
@@ -109,7 +110,7 @@ internal class WorkspaceManager : IInternalWorkspaceManager, IWorkspaceManager
 		_context.MonitorManager.MonitorsChanged += MonitorManager_MonitorsChanged;
 
 		// Create the workspaces.
-		foreach ((string name, IEnumerable<CreateLeafLayoutEngine> createLayoutEngines) in _workspacesToCreate)
+		foreach ((string name, IEnumerable<CreateLeafLayoutEngine>? createLayoutEngines) in _workspacesToCreate)
 		{
 			CreateWorkspace(name, createLayoutEngines);
 		}
@@ -178,9 +179,7 @@ internal class WorkspaceManager : IInternalWorkspaceManager, IWorkspaceManager
 		}
 		else
 		{
-			_workspacesToCreate.Add(
-				(name ?? $"Workspace {_workspaces.Count + 1}", createLayoutEngines ?? CreateLayoutEngines())
-			);
+			_workspacesToCreate.Add((name ?? $"Workspace {_workspaces.Count + 1}", createLayoutEngines));
 		}
 	}
 


### PR DESCRIPTION
Lock `ILayoutEngine` methods calls which can create new `ILayoutEngine` instances, from `Workspace`. This prevents race conditions when multiple threads are trying to performing layout operations for a single `Workspace` instance.

This should also resolve #460.
