### PR TITLE
Treat left and right key modifiers the same

### DIFF
--- a/src/Whim.CommandPalette/Variants/Menu/MenuVariantRowView.xaml.cs
+++ b/src/Whim.CommandPalette/Variants/Menu/MenuVariantRowView.xaml.cs
@@ -12,10 +12,13 @@ internal sealed partial class MenuVariantRowView
 {
 	public static double MenuRowHeight => 36;
 
+	private readonly IContext _context;
+
 	public MenuVariantRowViewModel ViewModel { get; }
 
-	public MenuVariantRowView(MatcherResult<MenuVariantRowModelData> matcherResult)
+	public MenuVariantRowView(IContext context, MatcherResult<MenuVariantRowModelData> matcherResult)
 	{
+		_context = context;
 		ViewModel = new MenuVariantRowViewModel(matcherResult);
 		UIElementExtensions.InitializeComponent(this, "Whim.CommandPalette", "Variants/Menu/MenuVariantRowView");
 	}
@@ -40,7 +43,7 @@ internal sealed partial class MenuVariantRowView
 
 		if (ViewModel.Model.Data.Keybind is not null)
 		{
-			CommandKeybind.Text = ViewModel.Model.Data.Keybind.ToString();
+			CommandKeybind.Text = ViewModel.Model.Data.Keybind.ToString(_context.KeybindManager.UnifyKeyModifiers);
 			CommandKeybindBorder.Visibility = Visibility.Visible;
 		}
 		else

--- a/src/Whim.CommandPalette/Variants/Menu/MenuVariantViewModel.cs
+++ b/src/Whim.CommandPalette/Variants/Menu/MenuVariantViewModel.cs
@@ -97,7 +97,7 @@ internal class MenuVariantViewModel : IVariantViewModel
 		_context = context;
 		_commandPaletteWindowViewModel = commandPaletteWindowViewModel;
 		_menuRowFactory =
-			menuRowFactory ?? ((MatcherResult<MenuVariantRowModelData> item) => new MenuVariantRowView(item));
+			menuRowFactory ?? ((MatcherResult<MenuVariantRowModelData> item) => new MenuVariantRowView(_context, item));
 
 		// Populate the commands to reduce the first render time.
 		PopulateItems(context.CommandManager);

--- a/src/Whim.Tests/Keybinds/KeyModifiersTests.cs
+++ b/src/Whim.Tests/Keybinds/KeyModifiersTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using Windows.Win32.UI.Input.KeyboardAndMouse;
 using Xunit;
 
 namespace Whim.Tests;
@@ -6,20 +7,21 @@ namespace Whim.Tests;
 public class KeyModifiersTests
 {
 	[Theory]
-	[InlineData(KeyModifiers.None, new string[] { })]
-	[InlineData(KeyModifiers.LControl, new string[] { "LCtrl" })]
-	[InlineData(KeyModifiers.RControl, new string[] { "RCtrl" })]
-	[InlineData(KeyModifiers.LShift, new string[] { "LShift" })]
-	[InlineData(KeyModifiers.RShift, new string[] { "RShift" })]
-	[InlineData(KeyModifiers.LAlt, new string[] { "LAlt" })]
-	[InlineData(KeyModifiers.RAlt, new string[] { "RAlt" })]
-	[InlineData(KeyModifiers.LWin, new string[] { "LWin" })]
-	[InlineData(KeyModifiers.RWin, new string[] { "RWin" })]
-	[InlineData(KeyModifiers.LControl | KeyModifiers.LShift, new string[] { "LCtrl", "LShift" })]
-	[InlineData(KeyModifiers.LControl | KeyModifiers.LAlt, new string[] { "LCtrl", "LAlt" })]
-	[InlineData(KeyModifiers.LControl | KeyModifiers.LWin, new string[] { "LWin", "LCtrl" })]
+	[InlineData(KeyModifiers.None, false, new string[] { })]
+	[InlineData(KeyModifiers.LControl, false, new string[] { "LCtrl" })]
+	[InlineData(KeyModifiers.RControl, false, new string[] { "RCtrl" })]
+	[InlineData(KeyModifiers.LShift, false, new string[] { "LShift" })]
+	[InlineData(KeyModifiers.RShift, false, new string[] { "RShift" })]
+	[InlineData(KeyModifiers.LAlt, false, new string[] { "LAlt" })]
+	[InlineData(KeyModifiers.RAlt, false, new string[] { "RAlt" })]
+	[InlineData(KeyModifiers.LWin, false, new string[] { "LWin" })]
+	[InlineData(KeyModifiers.RWin, false, new string[] { "RWin" })]
+	[InlineData(KeyModifiers.LControl | KeyModifiers.LShift, false, new string[] { "LCtrl", "LShift" })]
+	[InlineData(KeyModifiers.LControl | KeyModifiers.LAlt, false, new string[] { "LCtrl", "LAlt" })]
+	[InlineData(KeyModifiers.LControl | KeyModifiers.LWin, false, new string[] { "LWin", "LCtrl" })]
 	[InlineData(
 		KeyModifiers.LControl | KeyModifiers.LShift | KeyModifiers.LAlt,
+		false,
 		new string[] { "LCtrl", "LShift", "LAlt" }
 	)]
 	[InlineData(
@@ -31,12 +33,83 @@ public class KeyModifiersTests
 			| KeyModifiers.RAlt
 			| KeyModifiers.LShift
 			| KeyModifiers.RShift,
+		false,
 		new string[] { "LWin", "RWin", "LCtrl", "RCtrl", "LShift", "RShift", "LAlt", "RAlt" }
 	)]
-	public void GetParts_ReturnsCorrectParts(KeyModifiers modifiers, string[] expected)
+	[InlineData(KeyModifiers.None, true, new string[] { })]
+	[InlineData(KeyModifiers.LControl, true, new string[] { "Ctrl" })]
+	[InlineData(KeyModifiers.RControl, true, new string[] { "Ctrl" })]
+	[InlineData(KeyModifiers.LShift, true, new string[] { "Shift" })]
+	[InlineData(KeyModifiers.RShift, true, new string[] { "Shift" })]
+	[InlineData(KeyModifiers.LAlt, true, new string[] { "Alt" })]
+	[InlineData(KeyModifiers.RAlt, true, new string[] { "Alt" })]
+	[InlineData(KeyModifiers.LWin, true, new string[] { "Win" })]
+	[InlineData(KeyModifiers.RWin, true, new string[] { "Win" })]
+	[InlineData(KeyModifiers.LControl | KeyModifiers.LShift, true, new string[] { "Ctrl", "Shift" })]
+	[InlineData(KeyModifiers.LControl | KeyModifiers.LAlt, true, new string[] { "Ctrl", "Alt" })]
+	[InlineData(KeyModifiers.LControl | KeyModifiers.LWin, true, new string[] { "Win", "Ctrl" })]
+	[InlineData(
+		KeyModifiers.LControl | KeyModifiers.LShift | KeyModifiers.LAlt,
+		true,
+		new string[] { "Ctrl", "Shift", "Alt" }
+	)]
+	[InlineData(
+		KeyModifiers.LWin
+			| KeyModifiers.RWin
+			| KeyModifiers.LControl
+			| KeyModifiers.RControl
+			| KeyModifiers.LAlt
+			| KeyModifiers.RAlt
+			| KeyModifiers.LShift
+			| KeyModifiers.RShift,
+		true,
+		new string[] { "Win", "Ctrl", "Shift", "Alt" }
+	)]
+	public void GetParts_ReturnsCorrectParts(KeyModifiers modifiers, bool unifyKeyModifiers, string[] expected)
 	{
-		IEnumerable<string> parts = modifiers.GetParts();
+		IEnumerable<string> parts = modifiers.GetParts(unifyKeyModifiers);
 
 		Assert.Equal(expected, parts);
+	}
+
+	[Theory]
+	[InlineData(KeyModifiers.None, KeyModifiers.None)]
+	[InlineData(KeyModifiers.LControl, KeyModifiers.LControl)]
+	[InlineData(KeyModifiers.RControl, KeyModifiers.LControl)]
+	[InlineData(KeyModifiers.LShift, KeyModifiers.LShift)]
+	[InlineData(KeyModifiers.RShift, KeyModifiers.LShift)]
+	[InlineData(KeyModifiers.LAlt, KeyModifiers.LAlt)]
+	[InlineData(KeyModifiers.RAlt, KeyModifiers.LAlt)]
+	[InlineData(KeyModifiers.LWin, KeyModifiers.LWin)]
+	[InlineData(KeyModifiers.RWin, KeyModifiers.LWin)]
+	[InlineData(KeyModifiers.LControl | KeyModifiers.LShift, KeyModifiers.LControl | KeyModifiers.LShift)]
+	[InlineData(KeyModifiers.LControl | KeyModifiers.LAlt, KeyModifiers.LControl | KeyModifiers.LAlt)]
+	[InlineData(KeyModifiers.LControl | KeyModifiers.LWin, KeyModifiers.LControl | KeyModifiers.LWin)]
+	[InlineData(
+		KeyModifiers.LControl | KeyModifiers.LShift | KeyModifiers.LAlt,
+		KeyModifiers.LControl | KeyModifiers.LShift | KeyModifiers.LAlt
+	)]
+	[InlineData(
+		KeyModifiers.LWin
+			| KeyModifiers.RWin
+			| KeyModifiers.LControl
+			| KeyModifiers.RControl
+			| KeyModifiers.LAlt
+			| KeyModifiers.RAlt
+			| KeyModifiers.LShift
+			| KeyModifiers.RShift,
+		KeyModifiers.LWin | KeyModifiers.LControl | KeyModifiers.LAlt | KeyModifiers.LShift
+	)]
+	public void UnifyModifiers(KeyModifiers modifiers, KeyModifiers expectedModifiers)
+	{
+		// Given
+		IKeybind keybind = new Keybind(modifiers, VIRTUAL_KEY.VK_A);
+
+		// When
+		IKeybind unifiedKeybind = keybind.UnifyModifiers();
+
+		// Then
+		Assert.Equal(expectedModifiers, unifiedKeybind.Modifiers);
+		Assert.Equal(VIRTUAL_KEY.VK_A, unifiedKeybind.Key);
 	}
 }

--- a/src/Whim.Tests/Keybinds/KeybindManagerTests.cs
+++ b/src/Whim.Tests/Keybinds/KeybindManagerTests.cs
@@ -232,4 +232,47 @@ public class KeybindManagerTests
 		Assert.Single(allCommands);
 		Assert.Same(command, allCommands[0]);
 	}
