### PR TITLE
Fix workspace activation race condition

### DIFF
--- a/src/Whim.Tests/GlobalSuppressions.cs
+++ b/src/Whim.Tests/GlobalSuppressions.cs
@@ -13,3 +13,4 @@ using System.Diagnostics.CodeAnalysis;
 [assembly: SuppressMessage("Style", "IDE0008:Use explicit type")]
 [assembly: SuppressMessage("Style", "IDE0058:Expression value is never used")]
 [assembly: SuppressMessage("Style", "IDE0028:Simplify collection initialization")]
+[assembly: SuppressMessage("Reliability", "CA2007:Consider calling ConfigureAwait on the awaited task")]

--- a/src/Whim.Tests/Monitor/MonitorManagerTests.cs
+++ b/src/Whim.Tests/Monitor/MonitorManagerTests.cs
@@ -7,6 +7,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Drawing;
 using System.Linq;
 using System.Runtime.InteropServices;
+using System.Threading;
 using Windows.Win32.Foundation;
 using Windows.Win32.Graphics.Gdi;
 using Xunit;
@@ -59,6 +60,7 @@ public class MonitorManagerTests
 			InternalContext.SetupGet(x => x.CoreNativeManager).Returns(CoreNativeManager.Object);
 			InternalContext.SetupGet(x => x.MouseHook).Returns(MouseHook.Object);
 			InternalContext.SetupGet(x => x.WindowMessageMonitor).Returns(WindowMessageMonitor.Object);
+			InternalContext.SetupGet(x => x.LayoutLock).Returns(new ReaderWriterLockSlim());
 		}
 
 		[MemberNotNull(nameof(_monitorRects))]

--- a/src/Whim.Tests/Monitor/MonitorManagerTests.cs
+++ b/src/Whim.Tests/Monitor/MonitorManagerTests.cs
@@ -60,7 +60,7 @@ public class MonitorManagerTests
 			InternalContext.SetupGet(x => x.CoreNativeManager).Returns(CoreNativeManager.Object);
 			InternalContext.SetupGet(x => x.MouseHook).Returns(MouseHook.Object);
 			InternalContext.SetupGet(x => x.WindowMessageMonitor).Returns(WindowMessageMonitor.Object);
-			InternalContext.SetupGet(x => x.LayoutLock).Returns(new ReaderWriterLockSlim());
+			InternalContext.Setup(c => c.LayoutLock).Returns(new ReaderWriterLockSlim());
 		}
 
 		[MemberNotNull(nameof(_monitorRects))]

--- a/src/Whim.Tests/Workspace/WorkspaceManagerTests.cs
+++ b/src/Whim.Tests/Workspace/WorkspaceManagerTests.cs
@@ -1,6 +1,7 @@
 using Moq;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -9,6 +10,7 @@ using Xunit;
 
 namespace Whim.Tests;
 
+[SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "Unnecessary for tests")]
 public class WorkspaceManagerTests
 {
 	private class WorkspaceManagerTestWrapper : WorkspaceManager
@@ -44,9 +46,7 @@ public class WorkspaceManagerTests
 			Context.Setup(c => c.RouterManager).Returns(RouterManager.Object);
 
 			InternalContext.Setup(c => c.CoreNativeManager).Returns(CoreNativeManager.Object);
-#pragma warning disable CA2000 // Dispose objects before losing scope
 			InternalContext.Setup(c => c.LayoutLock).Returns(new ReaderWriterLockSlim());
-#pragma warning restore CA2000 // Dispose objects before losing scope
 
 			Monitors = monitors ?? new[] { new Mock<IMonitor>(), new Mock<IMonitor>() };
 			MonitorManager.Setup(m => m.Length).Returns(Monitors.Length);

--- a/src/Whim.Tests/Workspace/WorkspaceManagerTests.cs
+++ b/src/Whim.Tests/Workspace/WorkspaceManagerTests.cs
@@ -1145,7 +1145,7 @@ public class WorkspaceManagerTests
 		wrapper.MonitorManager
 			.Setup(m => m.GetMonitorAtPoint(It.IsAny<IPoint<int>>()))
 			.Returns(wrapper.Monitors[1].Object);
-		workspace.Setup(w => w.RemoveWindow(window.Object)).Returns(false);
+		workspace.Setup(w => w.RemoveWindow(window.Object)).ReturnsAsync(false);
 
 		// When a window is moved to a point, but the window cannot be removed from the old workspace
 		wrapper.WorkspaceManager.MoveWindowToPoint(window.Object, new Point<int>());
@@ -1176,7 +1176,7 @@ public class WorkspaceManagerTests
 		wrapper.MonitorManager
 			.Setup(m => m.GetMonitorAtPoint(It.IsAny<IPoint<int>>()))
 			.Returns(wrapper.Monitors[1].Object);
-		activeWorkspace.Setup(w => w.RemoveWindow(window.Object)).Returns(true);
+		activeWorkspace.Setup(w => w.RemoveWindow(window.Object)).ReturnsAsync(true);
 
 		// When a window is moved to a point
 		wrapper.WorkspaceManager.MoveWindowToPoint(window.Object, new Point<int>());
@@ -1207,7 +1207,7 @@ public class WorkspaceManagerTests
 		wrapper.MonitorManager
 			.Setup(m => m.GetMonitorAtPoint(It.IsAny<IPoint<int>>()))
 			.Returns(wrapper.Monitors[0].Object);
-		activeWorkspace.Setup(w => w.RemoveWindow(window.Object)).Returns(true);
+		activeWorkspace.Setup(w => w.RemoveWindow(window.Object)).ReturnsAsync(true);
 
 		// When a window is moved to a point
 		wrapper.WorkspaceManager.MoveWindowToPoint(window.Object, new Point<int>());
@@ -1581,15 +1581,11 @@ public class WorkspaceManagerTests
 		Wrapper wrapper = new(Array.Empty<Mock<IWorkspace>>());
 		wrapper.WorkspaceManager.Initialize();
 
-		// When creating a workspace
-		wrapper.WorkspaceManager.Add("workspace");
-		IWorkspace workspace = wrapper.WorkspaceManager["workspace"]!;
-
 		// Then changing the layout engine should trigger the event
 		Assert.Raises<ActiveLayoutEngineChangedEventArgs>(
 			h => wrapper.WorkspaceManager.ActiveLayoutEngineChanged += h,
 			h => wrapper.WorkspaceManager.ActiveLayoutEngineChanged -= h,
-			workspace.NextLayoutEngine
+			async () => await wrapper.WorkspaceManager.ActiveWorkspace.NextLayoutEngine()
 		);
 	}
 

--- a/src/Whim.Tests/Workspace/WorkspaceManagerTests.cs
+++ b/src/Whim.Tests/Workspace/WorkspaceManagerTests.cs
@@ -348,7 +348,7 @@ public class WorkspaceManagerTests
 		Wrapper wrapper = new(new[] { workspace, workspace2 });
 
 		// When enumerating the workspaces, then the workspaces are returned
-		Assert.Equal(new[] { workspace.Object, workspace2.Object }, wrapper.WorkspaceManager);
+		Assert.Equal(new[] { workspace.Object, workspace2.Object }, (IEnumerable<IWorkspace>?)wrapper.WorkspaceManager);
 	}
 	#endregion
 

--- a/src/Whim.Tests/Workspace/WorkspaceTests.cs
+++ b/src/Whim.Tests/Workspace/WorkspaceTests.cs
@@ -42,6 +42,7 @@ public class WorkspaceTests
 			Context.Setup(c => c.WindowManager).Returns(InternalWindowManager.As<IWindowManager>().Object);
 
 			InternalContext.Setup(ic => ic.CoreNativeManager).Returns(CoreNativeManager.Object);
+			InternalContext.SetupGet(x => x.LayoutLock).Returns(new ReaderWriterLockSlim());
 
 			LayoutEngine.Setup(l => l.ContainsEqual(LayoutEngine.Object)).Returns(true);
 			LayoutEngine.Setup(l => l.Name).Returns("Layout");

--- a/src/Whim.Tests/Workspace/WorkspaceTests.cs
+++ b/src/Whim.Tests/Workspace/WorkspaceTests.cs
@@ -151,7 +151,7 @@ public class WorkspaceTests
 	}
 
 	[Fact]
-	public void TrySetLayoutEngine_CannotFindEngine()
+	public async void TrySetLayoutEngine_CannotFindEngine()
 	{
 		// Given
 		Wrapper wrapper = new();
@@ -165,14 +165,14 @@ public class WorkspaceTests
 			);
 
 		// When
-		bool result = workspace.TrySetLayoutEngine("Layout2");
+		bool result = await workspace.TrySetLayoutEngine("Layout2");
 
 		// Then
 		Assert.False(result);
 	}
 
 	[Fact]
-	public void TrySetLayoutEngine_AlreadyActive()
+	public async void TrySetLayoutEngine_AlreadyActive()
 	{
 		// Given
 		Wrapper wrapper = new();
@@ -188,14 +188,14 @@ public class WorkspaceTests
 			);
 
 		// When
