### PR TITLE
Minor bugfixes that prevented first time startup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -354,3 +354,6 @@ MigrationBackup/
 
 # Installer
 bin/whim-install.exe
+
+# Rider
+.idea/

--- a/src/Whim.Bar.Tests/BarLayoutEngineTests.cs
+++ b/src/Whim.Bar.Tests/BarLayoutEngineTests.cs
@@ -289,4 +289,19 @@ public class BarLayoutEngineTests
 		innerLayoutEngine.Received(1).DoLayout(expectedGivenLocation, monitor);
 		layout.Should().Equal(expectedWindowStates);
 	}
+
+	[Theory]
+	[InlineAutoSubstituteData(0)]
+	[InlineAutoSubstituteData(-30)]
+	public void DoLayout_HeightMustBeNonNegative(int height, ILayoutEngine innerLayoutEngine, IMonitor monitor)
+	{
+		// Given
+		BarLayoutEngine engine = CreateSut(innerLayoutEngine);
+
+		// When
+		engine.DoLayout(new Location<int>() { Width = 100, Height = height }, monitor);
+
+		// Then
+		innerLayoutEngine.Received(1).DoLayout(Arg.Is<Location<int>>(l => l.Height == 0), monitor);
+	}
 }

--- a/src/Whim.Bar/BarLayoutEngine.cs
+++ b/src/Whim.Bar/BarLayoutEngine.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 namespace Whim.Bar;
@@ -44,7 +45,7 @@ public record BarLayoutEngine : BaseProxyLayoutEngine
 				X = location.X,
 				Y = location.Y + height,
 				Width = location.Width,
-				Height = location.Height - height
+				Height = Math.Max(0, location.Height - height)
 			};
 		return InnerLayoutEngine.DoLayout(proxiedLocation, monitor);
 	}

--- a/src/Whim.FloatingLayout.Tests/FloatingLayoutPluginTests.cs
+++ b/src/Whim.FloatingLayout.Tests/FloatingLayoutPluginTests.cs
@@ -13,7 +13,7 @@ public class FloatingLayoutPluginCustomization : ICustomization
 		IContext context = fixture.Freeze<IContext>();
 		IWorkspace workspace = fixture.Freeze<IWorkspace>();
 		IMonitor monitor = fixture.Freeze<IMonitor>();
-		ILocation<int> location = new Location<int>() { X = 1, Y = 2 };
+		ILocation<int> location = new Location<int>() { X = 1, Y = 2,  Width = 2, Height = 2};
 
 		// The workspace will have a null last focused window
 		workspace.LastFocusedWindow.Returns((IWindow?)null);
@@ -202,21 +202,25 @@ public class FloatingLayoutPluginTests
 	}
 
 	[Theory, AutoSubstituteData<FloatingLayoutPluginCustomization>]
-	public void MarkWindowAsFloating(IContext context, IWindow window, IWorkspace activeWorkspace)
+	public void MarkWindowAsFloating(IContext context, IWindow window, IWorkspace activeWorkspace, IMonitor monitor)
 	{
 		// Given
 		context.WorkspaceManager.GetWorkspaceForWindow(window).Returns(activeWorkspace);
+		Location<int> location = new Location<int>() { X = 1, Y = 2 };
 		activeWorkspace
 			.TryGetWindowLocation(window)
 			.Returns(
 				new WindowState()
 				{
-					Location = new Location<int>() { X = 1, Y = 2 },
+					Location = location,
 					Window = window,
 					WindowSize = WindowSize.Normal
 				}
 			);
-
+		Location<int> monitorWorkingArea = new() { X = 0, Y = 0, Width = 3, Height = 3 };
+		monitor.WorkingArea.Returns(monitorWorkingArea);
+		context.MonitorManager.GetMonitorAtPoint(location).Returns(monitor);
+		
 		FloatingLayoutPlugin plugin = CreateSut(context);
 
 		// When
@@ -245,21 +249,25 @@ public class FloatingLayoutPluginTests
 	}
 
 	[Theory, AutoSubstituteData<FloatingLayoutPluginCustomization>]
-	public void MarkWindowAsDocked_WindowIsFloating(IContext context, IWindow window, IWorkspace activeWorkspace)
+	public void MarkWindowAsDocked_WindowIsFloating(IContext context, IWindow window, IWorkspace activeWorkspace, IMonitor monitor)
 	{
 		// Given
 		context.WorkspaceManager.GetWorkspaceForWindow(window).Returns(activeWorkspace);
+		Location<int> location = new() { X = 1, Y = 2 };
 		activeWorkspace
 			.TryGetWindowLocation(window)
 			.Returns(
 				new WindowState()
 				{
-					Location = new Location<int>() { X = 1, Y = 2 },
+					Location = location,
 					Window = window,
 					WindowSize = WindowSize.Normal
 				}
 			);
-
+		Location<int> monitorWorkingArea = new() { X = 0, Y = 0, Width = 3, Height = 3 };
+		monitor.WorkingArea.Returns(monitorWorkingArea);
+		context.MonitorManager.GetMonitorAtPoint(location).Returns(monitor);
+		
 		FloatingLayoutPlugin plugin = CreateSut(context);
 		plugin.MarkWindowAsFloating(window);
 
@@ -287,21 +295,25 @@ public class FloatingLayoutPluginTests
 	}
 
 	[Theory, AutoSubstituteData<FloatingLayoutPluginCustomization>]