+
+	[Theory, AutoSubstituteData]
+	public void GetCommands_NotUnified_FailedLookup(IContext context)
+	{
+		// Given
+		IKeybindManager keybindManager = new KeybindManager(context) { UnifyKeyModifiers = false };
+		IKeybind keybind = new Keybind(KeyModifiers.RWin | KeyModifiers.RControl, VIRTUAL_KEY.VK_A);
+
+		// When
+		keybindManager.Add("command", keybind);
+		ICommand[] allCommands = keybindManager.GetCommands(
+			new Keybind(KeyModifiers.LWin | KeyModifiers.LControl, VIRTUAL_KEY.VK_A)
+		);
+
+		// Then
+		Assert.Empty(allCommands);
+	}
+
+	[Theory]
+	[InlineAutoSubstituteData(KeyModifiers.LWin | KeyModifiers.LControl, VIRTUAL_KEY.VK_A)]
+	[InlineAutoSubstituteData(KeyModifiers.RWin | KeyModifiers.RControl, VIRTUAL_KEY.VK_A)]
+	[InlineAutoSubstituteData(KeyModifiers.LWin | KeyModifiers.RControl, VIRTUAL_KEY.VK_A)]
+	public void GetCommands_NotUnified_Success(
+		KeyModifiers modifiers,
+		VIRTUAL_KEY key,
+		IContext context,
+		ICommand command
+	)
+	{
+		// Given
+		IKeybindManager keybindManager = new KeybindManager(context) { UnifyKeyModifiers = false };
+		IKeybind keybind = new Keybind(modifiers, key);
+
+		context.CommandManager.TryGetCommand("command").Returns(command);
+
+		// When
+		keybindManager.Add("command", keybind);
+		ICommand[] allCommands = keybindManager.GetCommands(keybind);
+
+		// Then
+		Assert.Single(allCommands);
+		Assert.Same(command, allCommands[0]);
+	}
 }

