### PR TITLE
Cache GitHub Actions

### DIFF
--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -47,42 +47,37 @@ jobs:
         run: |
           dotnet tool restore
 
-      # TODO: Remove
-      - name: Check dependencies
+      - name: Check C# formatting
         run: |
-          ls ~/.nuget/packages
+          dotnet tool run dotnet-csharpier . --check
 
-      # - name: Check C# formatting
-      #   run: |
-      #     dotnet tool run dotnet-csharpier . --check
+      - name: Check XAML formatting
+        run: |
+          dotnet tool run xstyler --recursive --d . --passive --config ./.xamlstylerrc
 
-      # - name: Check XAML formatting
-      #   run: |
-      #     dotnet tool run xstyler --recursive --d . --passive --config ./.xamlstylerrc
+      #   - name: Check analyzers
+      #     run: |
+      #       dotnet format analyzers Whim.sln --verify-no-changes --no-restore
 
-      # #   - name: Check analyzers
-      # #     run: |
-      # #       dotnet format analyzers Whim.sln --verify-no-changes --no-restore
+      - name: Add msbuild to PATH
+        uses: microsoft/setup-msbuild@v1.1
 
-      # - name: Add msbuild to PATH
-      #   uses: microsoft/setup-msbuild@v1.1
+      - name: Build
+        run: |
+          msbuild Whim.sln `
+            -p:Configuration=$env:Configuration `
+            -p:Platform=$env:Platform `
+            -p:BuildInParallel=true `
+            -maxCpuCount
+        env:
+          Configuration: ${{ matrix.configuration }}
+          Platform: ${{ matrix.platform }}
 
-      # - name: Build
-      #   run: |
-      #     msbuild Whim.sln `
-      #       -p:Configuration=$env:Configuration `
-      #       -p:Platform=$env:Platform `
-      #       -p:BuildInParallel=true `
-      #       -maxCpuCount
-      #   env:
-      #     Configuration: ${{ matrix.configuration }}
-      #     Platform: ${{ matrix.platform }}
+      - name: Test
+        run: |
+          dotnet test Whim.sln --collect:"XPlat Code Coverage;Format=opencover"
 
-      # - name: Test
-      #   run: |
-      #     dotnet test Whim.sln --collect:"XPlat Code Coverage;Format=opencover"
-
-      # - name: Upload coverage to Codecov
-      #   uses: codecov/codecov-action@v3.1.0
-      #   with:
-      #     files: src/**/TestResults/**/coverage.opencover.xml
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3.1.0
+        with:
+          files: src/**/TestResults/**/coverage.opencover.xml

--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -39,45 +39,45 @@ jobs:
 
       - name: Restore dependencies
         run: |
-          dotnet restore Whim.sln -p:Configuration=$env:Configuration --packages=${{ github.workspace }}/.nuget/packages
+          dotnet restore Whim.sln -p:Configuration=$env:Configuration -v:d
         env:
           Configuration: ${{ matrix.configuration }}
 
       - name: Install dotnet tools
         run: |
-          dotnet tool restore
+          dotnet tool restore -v:d
 
-      - name: Check C# formatting
-        run: |
-          dotnet tool run dotnet-csharpier . --check
+      # - name: Check C# formatting
+      #   run: |
+      #     dotnet tool run dotnet-csharpier . --check
 
-      - name: Check XAML formatting
-        run: |
-          dotnet tool run xstyler --recursive --d . --passive --config ./.xamlstylerrc
+      # - name: Check XAML formatting
+      #   run: |
+      #     dotnet tool run xstyler --recursive --d . --passive --config ./.xamlstylerrc
 
-      #   - name: Check analyzers
-      #     run: |
-      #       dotnet format analyzers Whim.sln --verify-no-changes --no-restore
+      # #   - name: Check analyzers
+      # #     run: |
+      # #       dotnet format analyzers Whim.sln --verify-no-changes --no-restore
 
-      - name: Add msbuild to PATH
-        uses: microsoft/setup-msbuild@v1.1
+      # - name: Add msbuild to PATH
+      #   uses: microsoft/setup-msbuild@v1.1
 
-      - name: Build
-        run: |
-          msbuild Whim.sln `
-            -p:Configuration=$env:Configuration `
-            -p:Platform=$env:Platform `
-            -p:BuildInParallel=true `
-            -maxCpuCount
-        env:
-          Configuration: ${{ matrix.configuration }}
-          Platform: ${{ matrix.platform }}
+      # - name: Build
+      #   run: |
+      #     msbuild Whim.sln `
+      #       -p:Configuration=$env:Configuration `
+      #       -p:Platform=$env:Platform `
+      #       -p:BuildInParallel=true `
+      #       -maxCpuCount
+      #   env:
+      #     Configuration: ${{ matrix.configuration }}
+      #     Platform: ${{ matrix.platform }}
 
-      - name: Test
-        run: |
-          dotnet test Whim.sln --collect:"XPlat Code Coverage;Format=opencover"
+      # - name: Test
+      #   run: |
+      #     dotnet test Whim.sln --collect:"XPlat Code Coverage;Format=opencover"
 
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3.1.0
-        with:
-          files: src/**/TestResults/**/coverage.opencover.xml
+      # - name: Upload coverage to Codecov
+      #   uses: codecov/codecov-action@v3.1.0
+      #   with:
+      #     files: src/**/TestResults/**/coverage.opencover.xml