-		bool result = workspace.TrySetLayoutEngine("Layout");
+		bool result = await workspace.TrySetLayoutEngine("Layout");
 
 		// Then
 		Assert.True(result);
 	}
 
 	[Fact]
-	public void TrySetLayoutEngine_Success()
+	public async void TrySetLayoutEngine_Success()
 	{
 		// Given
 		Wrapper wrapper = new();
@@ -213,7 +213,7 @@ public class WorkspaceTests
 			);
 
 		// When
-		bool result = workspace.TrySetLayoutEngine("Layout2");
+		bool result = await workspace.TrySetLayoutEngine("Layout2");
 
 		// Then
 		Assert.True(result);
@@ -241,7 +241,7 @@ public class WorkspaceTests
 
 	#region DoLayout
 	[Fact]
-	public void DoLayout_CannotFindMonitorForWorkspace()
+	public async void DoLayout_CannotFindMonitorForWorkspace()
 	{
 		// Given
 		Wrapper wrapper = new();
@@ -257,7 +257,7 @@ public class WorkspaceTests
 			);
 
 		// When
-		workspace.DoLayout();
+		await workspace.DoLayout();
 
 		// Then
 		wrapper.LayoutEngine.Verify(e => e.DoLayout(It.IsAny<ILocation<int>>(), It.IsAny<IMonitor>()), Times.Never);
@@ -266,7 +266,7 @@ public class WorkspaceTests
 	}
 
 	[Fact]
-	public void DoLayout_MinimizedWindow()
+	public async void DoLayout_MinimizedWindow()
 	{
 		// Given
 		Wrapper wrapper = new Wrapper().Setup_PassGarbageCollection();
@@ -283,7 +283,7 @@ public class WorkspaceTests
 			);
 
 		// When
-		workspace.AddWindow(window.Object);
+		await workspace.AddWindow(window.Object);
 		wrapper.TriggerWorkspaceLayoutStarted.Invocations.Clear();
 		wrapper.TriggerWorkspaceLayoutCompleted.Invocations.Clear();
 		workspace.WindowMinimizeStart(window.Object);
@@ -296,7 +296,7 @@ public class WorkspaceTests
 	}
 
 	[Fact]
-	public void DoLayout_GarbageCollect_IsNotAWindow()
+	public async void DoLayout_GarbageCollect_IsNotAWindow()
 	{
 		// Given
 		Wrapper wrapper = new();
@@ -315,7 +315,7 @@ public class WorkspaceTests
 		wrapper.CoreNativeManager.Setup(c => c.IsWindow(It.IsAny<HWND>())).Returns(false);
 
 		// When
-		workspace.AddWindow(window.Object);
+		await workspace.AddWindow(window.Object);
 
 		// Then
 		wrapper.WorkspaceManager.Verify(wm => wm.GetMonitorForWorkspace(workspace), Times.Never);
@@ -323,7 +323,7 @@ public class WorkspaceTests
 	}
 
 	[Fact]
-	public void DoLayout_GarbageCollect_HandleIsNotManaged()
+	public async void DoLayout_GarbageCollect_HandleIsNotManaged()
 	{
 		// Given
 		Wrapper wrapper = new();
@@ -345,7 +345,7 @@ public class WorkspaceTests
 			.Returns(false);
 
 		// When
-		workspace.AddWindow(window.Object);
+		await workspace.AddWindow(window.Object);
 
 		// Then
 		wrapper.WorkspaceManager.Verify(wm => wm.GetMonitorForWorkspace(workspace), Times.Never);
@@ -353,7 +353,7 @@ public class WorkspaceTests
 	}
 
 	[Fact]
-	public void DoLayout_TakeLatestDoLayout()
+	public async void DoLayout_TakeLatestDoLayout()
 	{
 		// Given
 		Wrapper wrapper = new Wrapper().Setup_PassGarbageCollection();
@@ -378,12 +378,12 @@ public class WorkspaceTests
 			});
 
 		// When
-		workspace.AddWindow(window.Object);
+		await workspace.AddWindow(window.Object);
 		wrapper.TriggerWorkspaceLayoutStarted.Invocations.Clear();
 		wrapper.TriggerWorkspaceLayoutCompleted.Invocations.Clear();
-		workspace.DoLayout();
+		await workspace.DoLayout();
 		wrapper.Setup_ExecuteTask();
-		workspace.DoLayout();
+		await workspace.DoLayout();
 
 		// Then
 		wrapper.NativeManager.Verify(n => n.ShowWindowNoActivate(It.IsAny<HWND>()), Times.Never);
@@ -417,7 +417,7 @@ public class WorkspaceTests
 	}
 
 	[Fact]
-	public void ContainsWindow_True_NormalWindow()
+	public async void ContainsWindow_True_NormalWindow()
 	{
 		// Given
 		Wrapper wrapper = new();
@@ -431,7 +431,7 @@ public class WorkspaceTests
 				"Workspace",
 				new ILayoutEngine[] { wrapper.LayoutEngine.Object }
 			);
-		workspace.AddWindow(window.Object);
+		await workspace.AddWindow(window.Object);
 
 		// When
 		bool result = workspace.ContainsWindow(window.Object);
@@ -441,7 +441,7 @@ public class WorkspaceTests
 	}
 
 	[Fact]
-	public void ContainsWindow_True_MinimizedWindow()
+	public async void ContainsWindow_True_MinimizedWindow()
 	{
 		// Given
 		Wrapper wrapper = new();
@@ -455,7 +455,7 @@ public class WorkspaceTests
 				"Workspace",
 				new ILayoutEngine[] { wrapper.LayoutEngine.Object }
 			);
-		workspace.AddWindow(window.Object);
+		await workspace.AddWindow(window.Object);
 		workspace.WindowMinimizeStart(window.Object);
 
 		// When
@@ -467,7 +467,7 @@ public class WorkspaceTests
 
 	#region WindowFocused
 	[Fact]
-	public void WindowFocused_ContainsWindow()
+	public async void WindowFocused_ContainsWindow()
 	{
 		// Given the window is in the workspace
 		Wrapper wrapper = new();
@@ -481,7 +481,7 @@ public class WorkspaceTests
 				"Workspace",
 				new ILayoutEngine[] { wrapper.LayoutEngine.Object }
 			);
-		workspace.AddWindow(window.Object);
+		await workspace.AddWindow(window.Object);
 
 		// When
 		workspace.WindowFocused(window.Object);
@@ -561,7 +561,7 @@ public class WorkspaceTests
 	}
 
 	[Fact]
-	public void NextLayoutEngine()
+	public async void NextLayoutEngine()
 	{
 		// Given
 		Wrapper wrapper = new();
@@ -576,14 +576,14 @@ public class WorkspaceTests
 			);
 
 		// When NextLayoutEngine is called
-		workspace.NextLayoutEngine();
+		await workspace.NextLayoutEngine();
 
 		// Then the active layout engine is set to the next one
 		Assert.True(Object.ReferenceEquals(layoutEngine.Object, workspace.ActiveLayoutEngine));
 	}
 
 	[Fact]
-	public void NextLayoutEngine_LastEngine()
+	public async void NextLayoutEngine_LastEngine()
 	{
 		// Given
 		Wrapper wrapper = new();
@@ -598,15 +598,15 @@ public class WorkspaceTests
 			);
 
 		// When NextLayoutEngine is called
-		workspace.NextLayoutEngine();
-		workspace.NextLayoutEngine();
+		await workspace.NextLayoutEngine();
+		await workspace.NextLayoutEngine();
 
 		// Then the active layout engine is set to the first one
 		Assert.True(Object.ReferenceEquals(wrapper.LayoutEngine.Object, workspace.ActiveLayoutEngine));
 	}
 
 	[Fact]
-	public void PreviousLayoutEngine()
+	public async void PreviousLayoutEngine()
 	{
 		// Given
 		Wrapper wrapper = new();
@@ -621,14 +621,14 @@ public class WorkspaceTests
 			);
 
 		// When PreviousLayoutEngine is called
-		workspace.PreviousLayoutEngine();
+		await workspace.PreviousLayoutEngine();
 
 		// Then the active layout engine is set to the previous one
 		Assert.True(Object.ReferenceEquals(layoutEngine.Object, workspace.ActiveLayoutEngine));
 	}
 
 	[Fact]
-	public void PreviousLayoutEngine_FirstEngine()
+	public async void PreviousLayoutEngine_FirstEngine()
 	{
 		// Given
 		Wrapper wrapper = new();
@@ -643,15 +643,15 @@ public class WorkspaceTests
 			);
 
 		// When PreviousLayoutEngine is called
-		workspace.PreviousLayoutEngine();
-		workspace.PreviousLayoutEngine();
+		await workspace.PreviousLayoutEngine();
+		await workspace.PreviousLayoutEngine();
 
 		// Then the active layout engine is set to the last one
 		Assert.True(Object.ReferenceEquals(wrapper.LayoutEngine.Object, workspace.ActiveLayoutEngine));
 	}
 
 	[Fact]
