### PR TITLE
Move `SetWindowPos` into a different thread

### DIFF
--- a/src/Whim.Bar.Tests/Workspace/WorkspaceWidgetViewModelTests.cs
+++ b/src/Whim.Bar.Tests/Workspace/WorkspaceWidgetViewModelTests.cs
@@ -98,6 +98,7 @@ public class WorkspaceWidgetViewModelTests
 		Assert.Equal(wrapper.Workspace.Object, viewModel.Workspaces[0].Workspace);
 	}
 
+	#region WorkspaceManager_MonitorWorkspaceChanged
 	[Fact]
 	public void WorkspaceManager_MonitorWorkspaceChanged_Deactivate()
 	{
@@ -156,6 +157,43 @@ public class WorkspaceWidgetViewModelTests
 		Assert.False(existingModel.ActiveOnMonitor);
 		Assert.True(addedWorkspaceModel.ActiveOnMonitor);
 	}
+
+	[Fact]
+	public void WorkspaceManager_MonitorWorkspaceChanged_DifferentMonitor()
+	{
+		// Given
+		Wrapper wrapper = new();
+		WorkspaceWidgetViewModel viewModel = new(wrapper.Context.Object, wrapper.Monitor.Object);
+
+		// Add workspace
+		Mock<IWorkspace> addedWorkspace = new();
+		wrapper.WorkspaceManager.Raise(
+			wm => wm.WorkspaceAdded += null,
+			new WorkspaceEventArgs() { Workspace = addedWorkspace.Object }
+		);
+
+		// Verify that the correct workspace is active on the monitor
+		WorkspaceModel existingModel = viewModel.Workspaces[0];
+		WorkspaceModel addedWorkspaceModel = viewModel.Workspaces[1];
+		Assert.True(existingModel.ActiveOnMonitor);
+		Assert.False(addedWorkspaceModel.ActiveOnMonitor);
+
+		// When
+		wrapper.WorkspaceManager.Raise(
+			wm => wm.MonitorWorkspaceChanged += null,
+			new MonitorWorkspaceChangedEventArgs()
+			{
+				Monitor = new Mock<IMonitor>().Object,
+				PreviousWorkspace = existingModel.Workspace,
+				CurrentWorkspace = addedWorkspaceModel.Workspace
+			}
+		);
+
+		// Then
+		Assert.True(existingModel.ActiveOnMonitor);
+		Assert.False(addedWorkspaceModel.ActiveOnMonitor);
+	}
+	#endregion
 
 	[Fact]
 	public void WorkspaceManager_WorkspaceRenamed_ExistingWorkspace()

--- a/src/Whim.Bar/Workspace/WorkspaceWidgetViewModel.cs
+++ b/src/Whim.Bar/Workspace/WorkspaceWidgetViewModel.cs
@@ -68,7 +68,7 @@ internal class WorkspaceWidgetViewModel : IDisposable
 
 	private void WorkspaceManager_MonitorWorkspaceChanged(object? sender, MonitorWorkspaceChangedEventArgs args)
 	{
-		if (args.Monitor != Monitor)
+		if (!args.Monitor.Equals(Monitor))
 		{
 			return;
 		}

--- a/src/Whim.Bar/Workspace/WorkspaceWidgetViewModel.cs
+++ b/src/Whim.Bar/Workspace/WorkspaceWidgetViewModel.cs
@@ -73,25 +73,9 @@ internal class WorkspaceWidgetViewModel : IDisposable
 			return;
 		}
 
-		// Set the old workspace's model to not be active on the monitor
-		if (args.PreviousWorkspace != null)
+		foreach (WorkspaceModel workspaceModel in Workspaces)
 		{
-			WorkspaceModel? oldWorkspaceModel = Workspaces.FirstOrDefault(
-				model => model.Workspace.Equals(args.PreviousWorkspace)
-			);
-			if (oldWorkspaceModel != null)
-			{
-				oldWorkspaceModel.ActiveOnMonitor = false;
-			}
-		}
-
-		// Set the new workspace's model to be active on the monitor
-		WorkspaceModel? newWorkspaceModel = Workspaces.FirstOrDefault(
-			model => model.Workspace.Equals(args.CurrentWorkspace)
-		);
-		if (newWorkspaceModel != null)
-		{
-			newWorkspaceModel.ActiveOnMonitor = true;
+			workspaceModel.ActiveOnMonitor = workspaceModel.Workspace.Equals(args.CurrentWorkspace);
 		}
 	}
 

--- a/src/Whim.Tests/Native/WindowDeferPosHandleTests.cs
+++ b/src/Whim.Tests/Native/WindowDeferPosHandleTests.cs
@@ -1,5 +1,6 @@
 using Moq;
 using System.Collections.Generic;
+using System.Threading;
 using Windows.Win32.Foundation;
 using Windows.Win32.UI.WindowsAndMessaging;
 using Xunit;
