### PR TITLE
Remove old windows

### DIFF
--- a/src/Whim.Tests/Window/WindowManagerTests.cs
+++ b/src/Whim.Tests/Window/WindowManagerTests.cs
@@ -562,6 +562,7 @@ public class WindowManagerTests
 
 		// Then
 		wrapper.InternalWorkspaceManager.Verify(wm => wm.WindowRemoved(It.IsAny<IWindow>()), Times.Once);
+		Assert.Empty(windowManager.Windows);
 	}
 
 	#region OnWindowMoveStart

--- a/src/Whim.Tests/Window/WindowTests.cs
+++ b/src/Whim.Tests/Window/WindowTests.cs
@@ -12,11 +12,14 @@ public class WindowTests
 	{
 		public Mock<IContext> Context { get; } = new();
 		public Mock<ICoreNativeManager> CoreNativeManager { get; } = new();
-		public Mock<IWindowManager> WindowManager { get; } = new();
+		public Mock<IWindowManager> WindowManager { get; }
+		public Mock<IInternalWindowManager> InternalWindowManager { get; } = new();
 		public Mock<INativeManager> NativeManager { get; } = new();
 
 		public Wrapper()
 		{
+			WindowManager = InternalWindowManager.As<IWindowManager>();
+
 			Context.Setup(c => c.NativeManager).Returns(NativeManager.Object);
 			Context.Setup(c => c.WindowManager).Returns(WindowManager.Object);
 

--- a/src/Whim.Tests/Workspace/WorkspaceManagerTests.cs
+++ b/src/Whim.Tests/Workspace/WorkspaceManagerTests.cs
@@ -12,8 +12,8 @@ public class WorkspaceManagerTests
 		// Yes, I know it's bad to have `_triggers` be `internal` in `WorkspaceManager`.
 		public WorkspaceManagerTriggers InternalTriggers => _triggers;
 
-		public WorkspaceManagerTestWrapper(IContext context)
-			: base(context) { }
+		public WorkspaceManagerTestWrapper(IContext context, ICoreNativeManager coreNativeManager)
+			: base(context, coreNativeManager) { }
 
 		public void Add(IWorkspace workspace) => _workspaces.Add(workspace);
 	}
@@ -24,6 +24,7 @@ public class WorkspaceManagerTests
 		public Mock<IMonitorManager> MonitorManager { get; } = new();
 		public Mock<IMonitor>[] Monitors { get; }
 		public Mock<IRouterManager> RouterManager { get; } = new();
+		public Mock<ICoreNativeManager> CoreNativeManager { get; } = new();
 		public Mock<INativeManager> NativeManager { get; } = new();
 		public WorkspaceManagerTestWrapper WorkspaceManager { get; }
 
@@ -55,7 +56,7 @@ public class WorkspaceManagerTests
 
 			RouterManager.Setup(r => r.RouteWindow(It.IsAny<IWindow>())).Returns(null as IWorkspace);
 
-			WorkspaceManager = new(Context.Object);
+			WorkspaceManager = new(Context.Object, CoreNativeManager.Object);
 			foreach (Mock<IWorkspace> workspace in workspaces ?? Array.Empty<Mock<IWorkspace>>())
 			{
 				WorkspaceManager.Add(workspace.Object);

--- a/src/Whim.Tests/Workspace/WorkspaceTests.cs
+++ b/src/Whim.Tests/Workspace/WorkspaceTests.cs
@@ -399,8 +399,8 @@ public class WorkspaceTests
 
 		wrapper.CoreNativeManager.Setup(c => c.IsWindow(It.IsAny<HWND>())).Returns(true);
 		wrapper.InternalWindowManager
-		.Setup(wm => wm.Windows.TryGetValue(It.IsAny<HWND>(), out It.Ref<IWindow?>.IsAny))
-		.Returns(false);
+			.Setup(wm => wm.Windows.TryGetValue(It.IsAny<HWND>(), out It.Ref<IWindow?>.IsAny))
+			.Returns(false);
 
 		// When
 		workspace.AddWindow(window.Object);

--- a/src/Whim.Tests/Workspace/WorkspaceTests.cs
+++ b/src/Whim.Tests/Workspace/WorkspaceTests.cs
@@ -94,15 +94,7 @@ public class WorkspaceTests
 			Mock<IWindow> window = new();
 			window.Setup(w => w.Equals(It.IsAny<IWindow>())).Returns(true);
 
-			InternalWindowManager
-				.Setup(wm => wm.Windows.TryGetValue(It.IsAny<HWND>(), out It.Ref<IWindow?>.IsAny))
-				.Callback(
-					(HWND hwnd, out IWindow? w) =>
-					{
-						w = window.Object;
-					}
-				)
-				.Returns(true);
+			InternalWindowManager.Setup(wm => wm.Windows.ContainsKey(It.IsAny<HWND>())).Returns(true);
 
 			return this;
 		}
@@ -297,80 +289,6 @@ public class WorkspaceTests
 			);
 
 		wrapper.CoreNativeManager.Setup(c => c.IsWindow(It.IsAny<HWND>())).Returns(false);