-	public void AddWindow_Fails_AlreadyIncludesWindow()
+	public async void AddWindow_Fails_AlreadyIncludesWindow()
 	{
 		// Given
 		Wrapper wrapper = new Wrapper().Setup_PassGarbageCollection();
@@ -666,8 +666,8 @@ public class WorkspaceTests
 			);
 
 		// When AddWindow is called
-		workspace.AddWindow(window.Object);
-		workspace.AddWindow(window.Object);
+		await workspace.AddWindow(window.Object);
+		await workspace.AddWindow(window.Object);
 
 		// Then the window is added to the layout engine
 		wrapper.LayoutEngine.Verify(l => l.AddWindow(window.Object), Times.Once);
@@ -675,7 +675,7 @@ public class WorkspaceTests
 	}
 
 	[Fact]
-	public void AddWindow_Success()
+	public async void AddWindow_Success()
 	{
 		// Given
 		Wrapper wrapper = new Wrapper().Setup_PassGarbageCollection();
@@ -690,7 +690,7 @@ public class WorkspaceTests
 			);
 
 		// When AddWindow is called
-		workspace.AddWindow(window.Object);
+		await workspace.AddWindow(window.Object);
 
 		// Then the window is added to the layout engine
 		wrapper.LayoutEngine.Verify(l => l.AddWindow(window.Object), Times.Once);
@@ -698,7 +698,7 @@ public class WorkspaceTests
 	}
 
 	[Fact]
-	public void RemoveWindow_Fails_AlreadyRemoved()
+	public async void RemoveWindow_Fails_AlreadyRemoved()
 	{
 		// Given
 		Wrapper wrapper = new();
@@ -713,8 +713,8 @@ public class WorkspaceTests
 			);
 
 		// When RemoveWindow is called
-		workspace.RemoveWindow(window.Object);
-		bool result = workspace.RemoveWindow(window.Object);
+		await workspace.RemoveWindow(window.Object);
+		bool result = await workspace.RemoveWindow(window.Object);
 
 		// Then the window is removed from the layout engine
 		Assert.False(result);
@@ -723,7 +723,7 @@ public class WorkspaceTests
 	}
 
 	[Fact]
-	public void RemoveWindow_Fails_DidNotRemoveFromLayoutEngine()
+	public async void RemoveWindow_Fails_DidNotRemoveFromLayoutEngine()
 	{
 		// Given
 		Wrapper wrapper = new();
@@ -736,11 +736,11 @@ public class WorkspaceTests
 				"Workspace",
 				new ILayoutEngine[] { wrapper.LayoutEngine.Object }
 			);
-		workspace.AddWindow(window.Object);
+		await workspace.AddWindow(window.Object);
 		wrapper.WorkspaceManager.Invocations.Clear();
 
 		// When RemoveWindow is called
-		bool result = workspace.RemoveWindow(window.Object);
+		bool result = await workspace.RemoveWindow(window.Object);
 
 		// Then the window is removed from the layout engine
 		Assert.False(result);
@@ -749,7 +749,7 @@ public class WorkspaceTests
 	}
 
 	[Fact]
-	public void RemoveWindow_Success()
+	public async void RemoveWindow_Success()
 	{
 		// Given
 		Wrapper wrapper = new();
@@ -762,13 +762,13 @@ public class WorkspaceTests
 				"Workspace",
 				new ILayoutEngine[] { wrapper.LayoutEngine.Object }
 			);
-		workspace.AddWindow(window.Object);
+		await workspace.AddWindow(window.Object);
 		workspace.WindowFocused(window.Object);
 		wrapper.WorkspaceManager.Invocations.Clear();
 		wrapper.LayoutEngine.Setup(l => l.RemoveWindow(window.Object)).Returns(new Mock<ILayoutEngine>().Object);
 
 		// When RemoveWindow is called
-		bool result = workspace.RemoveWindow(window.Object);
+		bool result = await workspace.RemoveWindow(window.Object);
 
 		// Then the window is removed from the layout engine
 		Assert.True(result);
@@ -777,7 +777,7 @@ public class WorkspaceTests
 	}
 
 	[Fact]
-	public void RemoveWindow_MinimizedWindow()
+	public async void RemoveWindow_MinimizedWindow()
 	{
 		// Given
 		Wrapper wrapper = new();
@@ -791,14 +791,14 @@ public class WorkspaceTests
 				"Workspace",
 				new ILayoutEngine[] { wrapper.LayoutEngine.Object }
 			);
-		workspace.AddWindow(window.Object);
+		await workspace.AddWindow(window.Object);
 		workspace.WindowMinimizeStart(window.Object);
 
 		wrapper.WorkspaceManager.Invocations.Clear();
 		wrapper.LayoutEngine.Invocations.Clear();
 
 		// When RemoveWindow is called
-		bool result = workspace.RemoveWindow(window.Object);
+		bool result = await workspace.RemoveWindow(window.Object);
 
 		// Then the window is not removed from the layout engine
 		Assert.True(result);
@@ -829,7 +829,7 @@ public class WorkspaceTests
 	}
 
 	[Fact]
-	public void FocusWindowInDirection_Fails_WindowIsMinimized()
+	public async void FocusWindowInDirection_Fails_WindowIsMinimized()
 	{
 		// Given
 		Wrapper wrapper = new();
@@ -843,7 +843,7 @@ public class WorkspaceTests
 				new ILayoutEngine[] { wrapper.LayoutEngine.Object }
 			);
 
-		workspace.AddWindow(window.Object);
+		await workspace.AddWindow(window.Object);
 		workspace.WindowMinimizeStart(window.Object);
 
 		// When FocusWindowInDirection is called
@@ -854,7 +854,7 @@ public class WorkspaceTests
 	}
 
 	[Fact]
-	public void FocusWindowInDirection_Success()
+	public async void FocusWindowInDirection_Success()
 	{
 		// Given
 		Wrapper wrapper = new();
@@ -867,7 +867,7 @@ public class WorkspaceTests
 				"Workspace",
 				new ILayoutEngine[] { wrapper.LayoutEngine.Object }
 			);
-		workspace.AddWindow(window.Object);
+		await workspace.AddWindow(window.Object);
 
 		// When FocusWindowInDirection is called
 		workspace.FocusWindowInDirection(Direction.Up, window.Object);
@@ -877,7 +877,7 @@ public class WorkspaceTests
 	}
 
 	[Fact]
-	public void SwapWindowInDirection_Fails_WindowIsNull()
+	public async void SwapWindowInDirection_Fails_WindowIsNull()
 	{
 		// Given
 		Wrapper wrapper = new();
@@ -891,14 +891,14 @@ public class WorkspaceTests
 			);
 
 		// When SwapWindowInDirection is called
-		workspace.SwapWindowInDirection(Direction.Up, null);
+		await workspace.SwapWindowInDirection(Direction.Up, null);
 
 		// Then the layout engine is not told to swap the window
 		wrapper.LayoutEngine.Verify(l => l.SwapWindowInDirection(Direction.Up, It.IsAny<IWindow>()), Times.Never);
 	}
 
 	[Fact]
-	public void SwapWindowInDirection_Fails_DoesNotContainWindow()
+	public async void SwapWindowInDirection_Fails_DoesNotContainWindow()
 	{
 		// Given
 		Wrapper wrapper = new();
@@ -913,14 +913,14 @@ public class WorkspaceTests
 			);
 
 		// When SwapWindowInDirection is called
-		workspace.SwapWindowInDirection(Direction.Up, window.Object);
+		await workspace.SwapWindowInDirection(Direction.Up, window.Object);
 
 		// Then the layout engine is not told to swap the window
 		wrapper.LayoutEngine.Verify(l => l.SwapWindowInDirection(Direction.Up, window.Object), Times.Never);
 	}
 
 	[Fact]
-	public void SwapWindowInDirection_Success()
+	public async void SwapWindowInDirection_Success()
 	{
 		// Given
 		Wrapper wrapper = new();
@@ -933,17 +933,17 @@ public class WorkspaceTests
 				"Workspace",
 				new ILayoutEngine[] { wrapper.LayoutEngine.Object }
 			);
-		workspace.AddWindow(window.Object);
+		await workspace.AddWindow(window.Object);
 
 		// When SwapWindowInDirection is called
-		workspace.SwapWindowInDirection(Direction.Up, window.Object);
+		await workspace.SwapWindowInDirection(Direction.Up, window.Object);
 
 		// Then the layout engine is told to swap the window
 		wrapper.LayoutEngine.Verify(l => l.SwapWindowInDirection(Direction.Up, window.Object), Times.Once);
 	}
 
 	[Fact]