--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -17,7 +17,7 @@ on:
 
 env:
   # We install the packages to the D:\ drive to avoid the slow IO on the C:\ drive.
-  # Based on https://github.com/actions/setup-dotnet/issues/260
+  # Based on https://github.com/actions/setup-dotnet/issues/260#issuecomment-1790162905
   NUGET_PACKAGES: D:\a\.nuget\packages
 
 jobs:

--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Cache NuGet packages
         uses: actions/cache@v2
         with:
-          path: $HOME/.nuget/packages
+          path: ~/.nuget/packages
           key: ${{ matrix.platform }}-nuget-${{ hashFiles('Directory.Packages.props') }}
           restore-keys: |
             ${{ matrix.platform }}-nuget-${{ hashFiles('Directory.Packages.props') }}
@@ -39,13 +39,18 @@ jobs:
 
       - name: Restore dependencies
         run: |
-          dotnet restore Whim.sln -p:Configuration=$env:Configuration -v:d
+          dotnet restore Whim.sln -p:Configuration=$env:Configuration
         env:
           Configuration: ${{ matrix.configuration }}
 
       - name: Install dotnet tools
         run: |
-          dotnet tool restore -v:d
+          dotnet tool restore
+
+      # TODO: Remove
+      - name: Check dependencies
+        run: |
+          ls ~/.nuget/packages
 
       # - name: Check C# formatting
       #   run: |

--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -32,8 +32,10 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{ github.workspace }}/.nuget/packages
-          key: ${{ runner.os }}-nuget-${{ hashFiles('**/packages.lock.json') }}
-          restore-keys: ${{ runner.os }}-nuget-
+          key: ${{ matrix.platform }}-nuget-${{ hashFiles('Directory.Packages.props') }}
+          restore-keys: |
+            ${{ matrix.platform }}-nuget-${{ hashFiles('Directory.Packages.props') }}
+            ${{ matrix.platform }}-nuget-
 
       - name: Restore dependencies
         run: |

--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -33,8 +33,7 @@ jobs:
         with:
           path: ${{ github.workspace }}/.nuget/packages
           key: ${{ runner.os }}-nuget-${{ hashFiles('**/packages.lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-nuget-
+          restore-keys: ${{ runner.os }}-nuget-
 
       - name: Restore dependencies
         run: |

--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -28,6 +28,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - name: Cache NuGet packages
+        uses: actions/cache@v2
+        with:
+          path: ${{ github.workspace }}/.nuget/packages
+          key: ${{ runner.os }}-nuget-${{ hashFiles('**/packages.lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-nuget-
+
       - name: Restore dependencies
         run: |
           dotnet restore Whim.sln -p:Configuration=$env:Configuration

--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -16,6 +16,8 @@ on:
       - "README.md"
 
 env:
+  # We install the packages to the D:\ drive to avoid the slow IO on the C:\ drive.
+  # Based on https://github.com/actions/setup-dotnet/issues/260
   NUGET_PACKAGES: D:\a\.nuget\packages
 
 jobs:
@@ -29,10 +31,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Cache NuGet packages
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ env.NUGET_PACKAGES }}
           key: ${{ matrix.platform }}-nuget-${{ hashFiles('Directory.Packages.props') }}

--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Cache NuGet packages
         uses: actions/cache@v2
         with:
-          path: ${{ github.workspace }}/.nuget/packages
+          path: $HOME/.nuget/packages
           key: ${{ matrix.platform }}-nuget-${{ hashFiles('Directory.Packages.props') }}
           restore-keys: |
             ${{ matrix.platform }}-nuget-${{ hashFiles('Directory.Packages.props') }}

--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -15,6 +15,9 @@ on:
       - ".github/pull_request_template.md"
       - "README.md"
 
+env:
+  NUGET_PACKAGES: D:\a\.nuget\packages
+
 jobs:
   commit:
     strategy:
@@ -31,7 +34,7 @@ jobs:
       - name: Cache NuGet packages
         uses: actions/cache@v2
         with:
-          path: ~/.nuget/packages
+          path: ${{ env.NUGET_PACKAGES }}
           key: ${{ matrix.platform }}-nuget-${{ hashFiles('Directory.Packages.props') }}
           restore-keys: |
             ${{ matrix.platform }}-nuget-${{ hashFiles('Directory.Packages.props') }}

--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Restore dependencies
         run: |
-          dotnet restore Whim.sln -p:Configuration=$env:Configuration
+          dotnet restore Whim.sln -p:Configuration=$env:Configuration --packages=${{ github.workspace }}/.nuget/packages
         env:
           Configuration: ${{ matrix.configuration }}
 


### PR DESCRIPTION
Improved `commit` workflow job times from an average of 8m to:

- 6m 30s uncached
- 5m 30s cached

Times were improved by:

- Adding caching
- Installing packages to the `D:\` drive, as described in <https://github.com/actions/setup-dotnet/issues/260#issuecomment-1790162905>
