### PR TITLE
Fix multi-monitor support

### DIFF
--- a/src/Whim/Native/CoreNativeManager.cs
+++ b/src/Whim/Native/CoreNativeManager.cs
@@ -75,21 +75,13 @@ internal class CoreNativeManager : ICoreNativeManager
 		return result;
 	}
 
-	public MONITORINFO? GetMonitorInfo(HMONITOR hMonitor)
-	{
-		MONITORINFO lpmi = default;
-		bool result = PInvoke.GetMonitorInfo(hMonitor, ref lpmi);
-		return result ? lpmi : null;
-	}
-
 	public MONITORINFOEXW? GetMonitorInfoEx(HMONITOR hMonitor)
 	{
 		unsafe
 		{
-			MONITORINFOEXW lpmi = default;
-
-			bool result = PInvoke.GetMonitorInfo(hMonitor, (MONITORINFO*)&lpmi);
-			return result ? lpmi : null;
+			MONITORINFOEXW infoEx = new() { monitorInfo = new MONITORINFO() { cbSize = (uint)sizeof(MONITORINFOEXW) } };
+			MONITORINFOEXW* infoExPtr = &infoEx;
+			return PInvoke.GetMonitorInfo(hMonitor, (MONITORINFO*)infoExPtr) ? infoEx : null;
 		}
 	}
 

--- a/src/Whim/Native/ICoreNativeManager.cs
+++ b/src/Whim/Native/ICoreNativeManager.cs
@@ -170,18 +170,6 @@ internal interface ICoreNativeManager
 	/// </remarks>
 	/// <param name="hMonitor"></param>
 	/// <returns></returns>
-	MONITORINFO? GetMonitorInfo(HMONITOR hMonitor);
-
-	/// <summary>
-	/// Retrieve information about a display monitor.
-	/// </summary>
-	/// <remarks>
-	/// This uses <see cref="PInvoke.GetMonitorInfo(HMONITOR, ref MONITORINFO)"/> <br/>
-	///
-	/// For more, see https://docs.microsoft.com/windows/win32/api/winuser/nf-winuser-getmonitorinfoa
-	/// </remarks>
-	/// <param name="hMonitor"></param>
-	/// <returns></returns>
 	MONITORINFOEXW? GetMonitorInfoEx(HMONITOR hMonitor);
 
 	/// <summary>


### PR DESCRIPTION
Fixed native calls in `GetMonitorInfoEx`, and removed unused `GetMonitorInfo`.