--- a/src/Whim.Tests/Keybinds/KeybindManagerTests.cs
+++ b/src/Whim.Tests/Keybinds/KeybindManagerTests.cs
@@ -210,4 +210,26 @@ public class KeybindManagerTests
 		Assert.NotNull(result);
 		Assert.Equal(new Keybind(KeyModifiers.LWin | KeyModifiers.LControl, VIRTUAL_KEY.VK_A), result);
 	}
+
+	[Theory]
+	[InlineAutoSubstituteData(KeyModifiers.LWin | KeyModifiers.LControl, VIRTUAL_KEY.VK_A)]
+	[InlineAutoSubstituteData(KeyModifiers.RWin | KeyModifiers.RControl, VIRTUAL_KEY.VK_A)]
+	[InlineAutoSubstituteData(KeyModifiers.LWin | KeyModifiers.RControl, VIRTUAL_KEY.VK_A)]
+	[InlineAutoSubstituteData(KeyModifiers.RWin | KeyModifiers.LControl, VIRTUAL_KEY.VK_A)]
+	public void GetCommands_Unified(KeyModifiers modifiers, VIRTUAL_KEY key, IContext context, ICommand command)
+	{
+		// Given
+		IKeybindManager keybindManager = new KeybindManager(context);
+		IKeybind keybind = new Keybind(KeyModifiers.RWin | KeyModifiers.RControl, VIRTUAL_KEY.VK_A);
+
+		context.CommandManager.TryGetCommand("command").Returns(command);
+
+		// When
+		keybindManager.Add("command", keybind);
+		ICommand[] allCommands = keybindManager.GetCommands(new Keybind(modifiers, key));
+
+		// Then
+		Assert.Single(allCommands);
+		Assert.Same(command, allCommands[0]);
+	}
 }