-	public void MoveWindowEdgesInDirection_Fails_WindowIsNull()
+	public async void MoveWindowEdgesInDirection_Fails_WindowIsNull()
 	{
 		// Given
 		Wrapper wrapper = new();
@@ -958,7 +958,7 @@ public class WorkspaceTests
 		IPoint<double> deltas = new Point<double>() { X = 0.3, Y = 0 };
 
 		// When MoveWindowEdgesInDirection is called
-		workspace.MoveWindowEdgesInDirection(Direction.Up, deltas, null);
+		await workspace.MoveWindowEdgesInDirection(Direction.Up, deltas, null);
 
 		// Then the layout engine is not told to move the window
 		wrapper.LayoutEngine.Verify(
@@ -968,7 +968,7 @@ public class WorkspaceTests
 	}
 
 	[Fact]
-	public void MoveWindowEdgesInDirection_Fails_DoesNotContainWindow()
+	public async void MoveWindowEdgesInDirection_Fails_DoesNotContainWindow()
 	{
 		// Given
 		Wrapper wrapper = new();
@@ -984,7 +984,7 @@ public class WorkspaceTests
 		IPoint<double> deltas = new Point<double>() { X = 0.3, Y = 0 };
 
 		// When MoveWindowEdgesInDirection is called
-		workspace.MoveWindowEdgesInDirection(Direction.Up, deltas, window.Object);
+		await workspace.MoveWindowEdgesInDirection(Direction.Up, deltas, window.Object);
 
 		// Then the layout engine is not told to move the window
 		wrapper.LayoutEngine.Verify(
@@ -994,7 +994,7 @@ public class WorkspaceTests
 	}
 
 	[Fact]
-	public void MoveWindowEdgesInDirection_Success()
+	public async void MoveWindowEdgesInDirection_Success()
 	{
 		// Given
 		Wrapper wrapper = new();
@@ -1007,18 +1007,18 @@ public class WorkspaceTests
 				"Workspace",
 				new ILayoutEngine[] { wrapper.LayoutEngine.Object }
 			);
-		workspace.AddWindow(window.Object);
+		await workspace.AddWindow(window.Object);
 		IPoint<double> deltas = new Point<double>() { X = 0.3, Y = 0 };
 
 		// When MoveWindowEdgesInDirection is called
-		workspace.MoveWindowEdgesInDirection(Direction.Up, deltas, window.Object);
+		await workspace.MoveWindowEdgesInDirection(Direction.Up, deltas, window.Object);
 
 		// Then the layout engine is told to move the window
 		wrapper.LayoutEngine.Verify(l => l.MoveWindowEdgesInDirection(Direction.Up, deltas, window.Object), Times.Once);
 	}
 
 	[Fact]
-	public void MoveWindowToPoint_Success_AddWindow()
+	public async void MoveWindowToPoint_Success_AddWindow()
 	{
 		// Given
 		Wrapper wrapper = new();
@@ -1039,7 +1039,7 @@ public class WorkspaceTests
 		wrapper.LayoutEngine.Setup(l => l.MoveWindowToPoint(window.Object, point)).Returns(resultingEngine.Object);
 
 		// When MoveWindowToPoint is called
-		workspace.MoveWindowToPoint(window.Object, point);
+		await workspace.MoveWindowToPoint(window.Object, point);
 
 		// Then the layout engine is told to move the window
 		wrapper.LayoutEngine.Verify(l => l.MoveWindowToPoint(window.Object, point), Times.Once);
@@ -1047,7 +1047,7 @@ public class WorkspaceTests
 	}
 
 	[Fact]
-	public void MoveWindowToPoint_Success_WindowIsMinimized()
+	public async void MoveWindowToPoint_Success_WindowIsMinimized()
 	{
 		// Given
 		Wrapper wrapper = new();
@@ -1067,13 +1067,13 @@ public class WorkspaceTests
 		resultingEngine.Setup(l => l.Name).Returns("Resulting engine");
 		wrapper.LayoutEngine.Setup(l => l.MoveWindowToPoint(window.Object, point)).Returns(resultingEngine.Object);
 
-		workspace.AddWindow(window.Object);
+		await workspace.AddWindow(window.Object);
 		workspace.WindowMinimizeStart(window.Object);
 
 		wrapper.LayoutEngine.Invocations.Clear();
 
 		// When MoveWindowToPoint is called
-		workspace.MoveWindowToPoint(window.Object, point);
+		await workspace.MoveWindowToPoint(window.Object, point);
 
 		// Then the layout engine is told to move the window
 		wrapper.LayoutEngine.Verify(l => l.MoveWindowToPoint(window.Object, point), Times.Once);
@@ -1081,7 +1081,7 @@ public class WorkspaceTests
 	}
 
 	[Fact]
-	public void MoveWindowToPoint_Success_WindowAlreadyExists()
+	public async void MoveWindowToPoint_Success_WindowAlreadyExists()
 	{
 		// Given
 		Wrapper wrapper = new();
@@ -1096,7 +1096,7 @@ public class WorkspaceTests
 				new ILayoutEngine[] { wrapper.LayoutEngine.Object }
 			);
 
-		workspace.AddWindow(window.Object);
+		await workspace.AddWindow(window.Object);
 		IPoint<double> point = new Point<double>() { X = 0.3, Y = 0.3 };
 
 		wrapper.LayoutEngine.Reset();
@@ -1110,7 +1110,7 @@ public class WorkspaceTests
 			.Returns(moveWindowToPointResult.Object);
 
 		// When MoveWindowToPoint is called
-		workspace.MoveWindowToPoint(window.Object, point);
+		await workspace.MoveWindowToPoint(window.Object, point);
 
 		// Then the layout engine is told to remove and add the window
 		wrapper.LayoutEngine.Verify(l => l.MoveWindowToPoint(window.Object, point), Times.Once);
@@ -1138,7 +1138,7 @@ public class WorkspaceTests
 	}
 
 	[Fact]
-	public void Deactivate()
+	public async void Deactivate()
 	{
 		// Given
 		Wrapper wrapper = new();
@@ -1153,8 +1153,8 @@ public class WorkspaceTests
 				"Workspace",
 				new ILayoutEngine[] { wrapper.LayoutEngine.Object }
 			);
-		workspace.AddWindow(window.Object);
-		workspace.AddWindow(window2.Object);
+		await workspace.AddWindow(window.Object);
+		await workspace.AddWindow(window2.Object);
 		wrapper.WorkspaceManager.Invocations.Clear();
 
 		// When Deactivate is called
@@ -1167,7 +1167,7 @@ public class WorkspaceTests
 	}
 
 	[Fact]
-	public void TryGetWindowLocation()
+	public async void TryGetWindowLocation()
 	{
 		// Given
 		Wrapper wrapper = new Wrapper().Setup_PassGarbageCollection();
@@ -1196,7 +1196,7 @@ public class WorkspaceTests
 				"Workspace",
 				new ILayoutEngine[] { wrapper.LayoutEngine.Object }
 			);
-		workspace.AddWindow(window.Object);
+		await workspace.AddWindow(window.Object);
 
 		// When TryGetWindowLocation is called
 		IWindowState? result = workspace.TryGetWindowLocation(window.Object);
@@ -1206,7 +1206,7 @@ public class WorkspaceTests
 	}
 
 	[Fact]
-	public void TryGetWindowLocation_MinimizedWindow()
+	public async void TryGetWindowLocation_MinimizedWindow()
 	{
 		// Given
 		Wrapper wrapper = new();
@@ -1221,7 +1221,7 @@ public class WorkspaceTests
 			);
 
 		// When
-		workspace.AddWindow(window.Object);
+		await workspace.AddWindow(window.Object);
 		workspace.WindowMinimizeStart(window.Object);
 		IWindowState windowState = workspace.TryGetWindowLocation(window.Object)!;
 
@@ -1235,7 +1235,7 @@ public class WorkspaceTests
 	}
 
 	[Fact]
-	public void Dispose()
+	public async void Dispose()
 	{
 		// Given
 		Wrapper wrapper = new();
@@ -1251,7 +1251,7 @@ public class WorkspaceTests
 				"Workspace",
 				new ILayoutEngine[] { wrapper.LayoutEngine.Object }
 			);
-		workspace.AddWindow(window.Object);
+		await workspace.AddWindow(window.Object);
 
 		// When Dispose is called
 		workspace.Dispose();
@@ -1261,7 +1261,7 @@ public class WorkspaceTests
 	}
 
 	[Fact]
-	public void WindowMinimizeStart()
+	public async void WindowMinimizeStart()
 	{
 		// Given
 		Wrapper wrapper = new();
@@ -1274,7 +1274,7 @@ public class WorkspaceTests
 				"Workspace",
 				new ILayoutEngine[] { wrapper.LayoutEngine.Object }
 			);
-		workspace.AddWindow(window.Object);
+		await workspace.AddWindow(window.Object);
 
 		// When WindowMinimizeStart is called
 		workspace.WindowMinimizeStart(window.Object);
@@ -1284,7 +1284,7 @@ public class WorkspaceTests
 	}
 
 	[Fact]
-	public void WindowMinimizeStart_Twice()
+	public async void WindowMinimizeStart_Twice()
 	{
 		// Given
 		Wrapper wrapper = new();
@@ -1297,7 +1297,7 @@ public class WorkspaceTests
 				"Workspace",
 				new ILayoutEngine[] { wrapper.LayoutEngine.Object }
 			);
-		workspace.AddWindow(window.Object);
+		await workspace.AddWindow(window.Object);
 
 		// When WindowMinimizeStart is called
 		workspace.WindowMinimizeStart(window.Object);