-
-		// When
-		workspace.AddWindow(window.Object);
-
-		// Then
-		wrapper.WorkspaceManager.Verify(wm => wm.GetMonitorForWorkspace(workspace), Times.Never);
-		wrapper.TriggerWorkspaceLayoutStarted.Verify(e => e.Invoke(It.IsAny<WorkspaceEventArgs>()), Times.Never);
-	}
-
-	[Fact]
-	public void DoLayout_GarbageCollect_HandleIsEqual()
-	{
-		// Given
-		Wrapper wrapper = new();
-
-		Mock<IWindow> window = new();
-		Mock<IWindow> windowInManager = new();
-		windowInManager.Setup(w => w.Equals(It.IsAny<IWindow>())).Returns(true);
-
-		using Workspace workspace =
-			new(
-				wrapper.Context.Object,
-				wrapper.CoreNativeManager.Object,
-				wrapper.Triggers,
-				"Workspace",
-				new ILayoutEngine[] { wrapper.LayoutEngine.Object }
-			);
-
-		wrapper.CoreNativeManager.Setup(c => c.IsWindow(It.IsAny<HWND>())).Returns(true);
-		wrapper.InternalWindowManager
-			.Setup(wm => wm.Windows.TryGetValue(It.IsAny<HWND>(), out It.Ref<IWindow?>.IsAny))
-			.Callback(
-				(HWND hwnd, out IWindow? w) =>
-				{
-					w = windowInManager.Object;
-				}
-			)
-			.Returns(true);
-
-		// When
-		workspace.AddWindow(window.Object);
-
-		// Then
-		wrapper.WorkspaceManager.Verify(wm => wm.GetMonitorForWorkspace(workspace), Times.Once);
-		wrapper.TriggerWorkspaceLayoutStarted.Verify(e => e.Invoke(It.IsAny<WorkspaceEventArgs>()), Times.Once);
-	}
-
-	[Fact]
-	public void DoLayout_GarbageCollect_HandleIsNotEqual()
-	{
-		// Given
-		Wrapper wrapper = new();
-
-		Mock<IWindow> window = new();
-
-		using Workspace workspace =
-			new(
-				wrapper.Context.Object,
-				wrapper.CoreNativeManager.Object,
-				wrapper.Triggers,
-				"Workspace",
-				new ILayoutEngine[] { wrapper.LayoutEngine.Object }
-			);
-
-		wrapper.CoreNativeManager.Setup(c => c.IsWindow(It.IsAny<HWND>())).Returns(true);
-		wrapper.InternalWindowManager
-			.Setup(wm => wm.Windows.TryGetValue(It.IsAny<HWND>(), out It.Ref<IWindow?>.IsAny))
-			.Callback(
-				(HWND hwnd, out IWindow? w) =>
-				{
-					w = new Mock<IWindow>().Object;
-				}
-			)
-			.Returns(true);
 
 		// When
 		workspace.AddWindow(window.Object);

--- a/src/Whim/Context/Context.cs
+++ b/src/Whim/Context/Context.cs
@@ -50,7 +50,7 @@ internal class Context : IContext
 		FilterManager = new FilterManager();
 		WindowManager = new WindowManager(this, CoreNativeManager, MouseHook);
 		MonitorManager = new MonitorManager(this, CoreNativeManager, MouseHook);
-		WorkspaceManager = new WorkspaceManager(this);
+		WorkspaceManager = new WorkspaceManager(this, CoreNativeManager);
 		_commandManager = new CommandManager();
 		PluginManager = new PluginManager(this, FileManager, _commandManager);
 		KeybindManager = new KeybindManager(this);

--- a/src/Whim/Native/CoreNativeManager.cs
+++ b/src/Whim/Native/CoreNativeManager.cs
@@ -233,6 +233,8 @@ internal class CoreNativeManager : ICoreNativeManager
 		return false;
 	}
 