--- a/src/Whim.Tests/Keybinds/KeybindManagerTests.cs
+++ b/src/Whim.Tests/Keybinds/KeybindManagerTests.cs
@@ -47,6 +47,25 @@ public class KeybindManagerTests
 	}
 
 	[Theory, AutoSubstituteData]
+	public void Add_UnifyKeyModifiers(IContext context, ICommand command)
+	{
+		// Given
+		IKeybindManager keybindManager = new KeybindManager(context);
+		IKeybind keybind = new Keybind(KeyModifiers.RWin | KeyModifiers.RControl, VIRTUAL_KEY.VK_A);
+
+		context.CommandManager.TryGetCommand("command").Returns(command);
+
+		// When
+		keybindManager.UnifyKeyModifiers = true;
+		keybindManager.Add("command", keybind);
+
+		// Then
+		IKeybind? result = keybindManager.TryGetKeybind("command");
+		Assert.NotNull(result);
+		Assert.Equal(new Keybind(KeyModifiers.LWin | KeyModifiers.LControl, VIRTUAL_KEY.VK_A), result);
+	}
+
+	[Theory, AutoSubstituteData]
 	public void GetCommands_DoesNotContainKeybind(IContext context)
 	{
 		// Given
@@ -96,6 +115,26 @@ public class KeybindManagerTests
 		Assert.Equal(2, allCommands.Length);
 		Assert.Equal(command, allCommands[0]);
 		Assert.Equal(command2, allCommands[1]);
+	}
+
+	[Theory, AutoSubstituteData]
+	public void GetCommands_UnifyKeyModifiers(IContext context, ICommand command)
+	{
+		// Given
+		IKeybindManager keybindManager = new KeybindManager(context);
+		IKeybind leftKeybind = new Keybind(KeyModifiers.LWin | KeyModifiers.LControl, VIRTUAL_KEY.VK_A);
+		IKeybind rightKeybind = new Keybind(KeyModifiers.RWin | KeyModifiers.RControl, VIRTUAL_KEY.VK_A);
+
+		context.CommandManager.TryGetCommand("command").Returns(command);
+
+		// When
+		keybindManager.UnifyKeyModifiers = true;
+		keybindManager.Add("command", rightKeybind);
+
+		// Then
+		ICommand[] allCommands = keybindManager.GetCommands(leftKeybind);
+		Assert.Single(allCommands);
+		Assert.Equal(command, allCommands[0]);
 	}
 
 	[Theory, AutoSubstituteData]
@@ -153,5 +192,22 @@ public class KeybindManagerTests
 		// Then
 		Assert.True(result);
 		Assert.Empty(keybindManager.GetCommands(keybind));