@@ -1308,7 +1308,7 @@ public class WorkspaceTests
 	}
 
 	[Fact]
-	public void WindowMinimizeEnd()
+	public async void WindowMinimizeEnd()
 	{
 		// Given
 		Wrapper wrapper = new();
@@ -1321,7 +1321,7 @@ public class WorkspaceTests
 				"Workspace",
 				new ILayoutEngine[] { wrapper.LayoutEngine.Object }
 			);
-		workspace.AddWindow(window.Object);
+		await workspace.AddWindow(window.Object);
 		workspace.WindowMinimizeStart(window.Object);
 		wrapper.LayoutEngine.Invocations.Clear();
 
@@ -1333,7 +1333,7 @@ public class WorkspaceTests
 	}
 
 	[Fact]
-	public void WindowMinimizeEnd_NotMinimized()
+	public async void WindowMinimizeEnd_NotMinimized()
 	{
 		// Given
 		Wrapper wrapper = new();
@@ -1346,7 +1346,7 @@ public class WorkspaceTests
 				"Workspace",
 				new ILayoutEngine[] { wrapper.LayoutEngine.Object }
 			);
-		workspace.AddWindow(window.Object);
+		await workspace.AddWindow(window.Object);
 		wrapper.LayoutEngine.Invocations.Clear();
 
 		// When WindowMinimizeEnd is called

--- a/src/Whim/Context/IInternalContext.cs
+++ b/src/Whim/Context/IInternalContext.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 
 namespace Whim;
 
@@ -11,9 +12,11 @@ internal interface IInternalContext : IDisposable
 
 	IWindowMessageMonitor WindowMessageMonitor { get; }
 
-	internal IKeybindHook KeybindHook { get; }
+	IKeybindHook KeybindHook { get; }
 
-	internal IMouseHook MouseHook { get; }
+	IMouseHook MouseHook { get; }
+
+	ReaderWriterLockSlim LayoutLock { get; }
 
 	void PreInitialize();
 

--- a/src/Whim/Context/IInternalContext.cs
+++ b/src/Whim/Context/IInternalContext.cs
@@ -16,6 +16,11 @@ internal interface IInternalContext : IDisposable
 
 	IMouseHook MouseHook { get; }
 
+	/// <summary>
+	/// This lock is used to prevent <see cref="IWindowManager"/> events from modifying the
+	/// <see cref="MonitorManager"/> and <see cref="WorkspaceManager"/> while a
+	/// <see cref="Workspace.DoLayout"/> layout is occurring.
+	/// </summary>
 	ReaderWriterLockSlim LayoutLock { get; }
 
 	void PreInitialize();

--- a/src/Whim/Context/InternalContext.cs
+++ b/src/Whim/Context/InternalContext.cs
@@ -1,3 +1,5 @@
+using System.Threading;
+
 namespace Whim;
 
 internal class InternalContext : IInternalContext
@@ -11,6 +13,8 @@ internal class InternalContext : IInternalContext
 	public IKeybindHook KeybindHook { get; }
 
 	public IMouseHook MouseHook { get; }
+
+	public ReaderWriterLockSlim LayoutLock { get; } = new();
 
 	public InternalContext(IContext context)
 	{

--- a/src/Whim/Monitor/MonitorManager.cs
+++ b/src/Whim/Monitor/MonitorManager.cs
@@ -88,8 +88,10 @@ internal class MonitorManager : IInternalMonitorManager, IMonitorManager
 
 		foreach (Monitor monitor in _monitors)
 		{
-			if (monitor._hmonitor == hMONITOR)
+			if (monitor._hmonitor.Equals(hMONITOR))
 			{
+				Logger.Debug($"Setting active monitor to {monitor}");
+
 				ActiveMonitor = monitor;
 				break;
 			}

--- a/src/Whim/Monitor/MonitorManager.cs
+++ b/src/Whim/Monitor/MonitorManager.cs
@@ -71,6 +71,7 @@ internal class MonitorManager : IInternalMonitorManager, IMonitorManager
 
 	public void WindowFocused(IWindow? window)
 	{
+		_internalContext.LayoutLock.EnterWriteLock();
 		Logger.Debug($"Focusing on {window}");
 
 		HWND hwnd = window?.Handle ?? _internalContext.CoreNativeManager.GetForegroundWindow();
@@ -89,6 +90,7 @@ internal class MonitorManager : IInternalMonitorManager, IMonitorManager
 				break;
 			}
 		}
+		_internalContext.LayoutLock.ExitWriteLock();
 	}
 
 	private void WindowMessageMonitor_SessionChanged(object? sender, WindowMessageMonitorEventArgs e)

--- a/src/Whim/Native/ICoreNativeManager.cs
+++ b/src/Whim/Native/ICoreNativeManager.cs
@@ -490,12 +490,21 @@ internal interface ICoreNativeManager
 	bool TryEnqueue(DispatcherQueueHandler callback);
 
 	/// <summary>
-	/// Executes the given <paramref name="task" />, and runs the returned <see cref="DispatcherQueueHandler" />
-	/// after the <paramref name="task" /> completes on the thread associated with the <see cref="DispatcherQueue" />.
+	/// Queues the specified work to run on the thread pool and returns a <see cref="Task{TResult}"/> object that
+	/// represents that work.
+	///
+	/// The cleanup callback is called on the UI thread when the task completes.
 	/// </summary>
-	/// <param name="task"></param>
-	/// <param name="cancellationToken"></param>
-	Task ExecuteTask(Func<DispatcherQueueHandler> task, CancellationToken cancellationToken);
+	/// <typeparam name="TWorkResult">Specifies the type of the result returned by the work callback.</typeparam>
+	/// <param name="work">The work to execute asynchronously.</param>
+	/// <param name="cleanup">The cleanup callback to execute when the task completes.</param>
+	/// <param name="cancellationToken">A cancellation token that can be used to cancel the work.</param>
+	/// <returns>A <see cref="Task{TResult}"/> object that represents the work queued to execute in the thread pool.</returns>
+	Task RunTask<TWorkResult>(
+		Func<TWorkResult> work,
+		Action<Task<TWorkResult>> cleanup,
+		CancellationToken cancellationToken
+	);
 
 	/// <summary>
 	/// Gets a <see cref="HWND" /> for the current window to use for the <see cref="WindowMessageMonitor" />.

--- a/src/Whim/Native/WindowDeferPosHandle.cs
+++ b/src/Whim/Native/WindowDeferPosHandle.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using Windows.Win32.Foundation;
 using Windows.Win32.UI.WindowsAndMessaging;