-	public void ToggleWindowFloating_ToFloating(IContext context, IWindow window, IWorkspace activeWorkspace)
+	public void ToggleWindowFloating_ToFloating(IContext context, IWindow window, IWorkspace activeWorkspace, IMonitor monitor)
 	{
 		// Given
 		context.WorkspaceManager.GetWorkspaceForWindow(window).Returns(activeWorkspace);
+		Location<int> location = new Location<int>() { X = 1, Y = 2 };
 		activeWorkspace
 			.TryGetWindowLocation(window)
 			.Returns(
 				new WindowState()
 				{
-					Location = new Location<int>() { X = 1, Y = 2 },
+					Location = location,
 					Window = window,
 					WindowSize = WindowSize.Normal
 				}
 			);
-
+		Location<int> monitorWorkingArea = new() { X = 0, Y = 0, Width = 3, Height = 3 };
+		monitor.WorkingArea.Returns(monitorWorkingArea);
+		context.MonitorManager.GetMonitorAtPoint(location).Returns(monitor);
+		
 		FloatingLayoutPlugin plugin = CreateSut(context);
 
 		// When
@@ -313,21 +325,25 @@ public class FloatingLayoutPluginTests
 	}
 
 	[Theory, AutoSubstituteData<FloatingLayoutPluginCustomization>]
