### PR TITLE
Fix incorrect monitor bounds for primary monitor

### DIFF
--- a/src/Whim.Tests/Monitor/MonitorTests.cs
+++ b/src/Whim.Tests/Monitor/MonitorTests.cs
@@ -14,24 +14,17 @@ internal class MonitorCustomization : ICustomization
 	{
 		IInternalContext internalCtx = fixture.Freeze<IInternalContext>();
 
-		internalCtx.CoreNativeManager.GetVirtualScreenLeft().Returns(0);
-		internalCtx.CoreNativeManager.GetVirtualScreenTop().Returns(0);
-		internalCtx.CoreNativeManager.GetVirtualScreenWidth().Returns(1920);
-		internalCtx.CoreNativeManager.GetVirtualScreenHeight().Returns(1080);
-
 		internalCtx.CoreNativeManager
-			.GetPrimaryDisplayWorkArea(out RECT _)
+			.GetMonitorInfoEx(Arg.Any<HMONITOR>())
 			.Returns(
-				(callInfo) =>
+				(_) =>
 				{
-					callInfo[0] = new RECT()
-					{
-						left = 10,
-						top = 10,
-						right = 1910,
-						bottom = 1070
-					};
-					return (BOOL)true;
+					MONITORINFOEXW infoEx = default;
+					infoEx.monitorInfo.rcMonitor = new RECT(0, 0, 1920, 1080);
+					infoEx.monitorInfo.rcWork = new RECT(10, 10, 1910, 1070);
+					infoEx.monitorInfo.dwFlags = 0;
+					infoEx.szDevice = "DISPLAY";
+					return infoEx;
 				}
 			);
 
@@ -113,20 +106,6 @@ public class MonitorTests
 	{
 		// Given
 		internalCtx.CoreNativeManager.HasMultipleMonitors().Returns(true);
-
-		internalCtx.CoreNativeManager
-			.GetMonitorInfoEx(Arg.Any<HMONITOR>())
-			.Returns(
-				(_) =>
-				{
-					MONITORINFOEXW infoEx = default;
-					infoEx.monitorInfo.rcMonitor = new RECT(0, 0, 1920, 1080);
-					infoEx.monitorInfo.rcWork = new RECT(10, 10, 1910, 1070);
-					infoEx.monitorInfo.dwFlags = 0;
-					infoEx.szDevice = "DISPLAY";
-					return infoEx;
-				}
-			);
 
 		uint effectiveDpiX = 144;
 		uint effectiveDpiY = 144;

--- a/src/Whim/Monitor/Monitor.cs
+++ b/src/Whim/Monitor/Monitor.cs
@@ -62,17 +62,7 @@ internal class Monitor : IMonitor
 
 	private ILocation<int> GetBounds()
 	{
-		if (IsPrimary)
-		{
-			return new Location<int>()
-			{
-				X = _internalContext.CoreNativeManager.GetVirtualScreenLeft(),
-				Y = _internalContext.CoreNativeManager.GetVirtualScreenTop(),
-				Width = _internalContext.CoreNativeManager.GetVirtualScreenWidth(),
-				Height = _internalContext.CoreNativeManager.GetVirtualScreenHeight()
-			};
-		}
-		else if (_internalContext.CoreNativeManager.GetMonitorInfoEx(_hmonitor) is MONITORINFOEXW infoEx)
+		if (_internalContext.CoreNativeManager.GetMonitorInfoEx(_hmonitor) is MONITORINFOEXW infoEx)
 		{
 			// Multiple monitor system.
 			return infoEx.monitorInfo.rcMonitor.ToLocation();

--- a/src/Whim/Monitor/Monitor.cs
+++ b/src/Whim/Monitor/Monitor.cs
@@ -1,5 +1,4 @@
 using System.Diagnostics.CodeAnalysis;
-using Windows.Win32.Foundation;
 using Windows.Win32.Graphics.Gdi;
 using Windows.Win32.UI.HiDpi;
 
@@ -33,7 +32,7 @@ internal class Monitor : IMonitor
 	[MemberNotNull(nameof(IsPrimary), nameof(Name), nameof(ScaleFactor))]
 	internal unsafe void Update(bool isPrimaryHMonitor)
 	{
-		IsPrimary = !_internalContext.CoreNativeManager.HasMultipleMonitors() || isPrimaryHMonitor;
+		IsPrimary = isPrimaryHMonitor || _internalContext.CoreNativeManager.HasMultipleMonitors() == false;
 		if (IsPrimary)
 		{
 			Name = "DISPLAY";
@@ -76,12 +75,7 @@ internal class Monitor : IMonitor
 
 	private ILocation<int> GetWorkingArea()
 	{
-		if (IsPrimary)
-		{
-			_internalContext.CoreNativeManager.GetPrimaryDisplayWorkArea(out RECT rect);
-			return rect.ToLocation();
-		}
-		else if (_internalContext.CoreNativeManager.GetMonitorInfoEx(_hmonitor) is MONITORINFOEXW infoEx)
+		if (_internalContext.CoreNativeManager.GetMonitorInfoEx(_hmonitor) is MONITORINFOEXW infoEx)
 		{
 			// Multiple monitor system.
 			return infoEx.monitorInfo.rcWork.ToLocation();

--- a/src/Whim/Native/CoreNativeManager.cs
+++ b/src/Whim/Native/CoreNativeManager.cs
@@ -52,19 +52,6 @@ internal class CoreNativeManager : ICoreNativeManager
 	public BOOL EnumDisplayMonitors(SafeHandle? hdc, RECT? lprcClip, MONITORENUMPROC lpfnEnum, LPARAM dwData) =>
 		PInvoke.EnumDisplayMonitors(new HDC(hdc?.DangerousGetHandle() ?? 0), lprcClip, lpfnEnum, dwData);
 
-	public BOOL GetPrimaryDisplayWorkArea(out RECT lpRect)
-	{
-		RECT rect = default;
-		BOOL result;
-		unsafe
-		{
-			result = PInvoke.SystemParametersInfo(SYSTEM_PARAMETERS_INFO_ACTION.SPI_GETWORKAREA, 0, &rect, 0);
-		}
-
-		lpRect = rect;
-		return result;
-	}
-
 	public MONITORINFOEXW? GetMonitorInfoEx(HMONITOR hMonitor)
 	{
 		unsafe
@@ -343,7 +330,8 @@ internal class CoreNativeManager : ICoreNativeManager
 
 	public Icon LoadIconFromHandle(nint hIcon) => Icon.FromHandle(hIcon);
 
-	public HMONITOR MonitorFromRect(in RECT lprc, MONITOR_FROM_FLAGS dwFlags) => PInvoke.MonitorFromRect(lprc, dwFlags);
+	public HMONITOR MonitorFromWindow(HWND hwnd, MONITOR_FROM_FLAGS dwFlags) =>
+		PInvoke.MonitorFromWindow(hwnd, dwFlags);
 
 	public bool SetWindowPos(
 		HWND hWnd,

--- a/src/Whim/Native/CoreNativeManager.cs
+++ b/src/Whim/Native/CoreNativeManager.cs
@@ -47,14 +47,6 @@ internal class CoreNativeManager : ICoreNativeManager
 		return res;
 	}
 
-	public int GetVirtualScreenLeft() => PInvoke.GetSystemMetrics(SYSTEM_METRICS_INDEX.SM_XVIRTUALSCREEN);
-
-	public int GetVirtualScreenTop() => PInvoke.GetSystemMetrics(SYSTEM_METRICS_INDEX.SM_YVIRTUALSCREEN);
-
-	public int GetVirtualScreenWidth() => PInvoke.GetSystemMetrics(SYSTEM_METRICS_INDEX.SM_CXVIRTUALSCREEN);
-
-	public int GetVirtualScreenHeight() => PInvoke.GetSystemMetrics(SYSTEM_METRICS_INDEX.SM_CYVIRTUALSCREEN);
-
 	public bool HasMultipleMonitors() => PInvoke.GetSystemMetrics(SYSTEM_METRICS_INDEX.SM_CMONITORS) != 0;
 
 	public BOOL EnumDisplayMonitors(SafeHandle? hdc, RECT? lprcClip, MONITORENUMPROC lpfnEnum, LPARAM dwData) =>
@@ -351,8 +343,7 @@ internal class CoreNativeManager : ICoreNativeManager
 
 	public Icon LoadIconFromHandle(nint hIcon) => Icon.FromHandle(hIcon);
 
-	public HMONITOR MonitorFromWindow(HWND hwnd, MONITOR_FROM_FLAGS dwFlags) =>
-		PInvoke.MonitorFromWindow(hwnd, dwFlags);
+	public HMONITOR MonitorFromRect(in RECT lprc, MONITOR_FROM_FLAGS dwFlags) => PInvoke.MonitorFromRect(lprc, dwFlags);
 
 	public bool SetWindowPos(
 		HWND hWnd,

--- a/src/Whim/Native/ICoreNativeManager.cs
+++ b/src/Whim/Native/ICoreNativeManager.cs
@@ -103,18 +103,6 @@ internal interface ICoreNativeManager
 	BOOL EnumDisplayMonitors(SafeHandle? hdc, RECT? lprcClip, MONITORENUMPROC lpfnEnum, LPARAM dwData);
 
 	/// <summary>
-	/// Retrieves the size of the work area on the primary display monitor.
-	/// </summary>
-	/// <remarks>
-	/// This uses <see cref="PInvoke.SystemParametersInfo(SYSTEM_PARAMETERS_INFO_ACTION, uint, void*, SYSTEM_PARAMETERS_INFO_UPDATE_FLAGS)"/> with <see cref="SYSTEM_PARAMETERS_INFO_ACTION.SPI_GETWORKAREA"/> <br/>
-	///
-	/// For more, see https://docs.microsoft.com/windows/win32/api/winuser/nf-winuser-systemparametersinfoa
-	/// </remarks>
-	/// <param name="workArea"></param>
-	/// <returns></returns>
-	BOOL GetPrimaryDisplayWorkArea(out RECT workArea);
-
-	/// <summary>
 	/// Retrieve information about a display monitor.
 	/// </summary>
 	/// <remarks>
@@ -506,8 +494,8 @@ internal interface ICoreNativeManager
 	/// <param name="hIcon"></param>
 	Icon LoadIconFromHandle(nint hIcon);
 
-	/// <inheritdoc cref="PInvoke.MonitorFromRect(in RECT, MONITOR_FROM_FLAGS)"/>
-	HMONITOR MonitorFromRect(in RECT lprc, MONITOR_FROM_FLAGS dwFlags);
+	/// <inheritdoc cref="PInvoke.MonitorFromWindow(HWND, MONITOR_FROM_FLAGS)"/>
+	HMONITOR MonitorFromWindow(HWND hwnd, MONITOR_FROM_FLAGS dwFlags);
 
 	/// <inheritdoc cref="PInvoke.SetWindowPos(HWND, HWND, int, int, int, int, SET_WINDOW_POS_FLAGS)"/>
 	bool SetWindowPos(HWND hWnd, HWND hWndInsertAfter, int x, int y, int cx, int cy, SET_WINDOW_POS_FLAGS uFlags);

--- a/src/Whim/Native/ICoreNativeManager.cs
+++ b/src/Whim/Native/ICoreNativeManager.cs
@@ -77,50 +77,6 @@ internal interface ICoreNativeManager
 	BOOL GetCursorPos(out IPoint<int> lpPoint);
 
 	/// <summary>
-	/// Get the coordinates for the left-side of the virtual screen.
-	/// </summary>
-	/// <remarks>
-	/// This uses <see cref="PInvoke.GetSystemMetrics(SYSTEM_METRICS_INDEX)"/> with <see cref="SYSTEM_METRICS_INDEX.SM_XVIRTUALSCREEN"/> <br/>
-	///
-	/// For more, see https://docs.microsoft.com/windows/win32/api/winuser/nf-winuser-getsystemmetrics
-	/// </remarks>
-	/// <returns></returns>
-	int GetVirtualScreenLeft();
-
-	/// <summary>
-	/// Get the coordinates for the top-side of the virtual screen.
-	/// </summary>
-	/// <remarks>
-	/// This uses <see cref="PInvoke.GetSystemMetrics(SYSTEM_METRICS_INDEX)"/> with <see cref="SYSTEM_METRICS_INDEX.SM_YVIRTUALSCREEN"/> <br/>
-	///
-	/// For more, see https://docs.microsoft.com/windows/win32/api/winuser/nf-winuser-getsystemmetrics
-	/// </remarks>
-	/// <returns></returns>
-	int GetVirtualScreenTop();
-
-	/// <summary>
-	/// Get the width of the virtual screen.
-	/// </summary>
-	/// <remarks>
-	/// This uses <see cref="PInvoke.GetSystemMetrics(SYSTEM_METRICS_INDEX)"/> with <see cref="SYSTEM_METRICS_INDEX.SM_CXVIRTUALSCREEN"/> <br/>
-	///
-	/// For more, see https://docs.microsoft.com/windows/win32/api/winuser/nf-winuser-getsystemmetrics
-	/// </remarks>
-	/// <returns></returns>
-	int GetVirtualScreenWidth();
-
-	/// <summary>
-	/// Get the height of the virtual screen.
-	/// </summary>
-	/// <remarks>
-	/// This uses <see cref="PInvoke.GetSystemMetrics(SYSTEM_METRICS_INDEX)"/> with <see cref="SYSTEM_METRICS_INDEX.SM_CYVIRTUALSCREEN"/> <br/>
-	///
-	/// For more, see https://docs.microsoft.com/windows/win32/api/winuser/nf-winuser-getsystemmetrics
-	/// </remarks>
-	/// <returns></returns>
-	int GetVirtualScreenHeight();
-
-	/// <summary>
 	/// Whether the desktop has multiple monitors.
 	/// </summary>
 	/// <remarks>
@@ -550,8 +506,8 @@ internal interface ICoreNativeManager
 	/// <param name="hIcon"></param>
 	Icon LoadIconFromHandle(nint hIcon);
 
-	/// <inheritdoc cref="PInvoke.MonitorFromWindow(HWND, MONITOR_FROM_FLAGS)"/>
-	HMONITOR MonitorFromWindow(HWND hwnd, MONITOR_FROM_FLAGS dwFlags);
+	/// <inheritdoc cref="PInvoke.MonitorFromRect(in RECT, MONITOR_FROM_FLAGS)"/>
+	HMONITOR MonitorFromRect(in RECT lprc, MONITOR_FROM_FLAGS dwFlags);
 
 	/// <inheritdoc cref="PInvoke.SetWindowPos(HWND, HWND, int, int, int, int, SET_WINDOW_POS_FLAGS)"/>
 	bool SetWindowPos(HWND hWnd, HWND hWndInsertAfter, int x, int y, int cx, int cy, SET_WINDOW_POS_FLAGS uFlags);


### PR DESCRIPTION
Replaced dedicated code for retrieving the primary monitor's bounds and working area with the existing calls for non-primary monitors. For some reason, the existing calls returned incorrect results.