@@ -17,14 +18,14 @@ namespace Whim;
 public sealed class WindowDeferPosHandle : IDisposable
 {
 	private readonly IContext _context;
+	private readonly CancellationToken? _cancellationToken;
 	private readonly List<(IWindowState windowState, HWND hwndInsertAfter, SET_WINDOW_POS_FLAGS? flags)> _windowStates =
 		new();
-	private readonly CancellationToken? _cancellationToken;
 
 	/// <summary>
 	/// The default flags to use when setting the window position.
 	/// </summary>
-	public const SET_WINDOW_POS_FLAGS DefaultFlags =
+	private const SET_WINDOW_POS_FLAGS DefaultFlags =
 		SET_WINDOW_POS_FLAGS.SWP_FRAMECHANGED
 		| SET_WINDOW_POS_FLAGS.SWP_NOACTIVATE
 		| SET_WINDOW_POS_FLAGS.SWP_NOCOPYBITS
@@ -34,19 +35,41 @@ public sealed class WindowDeferPosHandle : IDisposable
 	/// <summary>
 	/// Create a new <see cref="WindowDeferPosHandle"/> to set the position of multiple windows at once.
 	///
-	/// <see cref="WindowDeferPosHandle"/> must be used in conjunction with a <c>using</c> block
-	/// or statement, otherwise <see cref="INativeManager.EndDeferWindowPos"/> won't be called.
+	/// <see cref="WindowDeferPosHandle"/> must be used in conjunction with a <c>using</c> block,
+	/// a <c>using</c> statement, or by calling <see cref="Dispose"/> manually, otherwise
+	/// <see cref="INativeManager.EndDeferWindowPos"/> won't be called.
 	/// </summary>
 	/// <param name="context"></param>
 	/// <param name="cancellationToken">
-	/// A <see cref="CancellationToken"/> that can be used to cancel the operation, if set before
-	/// <see cref="Dispose"/> is called.
+	/// A <see cref="CancellationToken"/> that can be used to lay out the windows.
 	/// </param>
 	public WindowDeferPosHandle(IContext context, CancellationToken? cancellationToken = null)
 	{
 		Logger.Debug("Creating new WindowDeferPosHandle");
 		_context = context;
 		_cancellationToken = cancellationToken;
+	}
+
+	/// <summary>
+	/// Create a new <see cref="WindowDeferPosHandle"/> to set the position of multiple windows at once.
+	///
+	/// <see cref="WindowDeferPosHandle"/> must be used in conjunction with a <c>using</c> block,
+	/// a <c>using</c> statement, or by calling <see cref="Dispose"/> manually, otherwise
+	/// <see cref="INativeManager.EndDeferWindowPos"/> won't be called.
+	/// </summary>
+	/// <param name="context"></param>
+	/// <param name="windowStates"></param>
+	/// <param name="cancellationToken">
+	/// A <see cref="CancellationToken"/> that can be used to lay out the windows.
+	/// </param>
+	public WindowDeferPosHandle(
+		IContext context,
+		IEnumerable<(IWindowState windowState, HWND hwndInsertAfter, SET_WINDOW_POS_FLAGS? flags)> windowStates,
+		CancellationToken? cancellationToken = null
+	)
+		: this(context, cancellationToken)
+	{
+		_windowStates.AddRange(windowStates);
 	}
 
 	/// <summary>
@@ -98,117 +121,118 @@ public sealed class WindowDeferPosHandle : IDisposable
 
 		Logger.Debug($"Setting window position {numPasses} times");
 
-		int count = _windowStates.Count;
+		List<IWindow> toMinimize = new();
+		List<IWindow> toMaximize = new();
+		List<IWindow> toNormal = new();
+
 		for (int i = 0; i < numPasses; i++)
 		{
-			using InternalWindowDeferPosHandle handle = new(_context, count);
-			for (int j = 0; j < count; j++)
+			Logger.Debug($"Setting window position, pass {i + 1} of {numPasses}");
+			if (_cancellationToken?.IsCancellationRequested == true)
 			{
-				(IWindowState windowState, HWND hwndInsertAfter, SET_WINDOW_POS_FLAGS? flags) = _windowStates[j];
-				handle.DeferWindowPos(windowState, hwndInsertAfter, flags);
-			}
-		}
-
-		Logger.Debug("Finished setting window position");
-	}
-
-	private sealed class InternalWindowDeferPosHandle : IDisposable
-	{
-		private readonly IContext _context;
-		private HDWP _hWinPosInfo;
-		private readonly List<IWindow> _toMinimize;
-		private readonly List<IWindow> _toMaximize;
-		private readonly List<IWindow> _toNormal;
-
-		/// <summary>
-		/// Create a new <see cref="InternalWindowDeferPosHandle"/> for <paramref name="count"/> windows.
-		/// This is to be used when setting the position of multiple windows at once.
-		///
-		/// <see cref="WindowDeferPosHandle"/> must be used in conjunction with a <c>using</c> block
-		/// or statement, otherwise <see cref="INativeManager.EndDeferWindowPos"/> won't be called.
-		/// </summary>
-		/// <param name="context"></param>
-		/// <param name="count"></param>
-		public InternalWindowDeferPosHandle(IContext context, int count)
-		{
-			Logger.Debug("Creating new InternalWindowDeferPosHandle");
-			_context = context;
-			_hWinPosInfo = context.NativeManager.BeginDeferWindowPos(count);
-
-			_toMinimize = new List<IWindow>();
-			_toMaximize = new List<IWindow>();
-			_toNormal = new List<IWindow>();
-		}
-
-		public void DeferWindowPos(IWindowState windowState, HWND hwndInsertAfter, SET_WINDOW_POS_FLAGS? flags)
-		{
-			IWindow window = windowState.Window;
-
-			ILocation<int>? offset = _context.NativeManager.GetWindowOffset(window.Handle);
-			if (offset is null)
-			{
+				Logger.Debug("Cancellation requested, skipping setting window position");
 				return;
 			}
 
-			ILocation<int> location = windowState.Location.Add(offset);
-
-			WindowSize windowSize = windowState.WindowSize;
-
-			SET_WINDOW_POS_FLAGS uFlags = flags ?? DefaultFlags;
-
-			if (windowSize == WindowSize.Maximized)
+			// We don't cancel from here on out, as we're dealing with native code.
+			HDWP hdwp = _context.NativeManager.BeginDeferWindowPos(_windowStates.Count);
+			foreach ((IWindowState windowState, HWND hwndInsertAfter, SET_WINDOW_POS_FLAGS? flags) in _windowStates)
 			{
-				_toMaximize.Add(window);
-				uFlags = uFlags | SET_WINDOW_POS_FLAGS.SWP_NOMOVE | SET_WINDOW_POS_FLAGS.SWP_NOSIZE;
-			}
-			else if (windowSize == WindowSize.Minimized)
-			{
-				_toMinimize.Add(window);
-				uFlags = uFlags | SET_WINDOW_POS_FLAGS.SWP_NOMOVE | SET_WINDOW_POS_FLAGS.SWP_NOSIZE;
-			}
-			else
-			{
-				_toNormal.Add(window);
+				hdwp = DeferWindowPos(hdwp, windowState, hwndInsertAfter, flags, toMinimize, toMaximize, toNormal);
 			}
 
-			_hWinPosInfo = _context.NativeManager.DeferWindowPos(
-				_hWinPosInfo,
-				window.Handle,
-				hwndInsertAfter,
-				location.X,
-				location.Y,
-				location.Width,
-				location.Height,
-				uFlags
-			);
+			EndDeferWindowPos(hdwp, toMinimize, toMaximize, toNormal);
+
+			// Reset the window states.
+			if (i < numPasses - 1)
+			{
+				toMaximize.Clear();
+				toMinimize.Clear();
+				toNormal.Clear();
+			}
 		}
+		Logger.Debug("Finished setting window position");
+	}
 
-		public void Dispose()
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	private HDWP DeferWindowPos(
+		HDWP hdwp,
+		IWindowState windowState,
+		HWND hwndInsertAfter,
+		SET_WINDOW_POS_FLAGS? flags,
+		List<IWindow> toMinimize,
+		List<IWindow> toMaximize,
+		List<IWindow> toNormal
+	)
+	{
+		IWindow window = windowState.Window;
+
+		ILocation<int>? offset = _context.NativeManager.GetWindowOffset(window.Handle);
+		if (offset is null)
 		{
-			Logger.Debug("Disposing InternalWindowDeferPosHandle");
-			foreach (IWindow w in _toMinimize)
-			{
-				if (!w.IsMinimized)
-				{
-					_context.NativeManager.MinimizeWindow(w.Handle);
-				}
-			}
-
-			foreach (IWindow w in _toMaximize)
-			{
-				if (!w.IsMaximized)
-				{
-					_context.NativeManager.ShowWindowMaximized(w.Handle);
-				}
-			}
-
-			foreach (IWindow w in _toNormal)
-			{
-				_context.NativeManager.ShowWindowNoActivate(w.Handle);
-			}
-
-			_context.NativeManager.EndDeferWindowPos(_hWinPosInfo);
-			Logger.Debug("Disposed InternalWindowDeferPosHandle");
+			return hdwp;
 		}
+
+		ILocation<int> location = windowState.Location.Add(offset);
+		WindowSize windowSize = windowState.WindowSize;
+		SET_WINDOW_POS_FLAGS uFlags = flags ?? DefaultFlags;
+
+		if (windowSize == WindowSize.Maximized)
+		{
+			toMaximize.Add(window);
+			uFlags = uFlags | SET_WINDOW_POS_FLAGS.SWP_NOMOVE | SET_WINDOW_POS_FLAGS.SWP_NOSIZE;
+		}
+		else if (windowSize == WindowSize.Minimized)
+		{
+			toMinimize.Add(window);
+			uFlags = uFlags | SET_WINDOW_POS_FLAGS.SWP_NOMOVE | SET_WINDOW_POS_FLAGS.SWP_NOSIZE;
+		}
+		else
+		{
+			toNormal.Add(window);
+		}
+
+		return _context.NativeManager.DeferWindowPos(
+			hdwp,
+			window.Handle,
+			hwndInsertAfter,
+			location.X,
+			location.Y,
+			location.Width,
+			location.Height,
+			uFlags
+		);
+	}
+
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	private void EndDeferWindowPos(
+		HDWP hDWP,
+		List<IWindow> toMinimize,
+		List<IWindow> toMaximize,
+		List<IWindow> toNormal
+	)
+	{
+		foreach (IWindow w in toMinimize)
+		{
+			if (!w.IsMinimized)
+			{
+				_context.NativeManager.MinimizeWindow(w.Handle);
+			}
+		}
+
+		foreach (IWindow w in toMaximize)
+		{
+			if (!w.IsMaximized)
+			{
+				_context.NativeManager.ShowWindowMaximized(w.Handle);
+			}
+		}
+
+		foreach (IWindow w in toNormal)
+		{
+			_context.NativeManager.ShowWindowNoActivate(w.Handle);
+		}
+
+		_context.NativeManager.EndDeferWindowPos(hDWP);
 	}
 }

--- a/src/Whim/Native/WindowDeferPosHandle.cs
+++ b/src/Whim/Native/WindowDeferPosHandle.cs
@@ -140,7 +140,6 @@ public sealed class WindowDeferPosHandle : IDisposable
 			{
 				hdwp = DeferWindowPos(hdwp, windowState, hwndInsertAfter, flags, toMinimize, toMaximize, toNormal);
 			}
-
 			EndDeferWindowPos(hdwp, toMinimize, toMaximize, toNormal);
 
 			// Reset the window states.