+	}
+
+	[Theory, AutoSubstituteData]
+	public void UnifyKeyModifiers_SetToTrue(IContext context)
+	{
+		// Given
+		IKeybindManager keybindManager = new KeybindManager(context) { UnifyKeyModifiers = false };
+		IKeybind keybind = new Keybind(KeyModifiers.RWin | KeyModifiers.RControl, VIRTUAL_KEY.VK_A);
+
+		// When
+		keybindManager.Add("command", keybind);
+		keybindManager.UnifyKeyModifiers = true;
+
+		// Then
+		IKeybind? result = keybindManager.TryGetKeybind("command");
+		Assert.NotNull(result);
+		Assert.Equal(new Keybind(KeyModifiers.LWin | KeyModifiers.LControl, VIRTUAL_KEY.VK_A), result);
 	}
 }

--- a/src/Whim.Tests/Keybinds/KeybindTests.cs
+++ b/src/Whim.Tests/Keybinds/KeybindTests.cs
@@ -23,9 +23,41 @@ public class KeybindTests
 		VIRTUAL_KEY.VK_A,
 		"LWin + LCtrl + LShift + LAlt + A"
 	)]
+	[InlineData(KeyModifiers.RShift, VIRTUAL_KEY.VK_A, "RShift + A")]
+	[InlineData(KeyModifiers.RControl, VIRTUAL_KEY.VK_A, "RCtrl + A")]
 	public void Keybind_ToString_ReturnsCorrectString(KeyModifiers modifiers, VIRTUAL_KEY key, string expected)
 	{
 		Keybind keybind = new(modifiers, key);
 		Assert.Equal(expected, keybind.ToString());
+	}
+
+	[Theory]
+	[InlineData(KeyModifiers.None, VIRTUAL_KEY.VK_A, "A")]
+	[InlineData(KeyModifiers.LShift, VIRTUAL_KEY.VK_A, "Shift + A")]
+	[InlineData(KeyModifiers.LControl, VIRTUAL_KEY.VK_A, "Ctrl + A")]
+	[InlineData(KeyModifiers.LAlt, VIRTUAL_KEY.VK_A, "Alt + A")]
+	[InlineData(KeyModifiers.LShift | KeyModifiers.LControl, VIRTUAL_KEY.VK_A, "Ctrl + Shift + A")]
+	[InlineData(KeyModifiers.LControl | KeyModifiers.LAlt, VIRTUAL_KEY.VK_A, "Ctrl + Alt + A")]
+	[InlineData(KeyModifiers.LShift | KeyModifiers.LAlt, VIRTUAL_KEY.VK_A, "Shift + Alt + A")]
+	[InlineData(
+		KeyModifiers.LControl | KeyModifiers.LShift | KeyModifiers.LAlt,
+		VIRTUAL_KEY.VK_A,
+		"Ctrl + Shift + Alt + A"
+	)]
+	[InlineData(
+		KeyModifiers.LWin | KeyModifiers.LControl | KeyModifiers.LShift | KeyModifiers.LAlt,
+		VIRTUAL_KEY.VK_A,
+		"Win + Ctrl + Shift + Alt + A"
+	)]
+	[InlineData(KeyModifiers.RShift, VIRTUAL_KEY.VK_A, "Shift + A")]
+	[InlineData(KeyModifiers.RControl, VIRTUAL_KEY.VK_A, "Ctrl + A")]
+	public void Keybind_ToString_UnifyKeyModifiers_ReturnsCorrectString(
+		KeyModifiers modifiers,
+		VIRTUAL_KEY key,
+		string expected
+	)
+	{
+		Keybind keybind = new(modifiers, key);
+		Assert.Equal(expected, keybind.ToString(unifyKeyModifiers: true));
 	}
 }

--- a/src/Whim/Keybinds/IKeybind.cs
+++ b/src/Whim/Keybinds/IKeybind.cs
@@ -35,10 +35,20 @@ public interface IKeybind
 	/// <summary>
 	/// Modifiers like Alt, Ctrl, and Win.
 	/// </summary>
-	public KeyModifiers Modifiers { get; }
+	KeyModifiers Modifiers { get; }
 
 	/// <summary>
 	/// See https://docs.microsoft.com/en-us/windows/win32/inputdev/virtual-key-codes
 	/// </summary>