@@ -215,5 +216,31 @@ public class WindowDeferPosHandleTests
 				),
 			Times.Never
 		);
+	}
+
+	[Fact]
+	public void DeferWindowPos_Cancelled()
+	{
+		// Given
+		MocksBuilder mocks = new();
+
+		using CancellationTokenSource cts = new();
+		cts.Cancel();
+
+		WindowDeferPosHandle handle = new(mocks.Context.Object, cts.Token);
+
+		// When
+		handle.DeferWindowPos(
+			new WindowState()
+			{
+				Location = new Location<int>(),
+				Window = new Mock<IWindow>().Object,
+				WindowSize = WindowSize.Normal
+			}
+		);
+		handle.Dispose();
+
+		// Then
+		mocks.NativeManager.Verify(n => n.BeginDeferWindowPos(It.IsAny<int>()), Times.Never);
 	}
 }

--- a/src/Whim.Tests/Workspace/WorkspaceManagerTests.cs
+++ b/src/Whim.Tests/Workspace/WorkspaceManagerTests.cs
@@ -1,6 +1,8 @@
+using Microsoft.UI.Dispatching;
 using Moq;
 using System;
 using System.Linq;
+using System.Threading;
 using Xunit;
 
 namespace Whim.Tests;
@@ -63,6 +65,16 @@ public class WorkspaceManagerTests
 			}
 
 			Context.Setup(c => c.WorkspaceManager).Returns(WorkspaceManager);
+
+			CoreNativeManager
+				.Setup(c => c.ExecuteTask(It.IsAny<Func<DispatcherQueueHandler>>(), It.IsAny<CancellationToken>()))
+				.Callback<Func<DispatcherQueueHandler>, CancellationToken>(
+					(task, _) =>
+					{
+						var result = task();
+						result.Invoke();
+					}
+				);
 		}
 	}
 

--- a/src/Whim.Tests/Workspace/WorkspaceTests.cs
+++ b/src/Whim.Tests/Workspace/WorkspaceTests.cs
@@ -1,6 +1,8 @@
+using Microsoft.UI.Dispatching;
 using Moq;
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using Windows.Win32.Foundation;
 using Windows.Win32.UI.WindowsAndMessaging;
 using Xunit;
@@ -85,6 +87,16 @@ public class WorkspaceTests
 				WorkspaceLayoutStarted = TriggerWorkspaceLayoutStarted.Object,
 				WorkspaceLayoutCompleted = TriggerWorkspaceLayoutCompleted.Object
 			};
+
+			CoreNativeManager
+				.Setup(c => c.ExecuteTask(It.IsAny<Func<DispatcherQueueHandler>>(), It.IsAny<CancellationToken>()))
+				.Callback<Func<DispatcherQueueHandler>, CancellationToken>(
+					(task, _) =>
+					{
+						var result = task();
+						result.Invoke();
+					}
+				);
 		}
 
 		public Wrapper Setup_PassGarbageCollection()

--- a/src/Whim.Tests/Workspace/WorkspaceTests.cs
+++ b/src/Whim.Tests/Workspace/WorkspaceTests.cs
@@ -3,6 +3,7 @@ using Moq;
 using System;
 using System.Collections.Generic;
 using System.Threading;
+using System.Threading.Tasks;
 using Windows.Win32.Foundation;
 using Windows.Win32.UI.WindowsAndMessaging;
 using Xunit;
@@ -364,9 +365,13 @@ public class WorkspaceTests
 				new[] { wrapper.LayoutEngine.Object, new Mock<ILayoutEngine>().Object }
 			);
 
-		wrapper.CoreNativeManager.Setup(
-			c => c.ExecuteTask(It.IsAny<Func<DispatcherQueueHandler>>(), It.IsAny<CancellationToken>())
-		);
+		wrapper.CoreNativeManager
+			.Setup(c => c.ExecuteTask(It.IsAny<Func<DispatcherQueueHandler>>(), It.IsAny<CancellationToken>()))
+			.Returns(() =>
+			{
+				TaskCompletionSource<object> tcs = new();
+				return tcs.Task;
+			});
 
 		// When
 		workspace.AddWindow(window.Object);

--- a/src/Whim/Native/CoreNativeManager.cs
+++ b/src/Whim/Native/CoreNativeManager.cs
@@ -296,7 +296,7 @@ internal class CoreNativeManager : ICoreNativeManager
 	public bool TryEnqueue(DispatcherQueueHandler callback) =>
 		DispatcherQueue.GetForCurrentThread().TryEnqueue(callback);
 