--- a/src/Whim/Workspace/IInternalWorkspace.cs
+++ b/src/Whim/Workspace/IInternalWorkspace.cs
@@ -1,3 +1,5 @@
+using System.Threading.Tasks;
+
 namespace Whim;
 
 /// <summary>
@@ -15,11 +17,11 @@ internal interface IInternalWorkspace
 	/// Called when a window is about to be minimized.
 	/// </summary>
 	/// <param name="window"></param>
-	void WindowMinimizeStart(IWindow window);
+	Task WindowMinimizeStart(IWindow window);
 
 	/// <summary>
 	/// Called when a window is about to be unminimized.
 	/// </summary>
 	/// <param name="window"></param>
-	void WindowMinimizeEnd(IWindow window);
+	Task WindowMinimizeEnd(IWindow window);
 }

--- a/src/Whim/Workspace/IWorkspace.cs
+++ b/src/Whim/Workspace/IWorkspace.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace Whim;
 
@@ -23,19 +24,19 @@ public interface IWorkspace : IDisposable
 	/// <summary>
 	/// Rotate to the next layout engine.
 	/// </summary>
-	void NextLayoutEngine();
+	Task NextLayoutEngine();
 
 	/// <summary>
 	/// Rotate to the previous layout engine.
 	/// </summary>
-	void PreviousLayoutEngine();
+	Task PreviousLayoutEngine();
 
 	/// <summary>
 	/// Tries to set the layout engine to one with the <c>name</c>.
 	/// </summary>
 	/// <param name="name">The name of the layout engine to make active.</param>
 	/// <returns></returns>
-	bool TrySetLayoutEngine(string name);
+	Task<bool> TrySetLayoutEngine(string name);
 
 	/// <summary>
 	/// Trigger a layout.
@@ -44,7 +45,7 @@ public interface IWorkspace : IDisposable
 	/// An action to perform after the layout has been performed. This will be called before
 	/// <see cref="IWorkspaceManager.WorkspaceLayoutCompleted"/> .
 	/// </param>
-	void DoLayout(Action? afterLayout = null);
+	Task DoLayout(Action? afterLayout = null);
 	#endregion
 
 	#region Windows
@@ -64,13 +65,13 @@ public interface IWorkspace : IDisposable
 	/// Adds the window to the workspace.
 	/// </summary>
 	/// <param name="window"></param>
-	void AddWindow(IWindow window);
+	Task AddWindow(IWindow window);
 
 	/// <summary>
 	/// Removes the window from the workspace.
 	/// </summary>
 	/// <param name="window"></param>
-	bool RemoveWindow(IWindow window);
+	Task<bool> RemoveWindow(IWindow window);
 
 	/// <summary>
 	/// Returns true when the workspace contains the provided <paramref name="window"/>.
@@ -115,7 +116,7 @@ public interface IWorkspace : IDisposable
 	/// <param name="window">
 	/// The window to swap. If null, the currently focused window is swapped.
 	/// </param>
-	void SwapWindowInDirection(Direction direction, IWindow? window = null);
+	Task SwapWindowInDirection(Direction direction, IWindow? window = null);
 
 	/// <summary>
 	/// Change the <paramref name="window"/>'s <paramref name="edges"/> direction by
@@ -132,7 +133,7 @@ public interface IWorkspace : IDisposable
 	/// The window to change the edge of. If null, the currently focused window is
 	/// used.
 	/// </param>
-	void MoveWindowEdgesInDirection(Direction edges, IPoint<double> deltas, IWindow? window = null);
+	Task MoveWindowEdgesInDirection(Direction edges, IPoint<double> deltas, IWindow? window = null);
 
 	/// <summary>
 	/// Moves or adds the given <paramref name="window"/> to the given <paramref name="point"/>.
@@ -140,6 +141,6 @@ public interface IWorkspace : IDisposable
 	/// </summary>
 	/// <param name="window">The window to move.</param>
 	/// <param name="point">The point to move the window to.</param>
-	void MoveWindowToPoint(IWindow window, IPoint<double> point);
+	Task MoveWindowToPoint(IWindow window, IPoint<double> point);
 	#endregion
 }

--- a/src/Whim/Workspace/IWorkspace.cs
+++ b/src/Whim/Workspace/IWorkspace.cs
@@ -40,7 +40,11 @@ public interface IWorkspace : IDisposable
 	/// <summary>
 	/// Trigger a layout.
 	/// </summary>
-	void DoLayout();
+	/// <param name="afterLayout">
+	/// An action to perform after the layout has been performed. This will be called before
+	/// <see cref="IWorkspaceManager.WorkspaceLayoutCompleted"/> .
+	/// </param>
+	void DoLayout(Action? afterLayout = null);
 	#endregion
 
 	#region Windows

--- a/src/Whim/Workspace/Workspace.cs
+++ b/src/Whim/Workspace/Workspace.cs
@@ -223,7 +223,6 @@ internal class Workspace : IWorkspace, IInternalWorkspace
 		return UpdateLayoutEngine(-1);
 	}
 
-	// TODO
 	public Task<bool> TrySetLayoutEngine(string name)
 	{
 		Logger.Debug($"Trying to set layout engine {name} for workspace {Name}");

--- a/src/Whim/Workspace/Workspace.cs
+++ b/src/Whim/Workspace/Workspace.cs
@@ -575,6 +575,7 @@ internal class Workspace : IWorkspace, IInternalWorkspace
 		CancellationToken cancellationToken
 	)
 	{
+		_internalContext.LayoutLock.EnterReadLock();
 		Logger.Debug($"Setting window positions for workspace {Name}");
 		List<(IWindowState windowState, HWND hwndInsertAfter, SET_WINDOW_POS_FLAGS? flags)> windowStates = new();
 		Dictionary<HWND, IWindowState> windowLocations = new();
@@ -586,7 +587,10 @@ internal class Workspace : IWorkspace, IInternalWorkspace
 			windowLocations.Add(loc.Window.Handle, loc);
 		}
 
-		using WindowDeferPosHandle handle = new(_context, windowStates, cancellationToken);
+		WindowDeferPosHandle handle = new(_context, windowStates, cancellationToken);
+		handle.Dispose();
+
+		_internalContext.LayoutLock.ExitReadLock();
 		return windowLocations;
 	}
 

--- a/src/Whim/Workspace/Workspace.cs
+++ b/src/Whim/Workspace/Workspace.cs
@@ -522,6 +522,7 @@ internal class Workspace : IWorkspace, IInternalWorkspace
 			return;
 		}
 
+		Logger.Debug($"Starting layout for workspace {Name}");
 		_triggers.WorkspaceLayoutStarted(new WorkspaceEventArgs() { Workspace = this });
 
 		lock (_layoutLock)
@@ -531,11 +532,12 @@ internal class Workspace : IWorkspace, IInternalWorkspace
 			{
 				// Cancel the previous layout tasks
 				_cancellationTokenSource?.Cancel();
+				Logger.Debug($"Cancelling previous layout tasks for workspace {Name}");
 			}
 
 			// Set the window positions in another thread. Doing this in the same thread can block
 			// the UI thread, which can delay the handling of messages in the window manager - see #446.
-			_cancellationTokenSource ??= new();
+			_cancellationTokenSource = new();
 		}
 
 		// Execute the layout task
@@ -566,6 +568,7 @@ internal class Workspace : IWorkspace, IInternalWorkspace
 
 	private void SetWindowPos(ILayoutEngine engine, IMonitor monitor, CancellationToken cancellationToken)
 	{
+		Logger.Debug($"Setting window positions for workspace {Name}");
 		List<(IWindowState windowState, HWND hwndInsertAfter, SET_WINDOW_POS_FLAGS? flags)> windowStates = new();
 		foreach (IWindowState loc in engine.DoLayout(monitor.WorkingArea, monitor))
 		{

--- a/src/Whim/Workspace/Workspace.cs
+++ b/src/Whim/Workspace/Workspace.cs
@@ -196,14 +196,16 @@ internal class Workspace : IWorkspace, IInternalWorkspace
 			nextLayoutEngine = _layoutEngines[_activeLayoutEngineIndex];
 		}
 
-		DoLayout();
-		_triggers.ActiveLayoutEngineChanged(
-			new ActiveLayoutEngineChangedEventArgs()
-			{
-				Workspace = this,
-				PreviousLayoutEngine = prevLayoutEngine,
-				CurrentLayoutEngine = nextLayoutEngine
-			}
+		DoLayout(
+			() =>
+				_triggers.ActiveLayoutEngineChanged(
+					new ActiveLayoutEngineChangedEventArgs()
+					{
+						Workspace = this,
+						PreviousLayoutEngine = prevLayoutEngine,
+						CurrentLayoutEngine = nextLayoutEngine
+					}
+				)
 		);
 	}
 
@@ -257,14 +259,16 @@ internal class Workspace : IWorkspace, IInternalWorkspace
 			nextLayoutEngine = _layoutEngines[_activeLayoutEngineIndex];
 		}
 