-	public VIRTUAL_KEY Key { get; }
+	VIRTUAL_KEY Key { get; }
+
+	/// <summary>
+	/// Returns a string representation of the keybind.
+	/// </summary>
+	/// <param name="unifyKeyModifiers">
+	/// Whether to treat key modifiers like `LWin` and `RWin` as the same.
+	/// See <see cref="IKeybindManager.UnifyKeyModifiers"/>.
+	/// </param>
+	/// <returns></returns>
+	string ToString(bool unifyKeyModifiers);
 }

--- a/src/Whim/Keybinds/IKeybindManager.cs
+++ b/src/Whim/Keybinds/IKeybindManager.cs
@@ -6,6 +6,12 @@ namespace Whim;
 public interface IKeybindManager
 {
 	/// <summary>
+	/// Whether to treat key modifiers like `LWin` and `RWin` as the same.
+	/// For key modifiers which have a left and right variant, this will treat them as the same.
+	/// </summary>
+	bool UnifyKeyModifiers { get; set; }
+
+	/// <summary>
 	/// Adds a keybind.
 	/// </summary>
 	/// <remarks>

--- a/src/Whim/Keybinds/IKeybindManager.cs
+++ b/src/Whim/Keybinds/IKeybindManager.cs
@@ -9,6 +9,11 @@ public interface IKeybindManager
 	/// Whether to treat key modifiers like `LWin` and `RWin` as the same.
 	/// For key modifiers which have a left and right variant, this will treat them as the same.
 	/// </summary>
+	/// <remarks>
+	/// When this is set to <c>true</c>, all of the existing keybinds will be re-added in a unified
+	/// form.
+	/// All new keybinds will also be unified.
+	/// </remarks>
 	bool UnifyKeyModifiers { get; set; }
 
 	/// <summary>

--- a/src/Whim/Keybinds/IKeybindManager.cs
+++ b/src/Whim/Keybinds/IKeybindManager.cs
@@ -8,6 +8,7 @@ public interface IKeybindManager
 	/// <summary>
 	/// Whether to treat key modifiers like `LWin` and `RWin` as the same.
 	/// For key modifiers which have a left and right variant, this will treat them as the same.
+	/// Defaults to <c>true</c>.
 	/// </summary>
 	/// <remarks>
 	/// When this is set to <c>true</c>, all of the existing keybinds will be re-added in a unified

--- a/src/Whim/Keybinds/KeyModifiers.cs
+++ b/src/Whim/Keybinds/KeyModifiers.cs
@@ -137,4 +137,44 @@ public static class KeyModifiersExtensions
 		}
 		return parts.ToImmutable();
 	}
+
+	/// <summary>
+	/// Returns a new <see cref="IKeybind"/>, with the right modifiers replaced with left
+	/// modifiers.
+	/// </summary>
+	/// <param name="keybind"></param>
+	/// <returns></returns>
+	public static IKeybind UnifyModifiers(this IKeybind keybind) => new Keybind(keybind.Modifiers.Unify(), keybind.Key);
+
+	/// <summary>
+	/// Returns a new <see cref="KeyModifiers"/>, with the right modifiers replaced with left
+	/// modifiers.
+	/// </summary>
+	/// <param name="modifiers"></param>
+	/// <returns></returns>
+	public static KeyModifiers Unify(this KeyModifiers modifiers)
+	{
+		KeyModifiers newModifiers = modifiers;
+		if (modifiers.HasFlag(KeyModifiers.RWin))
+		{
+			newModifiers &= ~KeyModifiers.RWin;
+			newModifiers |= KeyModifiers.LWin;
+		}
+		if (modifiers.HasFlag(KeyModifiers.RControl))
+		{
+			newModifiers &= ~KeyModifiers.RControl;
+			newModifiers |= KeyModifiers.LControl;
+		}
+		if (modifiers.HasFlag(KeyModifiers.RShift))
+		{
+			newModifiers &= ~KeyModifiers.RShift;
+			newModifiers |= KeyModifiers.LShift;
+		}
+		if (modifiers.HasFlag(KeyModifiers.RAlt))
+		{
+			newModifiers &= ~KeyModifiers.RAlt;
+			newModifiers |= KeyModifiers.LAlt;
+		}
+		return newModifiers;
+	}
 }

--- a/src/Whim/Keybinds/KeyModifiers.cs
+++ b/src/Whim/Keybinds/KeyModifiers.cs
@@ -66,51 +66,75 @@ public static class KeyModifiersExtensions
 	/// by how keybindings are normally shown.
 	/// </summary>
 	/// <param name="modifiers"></param>
