### PR TITLE
Support safely overriding keybindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,34 @@ context.PluginManager.AddPlugin(barPlugin);
 
 Each plugin needs to be added to the `context` object.
 
+### Commands
+
+Whim stores commands ([`ICommand`](https://github.com/dalyIsaac/Whim/blob/main/src/Whim/Commands/ICommand.cs)), which are objects with a unique identifier, title, and executable action. Commands expose easy access to functionality from Whim's core, and loaded plugins.
+
+Command identifiers namespaced to the plugin which defines them. For example, the `whim.core` namespace is reserved for core commands, and `whim.gaps` is used by the `GapsPlugin` to define commands. Identifiers are based on the [`Name`](https://github.com/dalyIsaac/Whim/blob/main/src/Whim/Plugin/IPlugin.cs) property of the plugin - for example, [`GapsPlugin.Name`](https://github.com/dalyIsaac/Whim/blob/main/src/Whim.Gaps/GapsPlugin.cs).
+
+Each plugin can provide commands through the `PluginCommands` property of the [`IPlugin`](https://github.com/dalyIsaac/Whim/blob/main/src/Whim/Plugin/IPlugin.cs) interface.
+
+Custom commands can be created using the `whim.custom` namespace.
+
+### Keybinds
+
+Commands can be bound to keybinds ([`IKeybind`](https://github.com/dalyIsaac/Whim/blob/main/src/Whim/Keybinds/IKeybind.cs)).
+
+**Each command is bound to a single keybind.**
+
+**Each keybind can trigger multiple commands.**
+
+Keybinds can be overridden and removed in the config. For example:
+
+```csharp
+// Override the default keybind for showing/hiding the command palette.
+context.KeybindManager.SetKeybind("whim.command_palette.toggle", new Keybind(IKeybind.WinAlt, VIRTUAL_KEY.VK_P));
+
+// Remove the default keybind for closing the current workspace.
+context.KeybindManager.RemoveKeybind("whim.core.close_current_workspace);
+```
+
 ## Inspiration
 
 Whim is heavily inspired by the [workspacer](https://github.com/workspacer/workspacer) project, to which I've contributed to in the past. However, there are a few key differences:

--- a/README.md
+++ b/README.md
@@ -57,8 +57,9 @@ context.KeybindManager.RemoveKeybind("whim.core.close_current_workspace);
 ```
 
 > [!WARNING]
-> When overridding keybinds for plugins, make sure to set the keybind **after** calling `context.PluginManager.AddPlugin(plugin);`
-> This is because `PluginManager` will set the default keybinds for a plugin when it is added, overriding custom keybinds set before the plugin is added.
+> When overridding keybinds for plugins, make sure to set the keybind **after** calling `context.PluginManager.AddPlugin(plugin)`.
+>
+> Otherwise, `PluginManager.AddPlugin` will set the default keybinds, overriding custom keybinds set before the plugin is added.
 
 ## Inspiration
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ context.KeybindManager.SetKeybind("whim.command_palette.toggle", new Keybind(IKe
 context.KeybindManager.RemoveKeybind("whim.core.close_current_workspace);
 ```
 
+> [!WARNING]
+> When overridding keybinds for plugins, make sure to set the keybind **after** calling `context.PluginManager.AddPlugin(plugin);`
+> This is because `PluginManager` will set the default keybinds for a plugin when it is added, overriding custom keybinds set before the plugin is added.
+
 ## Inspiration
 
 Whim is heavily inspired by the [workspacer](https://github.com/workspacer/workspacer) project, to which I've contributed to in the past. However, there are a few key differences:

--- a/src/Whim.CommandPalette/CommandPalettePlugin.cs
+++ b/src/Whim.CommandPalette/CommandPalettePlugin.cs
@@ -12,7 +12,7 @@ public class CommandPalettePlugin : ICommandPalettePlugin
 	private bool _disposedValue;
 
 	/// <inheritdoc />
-	public string Name => "whim.commmand_palette";
+	public string Name => "whim.command_palette";
 
 	/// <summary>
 	/// The configuration for the command palette plugin.

--- a/src/Whim.Tests/Plugin/PluginManagerTests.cs
+++ b/src/Whim.Tests/Plugin/PluginManagerTests.cs
@@ -238,7 +238,9 @@ public class PluginManagerTests
 		ctx.KeybindManager
 			.Received(1)
 			.SetKeybind("whim.plugin2.command2", new Keybind(KeyModifiers.LControl, VIRTUAL_KEY.VK_A));
-		ctx.KeybindManager.Received(1).SetKeybind("whim.plugin3.command3", new Keybind(KeyModifiers.LShift, VIRTUAL_KEY.VK_B));
+		ctx.KeybindManager
+			.Received(1)
+			.SetKeybind("whim.plugin3.command3", new Keybind(KeyModifiers.LShift, VIRTUAL_KEY.VK_B));
 	}
 
 	[InlineAutoSubstituteData<PluginManagerCustomization>(

--- a/src/Whim.Tests/Plugin/PluginManagerTests.cs
+++ b/src/Whim.Tests/Plugin/PluginManagerTests.cs
@@ -234,11 +234,11 @@ public class PluginManagerTests
 		Assert.Equal("whim.plugin2.command22", commands[2].Id);
 		Assert.Equal("whim.plugin3.command3", commands[3].Id);
 
-		ctx.KeybindManager.Received(2).Add(Arg.Any<string>(), Arg.Any<Keybind>());
+		ctx.KeybindManager.Received(2).SetKeybind(Arg.Any<string>(), Arg.Any<Keybind>());
 		ctx.KeybindManager
 			.Received(1)
-			.Add("whim.plugin2.command2", new Keybind(KeyModifiers.LControl, VIRTUAL_KEY.VK_A));
-		ctx.KeybindManager.Received(1).Add("whim.plugin3.command3", new Keybind(KeyModifiers.LShift, VIRTUAL_KEY.VK_B));
+			.SetKeybind("whim.plugin2.command2", new Keybind(KeyModifiers.LControl, VIRTUAL_KEY.VK_A));
+		ctx.KeybindManager.Received(1).SetKeybind("whim.plugin3.command3", new Keybind(KeyModifiers.LShift, VIRTUAL_KEY.VK_B));
 	}
 
 	[InlineAutoSubstituteData<PluginManagerCustomization>(

--- a/src/Whim/Context/Context.cs
+++ b/src/Whim/Context/Context.cs
@@ -63,7 +63,7 @@ internal class Context : IContext
 
 		foreach ((string name, IKeybind keybind) in coreCommands.Keybinds)
 		{
-			KeybindManager.Add(name, keybind);
+			KeybindManager.SetKeybind(name, keybind);
 		}
 
 		// Load the user's config.

--- a/src/Whim/Keybinds/IKeybindManager.cs
+++ b/src/Whim/Keybinds/IKeybindManager.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Whim;
 
 /// <summary>
@@ -25,7 +27,21 @@ public interface IKeybindManager
 	/// </remarks>
 	/// <param name="commandId">The identifier of the command to bind to.</param>
 	/// <param name="keybind">The keybind to add.</param>
+	/// <exception cref="ArgumentException">Thrown if the command identifier is already bound to a keybind.</exception>
+	[Obsolete("Method is deprecated, please use SetKeybind(string, IKeybind) instead.")]
 	void Add(string commandId, IKeybind keybind);
+
+	/// <summary>
+	/// Sets a keybind.
+	/// If a keybind already exists for the given command, it will be overwritten.
+	/// </summary>
+	/// <remarks>
+	/// Keybinds can have multiple commands bound to them.
+	/// Commands can have a single keybind.
+	/// </remarks>
+	/// <param name="commandId">The identifier of the command to bind to.</param>
+	/// <param name="keybind">The keybind to set.</param>
+	void SetKeybind(string commandId, IKeybind keybind);
 
 	/// <summary>
 	/// Removes a keybind.

--- a/src/Whim/Keybinds/KeybindManager.cs
+++ b/src/Whim/Keybinds/KeybindManager.cs
@@ -39,14 +39,33 @@ internal class KeybindManager : IKeybindManager
 
 		foreach (KeyValuePair<string, IKeybind> keybind in keybinds)
 		{
-			Add(keybind.Key, keybind.Value);
+			SetKeybind(keybind.Key, keybind.Value);
 		}
 	}
 
+	[Obsolete("Method is deprecated, please use SetKeybind(string, IKeybind) instead.")]
 	public void Add(string commandId, IKeybind keybind)
 	{
+		Logger.Warning("Method is deprecated, please use SetKeybind(string, IKeybind) instead.");
 		Logger.Debug($"Adding keybind '{keybind}' for command '{commandId}'");
+
+		if (_commandsKeybindsMap.ContainsKey(commandId))
+		{
+			throw new ArgumentException($"Command '{commandId}' already has a keybind");
+		}
+
+		SetKeybind(commandId, keybind);
+	}
+
+	public void SetKeybind(string commandId, IKeybind keybind)
+	{
+		Logger.Debug($"Setting keybind '{keybind}' for command '{commandId}'");
 		keybind = UnifyKeyModifiers ? keybind.UnifyModifiers() : keybind;
+
+		if (_commandsKeybindsMap.TryGetValue(commandId, out IKeybind? existingKeybind))
+		{
+			_keybindsCommandsMap[existingKeybind].Remove(commandId);
+		}
 
 		if (!_keybindsCommandsMap.ContainsKey(keybind))
 		{
@@ -54,7 +73,7 @@ internal class KeybindManager : IKeybindManager
 		}
 
 		_keybindsCommandsMap[keybind].Add(commandId);
-		_commandsKeybindsMap.Add(commandId, keybind);
+		_commandsKeybindsMap[commandId] = keybind;
 	}
 
 	public ICommand[] GetCommands(IKeybind keybind)

--- a/src/Whim/Plugin/PluginManager.cs
+++ b/src/Whim/Plugin/PluginManager.cs
@@ -114,7 +114,7 @@ internal partial class PluginManager : IPluginManager
 
 		foreach ((string commandId, IKeybind keybind) in plugin.PluginCommands.Keybinds)
 		{
-			_context.KeybindManager.Add(commandId, keybind);
+			_context.KeybindManager.SetKeybind(commandId, keybind);
 		}
 
 		return plugin;


### PR DESCRIPTION
- Added `SetKeybind` to add/overwrite a keybind, and obsoleted `Add`. 
- Documented keybinds in README
- Fixed the name of `CommandPalettePlugin` to be `whim.command_palette`, not `whim.commmand_palette`.