### PR TITLE
Dragging window edges no longer triggers LayoutPreview

### DIFF
--- a/src/Whim.LayoutPreview.Tests/LayoutPreviewPluginTests.cs
+++ b/src/Whim.LayoutPreview.Tests/LayoutPreviewPluginTests.cs
@@ -108,7 +108,13 @@ public class LayoutPreviewPluginTests
 		// Given
 		Wrapper wrapper = new();
 		using LayoutPreviewPlugin plugin = new(wrapper.Context.Object);
-		WindowMovedEventArgs e = new() { Window = new Mock<IWindow>().Object, CursorDraggedPoint = null };
+		WindowMovedEventArgs e =
+			new()
+			{
+				Window = new Mock<IWindow>().Object,
+				CursorDraggedPoint = null,
+				MovedEdges = null
+			};
 
 		// When
 		plugin.PreInitialize();
@@ -125,7 +131,35 @@ public class LayoutPreviewPluginTests
 		// Given
 		Wrapper wrapper = new();
 		using LayoutPreviewPlugin plugin = new(wrapper.Context.Object);
-		WindowMovedEventArgs e = new() { Window = new Mock<IWindow>().Object, CursorDraggedPoint = null };
+		WindowMovedEventArgs e =
+			new()
+			{
+				Window = new Mock<IWindow>().Object,
+				CursorDraggedPoint = null,
+				MovedEdges = null
+			};
+
+		// When
+		plugin.PreInitialize();
+		wrapper.WindowManager.Raise(x => x.WindowMoved += null, e);
+
+		// Then
+		wrapper.MonitorManager.Verify(x => x.GetMonitorAtPoint(It.IsAny<IPoint<int>>()), Times.Never);
+	}
+
+	[Fact]
+	public void WindowMoved_MovingEdges()
+	{
+		// Given
+		Wrapper wrapper = new();
+		using LayoutPreviewPlugin plugin = new(wrapper.Context.Object);
+		WindowMovedEventArgs e =
+			new()
+			{
+				Window = new Mock<IWindow>().Object,
+				CursorDraggedPoint = new Location<int>(),
+				MovedEdges = Direction.LeftDown
+			};
 
 		// When
 		plugin.PreInitialize();
@@ -142,7 +176,12 @@ public class LayoutPreviewPluginTests
 		Wrapper wrapper = new();
 		using LayoutPreviewPlugin plugin = new(wrapper.Context.Object);
 		WindowMovedEventArgs e =
-			new() { Window = new Mock<IWindow>().Object, CursorDraggedPoint = new Location<int>() };
+			new()
+			{
+				Window = new Mock<IWindow>().Object,
+				CursorDraggedPoint = new Location<int>(),
+				MovedEdges = null
+			};
 		wrapper.WorkspaceManager.Setup(x => x.GetWorkspaceForMonitor(It.IsAny<IMonitor>())).Returns((IWorkspace?)null);
 
 		// When
@@ -162,7 +201,12 @@ public class LayoutPreviewPluginTests
 		Wrapper wrapper = new();
 		using LayoutPreviewPlugin plugin = new(wrapper.Context.Object);
 		WindowMovedEventArgs e =
-			new() { Window = new Mock<IWindow>().Object, CursorDraggedPoint = new Location<int>() };
+			new()
+			{
+				Window = new Mock<IWindow>().Object,
+				CursorDraggedPoint = new Location<int>(),
+				MovedEdges = null
+			};
 
 		// When
 		plugin.PreInitialize();
@@ -181,7 +225,13 @@ public class LayoutPreviewPluginTests
 		// Given
 		Wrapper wrapper = new();
 		using LayoutPreviewPlugin plugin = new(wrapper.Context.Object);
-		WindowMovedEventArgs e = new() { Window = new Mock<IWindow>().Object, CursorDraggedPoint = null };
+		WindowMovedEventArgs e =
+			new()
+			{
+				Window = new Mock<IWindow>().Object,
+				CursorDraggedPoint = null,
+				MovedEdges = null
+			};
 
 		// When
 		plugin.PreInitialize();

--- a/src/Whim.LayoutPreview/LayoutPreviewPlugin.cs
+++ b/src/Whim.LayoutPreview/LayoutPreviewPlugin.cs
@@ -56,7 +56,7 @@ public class LayoutPreviewPlugin : IPlugin, IDisposable
 
 	private void WindowMoved(object? sender, WindowMovedEventArgs e)
 	{
-		// Only run if the window is being dragged.
+		// Only run if the window is being dragged. If the window is being resized, we don't want to do anything.
 		if (e.CursorDraggedPoint is not IPoint<int> cursorDraggedPoint || e.MovedEdges is not null)
 		{
 			return;

--- a/src/Whim.LayoutPreview/LayoutPreviewPlugin.cs
+++ b/src/Whim.LayoutPreview/LayoutPreviewPlugin.cs
@@ -57,7 +57,7 @@ public class LayoutPreviewPlugin : IPlugin, IDisposable
 	private void WindowMoved(object? sender, WindowMovedEventArgs e)
 	{
 		// Only run if the window is being dragged.
-		if (e.CursorDraggedPoint is not IPoint<int> cursorDraggedPoint)
+		if (e.CursorDraggedPoint is not IPoint<int> cursorDraggedPoint || e.MovedEdges is not null)
 		{
 			return;
 		}

--- a/src/Whim.LayoutPreview/LayoutPreviewWindow.xaml.cs
+++ b/src/Whim.LayoutPreview/LayoutPreviewWindow.xaml.cs
@@ -52,6 +52,7 @@ internal sealed partial class LayoutPreviewWindow : Window, IDisposable
 
 		// Update the rendered window.
 		_prevWindowStates = windowStates;
+		_prevHoveredIndex = -1;
 
 		LayoutPreviewWindowItem[] items = new LayoutPreviewWindowItem[windowStates.Length];
 		for (int idx = 0; idx < windowStates.Length; idx++)
@@ -88,7 +89,7 @@ internal sealed partial class LayoutPreviewWindow : Window, IDisposable
 		IPoint<int> cursorPoint
 	)
 	{
-		if (prevWindowStates.Length != windowStates.Length)
+		if (prevWindowStates.Length != windowStates.Length || prevHoveredIndex == -1)
 		{
 			return true;
 		}
@@ -101,13 +102,10 @@ internal sealed partial class LayoutPreviewWindow : Window, IDisposable
 			}
 		}
 
-		if (prevHoveredIndex != -1)
+		IWindowState prevHoveredState = prevWindowStates[prevHoveredIndex];
+		if (!prevHoveredState.Location.ContainsPoint(cursorPoint))
 		{
-			IWindowState prevHoveredState = prevWindowStates[prevHoveredIndex];
-			if (!prevHoveredState.Location.ContainsPoint(cursorPoint))
-			{
-				return true;
-			}
+			return true;
 		}
 
 		return false;

--- a/src/Whim.Tests/Layout/DirectionTests.cs
+++ b/src/Whim.Tests/Layout/DirectionTests.cs
@@ -1,0 +1,21 @@
+using Xunit;
+
+namespace Whim.Tests;
+
+public class DirectionTests
+{
+	[InlineData(Direction.None, false)]
+	[InlineData(Direction.Left, true)]
+	[InlineData(Direction.Right, true)]
+	[InlineData(Direction.Up, false)]
+	[InlineData(Direction.Down, false)]
+	[InlineData(Direction.LeftUp, false)]
+	[InlineData(Direction.LeftDown, false)]
+	[InlineData(Direction.RightUp, false)]
+	[InlineData(Direction.RightDown, false)]
+	[Theory]
+	public void IsHorizontal(Direction direction, bool expected)
+	{
+		Assert.Equal(expected, direction.IsHorizontal());
+	}
+}

--- a/src/Whim/Layout/Direction.cs
+++ b/src/Whim/Layout/Direction.cs
@@ -64,31 +64,4 @@ public static class DirectionHelpers
 	/// </summary>
 	public static bool IsHorizontal(this Direction direction) =>
 		direction == Direction.Left || direction == Direction.Right;
-
-	/// <summary>
-	/// Returns the number of directions in the given direction.
-	/// </summary>
-	/// <param name="direction"></param>
-	/// <returns></returns>
-	public static int GetDirectionsCount(this Direction direction)
-	{
-		int count = 0;
-		if (direction.HasFlag(Direction.Left))
-		{
-			count++;
-		}
-		if (direction.HasFlag(Direction.Right))
-		{
-			count++;
-		}
-		if (direction.HasFlag(Direction.Up))
-		{
-			count++;
-		}
-		if (direction.HasFlag(Direction.Down))
-		{
-			count++;
-		}
-		return count;
-	}
 }

--- a/src/Whim/Layout/Direction.cs
+++ b/src/Whim/Layout/Direction.cs
@@ -64,4 +64,31 @@ public static class DirectionHelpers
 	/// </summary>
 	public static bool IsHorizontal(this Direction direction) =>
 		direction == Direction.Left || direction == Direction.Right;
+
+	/// <summary>
+	/// Returns the number of directions in the given direction.
+	/// </summary>
+	/// <param name="direction"></param>
+	/// <returns></returns>
+	public static int GetDirectionsCount(this Direction direction)
+	{
+		int count = 0;
+		if (direction.HasFlag(Direction.Left))
+		{
+			count++;
+		}
+		if (direction.HasFlag(Direction.Right))
+		{
+			count++;
+		}
+		if (direction.HasFlag(Direction.Up))
+		{
+			count++;
+		}
+		if (direction.HasFlag(Direction.Down))
+		{
+			count++;
+		}
+		return count;
+	}
 }

--- a/src/Whim/Window/WindowMovedEventArgs.cs
+++ b/src/Whim/Window/WindowMovedEventArgs.cs
@@ -11,7 +11,7 @@ public class WindowMovedEventArgs : WindowEventArgs
 	public required IPoint<int>? CursorDraggedPoint { get; init; }
 
 	/// <summary>
-	/// The edges that were moved.
+	/// The edges that were moved, if the window was being resized by dragging the edges.
 	/// </summary>
 	public required Direction? MovedEdges { get; init; }
 }

--- a/src/Whim/Window/WindowMovedEventArgs.cs
+++ b/src/Whim/Window/WindowMovedEventArgs.cs
@@ -9,4 +9,9 @@ public class WindowMovedEventArgs : WindowEventArgs
 	/// The cursor point. Only set if the window is being dragged.
 	/// </summary>
 	public required IPoint<int>? CursorDraggedPoint { get; init; }
+
+	/// <summary>
+	/// The edges that were moved.
+	/// </summary>
+	public required Direction? MovedEdges { get; init; }
 }


### PR DESCRIPTION
`WindowMovedEventArgs` now includes what edges have moved for a window, if the window was being resized by dragging the edges. If the window was being resized, the layout preview window isn't shown.