### PR TITLE
Dragging browser windows still causes tree crashes

### DIFF
--- a/src/Whim.Bar.Tests/ActiveLayout/ActiveLayoutWidgetViewModelTests.cs
+++ b/src/Whim.Bar.Tests/ActiveLayout/ActiveLayoutWidgetViewModelTests.cs
@@ -69,6 +69,60 @@ public class ActiveLayoutWidgetViewModelTests
 	}
 
 	[Fact]
+	public void WorkspaceManager_MonitorWorkspaceChanged_DifferentMonitorButEquals()
+	{
+		// Given
+		Wrapper wrapper = new();
+		ActiveLayoutWidgetViewModel viewModel = new(wrapper.Context.Object, wrapper.Monitor.Object);
+		Mock<IMonitor> monitor = new();
+		monitor.Setup(m => m.Equals(wrapper.Monitor.Object)).Returns(true);
+		wrapper.Monitor.Setup(m => m.Equals(monitor.Object)).Returns(true);
+
+		// When
+		// Then
+		Assert.PropertyChanged(
+			viewModel,
+			nameof(viewModel.ActiveLayoutEngine),
+			() =>
+				wrapper.WorkspaceManager.Raise(
+					wm => wm.MonitorWorkspaceChanged += null,
+					new MonitorWorkspaceChangedEventArgs()
+					{
+						Monitor = monitor.Object,
+						CurrentWorkspace = wrapper.Workspace.Object
+					}
+				)
+		);
+	}
+
+	[Fact]
+	public void WorkspaceManager_MonitorWorkspaceChanged_DifferentMonitor()
+	{
+		// Given
+		Wrapper wrapper = new();
+		ActiveLayoutWidgetViewModel viewModel = new(wrapper.Context.Object, wrapper.Monitor.Object);
+		Mock<IMonitor> monitor = new();
+		monitor.Setup(m => m.Equals(wrapper.Monitor.Object)).Returns(false);
+		wrapper.Monitor.Setup(m => m.Equals(monitor.Object)).Returns(false);
+
+		// When
+		// Then
+		TestUtils.Assert.PropertyNotChanged(
+			viewModel,
+			nameof(viewModel.ActiveLayoutEngine),
+			() =>
+				wrapper.WorkspaceManager.Raise(
+					wm => wm.MonitorWorkspaceChanged += null,
+					new MonitorWorkspaceChangedEventArgs()
+					{
+						Monitor = monitor.Object,
+						CurrentWorkspace = wrapper.Workspace.Object
+					}
+				)
+		);
+	}
+
+	[Fact]
 	public void Dispose()
 	{
 		// Given

--- a/src/Whim.Bar/ActiveLayout/ActiveLayoutWidgetViewModel.cs
+++ b/src/Whim.Bar/ActiveLayout/ActiveLayoutWidgetViewModel.cs
@@ -48,7 +48,7 @@ internal class ActiveLayoutWidgetViewModel : INotifyPropertyChanged, IDisposable
 
 	private void WorkspaceManager_MonitorWorkspaceChanged(object? sender, MonitorWorkspaceChangedEventArgs e)
 	{
-		if (e.Monitor == Monitor)
+		if (e.Monitor.Equals(Monitor))
 		{
 			OnPropertyChanged(nameof(ActiveLayoutEngine));
 		}

--- a/src/Whim.Bar/BarLayoutEngine.cs
+++ b/src/Whim.Bar/BarLayoutEngine.cs
@@ -5,7 +5,7 @@ namespace Whim.Bar;
 /// <summary>
 /// A proxy layout engine to reserve space for the bar in each monitor.
 /// </summary>
-public class BarLayoutEngine : BaseProxyLayoutEngine
+public record BarLayoutEngine : BaseProxyLayoutEngine
 {
 	private readonly BarConfig _barConfig;
 

--- a/src/Whim.Bar/FocusedWindow/FocusedWindowWidgetViewModel.cs
+++ b/src/Whim.Bar/FocusedWindow/FocusedWindowWidgetViewModel.cs
@@ -81,7 +81,7 @@ internal class FocusedWindowWidgetViewModel : INotifyPropertyChanged, IDisposabl
 	{
 		IMonitor? monitor = _context.WorkspaceManager.GetMonitorForWindow(e.Window);
 
-		if (monitor == _monitor)
+		if (_monitor.Equals(monitor))
 		{
 			Title = _getTitle(e.Window);
 		}

--- a/src/Whim.Bar/Workspace/WorkspaceWidgetViewModel.cs
+++ b/src/Whim.Bar/Workspace/WorkspaceWidgetViewModel.cs
@@ -40,24 +40,24 @@ internal class WorkspaceWidgetViewModel : IDisposable
 		foreach (IWorkspace workspace in _context.WorkspaceManager)
 		{
 			IMonitor? monitorForWorkspace = _context.WorkspaceManager.GetMonitorForWorkspace(workspace);
-			Workspaces.Add(new WorkspaceModel(context, this, workspace, Monitor == monitorForWorkspace));
+			Workspaces.Add(new WorkspaceModel(context, this, workspace, Monitor.Equals(monitorForWorkspace)));
 		}
 	}
 
 	private void WorkspaceManager_WorkspaceAdded(object? sender, WorkspaceEventArgs args)
 	{
-		if (Workspaces.Any(model => model.Workspace == args.Workspace))
+		if (Workspaces.Any(model => model.Workspace.Equals(args.Workspace)))
 		{
 			return;
 		}
 
 		IMonitor? monitorForWorkspace = _context.WorkspaceManager.GetMonitorForWorkspace(args.Workspace);
-		Workspaces.Add(new WorkspaceModel(_context, this, args.Workspace, Monitor == monitorForWorkspace));
+		Workspaces.Add(new WorkspaceModel(_context, this, args.Workspace, Monitor.Equals(monitorForWorkspace)));
 	}
 
 	private void WorkspaceManager_WorkspaceRemoved(object? sender, WorkspaceEventArgs args)
 	{
-		WorkspaceModel? workspaceModel = Workspaces.FirstOrDefault(model => model.Workspace == args.Workspace);
+		WorkspaceModel? workspaceModel = Workspaces.FirstOrDefault(model => model.Workspace.Equals(args.Workspace));
 		if (workspaceModel == null)
 		{
 			return;
@@ -77,7 +77,7 @@ internal class WorkspaceWidgetViewModel : IDisposable
 		if (args.PreviousWorkspace != null)
 		{
 			WorkspaceModel? oldWorkspaceModel = Workspaces.FirstOrDefault(
-				model => model.Workspace == args.PreviousWorkspace
+				model => model.Workspace.Equals(args.PreviousWorkspace)
 			);
 			if (oldWorkspaceModel != null)
 			{
@@ -87,7 +87,7 @@ internal class WorkspaceWidgetViewModel : IDisposable
 
 		// Set the new workspace's model to be active on the monitor
 		WorkspaceModel? newWorkspaceModel = Workspaces.FirstOrDefault(
-			model => model.Workspace == args.CurrentWorkspace
+			model => model.Workspace.Equals(args.CurrentWorkspace)
 		);
 		if (newWorkspaceModel != null)
 		{
@@ -97,7 +97,7 @@ internal class WorkspaceWidgetViewModel : IDisposable
 
 	private void WorkspaceManager_WorkspaceRenamed(object? sender, WorkspaceRenamedEventArgs e)
 	{
-		WorkspaceModel? workspace = Workspaces.FirstOrDefault(m => m.Workspace == e.Workspace);
+		WorkspaceModel? workspace = Workspaces.FirstOrDefault(m => m.Workspace.Equals(e.Workspace));
 		if (workspace == null)
 		{
 			return;

--- a/src/Whim.CommandPalette.Tests/CommandPaletteCommandsTests.cs
+++ b/src/Whim.CommandPalette.Tests/CommandPaletteCommandsTests.cs
@@ -1,6 +1,5 @@
 using FluentAssertions;
 using Moq;
-using Whim.TestUtils;
 using Xunit;
 
 namespace Whim.CommandPalette.Tests;
@@ -70,7 +69,7 @@ public class CommandPaletteCommandsTests
 	{
 		// Given
 		Wrapper wrapper = new();
-		ICommand command = new PluginCommandsTestUtils(wrapper.Commands).GetCommand(
+		ICommand command = new TestUtils.PluginCommandsTestUtils(wrapper.Commands).GetCommand(
 			"whim.command_palette.activate_workspace"
 		);
 
@@ -93,7 +92,9 @@ public class CommandPaletteCommandsTests
 	{
 		// Given
 		Wrapper wrapper = new();
-		ICommand command = new PluginCommandsTestUtils(wrapper.Commands).GetCommand("whim.command_palette.toggle");
+		ICommand command = new TestUtils.PluginCommandsTestUtils(wrapper.Commands).GetCommand(
+			"whim.command_palette.toggle"
+		);
 
 		// When
 		command.TryExecute();
@@ -107,7 +108,7 @@ public class CommandPaletteCommandsTests
 	{
 		// Given
 		Wrapper wrapper = new();
-		ICommand command = new PluginCommandsTestUtils(wrapper.Commands).GetCommand(
+		ICommand command = new TestUtils.PluginCommandsTestUtils(wrapper.Commands).GetCommand(
 			"whim.command_palette.rename_workspace"
 		);
 
@@ -129,7 +130,7 @@ public class CommandPaletteCommandsTests
 	{
 		// Given
 		Wrapper wrapper = new();
-		ICommand command = new PluginCommandsTestUtils(wrapper.Commands).GetCommand(
+		ICommand command = new TestUtils.PluginCommandsTestUtils(wrapper.Commands).GetCommand(
 			"whim.command_palette.create_workspace"
 		);
 
@@ -151,7 +152,7 @@ public class CommandPaletteCommandsTests
 	{
 		// Given
 		Wrapper wrapper = new();
-		ICommand command = new PluginCommandsTestUtils(wrapper.Commands).GetCommand(
+		ICommand command = new TestUtils.PluginCommandsTestUtils(wrapper.Commands).GetCommand(
 			"whim.command_palette.move_window_to_workspace"
 		);
 		CommandPaletteCommands commands = new(wrapper.Context.Object, wrapper.Plugin.Object);
@@ -277,7 +278,7 @@ public class CommandPaletteCommandsTests
 	{
 		// Given
 		Wrapper wrapper = new();
-		ICommand command = new PluginCommandsTestUtils(wrapper.Commands).GetCommand(
+		ICommand command = new TestUtils.PluginCommandsTestUtils(wrapper.Commands).GetCommand(
 			"whim.command_palette.move_multiple_windows_to_workspace"
 		);
 
@@ -305,7 +306,7 @@ public class CommandPaletteCommandsTests
 	{
 		// Given
 		Wrapper wrapper = new();
-		ICommand command = new PluginCommandsTestUtils(wrapper.Commands).GetCommand(
+		ICommand command = new TestUtils.PluginCommandsTestUtils(wrapper.Commands).GetCommand(
 			"whim.command_palette.remove_window"
 		);
 

--- a/src/Whim.FloatingLayout/FloatingLayoutEngine.cs
+++ b/src/Whim.FloatingLayout/FloatingLayoutEngine.cs
@@ -7,7 +7,7 @@ namespace Whim.FloatingLayout;
 /// <summary>
 /// A proxy layout engine to allow windows to be free-floating.
 /// </summary>
-internal class FloatingLayoutEngine : BaseProxyLayoutEngine
+internal record FloatingLayoutEngine : BaseProxyLayoutEngine
 {
 	private readonly IContext _context;
 	private readonly IInternalFloatingLayoutPlugin _plugin;

--- a/src/Whim.Gaps/GapsLayoutEngine.cs
+++ b/src/Whim.Gaps/GapsLayoutEngine.cs
@@ -5,7 +5,7 @@ namespace Whim.Gaps;
 /// <summary>
 /// A proxy layout engine to add gaps to the layout.
 /// </summary>
-public class GapsLayoutEngine : BaseProxyLayoutEngine
+public record GapsLayoutEngine : BaseProxyLayoutEngine
 {
 	private readonly GapsConfig _gapsConfig;
 

--- a/src/Whim.TestUtils/Assert.cs
+++ b/src/Whim.TestUtils/Assert.cs
@@ -1,4 +1,5 @@
 using System;
+using System.ComponentModel;
 using Xunit.Sdk;
 
 namespace Whim.TestUtils;
@@ -21,7 +22,7 @@ public class DoesNotRaiseException : XunitException
 /// <summary>
 /// Class containing methods with custom assertions.
 /// </summary>
-public static class WhimAssert
+public static class Assert
 {
 	/// <summary>
 	/// Asserts that an event is not raised.
@@ -51,6 +52,39 @@ public static class WhimAssert
 		if (raised)
 		{
 			throw new DoesNotRaiseException(typeof(T));
+		}
+	}
+
+	/// <summary>
+	/// Asserts that a property changed event is not raised for a property.
+	/// </summary>
+	/// <param name="item"></param>
+	/// <param name="propertyName"></param>
+	/// <param name="action"></param>
+	/// <exception cref="DoesNotRaiseException"></exception>
+	public static void PropertyNotChanged(INotifyPropertyChanged item, string propertyName, Action action)
+	{
+		bool raised = false;
+		void handler(object? sender, PropertyChangedEventArgs e)
+		{
+			if (e.PropertyName == propertyName)
+			{
+				raised = true;
+			}
+		}
+		item.PropertyChanged += handler;
+		try
+		{
+			action();
+		}
+		finally
+		{
+			item.PropertyChanged -= handler;
+		}
+
+		if (raised)
+		{
+			throw new DoesNotRaiseException(typeof(PropertyChangedEventArgs));
 		}
 	}
 }

--- a/src/Whim.TestUtils/LayoutEngineBaseTests.cs
+++ b/src/Whim.TestUtils/LayoutEngineBaseTests.cs
@@ -26,8 +26,8 @@ public abstract class LayoutEngineBaseTests
 		ILayoutEngine result = layoutEngine.AddWindow(window.Object);
 
 		// Then
-		Assert.NotSame(layoutEngine, result);
-		Assert.True(result.ContainsWindow(window.Object));
+		Xunit.Assert.NotSame(layoutEngine, result);
+		Xunit.Assert.True(result.ContainsWindow(window.Object));
 	}
 
 	[Fact]
@@ -41,9 +41,9 @@ public abstract class LayoutEngineBaseTests
 		ILayoutEngine result = layoutEngine.AddWindow(window.Object);
 
 		// Then
-		Assert.Same(layoutEngine, result);
-		Assert.True(result.ContainsWindow(window.Object));
-		Assert.Equal(1, result.Count);
+		Xunit.Assert.Same(layoutEngine, result);
+		Xunit.Assert.True(result.ContainsWindow(window.Object));
+		Xunit.Assert.Equal(1, result.Count);
 	}
 
 	[Fact]
@@ -57,9 +57,9 @@ public abstract class LayoutEngineBaseTests
 		ILayoutEngine result = layoutEngine.RemoveWindow(window.Object);
 
 		// Then
-		Assert.NotSame(layoutEngine, result);
-		Assert.False(result.ContainsWindow(window.Object));
-		Assert.Equal(0, result.Count);
+		Xunit.Assert.NotSame(layoutEngine, result);
+		Xunit.Assert.False(result.ContainsWindow(window.Object));
+		Xunit.Assert.Equal(0, result.Count);
 	}
 
 	[Fact]
@@ -73,9 +73,9 @@ public abstract class LayoutEngineBaseTests
 		ILayoutEngine result = layoutEngine.RemoveWindow(window.Object);
 
 		// Then
-		Assert.Same(layoutEngine, result);
-		Assert.False(result.ContainsWindow(window.Object));
-		Assert.Equal(0, result.Count);
+		Xunit.Assert.Same(layoutEngine, result);
+		Xunit.Assert.False(result.ContainsWindow(window.Object));
+		Xunit.Assert.Equal(0, result.Count);
 	}
 
 	[Fact]
@@ -89,7 +89,7 @@ public abstract class LayoutEngineBaseTests
 		bool result = layoutEngine.ContainsWindow(window.Object);
 
 		// Then
-		Assert.True(result);
+		Xunit.Assert.True(result);
 	}
 
 	[Fact]
@@ -103,7 +103,7 @@ public abstract class LayoutEngineBaseTests
 		bool result = layoutEngine.ContainsWindow(window.Object);
 
 		// Then
-		Assert.False(result);
+		Xunit.Assert.False(result);
 	}
 
 	[Fact]

--- a/src/Whim.TestUtils/PluginCommandsTestUtils.cs
+++ b/src/Whim.TestUtils/PluginCommandsTestUtils.cs
@@ -1,5 +1,4 @@
 using System.Linq;
-using Xunit;
 
 namespace Whim.TestUtils;
 
@@ -27,7 +26,7 @@ public class PluginCommandsTestUtils
 	public ICommand GetCommand(string id)
 	{
 		ICommand? command = _pluginCommands.Commands.FirstOrDefault(c => c.Id == id);
-		Assert.NotNull(command);
+		Xunit.Assert.NotNull(command);
 		return command!;
 	}
 }

--- a/src/Whim.TestUtils/TestLayoutEngine.cs
+++ b/src/Whim.TestUtils/TestLayoutEngine.cs
@@ -6,7 +6,7 @@ namespace Whim.TestUtils;
 /// <summary>
 /// A test layout engine that does nothing.
 /// </summary>
-public class TestLayoutEngine : ILayoutEngine
+public record TestLayoutEngine : ILayoutEngine
 {
 	/// <inheritdoc/>
 	public string Name => "Test Layout Engine";

--- a/src/Whim.TestUtils/TestProxyLayoutEngine.cs
+++ b/src/Whim.TestUtils/TestProxyLayoutEngine.cs
@@ -3,7 +3,7 @@ namespace Whim.TestUtils;
 /// <summary>
 /// A non-functional proxy layout engine that can be used for testing.
 /// </summary>
-public abstract class TestProxyLayoutEngine : BaseProxyLayoutEngine
+public abstract record TestProxyLayoutEngine : BaseProxyLayoutEngine
 {
 	/// <summary>
 	/// Creates a new <see cref="TestProxyLayoutEngine"/> with the given <paramref name="innerLayoutEngine"/>.

--- a/src/Whim.Tests/Keybinds/KeybindTests.cs
+++ b/src/Whim.Tests/Keybinds/KeybindTests.cs
@@ -28,28 +28,4 @@ public class KeybindTests
 		Keybind keybind = new(modifiers, key);
 		Assert.Equal(expected, keybind.ToString());
 	}
-
-	[Theory]
-	[InlineData(KeyModifiers.None, VIRTUAL_KEY.VK_A, new string[] { "A" })]
-	[InlineData(KeyModifiers.LShift, VIRTUAL_KEY.VK_A, new string[] { "LShift", "A" })]
-	[InlineData(KeyModifiers.LControl, VIRTUAL_KEY.VK_A, new string[] { "LCtrl", "A" })]
-	[InlineData(KeyModifiers.LAlt, VIRTUAL_KEY.VK_A, new string[] { "LAlt", "A" })]
-	[InlineData(KeyModifiers.LShift | KeyModifiers.LControl, VIRTUAL_KEY.VK_A, new string[] { "LCtrl", "LShift", "A" })]
-	[InlineData(KeyModifiers.LControl | KeyModifiers.LAlt, VIRTUAL_KEY.VK_A, new string[] { "LCtrl", "LAlt", "A" })]
-	[InlineData(KeyModifiers.LShift | KeyModifiers.LAlt, VIRTUAL_KEY.VK_A, new string[] { "LShift", "LAlt", "A" })]
-	[InlineData(
-		KeyModifiers.LControl | KeyModifiers.LShift | KeyModifiers.LAlt,
-		VIRTUAL_KEY.VK_A,
-		new string[] { "LCtrl", "LShift", "LAlt", "A" }
-	)]
-	[InlineData(
-		KeyModifiers.LWin | KeyModifiers.LControl | KeyModifiers.LShift | KeyModifiers.LAlt,
-		VIRTUAL_KEY.VK_A,
-		new string[] { "LWin", "LCtrl", "LShift", "LAlt", "A" }
-	)]
-	public void Keybind_AllKeys_ReturnsCorrect(KeyModifiers modifiers, VIRTUAL_KEY key, string[] expected)
-	{
-		Keybind keybind = new(modifiers, key);
-		Assert.Equal(expected, keybind.AllKeys);
-	}
 }

--- a/src/Whim.Tests/Layout/BaseProxyLayoutEngineTests.cs
+++ b/src/Whim.Tests/Layout/BaseProxyLayoutEngineTests.cs
@@ -1,5 +1,4 @@
 using Moq;
-using Whim.TestUtils;
 using Xunit;
 
 namespace Whim.Tests;
@@ -12,10 +11,11 @@ public class BaseProxyLayoutEngineTests
 	{
 		// Given
 		Mock<ILayoutEngine> innerLayoutEngine = new();
-		Mock<TestProxyLayoutEngine> proxyLayoutEngine = new(innerLayoutEngine.Object);
+		Mock<TestUtils.TestProxyLayoutEngine> proxyLayoutEngine = new(innerLayoutEngine.Object);
 
 		// When
-		TestProxyLayoutEngine? newEngine = proxyLayoutEngine.Object.GetLayoutEngine<TestProxyLayoutEngine>();
+		TestUtils.TestProxyLayoutEngine? newEngine =
+			proxyLayoutEngine.Object.GetLayoutEngine<TestUtils.TestProxyLayoutEngine>();
 
 		// Then
 		Assert.Same(proxyLayoutEngine.Object, newEngine);
@@ -25,16 +25,19 @@ public class BaseProxyLayoutEngineTests
 	public void GetLayoutEngine_IsInner()
 	{
 		// Given
-		Mock<ITestLayoutEngine> innerLayoutEngine = new();
-		innerLayoutEngine.Setup(x => x.GetLayoutEngine<ITestLayoutEngine>()).Returns(innerLayoutEngine.Object);
-		Mock<TestProxyLayoutEngine> proxyLayoutEngine = new(innerLayoutEngine.Object);
+		Mock<TestUtils.ITestLayoutEngine> innerLayoutEngine = new();
+		innerLayoutEngine
+			.Setup(x => x.GetLayoutEngine<TestUtils.ITestLayoutEngine>())
+			.Returns(innerLayoutEngine.Object);
+		Mock<TestUtils.TestProxyLayoutEngine> proxyLayoutEngine = new(innerLayoutEngine.Object);
 
 		// When
-		ITestLayoutEngine? newEngine = proxyLayoutEngine.Object.GetLayoutEngine<ITestLayoutEngine>();
+		TestUtils.ITestLayoutEngine? newEngine =
+			proxyLayoutEngine.Object.GetLayoutEngine<TestUtils.ITestLayoutEngine>();
 
 		// Then
 		Assert.Same(innerLayoutEngine.Object, newEngine);
-		innerLayoutEngine.Verify(x => x.GetLayoutEngine<ITestLayoutEngine>(), Times.Once);
+		innerLayoutEngine.Verify(x => x.GetLayoutEngine<TestUtils.ITestLayoutEngine>(), Times.Once);
 	}
 
 	[Fact]
@@ -42,10 +45,11 @@ public class BaseProxyLayoutEngineTests
 	{
 		// Given
 		Mock<ILayoutEngine> innerLayoutEngine = new();
-		Mock<TestProxyLayoutEngine> proxyLayoutEngine = new(innerLayoutEngine.Object);
+		Mock<TestUtils.TestProxyLayoutEngine> proxyLayoutEngine = new(innerLayoutEngine.Object);
 
 		// When
-		ITestLayoutEngine? newEngine = proxyLayoutEngine.Object.GetLayoutEngine<ITestLayoutEngine>();
+		TestUtils.ITestLayoutEngine? newEngine =
+			proxyLayoutEngine.Object.GetLayoutEngine<TestUtils.ITestLayoutEngine>();
 
 		// Then
 		Assert.Null(newEngine);
@@ -58,7 +62,8 @@ public class BaseProxyLayoutEngineTests
 	{
 		// Given
 		Mock<ILayoutEngine> innerLayoutEngine = new();
-		Mock<TestProxyLayoutEngine> proxyLayoutEngine = new(innerLayoutEngine.Object);
+		Mock<TestUtils.TestProxyLayoutEngine> proxyLayoutEngine = new(innerLayoutEngine.Object);
+		proxyLayoutEngine.Setup(p => p.Equals(proxyLayoutEngine.Object)).Returns(true);
 
 		// When
 		bool contains = proxyLayoutEngine.Object.ContainsEqual(proxyLayoutEngine.Object);
@@ -71,9 +76,9 @@ public class BaseProxyLayoutEngineTests
 	public void ContainsEqual_IsInner()
 	{
 		// Given
-		Mock<ITestLayoutEngine> innerLayoutEngine = new();
+		Mock<TestUtils.ITestLayoutEngine> innerLayoutEngine = new();
 		innerLayoutEngine.Setup(x => x.ContainsEqual(innerLayoutEngine.Object)).Returns(true);
-		Mock<TestProxyLayoutEngine> proxyLayoutEngine = new(innerLayoutEngine.Object);
+		Mock<TestUtils.TestProxyLayoutEngine> proxyLayoutEngine = new(innerLayoutEngine.Object);
 
 		// When
 		bool contains = proxyLayoutEngine.Object.ContainsEqual(innerLayoutEngine.Object);
@@ -88,7 +93,7 @@ public class BaseProxyLayoutEngineTests
 	{
 		// Given
 		Mock<ILayoutEngine> innerLayoutEngine = new();
-		Mock<TestProxyLayoutEngine> proxyLayoutEngine = new(innerLayoutEngine.Object);
+		Mock<TestUtils.TestProxyLayoutEngine> proxyLayoutEngine = new(innerLayoutEngine.Object);
 
 		// When
 		bool contains = proxyLayoutEngine.Object.ContainsEqual(new Mock<ILayoutEngine>().Object);
@@ -105,7 +110,7 @@ public class BaseProxyLayoutEngineTests
 		Mock<ILayoutEngine> innerLayoutEngine = new();
 		innerLayoutEngine.Setup(x => x.Identity).Returns(new LayoutEngineIdentity());
 
-		Mock<TestProxyLayoutEngine> proxyLayoutEngine = new(innerLayoutEngine.Object);
+		Mock<TestUtils.TestProxyLayoutEngine> proxyLayoutEngine = new(innerLayoutEngine.Object);
 
 		// When
 		LayoutEngineIdentity proxyIdentity = proxyLayoutEngine.Object.Identity;

--- a/src/Whim.Tests/Layout/LayoutEngineIdentityTests.cs
+++ b/src/Whim.Tests/Layout/LayoutEngineIdentityTests.cs
@@ -44,6 +44,34 @@ public class LayoutEngineIdentityTests
 	}
 
 	[Fact]
+	public void Equals_Operator_IsTrue()
+	{
+		// Given
+		LayoutEngineIdentity identity = new();
+
+		// When
+#pragma warning disable CS1718 // Comparison made to same variable
+		bool equals = identity == identity;
+#pragma warning restore CS1718 // Comparison made to same variable
+
+		// Then
+		Assert.True(equals);
+	}
+
+	[Fact]
+	public void NotEquals_Operator_Success()
+	{
+		// Given
+		LayoutEngineIdentity identity = new();
+
+		// When
+		bool equals = identity != new LayoutEngineIdentity();
+
+		// Then
+		Assert.True(equals);
+	}
+
+	[Fact]
 	public void GetHashCode_IsEqual()
 	{
 		// Given
@@ -54,5 +82,19 @@ public class LayoutEngineIdentityTests
 
 		// Then
 		Assert.Equal(identity.GetHashCode(), hashCode);
+	}
+
+	[Fact]
+	public void GetHashCode_IsNotEqual()
+	{
+		// Given
+		LayoutEngineIdentity identity = new();
+		LayoutEngineIdentity identity2 = new();
+
+		// When
+		int hashCode = identity.GetHashCode();
+
+		// Then
+		Assert.NotEqual(identity2.GetHashCode(), hashCode);
 	}
 }

--- a/src/Whim.Tests/Layout/LayoutEngineTests.cs
+++ b/src/Whim.Tests/Layout/LayoutEngineTests.cs
@@ -1,5 +1,4 @@
 using Moq;
-using Whim.TestUtils;
 using Xunit;
 
 namespace Whim.Tests;
@@ -11,7 +10,7 @@ public class LayoutEngineTests
 	public void GetLayoutEngine_IsT()
 	{
 		// Given
-		ILayoutEngine engine = new TestLayoutEngine();
+		ILayoutEngine engine = new TestUtils.TestLayoutEngine();
 
 		// When
 		ILayoutEngine? newEngine = engine.GetLayoutEngine<ILayoutEngine>();
@@ -25,12 +24,12 @@ public class LayoutEngineTests
 	public void GetLayoutEngine_IsProxy()
 	{
 		// Given
-		TestLayoutEngine engine = new();
-		Mock<TestProxyLayoutEngine> proxyInner = new(engine);
-		Mock<TestProxyLayoutEngine> proxyOuter = new(proxyInner.Object);
+		TestUtils.TestLayoutEngine engine = new();
+		Mock<TestUtils.TestProxyLayoutEngine> proxyInner = new(engine);
+		Mock<TestUtils.TestProxyLayoutEngine> proxyOuter = new(proxyInner.Object);
 
 		// When
-		TestLayoutEngine? newEngine = proxyOuter.Object.GetLayoutEngine<TestLayoutEngine>();
+		TestUtils.TestLayoutEngine? newEngine = proxyOuter.Object.GetLayoutEngine<TestUtils.TestLayoutEngine>();
 
 		// Then
 		Assert.Same(engine, newEngine);
@@ -41,10 +40,10 @@ public class LayoutEngineTests
 	public void GetLayoutEngine_Null()
 	{
 		// Given
-		ILayoutEngine engine = new TestLayoutEngine();
+		ILayoutEngine engine = new TestUtils.TestLayoutEngine();
 
 		// When
-		ILayoutEngine? newEngine = engine.GetLayoutEngine<ITestLayoutEngine>();
+		ILayoutEngine? newEngine = engine.GetLayoutEngine<TestUtils.ITestLayoutEngine>();
 
 		// Then
 		Assert.Null(newEngine);
@@ -56,7 +55,7 @@ public class LayoutEngineTests
 	public void ContainsEqual_IsT()
 	{
 		// Given
-		ILayoutEngine engine = new TestLayoutEngine();
+		ILayoutEngine engine = new TestUtils.TestLayoutEngine();
 
 		// When
 		bool contains = engine.ContainsEqual(engine);
@@ -69,9 +68,9 @@ public class LayoutEngineTests
 	public void ContainsEqual_IsProxy()
 	{
 		// Given
-		TestLayoutEngine engine = new();
-		Mock<TestProxyLayoutEngine> proxyInner = new(engine);
-		Mock<TestProxyLayoutEngine> proxyOuter = new(proxyInner.Object);
+		TestUtils.TestLayoutEngine engine = new();
+		Mock<TestUtils.TestProxyLayoutEngine> proxyInner = new(engine);
+		Mock<TestUtils.TestProxyLayoutEngine> proxyOuter = new(proxyInner.Object);
 
 		// When
 		bool contains = proxyOuter.Object.ContainsEqual(engine);
@@ -84,7 +83,7 @@ public class LayoutEngineTests
 	public void ContainsEqual_Null()
 	{
 		// Given
-		ILayoutEngine engine = new TestLayoutEngine();
+		ILayoutEngine engine = new TestUtils.TestLayoutEngine();
 
 		// When
 		bool contains = engine.ContainsEqual(new Mock<ILayoutEngine>().Object);

--- a/src/Whim.Tests/Monitor/MonitorTests.cs
+++ b/src/Whim.Tests/Monitor/MonitorTests.cs
@@ -203,6 +203,35 @@ public class MonitorTests
 	}
 
 	[Fact]
+	public void Equals_Operator_Success()
+	{
+		// Given
+		(Mock<ICoreNativeManager> nativeManagerMock, HMONITOR hmonitor) = CreatePrimaryMonitorMocks();
+
+		// When
+		Monitor monitor = new(nativeManagerMock.Object, hmonitor, false);
+		Monitor monitor2 = new(nativeManagerMock.Object, hmonitor, false);
+
+		// Then
+		Assert.True(monitor == monitor2);
+	}
+
+	[Fact]
+	public void NotEquals_Operator_Success()
+	{
+		// Given
+		(Mock<ICoreNativeManager> nativeManagerMock, HMONITOR hmonitor) = CreatePrimaryMonitorMocks();
+		HMONITOR hmonitor2 = new(2);
+
+		// When
+		Monitor monitor = new(nativeManagerMock.Object, hmonitor, false);
+		Monitor monitor2 = new(nativeManagerMock.Object, hmonitor2, false);
+
+		// Then
+		Assert.True(monitor != monitor2);
+	}
+
+	[Fact]
 	public void ToString_Success()
 	{
 		// Given

--- a/src/Whim.Tests/Native/HWNDTests.cs
+++ b/src/Whim.Tests/Native/HWNDTests.cs
@@ -48,4 +48,36 @@ public class HWNDTests
 		// Then
 		Assert.Equal(expected, result);
 	}
+
+	[Theory]
+	[InlineData(1, 1, true)]
+	[InlineData(1, 2, false)]
+	public void Equals_Operator(int value1, int value2, bool expected)
+	{
+		// Given
+		HWND hwnd1 = new(value1);
+		HWND hwnd2 = new(value2);
+
+		// When
+		bool result = hwnd1 == hwnd2;
+
+		// Then
+		Assert.Equal(expected, result);
+	}
+
+	[Theory]
+	[InlineData(1, 1, false)]
+	[InlineData(1, 2, true)]
+	public void NotEquals_Operator(int value1, int value2, bool expected)
+	{
+		// Given
+		HWND hwnd1 = new(value1);
+		HWND hwnd2 = new(value2);
+
+		// When
+		bool result = hwnd1 != hwnd2;
+
+		// Then
+		Assert.Equal(expected, result);
+	}
 }

--- a/src/Whim.Tests/Native/MouseHookTests.cs
+++ b/src/Whim.Tests/Native/MouseHookTests.cs
@@ -1,6 +1,5 @@
 using Moq;
 using System.Runtime.InteropServices;
-using Whim.TestUtils;
 using Windows.Win32;
 using Windows.Win32.Foundation;
 using Windows.Win32.UI.WindowsAndMessaging;
@@ -77,7 +76,7 @@ public class MouseHookTests
 		mouseHook.PostInitialize();
 
 		// Then
-		WhimAssert.DoesNotRaise<MouseEventArgs>(
+		TestUtils.Assert.DoesNotRaise<MouseEventArgs>(
 			h => mouseHook.MouseLeftButtonDown += h,
 			h => mouseHook.MouseLeftButtonDown -= h,
 			() => wrapper.HookProc!.Invoke(0, (WPARAM)PInvoke.WM_LBUTTONDOWN, 0)
@@ -95,7 +94,7 @@ public class MouseHookTests
 		mouseHook.PostInitialize();
 
 		// Then
-		WhimAssert.DoesNotRaise<MouseEventArgs>(
+		TestUtils.Assert.DoesNotRaise<MouseEventArgs>(
 			h => mouseHook.MouseLeftButtonDown += h,
 			h => mouseHook.MouseLeftButtonDown -= h,
 			() => wrapper.HookProc!.Invoke(0, (WPARAM)PInvoke.WM_LBUTTONDOWN, 1)
@@ -157,13 +156,13 @@ public class MouseHookTests
 		mouseHook.PostInitialize();
 
 		// Then
-		WhimAssert.DoesNotRaise<MouseEventArgs>(
+		TestUtils.Assert.DoesNotRaise<MouseEventArgs>(
 			h => mouseHook.MouseLeftButtonDown += h,
 			h => mouseHook.MouseLeftButtonDown -= h,
 			() => wrapper.HookProc!.Invoke(0, (WPARAM)PInvoke.WM_KEYDOWN, 1)
 		);
 
-		WhimAssert.DoesNotRaise<MouseEventArgs>(
+		TestUtils.Assert.DoesNotRaise<MouseEventArgs>(
 			h => mouseHook.MouseLeftButtonUp += h,
 			h => mouseHook.MouseLeftButtonUp -= h,
 			() => wrapper.HookProc!.Invoke(0, (WPARAM)PInvoke.WM_KEYDOWN, 1)

--- a/src/Whim.Tests/Window/WindowManagerTests.cs
+++ b/src/Whim.Tests/Window/WindowManagerTests.cs
@@ -3,7 +3,6 @@ using Moq;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
-using Whim.TestUtils;
 using Windows.Win32;
 using Windows.Win32.Foundation;
 using Windows.Win32.UI.Accessibility;
@@ -610,7 +609,7 @@ public class WindowManagerTests
 		windowManager.Initialize();
 
 		// Then
-		WhimAssert.DoesNotRaise<WindowMovedEventArgs>(
+		TestUtils.Assert.DoesNotRaise<WindowMovedEventArgs>(
 			h => windowManager.WindowMoved += h,
 			h => windowManager.WindowMoved -= h,
 			() => wrapper.WinEventProc!.Invoke((HWINEVENTHOOK)0, PInvoke.EVENT_OBJECT_LOCATIONCHANGE, hwnd, 0, 0, 0, 0)
@@ -634,7 +633,7 @@ public class WindowManagerTests
 		wrapper.Trigger_MouseLeftButtonDown().Trigger_MouseLeftButtonUp();
 
 		// Then
-		WhimAssert.DoesNotRaise<WindowMovedEventArgs>(
+		TestUtils.Assert.DoesNotRaise<WindowMovedEventArgs>(
 			h => windowManager.WindowMoved += h,
 			h => windowManager.WindowMoved -= h,
 			() => wrapper.WinEventProc!.Invoke((HWINEVENTHOOK)0, PInvoke.EVENT_OBJECT_LOCATIONCHANGE, hwnd, 0, 0, 0, 0)

--- a/src/Whim.Tests/Window/WindowStateTests.cs
+++ b/src/Whim.Tests/Window/WindowStateTests.cs
@@ -1,0 +1,190 @@
+using Moq;
+using Xunit;
+
+namespace Whim.Tests;
+
+public class WindowStateTests
+{
+	[Fact]
+	public void Equals_NotWindowState()
+	{
+		// Given
+		WindowState windowState =
+			new()
+			{
+				Location = new Location<int>(),
+				WindowSize = WindowSize.Normal,
+				Window = new Mock<IWindow>().Object
+			};
+
+		// When
+		bool result = windowState.Equals(new object());
+
+		// Then
+		Assert.False(result);
+	}
+
+	[Fact]
+	public void Equals_DifferentLocation()
+	{
+		// Given
+		Mock<IWindow> windowMock = new();
+		WindowState windowState1 =
+			new()
+			{
+				Location = new Location<int>(),
+				WindowSize = WindowSize.Normal,
+				Window = windowMock.Object
+			};
+		WindowState windowState2 =
+			new()
+			{
+				Location = new Location<int>() { X = 1, Y = 1 },
+				WindowSize = WindowSize.Normal,
+				Window = windowMock.Object
+			};
+
+		// When
+		bool result = windowState1.Equals(windowState2);
+
+		// Then
+		Assert.False(result);
+	}
+
+	[Fact]
+	public void Equals_DifferentWindowSize()
+	{
+		// Given
+		Mock<IWindow> windowMock = new();
+		WindowState windowState1 =
+			new()
+			{
+				Location = new Location<int>(),
+				WindowSize = WindowSize.Normal,
+				Window = windowMock.Object
+			};
+		WindowState windowState2 =
+			new()
+			{
+				Location = new Location<int>(),
+				WindowSize = WindowSize.Maximized,
+				Window = windowMock.Object
+			};
+
+		// When
+		bool result = windowState1.Equals(windowState2);
+
+		// Then
+		Assert.False(result);
+	}
+
+	[Fact]
+	public void Equals_DifferentWindow()
+	{
+		// Given
+		Mock<IWindow> windowMock1 = new();
+		Mock<IWindow> windowMock2 = new();
+		WindowState windowState1 =
+			new()
+			{
+				Location = new Location<int>(),
+				WindowSize = WindowSize.Normal,
+				Window = windowMock1.Object
+			};
+		WindowState windowState2 =
+			new()
+			{
+				Location = new Location<int>(),
+				WindowSize = WindowSize.Normal,
+				Window = windowMock2.Object
+			};
+
+		// When
+		bool result = windowState1.Equals(windowState2);
+
+		// Then
+		Assert.False(result);
+	}
+
+	[Fact]
+	public void Equals_Success()
+	{
+		// Given
+		Mock<IWindow> windowMock = new();
+		WindowState windowState1 =
+			new()
+			{
+				Location = new Location<int>(),
+				WindowSize = WindowSize.Normal,
+				Window = windowMock.Object
+			};
+		WindowState windowState2 =
+			new()
+			{
+				Location = new Location<int>(),
+				WindowSize = WindowSize.Normal,
+				Window = windowMock.Object
+			};
+
+		// When
+		bool result = windowState1.Equals(windowState2);
+
+		// Then
+		Assert.True(result);
+	}
+
+	[Fact]
+	public void Equals_Operator_Success()
+	{
+		// Given
+		Mock<IWindow> windowMock = new();
+		WindowState windowState1 =
+			new()
+			{
+				Location = new Location<int>(),
+				WindowSize = WindowSize.Normal,
+				Window = windowMock.Object
+			};
+		WindowState windowState2 =
+			new()
+			{
+				Location = new Location<int>(),
+				WindowSize = WindowSize.Normal,
+				Window = windowMock.Object
+			};
+
+		// When
+		bool result = windowState1 == windowState2;
+
+		// Then
+		Assert.True(result);
+	}
+
+	[Fact]
+	public void NotEquals_Operator_Success()
+	{
+		// Given
+		Mock<IWindow> windowMock1 = new();
+		Mock<IWindow> windowMock2 = new();
+		WindowState windowState1 =
+			new()
+			{
+				Location = new Location<int>(),
+				WindowSize = WindowSize.Normal,
+				Window = windowMock1.Object
+			};
+		WindowState windowState2 =
+			new()
+			{
+				Location = new Location<int>(),
+				WindowSize = WindowSize.Normal,
+				Window = windowMock2.Object
+			};
+
+		// When
+		bool result = windowState1 != windowState2;
+
+		// Then
+		Assert.True(result);
+	}
+}

--- a/src/Whim.Tests/Window/WindowTests.cs
+++ b/src/Whim.Tests/Window/WindowTests.cs
@@ -464,12 +464,10 @@ public class WindowTests
 	{
 		// Given
 		Wrapper wrapper = new();
-		Window? window = Window.CreateWindow(wrapper.Context.Object, wrapper.CoreNativeManager.Object, new HWND(123))! as Window;
-		Window? window2 = Window.CreateWindow(
-			wrapper.Context.Object,
-			wrapper.CoreNativeManager.Object,
-			new HWND(123)
-		)! as Window;
+		Window? window =
+			Window.CreateWindow(wrapper.Context.Object, wrapper.CoreNativeManager.Object, new HWND(123))! as Window;
+		Window? window2 =
+			Window.CreateWindow(wrapper.Context.Object, wrapper.CoreNativeManager.Object, new HWND(123))! as Window;
 
 		// When
 		bool equals = window == window2;
@@ -483,12 +481,10 @@ public class WindowTests
 	{
 		// Given
 		Wrapper wrapper = new();
-		Window? window = Window.CreateWindow(wrapper.Context.Object, wrapper.CoreNativeManager.Object, new HWND(123))! as Window;
-		Window? window2 = Window.CreateWindow(
-			wrapper.Context.Object,
-			wrapper.CoreNativeManager.Object,
-			new HWND(1234)
-		)! as Window;
+		Window? window =
+			Window.CreateWindow(wrapper.Context.Object, wrapper.CoreNativeManager.Object, new HWND(123))! as Window;
+		Window? window2 =
+			Window.CreateWindow(wrapper.Context.Object, wrapper.CoreNativeManager.Object, new HWND(1234))! as Window;
 
 		// When
 		bool equals = window != window2;

--- a/src/Whim.Tests/Window/WindowTests.cs
+++ b/src/Whim.Tests/Window/WindowTests.cs
@@ -446,9 +446,52 @@ public class WindowTests
 		// Given
 		Wrapper wrapper = new();
 		IWindow? window = Window.CreateWindow(wrapper.Context.Object, wrapper.CoreNativeManager.Object, new HWND(123))!;
+		IWindow? window2 = Window.CreateWindow(
+			wrapper.Context.Object,
+			wrapper.CoreNativeManager.Object,
+			new HWND(123)
+		)!;
 
 		// When
-		bool equals = window.Equals(window);
+		bool equals = window.Equals(window2);
+
+		// Then
+		Assert.True(equals);
+	}
+
+	[Fact]
+	public void Equals_Operator_Success()
+	{
+		// Given
+		Wrapper wrapper = new();
+		Window? window = Window.CreateWindow(wrapper.Context.Object, wrapper.CoreNativeManager.Object, new HWND(123))! as Window;
+		Window? window2 = Window.CreateWindow(
+			wrapper.Context.Object,
+			wrapper.CoreNativeManager.Object,
+			new HWND(123)
+		)! as Window;
+
+		// When
+		bool equals = window == window2;
+
+		// Then
+		Assert.True(equals);
+	}
+
+	[Fact]
+	public void NotEquals_Operator_Success()
+	{
+		// Given
+		Wrapper wrapper = new();
+		Window? window = Window.CreateWindow(wrapper.Context.Object, wrapper.CoreNativeManager.Object, new HWND(123))! as Window;
+		Window? window2 = Window.CreateWindow(
+			wrapper.Context.Object,
+			wrapper.CoreNativeManager.Object,
+			new HWND(1234)
+		)! as Window;
+
+		// When
+		bool equals = window != window2;
 
 		// Then
 		Assert.True(equals);

--- a/src/Whim.TreeLayout.Bar/TreeLayoutEngineWidgetViewModel.cs
+++ b/src/Whim.TreeLayout.Bar/TreeLayoutEngineWidgetViewModel.cs
@@ -55,7 +55,7 @@ public class TreeLayoutEngineWidgetViewModel : INotifyPropertyChanged, IDisposab
 
 	private void WorkspaceManager_MonitorWorkspaceChanged(object? sender, MonitorWorkspaceChangedEventArgs e)
 	{
-		if (e.Monitor == _monitor)
+		if (e.Monitor.Equals(_monitor))
 		{
 			OnPropertyChanged(string.Empty);
 		}

--- a/src/Whim.TreeLayout.CommandPalette.Tests/TreeLayoutCommandPaletteCommandsTests.cs
+++ b/src/Whim.TreeLayout.CommandPalette.Tests/TreeLayoutCommandPaletteCommandsTests.cs
@@ -1,6 +1,5 @@
 using Moq;
 using Whim.CommandPalette;
-using Whim.TestUtils;
 using Xunit;
 
 namespace Whim.TreeLayout.CommandPalette.Tests;
@@ -46,7 +45,7 @@ public class TreeLayoutCommandPaletteCommandsTests
 	{
 		// Given
 		Wrapper wrapper = new();
-		ICommand command = new PluginCommandsTestUtils(wrapper.Commands).GetCommand(
+		ICommand command = new TestUtils.PluginCommandsTestUtils(wrapper.Commands).GetCommand(
 			"whim.tree_layout.command_palette.set_direction"
 		);
 		wrapper.TreeLayoutPlugin.Setup(t => t.GetAddWindowDirection(wrapper.Monitor.Object)).Returns(Direction.Left);
@@ -63,7 +62,7 @@ public class TreeLayoutCommandPaletteCommandsTests
 	{
 		// Given
 		Wrapper wrapper = new();
-		ICommand command = new PluginCommandsTestUtils(wrapper.Commands).GetCommand(
+		ICommand command = new TestUtils.PluginCommandsTestUtils(wrapper.Commands).GetCommand(
 			"whim.tree_layout.command_palette.set_direction"
 		);
 		wrapper.TreeLayoutPlugin.Setup(t => t.GetAddWindowDirection(wrapper.Monitor.Object)).Returns((Direction?)null);

--- a/src/Whim.TreeLayout.Tests/LayoutEngine/MoveWindowToPointTests.cs
+++ b/src/Whim.TreeLayout.Tests/LayoutEngine/MoveWindowToPointTests.cs
@@ -446,8 +446,12 @@ public class MoveWindowToPointTests
 			);
 	}
 
-	[Fact]
-	public void MoveWindowToPoint_AlreadyContainsWindow()
+	[InlineData(0.25, 0.25)]
+	[InlineData(0.25, 0.75)]
+	[InlineData(0.75, 0.25)]
+	[InlineData(0.75, 0.75)]
+	[Theory]
+	public void MoveWindowToPoint_AlreadyContainsWindow(double x, double y)
 	{
 		// Given
 		Mock<IWindow> window = new();
@@ -458,7 +462,7 @@ public class MoveWindowToPointTests
 			wrapper.Identity
 		).AddWindow(window.Object);
 
-		IPoint<double> point = new Point<double>() { X = 0.5, Y = 0.5 };
+		IPoint<double> point = new Point<double>() { X = x, Y = y };
 
 		ILocation<int> location = new Location<int>() { Width = 100, Height = 100 };
 		Mock<IMonitor> monitor = new();

--- a/src/Whim.TreeLayout/TreeLayoutCommands.cs
+++ b/src/Whim.TreeLayout/TreeLayoutCommands.cs
@@ -26,28 +26,28 @@ public class TreeLayoutCommands : PluginCommands
 				title: "Add windows to the left of the current window",
 				callback: () =>
 					_treeLayoutPlugin.SetAddWindowDirection(_context.MonitorManager.ActiveMonitor, Direction.Left),
-				keybind: new Keybind(IKeybind.WinShift, VIRTUAL_KEY.VK_LEFT)
+				keybind: new Keybind(IKeybind.WinCtrlShift, VIRTUAL_KEY.VK_LEFT)
 			)
 			.Add(
 				identifier: "add_tree_direction_right",
 				title: "Add windows to the right of the current window",
 				callback: () =>
 					_treeLayoutPlugin.SetAddWindowDirection(_context.MonitorManager.ActiveMonitor, Direction.Right),
-				keybind: new Keybind(IKeybind.WinShift, VIRTUAL_KEY.VK_RIGHT)
+				keybind: new Keybind(IKeybind.WinCtrlShift, VIRTUAL_KEY.VK_RIGHT)
 			)
 			.Add(
 				identifier: "add_tree_direction_up",
 				title: "Add windows above the current window",
 				callback: () =>
 					_treeLayoutPlugin.SetAddWindowDirection(_context.MonitorManager.ActiveMonitor, Direction.Up),
-				keybind: new Keybind(IKeybind.WinShift, VIRTUAL_KEY.VK_UP)
+				keybind: new Keybind(IKeybind.WinCtrlShift, VIRTUAL_KEY.VK_UP)
 			)
 			.Add(
 				identifier: "add_tree_direction_down",
 				title: "Add windows below the current window",
 				callback: () =>
 					_treeLayoutPlugin.SetAddWindowDirection(_context.MonitorManager.ActiveMonitor, Direction.Down),
-				keybind: new Keybind(IKeybind.WinShift, VIRTUAL_KEY.VK_DOWN)
+				keybind: new Keybind(IKeybind.WinCtrlShift, VIRTUAL_KEY.VK_DOWN)
 			);
 	}
 }

--- a/src/Whim.TreeLayout/TreeLayoutEngine.cs
+++ b/src/Whim.TreeLayout/TreeLayoutEngine.cs
@@ -19,7 +19,7 @@ internal record NonRootWindowData(
 /// <summary>
 /// A tree layout engine allows users to create arbitrary window grid layouts.
 /// </summary>
-public class TreeLayoutEngine : ILayoutEngine
+public record TreeLayoutEngine : ILayoutEngine
 {
 	private readonly IContext _context;
 	private readonly ITreeLayoutPlugin _plugin;

--- a/src/Whim.TreeLayout/TreeLayoutEngine.cs
+++ b/src/Whim.TreeLayout/TreeLayoutEngine.cs
@@ -107,15 +107,18 @@ public class TreeLayoutEngine : ILayoutEngine
 	/// <summary>
 	/// Creates a new dictionary with the top-level split node.
 	/// </summary>
-	/// <param n="windowA"></param>
-	/// <param n="windowB"></param>
+	/// <param name="splitNode"></param>
 	/// <returns></returns>
-	private static WindowPathDict CreateTopSplitNodeDict(IWindow windowA, IWindow windowB)
+	private static WindowPathDict CreateTopSplitNodeDict(ISplitNode splitNode)
 	{
 		WindowPathDict.Builder dictBuilder = ImmutableDictionary.CreateBuilder<IWindow, ImmutableArray<int>>();
 
-		dictBuilder.Add(windowA, ImmutableArray.Create(0));
-		dictBuilder.Add(windowB, ImmutableArray.Create(1));
+		int idx = 0;
+		foreach (INode child in splitNode.Children)
+		{
+			dictBuilder.Add(((WindowNode)child).Window, ImmutableArray.Create(idx));
+			idx++;
+		}
 
 		return dictBuilder.ToImmutable();
 	}
@@ -138,7 +141,7 @@ public class TreeLayoutEngine : ILayoutEngine
 			case WindowNode rootNode:
 				Logger.Debug($"Root is window node, replacing with split node");
 				ISplitNode newRoot = new SplitNode(rootNode, newWindowNode, _plugin.GetAddWindowDirection(this));
-				return new TreeLayoutEngine(this, newRoot, CreateTopSplitNodeDict(rootNode.Window, window));
+				return new TreeLayoutEngine(this, newRoot, CreateTopSplitNodeDict(newRoot));
 
 			case ISplitNode rootNode:
 				return AddToSplitNode(newWindowNode, rootNode);
@@ -197,14 +200,8 @@ public class TreeLayoutEngine : ILayoutEngine
 	{
 		Logger.Debug($"Adding window {window} to layout engine {Name}");
 
-		TreeLayoutEngine treeLayoutEngine = this;
-
-		if (_windows.ContainsKey(window))
-		{
-			treeLayoutEngine = (TreeLayoutEngine)treeLayoutEngine.RemoveWindow(window);
-		}
-
-		return treeLayoutEngine.AddWindowAtPoint(window, point);
+		TreeLayoutEngine intermediateTree = (TreeLayoutEngine)RemoveWindow(window);
+		return intermediateTree.AddWindowAtPoint(window, point);
 	}
 
 	private ILayoutEngine AddWindowAtPoint(IWindow window, IPoint<double> point)
@@ -217,15 +214,7 @@ public class TreeLayoutEngine : ILayoutEngine
 			Direction newNodeDirection = Location.UnitSquare<double>().GetDirectionToPoint(point);
 
 			ISplitNode newRoot = new SplitNode(focusedWindowNode, newWindowNode, newNodeDirection);
-
-			if (newNodeDirection.InsertAfter())
-			{
-				return new TreeLayoutEngine(this, newRoot, CreateTopSplitNodeDict(focusedWindowNode.Window, window));
-			}
-			else
-			{
-				return new TreeLayoutEngine(this, newRoot, CreateTopSplitNodeDict(window, focusedWindowNode.Window));
-			}
+			return new TreeLayoutEngine(this, newRoot, CreateTopSplitNodeDict(newRoot));
 		}
 
 		if (_root is ISplitNode splitNode)

--- a/src/Whim.TreeLayout/TreeLayoutEngine.cs
+++ b/src/Whim.TreeLayout/TreeLayoutEngine.cs
@@ -528,7 +528,7 @@ public record TreeLayoutEngine : ILayoutEngine
 
 		if (_root is WindowNode windowNode)
 		{
-			if (windowNode.Window == window)
+			if (windowNode.Window.Equals(window))
 			{
 				return new TreeLayoutEngine(_context, _plugin, Identity);
 			}

--- a/src/Whim/Keybinds/IKeybind.cs
+++ b/src/Whim/Keybinds/IKeybind.cs
@@ -1,4 +1,3 @@
-using System.Collections.ObjectModel;
 using Windows.Win32.UI.Input.KeyboardAndMouse;
 
 namespace Whim;
@@ -42,9 +41,4 @@ public interface IKeybind
 	/// See https://docs.microsoft.com/en-us/windows/win32/inputdev/virtual-key-codes
 	/// </summary>
 	public VIRTUAL_KEY Key { get; }
-
-	/// <summary>
-	/// All the keys which make up this keybind.
-	/// </summary>
-	public ReadOnlyCollection<string> AllKeys { get; }
 }

--- a/src/Whim/Keybinds/KeyModifiers.cs
+++ b/src/Whim/Keybinds/KeyModifiers.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 
 namespace Whim;
 
@@ -68,7 +69,7 @@ public static class KeyModifiersExtensions
 	/// <returns></returns>
 	public static IEnumerable<string> GetParts(this KeyModifiers modifiers)
 	{
-		List<string> parts = new();
+		ImmutableArray<string>.Builder parts = ImmutableArray.CreateBuilder<string>();
 
 		if (modifiers.HasFlag(KeyModifiers.LWin))
 		{
@@ -110,6 +111,6 @@ public static class KeyModifiersExtensions
 			parts.Add("RAlt");
 		}
 
-		return parts;
+		return parts.ToImmutable();
 	}
 }

--- a/src/Whim/Keybinds/Keybind.cs
+++ b/src/Whim/Keybinds/Keybind.cs
@@ -1,23 +1,16 @@
-using System;
-using System.Collections.Generic;
-using System.Collections.ObjectModel;
+using System.Collections.Immutable;
 using Windows.Win32.UI.Input.KeyboardAndMouse;
 
 namespace Whim;
 
 /// <inheritdoc />
-public readonly struct Keybind : IKeybind, IEquatable<Keybind>
+public readonly record struct Keybind : IKeybind
 {
 	/// <inheritdoc />
 	public KeyModifiers Modifiers { get; }
 
 	/// <inheritdoc />
 	public VIRTUAL_KEY Key { get; }
-
-	/// <summary>
-	/// The keys which make up this keybind.
-	/// </summary>
-	public ReadOnlyCollection<string> AllKeys { get; }
 
 	/// <summary>
 	/// Saved representation of the keybind as a string.
@@ -34,34 +27,12 @@ public readonly struct Keybind : IKeybind, IEquatable<Keybind>
 		Modifiers = modifiers;
 		Key = key;
 
-		List<string> allKeys = new();
+		ImmutableArray<string>.Builder allKeys = ImmutableArray.CreateBuilder<string>();
 		allKeys.AddRange(Modifiers.GetParts());
 		allKeys.Add(Key.GetKeyString());
 
-		AllKeys = allKeys.AsReadOnly();
-		_allKeysStr = string.Join(" + ", AllKeys);
+		_allKeysStr = string.Join(" + ", allKeys.ToImmutable());
 	}
-
-	/// <inheritdoc />
-	public override bool Equals(object? obj) => obj is Keybind keybind && Equals(keybind);
-
-	/// <inheritdoc />
-	public bool Equals(Keybind other) => Modifiers == other.Modifiers && Key == other.Key;
-
-	/// <inheritdoc />
-	public static bool operator ==(Keybind left, Keybind right)
-	{
-		return left.Equals(right);
-	}
-
-	/// <inheritdoc />
-	public static bool operator !=(Keybind left, Keybind right)
-	{
-		return !(left == right);
-	}
-
-	/// <inheritdoc />
-	public override int GetHashCode() => HashCode.Combine(Modifiers, Key);
 
 	/// <inheritdoc />
 	public override string ToString() => _allKeysStr;

--- a/src/Whim/Layout/BaseProxyLayoutEngine.cs
+++ b/src/Whim/Layout/BaseProxyLayoutEngine.cs
@@ -21,7 +21,7 @@ public delegate ILayoutEngine CreateProxyLayoutEngine(ILayoutEngine engine);
 /// Proxy layout engine tests should extend the <c>Whim.TestUtils.ProxyLayoutEngineBaseTests</c>
 /// class, to verify they do not break in common scenarios.
 /// </remarks>
-public abstract class BaseProxyLayoutEngine : ILayoutEngine
+public abstract record BaseProxyLayoutEngine : ILayoutEngine
 {
 	/// <summary>
 	/// The proxied layout engine.
@@ -105,7 +105,7 @@ public abstract class BaseProxyLayoutEngine : ILayoutEngine
 	/// </returns>
 	public bool ContainsEqual(ILayoutEngine layoutEngine)
 	{
-		if (this == layoutEngine)
+		if (Equals(layoutEngine))
 		{
 			return true;
 		}

--- a/src/Whim/Layout/BaseProxyLayoutEngine.cs
+++ b/src/Whim/Layout/BaseProxyLayoutEngine.cs
@@ -105,7 +105,7 @@ public abstract record BaseProxyLayoutEngine : ILayoutEngine
 	/// </returns>
 	public bool ContainsEqual(ILayoutEngine layoutEngine)
 	{
-		if (Equals(layoutEngine))
+		if (this == (layoutEngine as BaseProxyLayoutEngine))
 		{
 			return true;
 		}

--- a/src/Whim/Layout/BaseProxyLayoutEngine.cs
+++ b/src/Whim/Layout/BaseProxyLayoutEngine.cs
@@ -105,7 +105,7 @@ public abstract record BaseProxyLayoutEngine : ILayoutEngine
 	/// </returns>
 	public bool ContainsEqual(ILayoutEngine layoutEngine)
 	{
-		if (this == (layoutEngine as BaseProxyLayoutEngine))
+		if (Equals(layoutEngine) || this == (layoutEngine as BaseProxyLayoutEngine))
 		{
 			return true;
 		}

--- a/src/Whim/Layout/ColumnLayoutEngine.cs
+++ b/src/Whim/Layout/ColumnLayoutEngine.cs
@@ -8,7 +8,7 @@ namespace Whim;
 /// <summary>
 /// Column layout engine with a stack data structure.
 /// </summary>
-public class ColumnLayoutEngine : ILayoutEngine
+public record ColumnLayoutEngine : ILayoutEngine
 {
 	/// <summary>
 	/// The stack of windows in the engine.

--- a/src/Whim/Layout/ColumnLayoutEngine.cs
+++ b/src/Whim/Layout/ColumnLayoutEngine.cs
@@ -74,7 +74,7 @@ public record ColumnLayoutEngine : ILayoutEngine
 	public bool ContainsWindow(IWindow window)
 	{
 		Logger.Debug($"Checking if layout engine {Name} contains window {window}");
-		return _stack.Any(x => x.Handle == window.Handle);
+		return _stack.Any(x => x.Equals(window));
 	}
 
 	/// <inheritdoc/>
@@ -148,7 +148,7 @@ public record ColumnLayoutEngine : ILayoutEngine
 		}
 
 		// Find the index of the window in the stack
-		int windowIndex = _stack.FindIndex(x => x.Handle == window.Handle);
+		int windowIndex = _stack.FindIndex(x => x.Equals(window));
 		if (windowIndex == -1)
 		{
 			Logger.Error($"Window {window} not found in layout engine {Name}");
@@ -173,7 +173,7 @@ public record ColumnLayoutEngine : ILayoutEngine
 		}
 
 		// Find the index of the window in the stack.
-		int windowIndex = _stack.FindIndex(x => x.Handle == window.Handle);
+		int windowIndex = _stack.FindIndex(x => x.Equals(window));
 		if (windowIndex == -1)
 		{
 			Logger.Error($"Window {window} not found in layout engine {Name}");

--- a/src/Whim/Layout/ILayoutEngine.cs
+++ b/src/Whim/Layout/ILayoutEngine.cs
@@ -13,8 +13,8 @@ public delegate ILayoutEngine CreateLeafLayoutEngine(LayoutEngineIdentity identi
 /// Layout engines dictate how windows are laid out.
 /// </summary>
 /// <remarks>
-/// Layout engines are immutable. All methods that change the layout engine return a new
-/// layout engine.
+/// Layout engines are immutable, and should be implemented as records. All methods that change the
+/// layout engine return a new layout engine.
 ///
 /// Layout engines are also composable, via the <see cref="BaseProxyLayoutEngine"/> class.
 ///

--- a/src/Whim/Layout/ILayoutEngine.cs
+++ b/src/Whim/Layout/ILayoutEngine.cs
@@ -152,7 +152,7 @@ public interface ILayoutEngine
 	/// </returns>
 	bool ContainsEqual(ILayoutEngine layoutEngine)
 	{
-		if (this == layoutEngine)
+		if (Equals(layoutEngine))
 		{
 			return true;
 		}

--- a/src/Whim/Layout/LayoutEngineIdentity.cs
+++ b/src/Whim/Layout/LayoutEngineIdentity.cs
@@ -26,5 +26,11 @@ public sealed class LayoutEngineIdentity
 	public override bool Equals(object? obj) => obj is LayoutEngineIdentity identity && _id == identity._id;
 
 	/// <inheritdoc/>
+	public static bool operator ==(LayoutEngineIdentity? left, LayoutEngineIdentity? right) => Equals(left, right);
+
+	/// <inheritdoc/>
+	public static bool operator !=(LayoutEngineIdentity? left, LayoutEngineIdentity? right) => !Equals(left, right);
+
+	/// <inheritdoc/>
 	public override int GetHashCode() => _id.GetHashCode();
 }

--- a/src/Whim/Monitor/IMonitor.cs
+++ b/src/Whim/Monitor/IMonitor.cs
@@ -5,7 +5,7 @@ namespace Whim;
 /// <summary>
 /// Represents a single display device.
 /// </summary>
-public interface IMonitor : IEquatable<IMonitor>
+public interface IMonitor
 {
 	/// <summary>
 	/// The name of the monitor.

--- a/src/Whim/Monitor/Monitor.cs
+++ b/src/Whim/Monitor/Monitor.cs
@@ -71,7 +71,12 @@ internal class Monitor : IMonitor
 		ScaleFactor = (int)((double)effectiveDpiX / 96 * 100);
 	}
 
-	public bool Equals(IMonitor? other) => other is Monitor monitor && _hmonitor == monitor._hmonitor;
+	/// <inheritdoc/>
+	public override bool Equals(object? other) => other is Monitor monitor && _hmonitor == monitor._hmonitor;
+
+	public static bool operator ==(Monitor? left, Monitor? right) => Equals(left, right);
+
+	public static bool operator !=(Monitor? left, Monitor? right) => !Equals(left, right);
 
 	public override int GetHashCode() => (int)(nint)_hmonitor;
 

--- a/src/Whim/Native/HDWP.cs
+++ b/src/Whim/Native/HDWP.cs
@@ -23,15 +23,6 @@ namespace Windows.Win32
 
 			/// <inheritdoc/>
 			public static explicit operator HDWP(nint value) => new(value);
-
-			/// <inheritdoc/>
-			public bool Equals(HDWP other) => Value == other.Value;
-
-			/// <inheritdoc/>
-			public override int GetHashCode() => Value.GetHashCode();
-
-			/// <inheritdoc/>
-			public override string ToString() => Value.ToString();
 		}
 	}
 }

--- a/src/Whim/Native/HDWP.cs
+++ b/src/Whim/Native/HDWP.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Diagnostics;
 
 namespace Windows.Win32
@@ -9,7 +8,7 @@ namespace Windows.Win32
 		/// A handle to a multiple-window position structure.
 		/// </summary>
 		[DebuggerDisplay("{Value}")]
-		public readonly struct HDWP : IEquatable<HDWP>
+		public readonly record struct HDWP
 		{
 			internal readonly nint Value;
 
@@ -26,16 +25,7 @@ namespace Windows.Win32
 			public static explicit operator HDWP(nint value) => new(value);
 
 			/// <inheritdoc/>
-			public static bool operator ==(HDWP left, HDWP right) => left.Value == right.Value;
-
-			/// <inheritdoc/>
-			public static bool operator !=(HDWP left, HDWP right) => !(left == right);
-
-			/// <inheritdoc/>
 			public bool Equals(HDWP other) => Value == other.Value;
-
-			/// <inheritdoc/>
-			public override bool Equals(object? obj) => obj is HDWP other && Equals(other);
 
 			/// <inheritdoc/>
 			public override int GetHashCode() => Value.GetHashCode();

--- a/src/Whim/Native/HWND.cs
+++ b/src/Whim/Native/HWND.cs
@@ -9,7 +9,7 @@ namespace Windows.Win32
 		/// A handle to a window.
 		/// </summary>
 		[DebuggerDisplay("{Value}")]
-		public readonly struct HWND : IEquatable<HWND>
+		public readonly record struct HWND
 		{
 			internal readonly IntPtr Value;
 
@@ -36,16 +36,7 @@ namespace Windows.Win32
 			public static explicit operator HWND(IntPtr value) => new(value);
 
 			/// <inheritdoc/>
-			public static bool operator ==(HWND left, HWND right) => left.Value == right.Value;
-
-			/// <inheritdoc/>
-			public static bool operator !=(HWND left, HWND right) => !(left == right);
-
-			/// <inheritdoc/>
 			public bool Equals(HWND other) => Value == other.Value;
-
-			/// <inheritdoc/>
-			public override bool Equals(object? obj) => obj is HWND other && Equals(other);
 
 			/// <inheritdoc/>
 			public override int GetHashCode() => Value.GetHashCode();

--- a/src/Whim/Native/HWND.cs
+++ b/src/Whim/Native/HWND.cs
@@ -34,15 +34,6 @@ namespace Windows.Win32
 
 			/// <inheritdoc/>
 			public static explicit operator HWND(IntPtr value) => new(value);
-
-			/// <inheritdoc/>
-			public bool Equals(HWND other) => Value == other.Value;
-
-			/// <inheritdoc/>
-			public override int GetHashCode() => Value.GetHashCode();
-
-			/// <inheritdoc/>
-			public override string ToString() => Value.ToString();
 		}
 	}
 }

--- a/src/Whim/Window/Window.cs
+++ b/src/Whim/Window/Window.cs
@@ -210,6 +210,10 @@ internal class Window : IWindow
 		return obj is Window window && window.Handle == Handle;
 	}
 
+	public static bool operator ==(Window? left, Window? right) => Equals(left, right);
+
+	public static bool operator !=(Window? left, Window? right) => !Equals(left, right);
+
 	/// <inheritdoc/>
 	public override int GetHashCode()
 	{

--- a/src/Whim/Window/Window.cs
+++ b/src/Whim/Window/Window.cs
@@ -207,7 +207,8 @@ internal class Window : IWindow
 			return false;
 		}
 
-		return obj is Window window && window.Handle == Handle;
+		// It won't reach here if the type is different
+		return ((Window)obj).Handle == Handle;
 	}
 
 	public static bool operator ==(Window? left, Window? right) => Equals(left, right);

--- a/src/Whim/Window/WindowManager.cs
+++ b/src/Whim/Window/WindowManager.cs
@@ -118,6 +118,13 @@ internal class WindowManager : IWindowManager
 	public IWindow? CreateWindow(HWND hwnd)
 	{
 		Logger.Debug($"Adding window {hwnd}");
+
+		if (_windows.TryGetValue(hwnd, out IWindow? window) && window != null)
+		{
+			Logger.Debug($"Window {hwnd} already exists");
+			return window;
+		}
+
 		return Window.CreateWindow(_context, _coreNativeManager, hwnd);
 	}
 

--- a/src/Whim/Window/WindowState.cs
+++ b/src/Whim/Window/WindowState.cs
@@ -29,10 +29,10 @@ public class WindowState : IWindowState
 			return false;
 		}
 
-		return obj is WindowState location
-			&& Location.Equals(location.Location)
-			&& WindowSize == location.WindowSize
-			&& Window.Equals(location.Window);
+		return obj is WindowState state
+			&& Location.Equals(state.Location)
+			&& WindowSize == state.WindowSize
+			&& Window.Equals(state.Window);
 	}
 
 	/// <inheritdoc />

--- a/src/Whim/Window/WindowState.cs
+++ b/src/Whim/Window/WindowState.cs
@@ -36,5 +36,11 @@ public class WindowState : IWindowState
 	}
 
 	/// <inheritdoc />
+	public static bool operator ==(WindowState? left, WindowState? right) => Equals(left, right);
+
+	/// <inheritdoc />
+	public static bool operator !=(WindowState? left, WindowState? right) => !Equals(left, right);
+
+	/// <inheritdoc />
 	public override int GetHashCode() => HashCode.Combine(Location, WindowSize, Window);
 }

--- a/src/Whim/Workspace/Workspace.cs
+++ b/src/Whim/Workspace/Workspace.cs
@@ -288,7 +288,7 @@ internal class Workspace : IWorkspace, IInternalWorkspace
 		{
 			Logger.Debug($"Removing window {window} from workspace {Name}");
 
-			if (LastFocusedWindow == window)
+			if (window.Equals(LastFocusedWindow))
 			{
 				LastFocusedWindow = null;
 			}

--- a/src/Whim/Workspace/WorkspaceManager.cs
+++ b/src/Whim/Workspace/WorkspaceManager.cs
@@ -349,7 +349,7 @@ internal class WorkspaceManager : IInternalWorkspaceManager, IWorkspaceManager
 		// Linear search for the monitor that contains the workspace.
 		foreach ((IMonitor m, IWorkspace w) in _monitorWorkspaceMap)
 		{
-			if (w == workspace)
+			if (w.Equals(workspace))
 			{
 				Logger.Debug($"Found monitor {m} for workspace {workspace}");
 				return m;
@@ -573,7 +573,7 @@ internal class WorkspaceManager : IInternalWorkspaceManager, IWorkspaceManager
 			return;
 		}
 
-		if (oldMonitor == monitor)
+		if (oldMonitor.Equals(monitor))
 		{
 			Logger.Error($"Window {window} is already on monitor {monitor}");
 			return;


### PR DESCRIPTION
This fixes #484 by:

- Using `Equals` instead of `==` for comparing `Window` objects. This is likely the cause of the issue.
- Using the `SplitNode` to determine the path for the windows. This reduces complexity.

Associated changes in this PR include:

- `Whim`
  - Removing the unused `IKeybind.AllKeys` property.
  - Switching to a more performant list initialization method for `KeyModifiers.GetParts`.
  - Changing `Keybind` to be a `record`.
  - Updated `ILayoutEngine` implementations to be `record`s.
  - Implementing operator overloading for classes which also implement `Equals`.
  - Updating `HDWP` and `HWND` to be `record`s.
  - Reusing existing `Window` objects when possible.
- `Whim.TestUtils`
  - Renamed `WhimAssert` to `Assert` - it should be accessed via `TestUtils.Assert`.
  - Added `Assert.PropertyNotChanged`.
- `Whim.TreeLayout`
  - Changed `TreeLayoutCommands` to use different keybinds from `CoreCommands`.
  - Always remove the given `Window` from the `TreeLayoutEngine` when moving a window.