+	/// <param name="unifyKeyModifiers">
+	/// Whether to treat key modifiers like `LWin` and `RWin` as the same.
+	/// See <see cref="IKeybindManager.UnifyKeyModifiers"/>.
+	/// </param>
 	/// <returns></returns>
-	public static IEnumerable<string> GetParts(this KeyModifiers modifiers)
-	{
-		ImmutableArray<string>.Builder parts = ImmutableArray.CreateBuilder<string>();
+	public static IEnumerable<string> GetParts(this KeyModifiers modifiers, bool unifyKeyModifiers) =>
+		unifyKeyModifiers ? GetUnifiedModifiers(modifiers) : GetDisjointModifiers(modifiers);
 
+	private static IEnumerable<string> GetUnifiedModifiers(KeyModifiers modifiers)
+	{
+		// Uses the ImmutableArray<T> builder to avoid type checks at runtime. See
+		// https://devblogs.microsoft.com/dotnet/please-welcome-immutablearrayt
+		ImmutableArray<string>.Builder parts = ImmutableArray.CreateBuilder<string>();
+		if (modifiers.HasFlag(KeyModifiers.LWin) || modifiers.HasFlag(KeyModifiers.RWin))
+		{
+			parts.Add("Win");
+		}
+		if (modifiers.HasFlag(KeyModifiers.LControl) || modifiers.HasFlag(KeyModifiers.RControl))
+		{
+			parts.Add("Ctrl");
+		}
+		if (modifiers.HasFlag(KeyModifiers.LShift) || modifiers.HasFlag(KeyModifiers.RShift))
+		{
+			parts.Add("Shift");
+		}
+		if (modifiers.HasFlag(KeyModifiers.LAlt) || modifiers.HasFlag(KeyModifiers.RAlt))
+		{
+			parts.Add("Alt");
+		}
+		return parts.ToImmutable();
+	}
+
+	private static IEnumerable<string> GetDisjointModifiers(KeyModifiers modifiers)
+	{
+		// Uses the ImmutableArray<T> builder to avoid type checks at runtime. See
+		// https://devblogs.microsoft.com/dotnet/please-welcome-immutablearrayt
+		ImmutableArray<string>.Builder parts = ImmutableArray.CreateBuilder<string>();
 		if (modifiers.HasFlag(KeyModifiers.LWin))
 		{
 			parts.Add("LWin");
 		}
-
 		if (modifiers.HasFlag(KeyModifiers.RWin))
 		{
 			parts.Add("RWin");
 		}
-
 		if (modifiers.HasFlag(KeyModifiers.LControl))
 		{
 			parts.Add("LCtrl");
 		}
-
 		if (modifiers.HasFlag(KeyModifiers.RControl))
 		{
 			parts.Add("RCtrl");
 		}
-
 		if (modifiers.HasFlag(KeyModifiers.LShift))
 		{
 			parts.Add("LShift");
 		}
-
 		if (modifiers.HasFlag(KeyModifiers.RShift))
 		{
 			parts.Add("RShift");
 		}
-
 		if (modifiers.HasFlag(KeyModifiers.LAlt))
 		{
 			parts.Add("LAlt");
 		}
-
 		if (modifiers.HasFlag(KeyModifiers.RAlt))
 		{
 			parts.Add("RAlt");
 		}
-
 		return parts.ToImmutable();
 	}
 }

--- a/src/Whim/Keybinds/Keybind.cs
+++ b/src/Whim/Keybinds/Keybind.cs
@@ -24,21 +24,19 @@ public readonly record struct Keybind : IKeybind
 	}
 
 	/// <inheritdoc />
-	public override string ToString()
-	{
-		StringBuilder sb = new();
-		sb.AppendJoin(" + ", Modifiers.GetParts(false));
-		sb.Append(" + ");
-		sb.Append(Key.GetKeyString());
-		return sb.ToString();
-	}
+	public override string ToString() => ToString(false);
 
 	/// <inheritdoc />
 	public string ToString(bool unifyKeyModifiers)
 	{
 		StringBuilder sb = new();
 		sb.AppendJoin(" + ", Modifiers.GetParts(unifyKeyModifiers));
-		sb.Append(" + ");
+
+		if (sb.Length > 0)
+		{
+			sb.Append(" + ");
+		}
+
 		sb.Append(Key.GetKeyString());
 		return sb.ToString();
 	}