+	public bool IsWindow(HWND hWnd) => PInvoke.IsWindow(hWnd);
+
 	public bool HasNoVisibleOwner(HWND hwnd)
 	{
 		HWND owner = PInvoke.GetWindow(hwnd, GET_WINDOW_CMD.GW_OWNER);

--- a/src/Whim/Native/HWND.cs
+++ b/src/Whim/Native/HWND.cs
@@ -34,6 +34,9 @@ namespace Windows.Win32
 
 			/// <inheritdoc/>
 			public static explicit operator HWND(IntPtr value) => new(value);
+
+			/// <inheritdoc/>
+			public override string ToString() => Value.ToString();
 		}
 	}
 }

--- a/src/Whim/Native/ICoreNativeManager.cs
+++ b/src/Whim/Native/ICoreNativeManager.cs
@@ -354,6 +354,9 @@ internal interface ICoreNativeManager
 	/// <returns></returns>
 	bool IsSystemWindow(HWND hwnd, string className);
 
+	/// <inheritdoc cref="PInvoke.IsWindow(HWND)"/>
+	bool IsWindow(HWND hWnd);
+
 	/// <summary>Installs or updates a window subclass callback.</summary>
 	/// <param name="hWnd">
 	/// <para>Type: <b>HWND</b> The handle of the window being subclassed.</para>

--- a/src/Whim/NativeMethods.txt
+++ b/src/Whim/NativeMethods.txt
@@ -51,6 +51,7 @@ ICON_BIG
 ICON_SMALL
 ICON_SMALL2
 IsIconic
+IsWindow
 IsWindowVisible
 IsZoomed
 KBDLLHOOKSTRUCT

--- a/src/Whim/Window/IInternalWindowManager.cs
+++ b/src/Whim/Window/IInternalWindowManager.cs
@@ -1,0 +1,18 @@
+using System.Collections.Generic;
+using Windows.Win32.Foundation;
+
+namespace Whim;
+
+internal interface IInternalWindowManager
+{
+	void OnWindowAdded(IWindow window);
+	void OnWindowFocused(IWindow? window);
+	void OnWindowRemoved(IWindow window);
+	void OnWindowMinimizeStart(IWindow window);
+	void OnWindowMinimizeEnd(IWindow window);
+
+	/// <summary>
+	/// Map of <see cref="HWND"/> to <see cref="IWindow"/> for easy <see cref="IWindow"/> lookup.
+	/// </summary>
+	IReadOnlyDictionary<HWND, IWindow> Windows { get; }
+}

--- a/src/Whim/Window/Window.cs
+++ b/src/Whim/Window/Window.cs
@@ -95,7 +95,7 @@ internal class Window : IWindow
 
 		// We manually call OnWindowFocused as an already focused window may have switched to a
 		// different workspace.
-		(_context.WindowManager as WindowManager)?.OnWindowFocused(this);
+		((IInternalWindowManager)_context.WindowManager).OnWindowFocused(this);
 	}
 
 	/// <inheritdoc/>
@@ -114,7 +114,7 @@ internal class Window : IWindow
 
 		// We manually call OnWindowFocused as an already focused window may have switched to a
 		// different workspace.
-		(_context.WindowManager as WindowManager)?.OnWindowFocused(this);
+		((IInternalWindowManager)_context.WindowManager).OnWindowFocused(this);
 	}
 
 	/// <inheritdoc/>

--- a/src/Whim/Window/WindowManager.cs
+++ b/src/Whim/Window/WindowManager.cs
@@ -306,6 +306,12 @@ internal class WindowManager : IWindowManager, IInternalWindowManager
 			return null;
 		}
 
