### PR TITLE
Lazily evaluate Bounds and WorkingArea

### DIFF
--- a/src/Whim.Tests/Monitor/MonitorTests.cs
+++ b/src/Whim.Tests/Monitor/MonitorTests.cs
@@ -112,7 +112,6 @@ public class MonitorTests
 	internal void CreateMonitor_MultipleMonitors(IInternalContext internalCtx, HMONITOR hmonitor)
 	{
 		// Given
-
 		internalCtx.CoreNativeManager.HasMultipleMonitors().Returns(true);
 
 		internalCtx.CoreNativeManager
@@ -162,6 +161,24 @@ public class MonitorTests
 			monitor.WorkingArea
 		);
 		Assert.Equal(150, monitor.ScaleFactor);
+	}
+
+	[Theory, AutoSubstituteData<MonitorCustomization>]
+	internal void CreateMonitor_CreationFailed(IInternalContext internalCtx, HMONITOR hmonitor)
+	{
+		// Given
+		bool isPrimaryHMonitor = false;
+		internalCtx.CoreNativeManager.HasMultipleMonitors().Returns(true);
+		internalCtx.CoreNativeManager.GetMonitorInfoEx(Arg.Any<HMONITOR>()).Returns((_) => null);
+
+		// When
+		Monitor monitor = new(internalCtx, hmonitor, isPrimaryHMonitor);
+
+		// Then
+		Assert.Equal("NOT A DISPLAY", monitor.Name);
+		Assert.False(monitor.IsPrimary);
+		Assert.Equal(new Location<int>(), monitor.Bounds);
+		Assert.Equal(new Location<int>(), monitor.WorkingArea);
 	}
 
 	[Theory, AutoSubstituteData<MonitorCustomization>]

--- a/src/Whim/Monitor/Monitor.cs
+++ b/src/Whim/Monitor/Monitor.cs
@@ -45,6 +45,7 @@ internal class Monitor : IMonitor
 		}
 		else
 		{
+			Logger.Error($"Failed to get name for monitor {_hmonitor}");
 			Name = "NOT A DISPLAY";
 		}
 
@@ -78,6 +79,7 @@ internal class Monitor : IMonitor
 		}
 		else
 		{
+			Logger.Error($"Failed to get bounds for monitor {_hmonitor}");
 			return new Location<int>();
 		}
 	}
@@ -96,6 +98,7 @@ internal class Monitor : IMonitor
 		}
 		else
 		{
+			Logger.Error($"Failed to get working area for monitor {_hmonitor}");
 			return new Location<int>();
 		}
 	}


### PR DESCRIPTION
Lazily evaluate `Bounds` and `WorkingArea`, to handle RDP returning some incorrect values during display changes.