--- a/src/Whim/Keybinds/Keybind.cs
+++ b/src/Whim/Keybinds/Keybind.cs
@@ -1,4 +1,4 @@
-using System.Collections.Immutable;
+using System.Text;
 using Windows.Win32.UI.Input.KeyboardAndMouse;
 
 namespace Whim;
@@ -13,11 +13,6 @@ public readonly record struct Keybind : IKeybind
 	public VIRTUAL_KEY Key { get; }
 
 	/// <summary>
-	/// Saved representation of the keybind as a string.
-	/// </summary>
-	private readonly string _allKeysStr;
-
-	/// <summary>
 	/// Creates a new keybind.
 	/// </summary>
 	/// <param name="modifiers">The modifiers for the keybind.</param>
@@ -26,14 +21,25 @@ public readonly record struct Keybind : IKeybind
 	{
 		Modifiers = modifiers;
 		Key = key;
-
-		ImmutableArray<string>.Builder allKeys = ImmutableArray.CreateBuilder<string>();
-		allKeys.AddRange(Modifiers.GetParts());
-		allKeys.Add(Key.GetKeyString());
-
-		_allKeysStr = string.Join(" + ", allKeys.ToImmutable());
 	}
 
 	/// <inheritdoc />
-	public override string ToString() => _allKeysStr;
+	public override string ToString()
+	{
+		StringBuilder sb = new();
+		sb.AppendJoin(" + ", Modifiers.GetParts(false));
+		sb.Append(" + ");
+		sb.Append(Key.GetKeyString());
+		return sb.ToString();
+	}
+
+	/// <inheritdoc />
+	public string ToString(bool unifyKeyModifiers)
+	{
+		StringBuilder sb = new();
+		sb.AppendJoin(" + ", Modifiers.GetParts(unifyKeyModifiers));
+		sb.Append(" + ");
+		sb.Append(Key.GetKeyString());
+		return sb.ToString();
+	}
 }

--- a/src/Whim/Keybinds/KeybindManager.cs
+++ b/src/Whim/Keybinds/KeybindManager.cs
@@ -32,6 +32,7 @@ internal class KeybindManager : IKeybindManager
 	public ICommand[] GetCommands(IKeybind keybind)
 	{
 		Logger.Debug($"Getting commands for keybind '{keybind}'");
+		keybind = UnifyKeyModifiers ? keybind.UnifyModifiers() : keybind;
 
 		if (_keybindsCommandsMap.TryGetValue(keybind, out List<string>? commandIds))
 		{

--- a/src/Whim/Keybinds/KeybindManager.cs
+++ b/src/Whim/Keybinds/KeybindManager.cs
@@ -9,6 +9,8 @@ internal class KeybindManager : IKeybindManager
 	private readonly Dictionary<IKeybind, List<string>> _keybindsCommandsMap = new();
 	private readonly Dictionary<string, IKeybind> _commandsKeybindsMap = new();
 
+	public bool UnifyKeyModifiers { get; set; } = true;
+
 	public KeybindManager(IContext context)
 	{
 		_context = context;

--- a/src/Whim/Keybinds/KeybindManager.cs
+++ b/src/Whim/Keybinds/KeybindManager.cs
@@ -23,6 +23,7 @@ internal class KeybindManager : IKeybindManager
 		{
 			if (value && _uniqueKeyModifiers == false)
 			{
+				_uniqueKeyModifiers = true;
 				UnifyKeybinds();
 			}
 


### PR DESCRIPTION
Added the Boolean flag `IKeybindManager.UnifyKeyModifiers` to treat key modifiers like <kbd>LWin</kbd> and <kbd>RWin</kbd> as the same key. `UnifyKeyModifiers` defaults to `true`.

When `UnifyKeyModifiers` changes to `true`, `KeybindManager` reregisters all keybinds automatically.

Unifying keybinds means that keys like <kbd>RWin</kbd>, <kbd>RCtrl</kbd> etc. are replaced with <kbd>LWin</kbd>, <kbd>LCtrl</kbd> etc. This simplifies lookup - instead of having to deal with the (small) combinatorial explosion of keybind modifier combinations, we can do a simple key-value lookup.

