### PR TITLE
Hide BarWindows in taskbar and ALT+TAB

### DIFF
--- a/src/Whim.Bar/BarWindow.xaml.cs
+++ b/src/Whim.Bar/BarWindow.xaml.cs
@@ -45,6 +45,7 @@ public sealed partial class BarWindow : Microsoft.UI.Xaml.Window
 		// Workaround for https://github.com/microsoft/microsoft-ui-xaml/issues/3689
 		Title = "Whim Bar";
 		_context.NativeManager.HideCaptionButtons(WindowState.Window.Handle);
+		_context.NativeManager.SetExToolWindow(WindowState.Window.Handle);
 		this.SetIsShownInSwitchers(false);
 		this.SetSystemBackdrop();
 

--- a/src/Whim/Native/INativeManager.cs
+++ b/src/Whim/Native/INativeManager.cs
@@ -184,4 +184,11 @@ public interface INativeManager
 	/// </summary>
 	/// <param name="hwnd"></param>
 	void RemoveWindowExTransparent(HWND hwnd);
+
+	/// <summary>
+	/// Sets the given <paramref name="hwnd"/> to be a toolwindow.
+	/// A tool window does not appear in the taskbar or in the dialog that appears when the user presses ALT+TAB.
+	/// </summary>
+	/// <param name="hwnd"></param>
+	void SetExToolWindow(HWND hwnd);
 }

--- a/src/Whim/Native/NativeManager.cs
+++ b/src/Whim/Native/NativeManager.cs
@@ -317,4 +317,15 @@ public partial class NativeManager : INativeManager
 			exStyle & ~(int)WINDOW_EX_STYLE.WS_EX_LAYERED
 		);
 	}
+
+	/// <inheritdoc/>
+	public void SetExToolWindow(HWND hwnd)
+	{
+		int exStyle = PInvoke.GetWindowLong(hwnd, WINDOW_LONG_PTR_INDEX.GWL_EXSTYLE);
+		_ = PInvoke.SetWindowLong(
+			hwnd,
+			WINDOW_LONG_PTR_INDEX.GWL_EXSTYLE,
+			exStyle | (int)WINDOW_EX_STYLE.WS_EX_TOOLWINDOW
+		);
+	}
 }


### PR DESCRIPTION
 Add EX_TOOLWINDOW flag to BarWindows to prevent them from showing upp in the taskbar and in ALT+TAB