### PR TITLE
Don't wipe `IWorkspace.LastFocusedWindow` after an unmonitored window is focused

### DIFF
--- a/src/Whim.FocusIndicator/FocusIndicatorPlugin.cs
+++ b/src/Whim.FocusIndicator/FocusIndicatorPlugin.cs
@@ -36,6 +36,7 @@ public class FocusIndicatorPlugin : IFocusIndicatorPlugin
 	{
 		_context.FilterManager.IgnoreTitleMatch(FocusIndicatorConfig.Title);
 
+		_context.WindowManager.WindowMoveStart += WindowManager_WindowMoveStart;
 		_context.WindowManager.WindowFocused += WindowManager_WindowFocused;
 	}
 
@@ -56,6 +57,8 @@ public class FocusIndicatorPlugin : IFocusIndicatorPlugin
 	}
 
 	private void DispatcherTimer_Tick(object? sender, object e) => Hide();
+
+	private void WindowManager_WindowMoveStart(object? sender, WindowMovedEventArgs e) => Hide();
 
 	private void WindowManager_WindowFocused(object? sender, WindowFocusedEventArgs e)
 	{

--- a/src/Whim/Workspace/IWorkspace.cs
+++ b/src/Whim/Workspace/IWorkspace.cs
@@ -50,7 +50,9 @@ public interface IWorkspace : IDisposable
 	IEnumerable<IWindow> Windows { get; }
 
 	/// <summary>
-	/// The currently focused window.
+	/// The last focused window. This is still set when the window has lost focus (provided another
+	/// window in the workspace does not have focus). This is useful in cases like when the
+	/// command palette is opened and wants to perform an action on the last focused window.
 	/// </summary>
 	IWindow? LastFocusedWindow { get; }
 

--- a/src/Whim/Workspace/Workspace.cs
+++ b/src/Whim/Workspace/Workspace.cs
@@ -124,11 +124,6 @@ internal class Workspace : IWorkspace, IInternalWorkspace
 				LastFocusedWindow = window;
 				Logger.Debug($"Focused window {window} in workspace {Name}");
 			}
-			else
-			{
-				Logger.Debug($"Window {window} is not a normal window in workspace {Name}");
-				LastFocusedWindow = null;
-			}
 		}
 	}
 


### PR DESCRIPTION
This was preventing the command palette from performing actions.