-	public void ToggleWindowFloating_ToDocked(IContext context, IWindow window, IWorkspace activeWorkspace)
+	public void ToggleWindowFloating_ToDocked(IContext context, IWindow window, IWorkspace activeWorkspace, IMonitor monitor)
 	{
 		// Given
 		context.WorkspaceManager.GetWorkspaceForWindow(window).Returns(activeWorkspace);
+		Location<int> location = new() { X = 1, Y = 2 };
 		activeWorkspace
 			.TryGetWindowLocation(window)
 			.Returns(
 				new WindowState()
 				{
-					Location = new Location<int>() { X = 1, Y = 2 },
+					Location = location,
 					Window = window,
 					WindowSize = WindowSize.Normal
 				}
 			);
-
+		Location<int> monitorWorkingArea = new() { X = 0, Y = 0, Width = 3, Height = 3 };
+		monitor.WorkingArea.Returns(monitorWorkingArea);
+		context.MonitorManager.GetMonitorAtPoint(location).Returns(monitor);
+		
 		FloatingLayoutPlugin plugin = CreateSut(context);
 
 		plugin.MarkWindowAsFloating(window);
@@ -391,22 +407,27 @@ public class FloatingLayoutPluginTests
 	public void MarkWindowAsDockedInLayoutEngine_WindowIsFloating(
 		IContext context,
 		IWindow window,
-		IWorkspace activeWorkspace
+		IWorkspace activeWorkspace,
+		IMonitor monitor
 	)
 	{
 		// Given
 		ILayoutEngine layoutEngine = activeWorkspace.ActiveLayoutEngine;
 		context.WorkspaceManager.GetWorkspaceForWindow(window).Returns(activeWorkspace);
+		Location<int> location = new() { X = 1, Y = 2 };
 		activeWorkspace
 			.TryGetWindowLocation(window)
 			.Returns(
 				new WindowState()
 				{
-					Location = new Location<int>() { X = 1, Y = 2 },
+					Location = location,
 					Window = window,
 					WindowSize = WindowSize.Normal
 				}
 			);
+		Location<int> monitorWorkingArea = new() { X = 0, Y = 0, Width = 3, Height = 3 };
+		monitor.WorkingArea.Returns(monitorWorkingArea);
+		context.MonitorManager.GetMonitorAtPoint(location).Returns(monitor);
 
 		FloatingLayoutPlugin plugin = CreateSut(context);
 		plugin.MarkWindowAsFloating(window);
@@ -434,7 +455,8 @@ public class FloatingLayoutPluginTests
 		IContext context,
 		IWindow window,
 		ILayoutEngine layoutEngine2,
-		IWorkspace activeWorkspace
+		IWorkspace activeWorkspace,
+		IMonitor monitor
 	)
 	{
 		// Given
@@ -442,16 +464,20 @@ public class FloatingLayoutPluginTests
 		layoutEngine2.Identity.Returns(new LayoutEngineIdentity());
 
 		context.WorkspaceManager.GetWorkspaceForWindow(window).Returns(activeWorkspace);
+		Location<int> location = new() { X = 1, Y = 2 };
 		activeWorkspace
 			.TryGetWindowLocation(window)
 			.Returns(
 				new WindowState()
 				{
-					Location = new Location<int>() { X = 1, Y = 2 },
+					Location = location,
 					Window = window,
 					WindowSize = WindowSize.Normal
 				}
 			);
+		Location<int> monitorWorkingArea = new() { X = 0, Y = 0, Width = 3, Height = 3 };
+		monitor.WorkingArea.Returns(monitorWorkingArea);
+		context.MonitorManager.GetMonitorAtPoint(location).Returns(monitor);
 
 		// When
 		FloatingLayoutPlugin plugin = CreateSut(context);

--- a/src/Whim.Gaps.Tests/GapsLayoutEngineTests.cs
+++ b/src/Whim.Gaps.Tests/GapsLayoutEngineTests.cs
@@ -127,6 +127,288 @@ public class GapsLayoutEngineTests
 		windowStates.Should().Equal(expectedWindowStates);
 	}
 
+	public static IEnumerable<object[]> DoLayout_OutOfBoundsData()
+	{
+		// A window whose width returned by the layout engine as less than zero should not have the
+		// gap applied in the x direction
+		IWindow window1 = Substitute.For<IWindow>();
+		yield return new object[]
+		{
+			new GapsConfig { OuterGap = 10, InnerGap = 5 },
+			window1,
+			new Location<int>()
+			{
+				X = 5,
+				Y = 5,
+				Width = -100,
+				Height = 1080
+			},
+			new IWindowState[]
+			{
+				new WindowState()
+				{
+					Window = window1,
+					Location = new Location<int>()
+					{
+						X = 5,
+						Y = 5,
+						Width = 0,
+						Height = 1080
+					},
+					WindowSize = WindowSize.Normal
+				}
+			}
+		};
+
+		// A window whose width returned by the layout engine as zero should not have the gap applied
+		// in the x direction
+		IWindow window2 = Substitute.For<IWindow>();
+		yield return new object[]
+		{
+			new GapsConfig { OuterGap = 10, InnerGap = 5 },
+			window2,
+			new Location<int>()
+			{
+				X = 5,
+				Y = 5,
+				Width = 0,
+				Height = 1080
+			},
+			new IWindowState[]
+			{
+				new WindowState()
+				{
+					Window = window2,
+					Location = new Location<int>()
+					{
+						X = 5,
+						Y = 5,
+						Width = 0,
+						Height = 1080
+					},
+					WindowSize = WindowSize.Normal
+				}
+			}
+		};
+
+		// A window whose width is less than the gap should not have the gap applied in the x direction
+		IWindow window3 = Substitute.For<IWindow>();
+		yield return new object[]
+		{
+			new GapsConfig { OuterGap = 10, InnerGap = 5 },
+			window3,
+			new Location<int>()
+			{
+				X = 5,
+				Y = 5,
+				Width = 5,
+				Height = 1080
+			},
+			new IWindowState[]
+			{
+				new WindowState()
+				{
+					Window = window3,
+					Location = new Location<int>()
+					{
+						X = 5,
+						Y = 5,
+						Width = 5,
+						Height = 1080
+					},
+					WindowSize = WindowSize.Normal
+				}
+			}
+		};
+
+		// A window whose height returned by the layout engine as less than zero should not have the
+		// gap applied in the y direction
+		IWindow window4 = Substitute.For<IWindow>();
+		yield return new object[]
+		{
+			new GapsConfig { OuterGap = 10, InnerGap = 5 },
+			window4,
+			new Location<int>()
+			{
+				X = 5,
+				Y = 5,
+				Width = 1920,
+				Height = -100
+			},
+			new IWindowState[]
+			{
+				new WindowState()
+				{
+					Window = window4,
+					Location = new Location<int>()
+					{
+						X = 5,
+						Y = 5,
+						Width = 1920,
+						Height = 0
+					},
+					WindowSize = WindowSize.Normal
+				}
+			}
+		};
+
+		// A window whose height returned by the layout engine as zero should not have the gap applied
+		// in the y direction
+		IWindow window5 = Substitute.For<IWindow>();
+		yield return new object[]
+		{
+			new GapsConfig { OuterGap = 10, InnerGap = 5 },
+			window5,
+			new Location<int>()
+			{
+				X = 5,
+				Y = 5,
+				Width = 1920,
+				Height = 0
+			},
+			new IWindowState[]
+			{
+				new WindowState()
+				{
+					Window = window5,
+					Location = new Location<int>()
+					{
+						X = 5,
+						Y = 5,
+						Width = 1920,
+						Height = 0
+					},
+					WindowSize = WindowSize.Normal
+				}
+			}
+		};
+
+		// A window whose height is less than the gap should not have the gap applied in the y direction
+		IWindow window6 = Substitute.For<IWindow>();
+		yield return new object[]
+		{
+			new GapsConfig { OuterGap = 10, InnerGap = 5 },
+			window6,
+			new Location<int>()
+			{
+				X = 5,
+				Y = 5,
+				Width = 1920,
+				Height = 5
+			},
+			new IWindowState[]
+			{
+				new WindowState()
+				{
+					Window = window6,
+					Location = new Location<int>()
+					{
+						X = 5,
+						Y = 5,
+						Width = 1920,
+						Height = 5
+					},
+					WindowSize = WindowSize.Normal
+				}
+			}
+		};
+
+		// A window whose width and height are less than the gap should not have the gap applied in
+		// either direction
+		IWindow window7 = Substitute.For<IWindow>();
+		yield return new object[]
+		{
+			new GapsConfig { OuterGap = 10, InnerGap = 5 },
+			window7,
+			new Location<int>()
+			{
+				X = 5,
+				Y = 5,
+				Width = 5,
+				Height = 5
+			},
+			new IWindowState[]
+			{
+				new WindowState()
+				{
+					Window = window7,
+					Location = new Location<int>()
+					{
+						X = 5,
+						Y = 5,
+						Width = 5,
+						Height = 5
+					},
+					WindowSize = WindowSize.Normal
+				}
+			}
+		};
+
+		// A window whose width and height are zero should not have the gap applied in either direction
+		IWindow window8 = Substitute.For<IWindow>();
+		yield return new object[]
+		{
+			new GapsConfig { OuterGap = 10, InnerGap = 5 },
+			window8,
+			new Location<int>()
+			{
+				X = 5,
+				Y = 5,
+				Width = 0,
+				Height = 0
+			},
+			new IWindowState[]
+			{
+				new WindowState()
+				{
+					Window = window8,
+					Location = new Location<int>()
+					{
+						X = 5,
+						Y = 5,
+						Width = 0,
+						Height = 0
+					},
+					WindowSize = WindowSize.Normal
+				}
+			}
+		};
+	}
+
+	[Theory]
+	[MemberData(nameof(DoLayout_OutOfBoundsData))]
+	public void DoLayout_OutOfBounds(
+		GapsConfig gapsConfig,
+		IWindow window,
+		Location<int> location,
+		IWindowState[] expectedWindowStates
+	)
+	{
+		// Given
+		ILayoutEngine innerLayoutEngine = Substitute.For<ILayoutEngine>();
+		innerLayoutEngine
+			.DoLayout(location, Arg.Any<IMonitor>())
+			.Returns(
+				new IWindowState[]
+				{
+					new WindowState()
+					{
+						Window = window,
+						Location = location,
+						WindowSize = WindowSize.Normal
+					}
+				}
+			);
+
+		GapsLayoutEngine gapsLayoutEngine = new(gapsConfig, innerLayoutEngine);
+
+		// When
+		IWindowState[] windowStates = gapsLayoutEngine.DoLayout(location, Substitute.For<IMonitor>()).ToArray();
+
+		// Then
+		windowStates.Should().Equal(expectedWindowStates);
+	}
+
 	[Theory, AutoSubstituteData]
 	public void Count(ILayoutEngine innerLayoutEngine)
 	{

--- a/src/Whim.Gaps/GapsLayoutEngine.cs
+++ b/src/Whim.Gaps/GapsLayoutEngine.cs
@@ -62,15 +62,33 @@ public record GapsLayoutEngine : BaseProxyLayoutEngine
 
 		foreach (IWindowState loc in InnerLayoutEngine.DoLayout(proxiedLocation, monitor))
 		{
+			int x = loc.Location.X + innerGap;
+			int y = loc.Location.Y + innerGap;
+			int width = loc.Location.Width - doubleInnerGap;
+			int height = loc.Location.Height - doubleInnerGap;
+
+			// Get the location of the window with the gaps applied. If the window is too small in
+			// a given dimension, then we don't apply the gap in that dimension.
+			if (width <= 0)
+			{
+				x = loc.Location.X;
+				width = Math.Max(0, loc.Location.Width);
+			}
+			if (height <= 0)
+			{
+				y = loc.Location.Y;
+				height = Math.Max(0, loc.Location.Height);
+			}
+
 			yield return new WindowState()
 			{
 				Window = loc.Window,
 				Location = new Location<int>()
 				{
-					X = loc.Location.X + innerGap,
-					Y = loc.Location.Y + innerGap,
-					Width = Math.Max(0, loc.Location.Width - doubleInnerGap),
-					Height = Math.Max(0, loc.Location.Height - doubleInnerGap)
+					X = x,
+					Y = y,
+					Width = width,
+					Height = height
 				},
 				WindowSize = loc.WindowSize
 			};

--- a/src/Whim.Gaps/GapsLayoutEngine.cs
+++ b/src/Whim.Gaps/GapsLayoutEngine.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 namespace Whim.Gaps;
@@ -68,8 +69,8 @@ public record GapsLayoutEngine : BaseProxyLayoutEngine
 				{
 					X = loc.Location.X + innerGap,
 					Y = loc.Location.Y + innerGap,
-					Width = loc.Location.Width - doubleInnerGap,
-					Height = loc.Location.Height - doubleInnerGap
+					Width = Math.Max(0, loc.Location.Width - doubleInnerGap),
+					Height = Math.Max(0, loc.Location.Height - doubleInnerGap)
 				},
 				WindowSize = loc.WindowSize
 			};

--- a/src/Whim.LayoutPreview.Tests/LayoutPreviewPluginTests.cs
+++ b/src/Whim.LayoutPreview.Tests/LayoutPreviewPluginTests.cs
@@ -26,8 +26,17 @@ public class LayoutPreviewPluginTests
 
 			MonitorManager.Setup(x => x.GetMonitorAtPoint(It.IsAny<IPoint<int>>())).Returns(Monitor.Object);
 
-			Monitor.Setup(x => x.WorkingArea)
-				.Returns(new Location<int>() { X = 0, Y = 0, Width = 1920, Height = 1080 });
+			Monitor
+				.Setup(x => x.WorkingArea)
+				.Returns(
+					new Location<int>()
+					{
+						X = 0,
+						Y = 0,
+						Width = 1920,
+						Height = 1080
+					}
+				);
 
 			WorkspaceManager.Setup(x => x.GetWorkspaceForMonitor(Monitor.Object)).Returns(Workspace.Object);
 

--- a/src/Whim.LayoutPreview.Tests/LayoutPreviewPluginTests.cs
+++ b/src/Whim.LayoutPreview.Tests/LayoutPreviewPluginTests.cs
@@ -26,7 +26,8 @@ public class LayoutPreviewPluginTests
 
 			MonitorManager.Setup(x => x.GetMonitorAtPoint(It.IsAny<IPoint<int>>())).Returns(Monitor.Object);
 
-			Monitor.Setup(x => x.WorkingArea).Returns(new Location<int>());
+			Monitor.Setup(x => x.WorkingArea)
+				.Returns(new Location<int>() { X = 0, Y = 0, Width = 1920, Height = 1080 });
 
 			WorkspaceManager.Setup(x => x.GetWorkspaceForMonitor(Monitor.Object)).Returns(Workspace.Object);
 

--- a/src/Whim.LayoutPreview.Tests/NonNegativeValueConverterTests.cs
+++ b/src/Whim.LayoutPreview.Tests/NonNegativeValueConverterTests.cs
@@ -8,13 +8,29 @@ public class NonNegativeValueConverterTests
 	[InlineData(0, 0)]
 	[InlineData(1, 1)]
 	[Theory]
-	public void Convert(int input, int expected)
+	public void Convert_Int(int input, int expected)
 	{
 		// Given
 		NonNegativeValueConverter converter = new();
 
 		// When
 		int actual = (int)converter.Convert(input, typeof(int), new object(), "")!;
+
+		// Then
+		Assert.Equal(expected, actual);
+	}
+
+	[InlineData(-1.0, 0)]
+	[InlineData(0.0, 0)]
+	[InlineData(1.0, 1)]
+	[Theory]
+	public void Convert_Double(double input, double expected)
+	{
+		// Given
+		NonNegativeValueConverter converter = new();
+
+		// When
+		double actual = (double)converter.Convert(input, typeof(double), new object(), "")!;
 
 		// Then
 		Assert.Equal(expected, actual);

--- a/src/Whim.LayoutPreview.Tests/NonNegativeValueConverterTests.cs
+++ b/src/Whim.LayoutPreview.Tests/NonNegativeValueConverterTests.cs
@@ -1,0 +1,38 @@
+using Xunit;
+
+namespace Whim.LayoutPreview.Tests;
+
+public class NonNegativeValueConverterTests
+{
+	[InlineData(-1, 0)]
+	[InlineData(0, 0)]
+	[InlineData(1, 1)]
+	[Theory]
+	public void Convert(int input, int expected)
+	{
+		// Given
+		NonNegativeValueConverter converter = new();
+
+		// When
+		int actual = (int)converter.Convert(input, typeof(int), new object(), "")!;
+
+		// Then
+		Assert.Equal(expected, actual);
+	}
+
+	[Fact]
+	public void ConvertBack()
+	{
+		// Given
+		NonNegativeValueConverter converter = new();
+
+		// When
+		object actual()
+		{
+			return converter.ConvertBack(0, typeof(int), new object(), "");
+		}
+
+		// Then
+		Assert.Throws<NotImplementedException>(actual);
+	}
+}

--- a/src/Whim.LayoutPreview/LayoutPreviewWindowItem.xaml
+++ b/src/Whim.LayoutPreview/LayoutPreviewWindowItem.xaml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8" ?>
+﻿<?xml version="1.0" encoding="utf-8" ?>
 <UserControl
 	x:Class="Whim.LayoutPreview.LayoutPreviewWindowItem"
 	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
@@ -11,11 +11,11 @@
 	HorizontalContentAlignment="Stretch"
 	VerticalContentAlignment="Stretch"
 	mc:Ignorable="d">
-	
+
 	<UserControl.Resources>
 		<local:NonNegativeValueConverter x:Key="NonNegativeValueConverter" />
 	</UserControl.Resources>
-	
+
 	<RelativePanel x:Name="Panel" CornerRadius="4">
 		<StackPanel RelativePanel.AlignHorizontalCenterWithPanel="True" RelativePanel.AlignVerticalCenterWithPanel="True">
 			<Image

--- a/src/Whim.LayoutPreview/LayoutPreviewWindowItem.xaml
+++ b/src/Whim.LayoutPreview/LayoutPreviewWindowItem.xaml
@@ -6,12 +6,16 @@
 	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
 	xmlns:local="using:Whim.LayoutPreview"
 	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-	Width="{x:Bind Path=WindowState.Location.Width}"
-	Height="{x:Bind Path=WindowState.Location.Height}"
+	Width="{x:Bind Path=WindowState.Location.Width, Converter={StaticResource NonNegativeValueConverter}}"
+	Height="{x:Bind Path=WindowState.Location.Height, Converter={StaticResource NonNegativeValueConverter}}"
 	HorizontalContentAlignment="Stretch"
 	VerticalContentAlignment="Stretch"
 	mc:Ignorable="d">
-
+	
+	<UserControl.Resources>
+		<local:NonNegativeValueConverter x:Key="NonNegativeValueConverter" />
+	</UserControl.Resources>
+	
 	<RelativePanel x:Name="Panel" CornerRadius="4">
 		<StackPanel RelativePanel.AlignHorizontalCenterWithPanel="True" RelativePanel.AlignVerticalCenterWithPanel="True">
 			<Image

--- a/src/Whim.LayoutPreview/NonNegativeValueConverter.cs
+++ b/src/Whim.LayoutPreview/NonNegativeValueConverter.cs
@@ -1,0 +1,22 @@
+using Microsoft.UI.Xaml.Data;
+using System;
+
+namespace Whim.LayoutPreview;
+
+public class NonNegativeValueConverter : IValueConverter
+{
+	public object Convert(object value, Type targetType, object parameter, string language)
+	{
+		bool isNegative = value switch {
+			int i => i < 0,
+			double d => d < 0,
+			_ => throw new ArgumentException($"Unexpected type {value.GetType().Name}", nameof(value))
+		};
+		return System.Convert.ChangeType(isNegative ? 0 : value, targetType);
+	}
+
+	public object ConvertBack(object value, Type targetType, object parameter, string language)
+	{
+		throw new NotImplementedException();
+	}
+}

--- a/src/Whim.LayoutPreview/NonNegativeValueConverter.cs
+++ b/src/Whim.LayoutPreview/NonNegativeValueConverter.cs
@@ -3,11 +3,12 @@ using System;
 
 namespace Whim.LayoutPreview;
 
-public class NonNegativeValueConverter : IValueConverter
+internal class NonNegativeValueConverter : IValueConverter
 {
 	public object Convert(object value, Type targetType, object parameter, string language)
 	{
-		bool isNegative = value switch {
+		bool isNegative = value switch
+		{
 			int i => i < 0,
 			double d => d < 0,
 			_ => throw new ArgumentException($"Unexpected type {value.GetType().Name}", nameof(value))

--- a/src/Whim.Tests/Workspace/WorkspaceManagerTests.cs
+++ b/src/Whim.Tests/Workspace/WorkspaceManagerTests.cs
@@ -19,10 +19,26 @@ public class WorkspaceManagerCustomization : ICustomization
 	{
 		// By default, create two monitors.
 		IMonitor monitor1 = Substitute.For<IMonitor>();
-		monitor1.WorkingArea.Returns(new Location<int>() { X = 0, Y = 0, Width = 1920, Height = 1080 });
+		monitor1.WorkingArea.Returns(
+			new Location<int>()
+			{
+				X = 0,
+				Y = 0,
+				Width = 1920,
+				Height = 1080
+			}
+		);
 		IMonitor monitor2 = Substitute.For<IMonitor>();
-		monitor2.WorkingArea.Returns(new Location<int>() { X = 1920, Y = 360, Width = 1080, Height = 720 });
-		
+		monitor2.WorkingArea.Returns(
+			new Location<int>()
+			{
+				X = 1920,
+				Y = 360,
+				Width = 1080,
+				Height = 720
+			}
+		);
+
 		IMonitor[] monitors = new[] { monitor1, monitor2 };
 		fixture.Inject(monitors);
 

--- a/src/Whim.Tests/Workspace/WorkspaceManagerTests.cs
+++ b/src/Whim.Tests/Workspace/WorkspaceManagerTests.cs
@@ -18,7 +18,12 @@ public class WorkspaceManagerCustomization : ICustomization
 	public void Customize(IFixture fixture)
 	{
 		// By default, create two monitors.
-		IMonitor[] monitors = new[] { Substitute.For<IMonitor>(), Substitute.For<IMonitor>() };
+		IMonitor monitor1 = Substitute.For<IMonitor>();
+		monitor1.WorkingArea.Returns(new Location<int>() { X = 0, Y = 0, Width = 1920, Height = 1080 });
+		IMonitor monitor2 = Substitute.For<IMonitor>();
+		monitor2.WorkingArea.Returns(new Location<int>() { X = 1920, Y = 360, Width = 1080, Height = 720 });
+		
+		IMonitor[] monitors = new[] { monitor1, monitor2 };
 		fixture.Inject(monitors);
 
 		IContext ctx = fixture.Freeze<IContext>();

--- a/src/Whim/ConfigLoader/ConfigLoader.cs
+++ b/src/Whim/ConfigLoader/ConfigLoader.cs
@@ -18,15 +18,6 @@ internal class ConfigLoader
 	private readonly IFileManager _fileManager;
 	private readonly string _configFilePath;
 
-	private bool DoesConfigExist() => File.Exists(_configFilePath);
-
-	/// <summary>
-	/// Loads the Whim config from the Whim config file, if it exists.
-	/// Otherwise, it will create a new Whim config file.
-	/// </summary>
-	/// <returns>The Whim config.</returns>
-	private string LoadRawConfig() => File.ReadAllText(_configFilePath);
-
 	public ConfigLoader(IFileManager fileManager)
 	{
 		_fileManager = fileManager;
@@ -87,7 +78,7 @@ internal class ConfigLoader
 		string template = ReadTemplateConfigFile(assembly);
 
 		// Save the files.
-		File.WriteAllText(_configFilePath, template);
+		_fileManager.WriteAllText(_configFilePath, template);
 	}
 
 	/// <summary>
@@ -101,13 +92,12 @@ internal class ConfigLoader
 		_fileManager.EnsureDirExists(_fileManager.WhimDir);
 
 		// Acquire the Whim config.
-		bool configExists = DoesConfigExist();
-		if (!configExists)
+		if (!_fileManager.FileExists(_configFilePath))
 		{
 			CreateConfig();
 		}
 
-		string rawConfig = LoadRawConfig();
+		string rawConfig = _fileManager.ReadAllText(_configFilePath);
 
 		// Evaluate the Whim config.
 		ScriptOptions options = ScriptOptions.Default;

--- a/src/Whim/Files/FileManager.cs
+++ b/src/Whim/Files/FileManager.cs
@@ -30,7 +30,7 @@ internal class FileManager : IFileManager
 
 	/// <inheritdoc />
 	public Stream OpenRead(string filePath) => File.OpenRead(filePath);
-	
+
 	/// <inheritdoc />
 	public string ReadAllText(string filePath) => File.ReadAllText(filePath);
 

--- a/src/Whim/Files/FileManager.cs
+++ b/src/Whim/Files/FileManager.cs
@@ -30,7 +30,18 @@ internal class FileManager : IFileManager
 
 	/// <inheritdoc />
 	public Stream OpenRead(string filePath) => File.OpenRead(filePath);
+	
+	/// <inheritdoc />
+	public string ReadAllText(string filePath) => File.ReadAllText(filePath);
 
 	/// <inheritdoc />
-	public void WriteAllText(string filePath, string contents) => File.WriteAllText(filePath, contents);
+	public void WriteAllText(string filePath, string contents)
+	{
+		string? parentPath = Path.GetDirectoryName(filePath);
+		if (parentPath != null)
+		{
+			EnsureDirExists(parentPath);
+		}
+		File.WriteAllText(filePath, contents);
+	}
 }

--- a/src/Whim/Files/IFileManager.cs
+++ b/src/Whim/Files/IFileManager.cs
@@ -45,6 +45,13 @@ public interface IFileManager
 	Stream OpenRead(string filePath);
 
 	/// <summary>
+	/// Opens a text file, reads all the text in the file, and then closes the file.
+	/// </summary>
+	/// <param name="filePath">The file path.</param>
+	/// <returns>A string containing all the text in the file.</returns>
+	string ReadAllText(string filePath);
+
+	/// <summary>
 	/// WRites the given <paramref name="contents"/> to the given <paramref name="filePath"/>.
 	/// </summary>
 	/// <param name="filePath">The file path.</param>

--- a/src/Whim/Location/Location.cs
+++ b/src/Whim/Location/Location.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Diagnostics;
 using System.Numerics;
 
 namespace Whim;
@@ -28,31 +27,11 @@ public record Location<T> : ILocation<T>, IEquatable<Location<T>>
 	/// <inheritdoc />
 	public T Y { get; set; } = T.Zero;
 
-	private T _width = T.Zero;
+	/// <inheritdoc />
+	public T Width { get; set; } = T.Zero;
 
 	/// <inheritdoc />
-	public T Width
-	{
-		get => _width;
-		set
-		{
-			Debug.Assert(!T.IsNaN(value) && value >= T.Zero);
-			_width = value;
-		}
-	}
-
-	private T _height = T.Zero;
-
-	/// <inheritdoc />
-	public T Height
-	{
-		get => _height;
-		set
-		{
-			Debug.Assert(!T.IsNaN(value) && value >= T.Zero);
-			_height = value;
-		}
-	}
+	public T Height { get; set; } = T.Zero;
 
 	/// <summary>
 	/// Creates a new <see cref="Location{T}"/> with zero values.

--- a/src/Whim/Location/Location.cs
+++ b/src/Whim/Location/Location.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 using System.Numerics;
 
 namespace Whim;
@@ -27,11 +28,31 @@ public record Location<T> : ILocation<T>, IEquatable<Location<T>>
 	/// <inheritdoc />
 	public T Y { get; set; } = T.Zero;
 
-	/// <inheritdoc />
-	public T Width { get; set; } = T.Zero;
+	private T _width = T.Zero;
 
 	/// <inheritdoc />
-	public T Height { get; set; } = T.Zero;
+	public T Width
+	{
+		get => _width;
+		set
+		{
+			Debug.Assert(value >= T.Zero);
+			_width = value;
+		}
+	}
+
+	private T _height = T.Zero;
+
+	/// <inheritdoc />
+	public T Height
+	{
+		get => _height;
+		set
+		{
+			Debug.Assert(value >= T.Zero);
+			_height = value;
+		}
+	}
 
 	/// <summary>
 	/// Creates a new <see cref="Location{T}"/> with zero values.

--- a/src/Whim/Location/Location.cs
+++ b/src/Whim/Location/Location.cs
@@ -36,7 +36,7 @@ public record Location<T> : ILocation<T>, IEquatable<Location<T>>
 		get => _width;
 		set
 		{
-			Debug.Assert(value >= T.Zero);
+			Debug.Assert(!T.IsNaN(value) && value >= T.Zero);
 			_width = value;
 		}
 	}
@@ -49,7 +49,7 @@ public record Location<T> : ILocation<T>, IEquatable<Location<T>>
 		get => _height;
 		set
 		{
-			Debug.Assert(value >= T.Zero);
+			Debug.Assert(!T.IsNaN(value) && value >= T.Zero);
 			_height = value;
 		}
 	}

--- a/src/Whim/Monitor/IMonitor.cs
+++ b/src/Whim/Monitor/IMonitor.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 
 namespace Whim;
 
@@ -71,6 +72,8 @@ public static class MonitorHelpers
 	/// <returns>The converted point, where x and y are in the range [0, 1].</returns>
 	public static IPoint<double> ToUnitSquare(this ILocation<int> monitor, IPoint<int> point, bool respectSign = false)
 	{
+		Debug.Assert(monitor.Width != 0);
+		Debug.Assert(monitor.Height != 0);
 		double x = (double)point.X / monitor.Width;
 		double y = (double)point.Y / monitor.Height;
 
@@ -88,6 +91,8 @@ public static class MonitorHelpers
 	/// <returns>The converted point, where x and y are in the range [0, 1].</returns>
 	public static ILocation<double> ToUnitSquare(this ILocation<int> monitor, ILocation<int> location)
 	{
+		Debug.Assert(monitor.Width != 0);
+		Debug.Assert(monitor.Height != 0);
 		double x = Math.Abs((double)location.X / monitor.Width);
 		double y = Math.Abs((double)location.Y / monitor.Height);
 		double width = Math.Abs((double)location.Width / monitor.Width);

--- a/src/Whim/Native/WindowExtensions.cs
+++ b/src/Whim/Native/WindowExtensions.cs
@@ -58,7 +58,7 @@ public static class WindowExtensions
 		}
 		catch (NotImplementedException)
 		{
-			Logger.Debug($"{nameof(AppWindow.IsShownInSwitchers)} isn't implemented, ignoring attempt to set it to: {show}");
+			Logger.Error($"{nameof(AppWindow.IsShownInSwitchers)} isn't implemented, ignoring attempt to set it to: {show}");
 		}
 	}
 

--- a/src/Whim/Native/WindowExtensions.cs
+++ b/src/Whim/Native/WindowExtensions.cs
@@ -58,7 +58,9 @@ public static class WindowExtensions
 		}
 		catch (NotImplementedException)
 		{
-			Logger.Error($"{nameof(AppWindow.IsShownInSwitchers)} isn't implemented, ignoring attempt to set it to: {show}");
+			Logger.Error(
+				$"{nameof(AppWindow.IsShownInSwitchers)} isn't implemented, ignoring attempt to set it to: {show}"
+			);
 		}
 	}
 

--- a/src/Whim/Native/WindowExtensions.cs
+++ b/src/Whim/Native/WindowExtensions.cs
@@ -2,6 +2,7 @@ using Microsoft.UI;
 using Microsoft.UI.Composition.SystemBackdrops;
 using Microsoft.UI.Windowing;
 using Microsoft.UI.Xaml.Media;
+using System;
 using Windows.Win32.Foundation;
 
 namespace Whim;
@@ -51,7 +52,14 @@ public static class WindowExtensions
 	/// <param name="show"></param>
 	public static void SetIsShownInSwitchers(this Microsoft.UI.Xaml.Window window, bool show)
 	{
-		window.GetAppWindow().IsShownInSwitchers = show;
+		try
+		{
+			window.GetAppWindow().IsShownInSwitchers = show;
+		}
+		catch (NotImplementedException)
+		{
+			Logger.Debug($"{nameof(AppWindow.IsShownInSwitchers)} isn't implemented, ignoring attempt to set it to: {show}");
+		}
 	}
 
 	/// <summary>

--- a/src/Whim/Workspace/Workspace.cs
+++ b/src/Whim/Workspace/Workspace.cs
@@ -517,6 +517,12 @@ internal class Workspace : IWorkspace, IInternalWorkspace
 	{
 		Logger.Debug($"Workspace {Name}");
 
+		if (_disposedValue)
+		{
+			Logger.Debug($"Workspace {Name} is disposed, skipping layout");
+			return Task.CompletedTask;
+		}
+
 		if (GarbageCollect())
 		{
 			Logger.Debug($"Garbage collected windows, skipping layout for workspace {Name}");
@@ -562,7 +568,6 @@ internal class Workspace : IWorkspace, IInternalWorkspace
 				{
 					if (_layoutQueue.IsEmpty)
 					{
-						_cancellationTokenSource?.Dispose();
 						_cancellationTokenSource = null;
 					}
 


### PR DESCRIPTION
This contains minor fixes I had to make to get things running.

Changes made:
* Prevent negative Width and Height values for `PreviewWindowItem` and `Location`
* Run `EnsureDirExists` before writing anything using `FileManager`
* Skip `doLayout` on disposed workspace
* Ignore calls to `SetIsShownInSwitchers` which throw `NotImplementedException`

More details in each commit message.