-		DoLayout();
-		_triggers.ActiveLayoutEngineChanged(
-			new ActiveLayoutEngineChangedEventArgs()
-			{
-				Workspace = this,
-				PreviousLayoutEngine = prevLayoutEngine,
-				CurrentLayoutEngine = nextLayoutEngine
-			}
+		DoLayout(
+			() =>
+				_triggers.ActiveLayoutEngineChanged(
+					new ActiveLayoutEngineChangedEventArgs()
+					{
+						Workspace = this,
+						PreviousLayoutEngine = prevLayoutEngine,
+						CurrentLayoutEngine = nextLayoutEngine
+					}
+				)
 		);
 
 		return true;
@@ -289,8 +293,7 @@ internal class Workspace : IWorkspace, IInternalWorkspace
 			}
 		}
 
-		DoLayout();
-		window.Focus();
+		DoLayout(window.Focus);
 	}
 
 	public bool RemoveWindow(IWindow window)
@@ -504,7 +507,7 @@ internal class Workspace : IWorkspace, IInternalWorkspace
 		return location;
 	}
 
-	public void DoLayout()
+	public void DoLayout(Action? afterLayout = null)
 	{
 		Logger.Debug($"Workspace {Name}");
 
@@ -564,6 +567,10 @@ internal class Workspace : IWorkspace, IInternalWorkspace
 						// Add the window locations to the map
 						_windowLocations = t.Result;
 					}
+
+					// Trigger the layout completed event
+					afterLayout?.Invoke();
+					_triggers.WorkspaceLayoutCompleted(new WorkspaceEventArgs() { Workspace = this });
 				},
 				uiScheduler
 			);

--- a/src/Whim/Workspace/WorkspaceManager.cs
+++ b/src/Whim/Workspace/WorkspaceManager.cs
@@ -448,7 +448,6 @@ internal class WorkspaceManager : IInternalWorkspaceManager, IWorkspaceManager
 		}
 
 		_windowWorkspaceMap.TryGetValue(window, out IWorkspace? workspaceFocused);
-
 		if (workspaceFocused != null && !workspaceFocused.Equals(ActiveWorkspace))
 		{
 			Activate(workspaceFocused);

--- a/src/Whim/Workspace/WorkspaceManager.cs
+++ b/src/Whim/Workspace/WorkspaceManager.cs
@@ -685,14 +685,6 @@ internal class WorkspaceManager : IInternalWorkspaceManager, IWorkspaceManager
 
 		Logger.Debug($"Moving window {window} to workspace {targetWorkspace} in monitor {targetMonitor}");
 
-		bool isSameWorkspace = targetWorkspace.Equals(oldWorkspace);
-		// If the window is being moved to a different workspace, remove it from the current workspace.
-		if (!isSameWorkspace && !oldWorkspace.RemoveWindow(window))
-		{
-			Logger.Error($"Could not remove window {window} from workspace {oldWorkspace}");
-			return;
-		}
-
 		// Normalize `point` into the unit square.
 		IPoint<int> pointInMonitor = targetMonitor.WorkingArea.ToMonitorCoordinates(point);
 		IPoint<double> normalized = targetMonitor.WorkingArea.ToUnitSquare(pointInMonitor);
@@ -700,10 +692,11 @@ internal class WorkspaceManager : IInternalWorkspaceManager, IWorkspaceManager
 		Logger.Debug($"Normalized point: {normalized}");
 		targetWorkspace.MoveWindowToPoint(window, normalized);
 
-		// If the window is being moved to a different workspace, update the reference in the window map.
-		if (!isSameWorkspace)
+		// If the window is being moved to a different workspace, remove it from the current workspace.
+		if (!targetWorkspace.Equals(oldWorkspace))
 		{
 			_windowWorkspaceMap[window] = targetWorkspace;
+			oldWorkspace.RemoveWindow(window);
 		}
 
 		// Trigger layouts.

--- a/src/Whim/Workspace/WorkspaceManager.cs
+++ b/src/Whim/Workspace/WorkspaceManager.cs
@@ -77,10 +77,10 @@ internal class WorkspaceManager : IInternalWorkspaceManager, IWorkspaceManager
 	{
 		get
 		{
-			// TODO: Remove
-			Logger.Debug($"Getting active workspace for monitor {_context.MonitorManager.ActiveMonitor}");
+			IMonitor activeMonitor = _context.MonitorManager.ActiveMonitor;
+			Logger.Debug($"Getting active workspace for monitor {activeMonitor}");
 
-			return _monitorWorkspaceMap.TryGetValue(_context.MonitorManager.ActiveMonitor, out IWorkspace? workspace)
+			return _monitorWorkspaceMap.TryGetValue(activeMonitor, out IWorkspace? workspace)
 				? workspace
 				: _workspaces[0];
 		}
@@ -269,26 +269,14 @@ internal class WorkspaceManager : IInternalWorkspaceManager, IWorkspaceManager
 		// Get the old workspace for the event.
 		IWorkspace? oldWorkspace = GetWorkspaceForMonitor(activeMonitor);
 
-		// TODO: Remove
-		Logger.Debug($"Old workspace: {oldWorkspace}");
-
 		// Find the monitor which just lost `workspace`.
 		IMonitor? loserMonitor = GetMonitorForWorkspace(workspace);
-
-		// TODO: Remove
-		Logger.Debug($"Loser monitor: {loserMonitor}");
 
 		// Update the active monitor. Having this line before the old workspace is deactivated
 		// is important, as WindowManager.OnWindowHidden() checks to see if a window is in a
 		// visible workspace when it receives the EVENT_OBJECT_HIDE event.
-		// TODO: Remove
-		Logger.Debug($"Updating active monitor to {activeMonitor} for workspace {workspace}");
 		_monitorWorkspaceMap[activeMonitor] = workspace;
 
-		// TODO: Clean this up.
-		// Send out an event about the losing monitor.
-
-		// TODO: Clean this up.
 		(IWorkspace workspace, IMonitor monitor)? layoutOldWorkspace = null;
 		if (loserMonitor != null && oldWorkspace != null && !loserMonitor.Equals(activeMonitor))
 		{
@@ -297,12 +285,8 @@ internal class WorkspaceManager : IInternalWorkspaceManager, IWorkspaceManager
 		}
 		_internalContext.LayoutLock.ExitWriteLock();
 
-		// TODO: Remove
-		Logger.Debug($"Layouting workspace {workspace} in active monitor {activeMonitor}");
-
 		if (layoutOldWorkspace is (IWorkspace, IMonitor) oldWorkspaceValue)
 		{
-			// TODO: Remove
 			Logger.Debug($"Layouting workspace {oldWorkspace} in loser monitor {loserMonitor}");
 			oldWorkspace?.DoLayout();
 			MonitorWorkspaceChanged?.Invoke(
@@ -465,9 +449,6 @@ internal class WorkspaceManager : IInternalWorkspaceManager, IWorkspaceManager
 
 		_windowWorkspaceMap.TryGetValue(window, out IWorkspace? workspaceFocused);
 
-		// TODO: Remove
-		Logger.Debug($"Focused workspace: {workspaceFocused}");
-		Logger.Debug($"Active workspace: {ActiveWorkspace}");
 		if (workspaceFocused != null && !workspaceFocused.Equals(ActiveWorkspace))
 		{
 			Activate(workspaceFocused);

--- a/src/Whim/Workspace/WorkspaceManager.cs
+++ b/src/Whim/Workspace/WorkspaceManager.cs
@@ -711,13 +711,13 @@ internal class WorkspaceManager : IInternalWorkspaceManager, IWorkspaceManager
 		Logger.Debug(
 			$"Moving window {window} to workspace {targetWorkspace} in monitor {targetMonitor} at normalized point {normalized}"
 		);
-		targetWorkspace.MoveWindowToPoint(window, normalized);
 
 		// If the window is being moved to a different workspace, remove it from the current workspace.
 		if (!isSameWorkspace)
 		{
-			_windowWorkspaceMap[window] = targetWorkspace;
+			oldWorkspace.RemoveWindow(window);
 		}
+		targetWorkspace.MoveWindowToPoint(window, normalized);
 
 		// Trigger layouts.
 		window.Focus();


### PR DESCRIPTION
Added a `ReaderWriterLockSlim` to prevent `WindowManager` from modifying `MonitorManager` and `WorkspaceManager` while a `Workspace.DoLayout` is occurring in a different thread. `Reader` locks are used for `Workspace.DoLayout`, while `Writer` locks are used for `WindowManager` methods which modify `MonitorManager` and `WorkspaceManager`. This was done to fix a race condition between `Workspace.DoLayout` being called on the wrong monitor after `MonitorManager.WindowFocused` was called.

`WindowDeferPosHandle` was simplified to reduce the allocations and instantiations, by removing the `InternalWindowDeferPosHandle` and accepting an enumerable of windows to layout.

`Workspace` now uses a queue to cancel all prior layouts which are currently in progress.

`IWorkspace` now (regrettably) returns `Task` for `DoLayout` and methods which call `DoLayout` (e.g. `AddWindow`). This is to allow the caller to `await` the layout operation. However, it would be nice to remove all `Task.Run` calls in the future, for simplicity's sake.