+		if (!_coreNativeManager.HasNoVisibleOwner(hwnd))
+		{
+			Logger.Verbose($"Window {hwnd.Value} has a visible owner, ignoring");
+			return null;
+		}
+
 		IWindow? window = CreateWindow(hwnd);
 		if (window == null)
 		{

--- a/src/Whim/Window/WindowManager.cs
+++ b/src/Whim/Window/WindowManager.cs
@@ -116,7 +116,7 @@ internal class WindowManager : IWindowManager, IInternalWindowManager
 
 	public IWindow? CreateWindow(HWND hwnd)
 	{
-		Logger.Debug($"Adding window {hwnd.Value}");
+		Logger.Debug($"Adding window {hwnd}");
 
 		if (_windows.TryGetValue(hwnd, out IWindow? window) && window != null)
 		{

--- a/src/Whim/Window/WindowManager.cs
+++ b/src/Whim/Window/WindowManager.cs
@@ -287,15 +287,6 @@ internal class WindowManager : IWindowManager, IInternalWindowManager
 	private IWindow? AddWindow(HWND hwnd)
 	{
 		Logger.Debug($"Adding window {hwnd.Value}");
-		// if (
-		// 	_coreNativeManager.IsSplashScreen(hwnd)
-		// 	|| _coreNativeManager.IsCloakedWindow(hwnd)
-		// 	|| !_coreNativeManager.IsStandardWindow(hwnd)
-		// 	|| !_coreNativeManager.HasNoVisibleOwner(hwnd)
-		// )
-		// {
-		// 	return null;
-		// }
 
 		if (_coreNativeManager.IsSplashScreen(hwnd))
 		{

--- a/src/Whim/Workspace/Workspace.cs
+++ b/src/Whim/Workspace/Workspace.cs
@@ -577,17 +577,9 @@ internal class Workspace : IWorkspace, IInternalWorkspace
 				Logger.Debug($"Window {window.Handle} is no longer a window.");
 				removeWindow = true;
 			}
-			else if (windowManager.Windows.TryGetValue(window.Handle, out IWindow? windowInManager))
+			else if (!windowManager.Windows.ContainsKey(window.Handle))
 			{
-				if (!windowInManager.Equals(window))
-				{
-					Logger.Debug($"Window {window.Handle} is no longer the same window.");
-					removeWindow = true;
-				}
-			}
-			else
-			{
-				Logger.Debug($"Window {window.Handle} is no longer managed.");
+				Logger.Debug($"Window {window.Handle} is somehow no longer managed.");
 				removeWindow = true;
 			}
 

--- a/src/Whim/Workspace/Workspace.cs
+++ b/src/Whim/Workspace/Workspace.cs
@@ -577,12 +577,17 @@ internal class Workspace : IWorkspace, IInternalWorkspace
 				Logger.Debug($"Window {window.Handle} is no longer a window.");
 				removeWindow = true;
 			}
-			else if (
-				windowManager.Windows.TryGetValue(window.Handle, out IWindow? windowInManager)
-				&& !windowInManager.Equals(window)
-			)
+			else if (windowManager.Windows.TryGetValue(window.Handle, out IWindow? windowInManager))
 			{
-				Logger.Debug($"Window {window.Handle} is no longer the same window.");
+				if (!windowInManager.Equals(window))
+				{
+					Logger.Debug($"Window {window.Handle} is no longer the same window.");
+					removeWindow = true;
+				}
+			}
+			else
+			{
+				Logger.Debug($"Window {window.Handle} is no longer managed.");
 				removeWindow = true;
 			}
 

--- a/src/Whim/Workspace/WorkspaceManager.cs
+++ b/src/Whim/Workspace/WorkspaceManager.cs
@@ -24,6 +24,7 @@ internal class WorkspaceManager : IInternalWorkspaceManager, IWorkspaceManager
 	private bool _initialized;
 
 	private readonly IContext _context;
+	private readonly ICoreNativeManager _coreNativeManager;
 	protected readonly WorkspaceManagerTriggers _triggers;
 
 	/// <summary>
@@ -89,9 +90,10 @@ internal class WorkspaceManager : IInternalWorkspaceManager, IWorkspaceManager
 
 	private bool _disposedValue;
 
-	public WorkspaceManager(IContext context)
+	public WorkspaceManager(IContext context, ICoreNativeManager coreNativeManager)
 	{
 		_context = context;
+		_coreNativeManager = coreNativeManager;
 		_triggers = new WorkspaceManagerTriggers()
 		{
 			ActiveLayoutEngineChanged = (ActiveLayoutEngineChangedEventArgs e) =>
@@ -165,7 +167,8 @@ internal class WorkspaceManager : IInternalWorkspaceManager, IWorkspaceManager
 		}
 
 		// Create the workspace.
-		Workspace workspace = new(_context, _triggers, name ?? $"Workspace {_workspaces.Count + 1}", layoutEngines);
+		Workspace workspace =
+			new(_context, _coreNativeManager, _triggers, name ?? $"Workspace {_workspaces.Count + 1}", layoutEngines);
 		_workspaces.Add(workspace);
 		WorkspaceAdded?.Invoke(this, new WorkspaceEventArgs() { Workspace = workspace });
 		return workspace;


### PR DESCRIPTION
At the start of `DoLayout`, before starting to call `DeferWindowPos`, Whim now checks that each window in the workspace identifies an existing window. If the window does not, Whim removes the window from itself. Additionally, the `DeferWindowPos` call is cancelled, relying instead on the subsequent `DoLayout` call after the window has been removed.