-	public async Task RunTask(Task<DispatcherQueueHandler> task)
+	public async Task ExecuteTask(Task<DispatcherQueueHandler> task)
 	{
 		DispatcherQueue dispatcherQueue = DispatcherQueue.GetForCurrentThread();
 		DispatcherQueueHandler callback = await task.ConfigureAwait(false);

--- a/src/Whim/Native/CoreNativeManager.cs
+++ b/src/Whim/Native/CoreNativeManager.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Drawing;
 using System.Runtime.InteropServices;
+using System.Threading;
 using System.Threading.Tasks;
 using Windows.Win32;
 using Windows.Win32.Foundation;
@@ -296,10 +297,10 @@ internal class CoreNativeManager : ICoreNativeManager
 	public bool TryEnqueue(DispatcherQueueHandler callback) =>
 		DispatcherQueue.GetForCurrentThread().TryEnqueue(callback);
 
-	public async Task ExecuteTask(Task<DispatcherQueueHandler> task)
+	public async Task ExecuteTask(Func<DispatcherQueueHandler> task, CancellationToken cancellationToken)
 	{
 		DispatcherQueue dispatcherQueue = DispatcherQueue.GetForCurrentThread();
-		DispatcherQueueHandler callback = await task.ConfigureAwait(false);
+		DispatcherQueueHandler callback = await Task.Run(task, cancellationToken).ConfigureAwait(false);
 		dispatcherQueue.TryEnqueue(callback);
 	}
 

--- a/src/Whim/Native/CoreNativeManager.cs
+++ b/src/Whim/Native/CoreNativeManager.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Drawing;
 using System.Runtime.InteropServices;
+using System.Threading.Tasks;
 using Windows.Win32;
 using Windows.Win32.Foundation;
 using Windows.Win32.Graphics.Dwm;
@@ -294,6 +295,13 @@ internal class CoreNativeManager : ICoreNativeManager
 
 	public bool TryEnqueue(DispatcherQueueHandler callback) =>
 		DispatcherQueue.GetForCurrentThread().TryEnqueue(callback);
+
+	public async Task RunTask(Task<DispatcherQueueHandler> task)
+	{
+		DispatcherQueue dispatcherQueue = DispatcherQueue.GetForCurrentThread();
+		DispatcherQueueHandler callback = await task.ConfigureAwait(false);
+		dispatcherQueue.TryEnqueue(callback);
+	}
 
 	private Microsoft.UI.Xaml.Window? _window;
 

--- a/src/Whim/Native/ICoreNativeManager.cs
+++ b/src/Whim/Native/ICoreNativeManager.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Runtime.InteropServices;
+using System.Threading.Tasks;
 using Windows.Win32;
 using Windows.Win32.Foundation;
 using Windows.Win32.Graphics.Gdi;
@@ -486,6 +487,15 @@ internal interface ICoreNativeManager
 	/// <param name="callback">The task to execute.</param>
 	/// <returns><see langword="true" /> indicates that the task was added to the queue; <see langword="false" />, otherwise.</returns>
 	bool TryEnqueue(DispatcherQueueHandler callback);
+
+	/// <summary>
+	/// Runs the given <paramref name="task" /> in a <see cref="Task" />.
+	///
+	/// The returned <see cref="DispatcherQueueHandler" /> should be called when the task is complete to run the
+	/// callback on the thread associated with the <see cref="DispatcherQueue" />.
+	/// </summary>
+	/// <param name="task"></param>
+	Task RunTask(Task<DispatcherQueueHandler> task);
 
 	/// <summary>
 	/// Gets a <see cref="HWND" /> for the current window to use for the <see cref="WindowMessageMonitor" />.

--- a/src/Whim/Native/ICoreNativeManager.cs
+++ b/src/Whim/Native/ICoreNativeManager.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Runtime.InteropServices;
+using System.Threading;
 using System.Threading.Tasks;
 using Windows.Win32;
 using Windows.Win32.Foundation;
@@ -493,7 +494,8 @@ internal interface ICoreNativeManager
 	/// after the <paramref name="task" /> completes on the thread associated with the <see cref="DispatcherQueue" />.
 	/// </summary>
 	/// <param name="task"></param>
-	Task ExecuteTask(Task<DispatcherQueueHandler> task);
+	/// <param name="cancellationToken"></param>
+	Task ExecuteTask(Func<DispatcherQueueHandler> task, CancellationToken cancellationToken);
 
 	/// <summary>
 	/// Gets a <see cref="HWND" /> for the current window to use for the <see cref="WindowMessageMonitor" />.

--- a/src/Whim/Native/ICoreNativeManager.cs
+++ b/src/Whim/Native/ICoreNativeManager.cs
@@ -489,13 +489,11 @@ internal interface ICoreNativeManager
 	bool TryEnqueue(DispatcherQueueHandler callback);
 
 	/// <summary>
-	/// Runs the given <paramref name="task" /> in a <see cref="Task" />.
-	///
-	/// The returned <see cref="DispatcherQueueHandler" /> should be called when the task is complete to run the
-	/// callback on the thread associated with the <see cref="DispatcherQueue" />.
+	/// Executes the given <paramref name="task" />, and runs the returned <see cref="DispatcherQueueHandler" />
+	/// after the <paramref name="task" /> completes on the thread associated with the <see cref="DispatcherQueue" />.
 	/// </summary>
 	/// <param name="task"></param>
-	Task RunTask(Task<DispatcherQueueHandler> task);
+	Task ExecuteTask(Task<DispatcherQueueHandler> task);
 
 	/// <summary>
 	/// Gets a <see cref="HWND" /> for the current window to use for the <see cref="WindowMessageMonitor" />.

--- a/src/Whim/Native/WindowDeferPosHandle.cs
+++ b/src/Whim/Native/WindowDeferPosHandle.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using Windows.Win32.Foundation;
 using Windows.Win32.UI.WindowsAndMessaging;
 
@@ -18,6 +19,7 @@ public sealed class WindowDeferPosHandle : IDisposable
 	private readonly IContext _context;
 	private readonly List<(IWindowState windowState, HWND hwndInsertAfter, SET_WINDOW_POS_FLAGS? flags)> _windowStates =
 		new();
+	private readonly CancellationToken? _cancellationToken;
 
 	/// <summary>
 	/// The default flags to use when setting the window position.
@@ -36,10 +38,15 @@ public sealed class WindowDeferPosHandle : IDisposable
 	/// or statement, otherwise <see cref="INativeManager.EndDeferWindowPos"/> won't be called.
 	/// </summary>
 	/// <param name="context"></param>
-	public WindowDeferPosHandle(IContext context)
+	/// <param name="cancellationToken">
+	/// A <see cref="CancellationToken"/> that can be used to cancel the operation, if set before
+	/// <see cref="Dispose"/> is called.
+	/// </param>
+	public WindowDeferPosHandle(IContext context, CancellationToken? cancellationToken = null)
 	{
 		Logger.Debug("Creating new WindowDeferPosHandle");
 		_context = context;
+		_cancellationToken = cancellationToken;
 	}
 
 	/// <summary>
@@ -70,6 +77,12 @@ public sealed class WindowDeferPosHandle : IDisposable
 	public void Dispose()
 	{
 		Logger.Debug("Disposing WindowDeferPosHandle");
+
+		if (_cancellationToken?.IsCancellationRequested == true)
+		{
+			Logger.Debug("Cancellation requested, not setting window position");
+			return;
+		}
 
 		// Check to see if any monitors have non-100% scaling.
 		// If so, we need to set the window position twice.

--- a/src/Whim/Native/WindowDeferPosHandle.cs
+++ b/src/Whim/Native/WindowDeferPosHandle.cs
@@ -80,7 +80,7 @@ public sealed class WindowDeferPosHandle : IDisposable
 
 		if (_cancellationToken?.IsCancellationRequested == true)
 		{
-			Logger.Debug("Cancellation requested, not setting window position");
+			Logger.Debug("Cancellation requested, skipping setting window position");
 			return;
 		}
 

--- a/src/Whim/Workspace/IInternalWorkspaceManager.cs
+++ b/src/Whim/Workspace/IInternalWorkspaceManager.cs
@@ -17,6 +17,10 @@ internal interface IInternalWorkspaceManager
 	/// <summary>
 	/// Called when a window has been focused by the <see cref="IWindowManager"/>.
 	/// </summary>
+	/// <remarks>
+	/// <paramref name="window"/> can be null, as it will result in <see cref="IWorkspace.LastFocusedWindow"/>
+	/// being set to null.
+	/// </remarks>
 	/// <param name="window">The window that was focused.</param>
 	void WindowFocused(IWindow? window);
 

--- a/src/Whim/Workspace/Workspace.cs
+++ b/src/Whim/Workspace/Workspace.cs
@@ -501,7 +501,7 @@ internal class Workspace : IWorkspace, IInternalWorkspace
 		return location;
 	}
 
-	public async void DoLayout()
+	public void DoLayout()
 	{
 		Logger.Debug($"Workspace {Name}");
 
@@ -547,7 +547,6 @@ internal class Workspace : IWorkspace, IInternalWorkspace
 			);
 			_layoutTask = (task, cancellationTokenSource);
 		}
-		await task.ConfigureAwait(false);
 	}
 
 	private DispatcherQueueHandler SetWindowPos(


### PR DESCRIPTION
Previously, double clicking a focused window from the taskbar would cause the window to minimize and restore, triggering a layout loop. To fix this, Whim now sets the layouts of windows in a separate thread. This means that Whim can respond to window events more quickly, as it doesn't have to wait for the layout to finish before responding to a new event.

There was a race condition in `WorkspaceWidgetViewModel`. This has been fixed by simplifying the logic for setting `WorkspaceModel.ActiveOnMonitor`.