### PR TITLE
Layout Firefox when it launches

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,16 @@ context.RouterManager.Add((window) =>
 context.FilterManager.IgnoreTitleMatch("Whim Bar");
 ```
 
+## Window manager
+
+The [`IWindowManager`](https://github.com/dalyIsaac/Whim/blob/main/src/Whim/Window/IWindowManager.cs) is used by Whim to manage [`IWindow`](https://github.com/dalyIsaac/Whim/blob/main/src/Whim/Window/IWindow.cs)s. It listens to window events from Windows and notifies listeners (Whim core, plugins, etc.).
+
+For example, the most commonly subscribed event is the `WindowFocused` event, used by the `Whim.FocusIndicator` and `Whim.Bar` plugins.
+
+The `IWindowManager` also exposes an `IFilterManager` called `LocationRestoringFilterManager`. Some applications like to restore their window positions when they start (e.g., Firefox, JetBrains Gateway). As a window manager, this is undesirable. `LocationRestoringFilterManager` listens to `WindowMoved` events for these windows and will force their parent `IWorkspace` to do a layout two seconds after their first `WindowMoved` event, attempting to restore the window to its correct position.
+
+If this doesn't work, dragging a window's edge will force a layout, which should fix the window's position. This is an area which could use further improvement.
+
 ## Architecture
 
 > In progress...

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ context.FilterManager.IgnoreTitleMatch("Whim Bar");
 
 The [`IWindowManager`](https://github.com/dalyIsaac/Whim/blob/main/src/Whim/Window/IWindowManager.cs) is used by Whim to manage [`IWindow`](https://github.com/dalyIsaac/Whim/blob/main/src/Whim/Window/IWindow.cs)s. It listens to window events from Windows and notifies listeners (Whim core, plugins, etc.).
 
-For example, the most commonly subscribed event is the `WindowFocused` event, used by the `Whim.FocusIndicator` and `Whim.Bar` plugins.
+For example, the `WindowFocused` event is used by the `Whim.FocusIndicator` and `Whim.Bar` plugins to update their indications of the currently focused window.
 
 The `IWindowManager` also exposes an `IFilterManager` called `LocationRestoringFilterManager`. Some applications like to restore their window positions when they start (e.g., Firefox, JetBrains Gateway). As a window manager, this is undesirable. `LocationRestoringFilterManager` listens to `WindowMoved` events for these windows and will force their parent `IWorkspace` to do a layout two seconds after their first `WindowMoved` event, attempting to restore the window to its correct position.
 

--- a/src/Whim.Tests/Router/FilterManagerTests.cs
+++ b/src/Whim.Tests/Router/FilterManagerTests.cs
@@ -59,40 +59,21 @@ public class FilterManagerTests
 	}
 
 	[Theory, AutoSubstituteData]
-	public void ClearKeepDefaults(IWindow window, IWindow searchUIWindow)
+	public void Clear(IWindow window)
 	{
 		// Given
 		FilterManager filterManager = new();
+		FilteredWindows.LoadWindowsIgnoredByWhim(filterManager);
 		filterManager.IgnoreWindowClass("Test");
 
 		window.WindowClass.Returns("Test");
-		searchUIWindow.ProcessName.Returns("SearchUI.exe");
 
-		// When the filter manager is cleared, and the defaults are cleared
-		filterManager.Clear(clearDefaults: true);
+		// When the filter manager is cleared
+		filterManager.Clear();
 
-		// Then neither window should be ignored
+		// Then the window should be ignored
 		Assert.False(filterManager.ShouldBeIgnored(window));
-		Assert.False(filterManager.ShouldBeIgnored(searchUIWindow));
-	}
-
-	[Theory, AutoSubstituteData]
-	public void ClearAll(IWindow window, IWindow searchUIWindow)
-	{
-		// Given
-		FilterManager filterManager = new();
-		filterManager.IgnoreWindowClass("Test");
-
-		window.WindowClass.Returns("Test");
-		searchUIWindow.ProcessName.Returns("SearchUI.exe");
-
-		// When the filter manager is cleared, and the defaults are kept
-		filterManager.Clear(clearDefaults: false);
-
-		// Then the window should be ignored, but not the search UI window
-		Assert.False(filterManager.ShouldBeIgnored(window));
-		Assert.True(filterManager.ShouldBeIgnored(searchUIWindow));
-	}
+	}ShouldIgnore
 
 	[Theory, AutoSubstituteData]
 	public void CustomFilter(IWindow window)
@@ -103,6 +84,7 @@ public class FilterManagerTests
 
 		window.WindowClass.Returns("Test");
 
-		Assert.True(filterManager.ShouldBeIgnored(window));
+		Assert.True(filterManager.CheckWindow(window));
 	}
 }
+ShouldIgnoreShouldIgnoreShouldIgnore

--- a/src/Whim.Tests/Router/FilterManagerTests.cs
+++ b/src/Whim.Tests/Router/FilterManagerTests.cs
@@ -71,9 +71,9 @@ public class FilterManagerTests
 		// When the filter manager is cleared
 		filterManager.Clear();
 
-		// Then the window should be ignored
+		// Then the window should be ignored, but not the search UI window
 		Assert.False(filterManager.ShouldBeIgnored(window));
-	}ShouldIgnore
+	}
 
 	[Theory, AutoSubstituteData]
 	public void CustomFilter(IWindow window)
@@ -84,7 +84,6 @@ public class FilterManagerTests
 
 		window.WindowClass.Returns("Test");
 
-		Assert.True(filterManager.CheckWindow(window));
+		Assert.True(filterManager.ShouldBeIgnored(window));
 	}
 }
-ShouldIgnoreShouldIgnoreShouldIgnore

--- a/src/Whim.Tests/Window/WindowManagerTests.cs
+++ b/src/Whim.Tests/Window/WindowManagerTests.cs
@@ -110,7 +110,7 @@ public class WindowManagerTests
 			});
 		internalCtx.CoreNativeManager
 			.GetProcessNameAndPath((int)_processId)
-			.Returns(("firefox.exe", "C:\\Program Files\\Firefox Developer Edition\\firefox.exe"));
+			.Returns(("chrome.exe", "C:\\Program Files\\Google Chrome\\chrome.exe"));
 	}
 
 	private WindowManagerTests Trigger_MouseLeftButtonDown(IInternalContext internalCtx)
@@ -757,7 +757,6 @@ public class WindowManagerTests
 		IWorkspace workspace = Substitute.For<IWorkspace>();
 		ctx.WorkspaceManager.GetWorkspaceForWindow(Arg.Any<IWindow>()).Returns(workspace);
 
-		// Set up TryEnqueue
 		internalCtx.CoreNativeManager
 			.When(cnm => cnm.TryEnqueue(Arg.Any<DispatcherQueueHandler>()))
 			.Do(callInfo =>
@@ -765,6 +764,10 @@ public class WindowManagerTests
 				var handler = callInfo.ArgAt<DispatcherQueueHandler>(0);
 				handler.Invoke();
 			});
+
+		internalCtx.CoreNativeManager
+			.GetProcessNameAndPath((int)_processId)
+			.Returns(("firefox.exe", "C:\\Program Files\\Mozilla Firefox\\firefox.exe"));
 
 		return workspace;
 	}
@@ -780,7 +783,6 @@ public class WindowManagerTests
 			ctx,
 			internalCtx
 		);
-		windowManager.PreInitialize();
 		IWorkspace workspace = Setup_LocationRestoring_Success(ctx, internalCtx, hwnd);
 		ctx.WorkspaceManager.GetWorkspaceForWindow(Arg.Any<IWindow>()).Returns((IWorkspace?)null);
 
@@ -807,7 +809,6 @@ public class WindowManagerTests
 			ctx,
 			internalCtx
 		);
-		windowManager.PreInitialize();
 		IWorkspace workspace = Setup_LocationRestoring_Success(ctx, internalCtx, hwnd);
 
 		// When the window is moved
@@ -836,7 +837,6 @@ public class WindowManagerTests
 			ctx,
 			internalCtx
 		);
-		windowManager.PreInitialize();
 		IWorkspace workspace = Setup_LocationRestoring_Success(ctx, internalCtx, hwnd);
 
 		// When the window is moved for the second time
@@ -858,7 +858,6 @@ public class WindowManagerTests
 			ctx,
 			internalCtx
 		);
-		windowManager.PreInitialize();
 		IWorkspace workspace = Setup_LocationRestoring_Success(ctx, internalCtx, hwnd);
 
 		// When the window is moved and then removed

--- a/src/Whim.Tests/Window/WindowManagerTests.cs
+++ b/src/Whim.Tests/Window/WindowManagerTests.cs
@@ -1,10 +1,12 @@
 using AutoFixture;
 using FluentAssertions;
+using Microsoft.UI.Dispatching;
 using NSubstitute;
 using NSubstitute.ReceivedExtensions;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Threading.Tasks;
 using Whim.TestUtils;
 using Windows.Win32;
 using Windows.Win32.Foundation;
@@ -690,6 +692,189 @@ public class WindowManagerTests
 	#endregion
 
 	#region OnWindowMoved
+	private static (CaptureWinEventProc, WindowManager, HWND) Setup_LocationRestoring(
+		IContext ctx,
+		IInternalContext internalCtx
+	)
+	{
+		HWND hwnd = new(1);
+		CaptureWinEventProc capture = CaptureWinEventProc.Create(internalCtx);
+		AllowWindowCreation(ctx, internalCtx, hwnd);
+		WindowManager windowManager = new(ctx, internalCtx);
+		windowManager.Initialize();
+		return (capture, windowManager, hwnd);
+	}
+
+	[Theory, AutoSubstituteData<WindowManagerCustomization>]
+	internal void WindowsEventHook_OnWindowMoved_DoesNotRaise_ProcessFileNameIsNull(
+		IContext ctx,
+		IInternalContext internalCtx
+	)
+	{
+		// Given the window has no process file name
+		internalCtx.CoreNativeManager.GetProcessNameAndPath((int)_processId).Returns(("", null));
+		(CaptureWinEventProc capture, WindowManager windowManager, HWND hwnd) = Setup_LocationRestoring(
+			ctx,
+			internalCtx
+		);
+
+		// When the window is moved
+		// Then no event is raised
+		CustomAssert.DoesNotRaise<WindowMovedEventArgs>(
+			h => windowManager.WindowMoved += h,
+			h => windowManager.WindowMoved -= h,
+			() => capture.WinEventProc!.Invoke((HWINEVENTHOOK)0, PInvoke.EVENT_OBJECT_LOCATIONCHANGE, hwnd, 0, 0, 0, 0)
+		);
+	}
+
+	[Theory, AutoSubstituteData<WindowManagerCustomization>]
+	internal void WindowsEventHook_OnWindowMoved_DoesNotRaise_WindowDoesNotRestore(
+		IContext ctx,
+		IInternalContext internalCtx
+	)
+	{
+		// Given the window is not registered as restoring
+		(CaptureWinEventProc capture, WindowManager windowManager, HWND hwnd) = Setup_LocationRestoring(
+			ctx,
+			internalCtx
+		);
+
+		// When the window is moved
+		// Then no event is raised
+		CustomAssert.DoesNotRaise<WindowMovedEventArgs>(
+			h => windowManager.WindowMoved += h,
+			h => windowManager.WindowMoved -= h,
+			() => capture.WinEventProc!.Invoke((HWINEVENTHOOK)0, PInvoke.EVENT_OBJECT_LOCATIONCHANGE, hwnd, 0, 0, 0, 0)
+		);
+	}
+
+	private static IWorkspace Setup_LocationRestoring_Success(
+		IContext ctx,
+		IInternalContext internalCtx,
+		WindowManager windowManager,
+		HWND hwnd
+	)
+	{
+		IWindow window = Window.CreateWindow(ctx, internalCtx, hwnd)!;
+		windowManager.LocationRestoringProcessFileNames.Add("path");
+
+		IWorkspace workspace = Substitute.For<IWorkspace>();
+		ctx.WorkspaceManager.GetWorkspaceForWindow(Arg.Any<IWindow>()).Returns(workspace);
+
+		// Set up TryEnqueue
+		internalCtx.CoreNativeManager
+			.When(cnm => cnm.TryEnqueue(Arg.Any<DispatcherQueueHandler>()))
+			.Do(callInfo =>
+			{
+				var handler = callInfo.ArgAt<DispatcherQueueHandler>(0);
+				handler.Invoke();
+			});
+
+		return workspace;
+	}
+
+	[Theory, AutoSubstituteData<WindowManagerCustomization>]
+	internal async void WindowsEventHook_OnWindowMoved_Raises_CannotFindWorkspaceForWindow(
+	IContext ctx,
+	IInternalContext internalCtx
+)
+	{
+		// Given the window is registered as restoring, but no workspace is found for it
+		(CaptureWinEventProc capture, WindowManager windowManager, HWND hwnd) = Setup_LocationRestoring(
+			ctx,
+			internalCtx
+		);
+		IWorkspace workspace = Setup_LocationRestoring_Success(ctx, internalCtx, windowManager, hwnd);
+		ctx.WorkspaceManager.GetWorkspaceForWindow(Arg.Any<IWindow>()).Returns((IWorkspace?)null);
+
+		// When the window is moved
+		// Then an event is raised, but the workspace is not asked to do a layout
+		var result = Assert.Raises<WindowMovedEventArgs>(
+			h => windowManager.WindowMoved += h,
+			h => windowManager.WindowMoved -= h,
+			() => capture.WinEventProc!.Invoke((HWINEVENTHOOK)0, PInvoke.EVENT_OBJECT_LOCATIONCHANGE, hwnd, 0, 0, 0, 0)
+		);
+		await Task.Delay(2200);
+
+		Assert.Null(result.Arguments.CursorDraggedPoint);
+		Assert.Null(result.Arguments.MovedEdges);
+		Assert.NotNull(result.Arguments.Window);
+		workspace.DidNotReceive().DoLayout();
+	}
+
+	[Theory, AutoSubstituteData<WindowManagerCustomization>]
+	internal async void WindowsEventHook_OnWindowMoved_Raises_DoLayout(IContext ctx, IInternalContext internalCtx)
+	{
+		// Given the window is registered as restoring, and a workspace is found for it
+		(CaptureWinEventProc capture, WindowManager windowManager, HWND hwnd) = Setup_LocationRestoring(
+			ctx,
+			internalCtx
+		);
+		IWorkspace workspace = Setup_LocationRestoring_Success(ctx, internalCtx, windowManager, hwnd);
+
+		// When the window is moved
+		// Then an event is raised, and the workspace is asked to do a layout
+		var result = Assert.Raises<WindowMovedEventArgs>(
+			h => windowManager.WindowMoved += h,
+			h => windowManager.WindowMoved -= h,
+			() => capture.WinEventProc!.Invoke((HWINEVENTHOOK)0, PInvoke.EVENT_OBJECT_LOCATIONCHANGE, hwnd, 0, 0, 0, 0)
+		);
+		await Task.Delay(2200);
+
+		Assert.Null(result.Arguments.CursorDraggedPoint);
+		Assert.Equal(result.Arguments.MovedEdges, Direction.None);
+		Assert.NotNull(result.Arguments.Window);
+		workspace.Received(1).DoLayout();
+	}
+
+	[Theory, AutoSubstituteData<WindowManagerCustomization>]
+	internal void WindowsEventHook_OnWindowMoved_DoesNotRaise_WindowAlreadyHandled(
+		IContext ctx,
+		IInternalContext internalCtx
+	)
+	{
+		// Given the window is registered as restoring, a workspace is found for it, and the window is already handled
+		(CaptureWinEventProc capture, WindowManager windowManager, HWND hwnd) = Setup_LocationRestoring(
+			ctx,
+			internalCtx
+		);
+		IWorkspace workspace = Setup_LocationRestoring_Success(ctx, internalCtx, windowManager, hwnd);
+
+		// When the window is moved for the second time
+		capture.WinEventProc!.Invoke((HWINEVENTHOOK)0, PInvoke.EVENT_OBJECT_LOCATIONCHANGE, hwnd, 0, 0, 0, 0);
+
+		// Then no event is raised
+		CustomAssert.DoesNotRaise<WindowMovedEventArgs>(
+			h => windowManager.WindowMoved += h,
+			h => windowManager.WindowMoved -= h,
+			() => capture.WinEventProc!.Invoke((HWINEVENTHOOK)0, PInvoke.EVENT_OBJECT_LOCATIONCHANGE, hwnd, 0, 0, 0, 0)
+		);
+	}
+
+	[Theory, AutoSubstituteData<WindowManagerCustomization>]
+	internal async void WindowsEventHook_OnWindowMoved_WindowGetsRemoved(IContext ctx, IInternalContext internalCtx)
+	{
+		// Given the window has been been handled, but is removed
+		(CaptureWinEventProc capture, WindowManager windowManager, HWND hwnd) = Setup_LocationRestoring(
+			ctx,
+			internalCtx
+		);
+		IWorkspace workspace = Setup_LocationRestoring_Success(ctx, internalCtx, windowManager, hwnd);
+
+		// When the window is moved and then removed
+		capture.WinEventProc!.Invoke((HWINEVENTHOOK)0, PInvoke.EVENT_OBJECT_LOCATIONCHANGE, hwnd, 0, 0, 0, 0);
+		await Task.Delay(2200).ConfigureAwait(true);
+
+		capture.WinEventProc!.Invoke((HWINEVENTHOOK)0, PInvoke.EVENT_OBJECT_DESTROY, hwnd, 0, 0, 0, 0);
+		await Task.Delay(2200).ConfigureAwait(true);
+
+		capture.WinEventProc!.Invoke((HWINEVENTHOOK)0, PInvoke.EVENT_OBJECT_LOCATIONCHANGE, hwnd, 0, 0, 0, 0);
+		await Task.Delay(2200).ConfigureAwait(true);
+
+		// Then the workspace is asked to do two layouts
+		workspace.Received(2).DoLayout();
+	}
+
 	[Theory, AutoSubstituteData<WindowManagerCustomization>]
 	internal void WindowsEventHook_OnWindowMoved_DoesNotRaise(IContext ctx, IInternalContext internalCtx)
 	{
@@ -714,20 +899,20 @@ public class WindowManagerTests
 	[Theory, AutoSubstituteData<WindowManagerCustomization>]
 	internal void WindowsEventHook_OnWindowMoved_DoesNotRaise_MouseIsUp(IContext ctx, IInternalContext internalCtx)
 	{
-		// Given
+		// Given the window has not had OnWindowMoveStart called
 		HWND hwnd = new(1);
 		CaptureWinEventProc capture = CaptureWinEventProc.Create(internalCtx);
 		AllowWindowCreation(ctx, internalCtx, hwnd);
 
 		WindowManager windowManager = new(ctx, internalCtx);
 
-		// When
+		// When the window is moved
 		windowManager.Initialize();
 		windowManager.PostInitialize();
 
 		Trigger_MouseLeftButtonDown(internalCtx).Trigger_MouseLeftButtonUp(internalCtx);
 
-		// Then
+		// Then no event is raised
 		CustomAssert.DoesNotRaise<WindowMovedEventArgs>(
 			h => windowManager.WindowMoved += h,
 			h => windowManager.WindowMoved -= h,

--- a/src/Whim.Tests/Window/WindowManagerTests.cs
+++ b/src/Whim.Tests/Window/WindowManagerTests.cs
@@ -827,7 +827,7 @@ public class WindowManagerTests
 	}
 
 	[Theory, AutoSubstituteData<WindowManagerCustomization>]
-	internal void WindowsEventHook_OnWindowMoved_DoesNotRaise_WindowAlreadyHandled(
+	internal async void WindowsEventHook_OnWindowMoved_DoesNotRaise_WindowAlreadyHandled(
 		IContext ctx,
 		IInternalContext internalCtx
 	)
@@ -841,6 +841,7 @@ public class WindowManagerTests
 
 		// When the window is moved for the second time
 		capture.WinEventProc!.Invoke((HWINEVENTHOOK)0, PInvoke.EVENT_OBJECT_LOCATIONCHANGE, hwnd, 0, 0, 0, 0);
+		await Task.Delay(2200).ConfigureAwait(true);
 
 		// Then no event is raised
 		CustomAssert.DoesNotRaise<WindowMovedEventArgs>(
@@ -848,6 +849,7 @@ public class WindowManagerTests
 			h => windowManager.WindowMoved -= h,
 			() => capture.WinEventProc!.Invoke((HWINEVENTHOOK)0, PInvoke.EVENT_OBJECT_LOCATIONCHANGE, hwnd, 0, 0, 0, 0)
 		);
+		await Task.Delay(2200).ConfigureAwait(true);
 	}
 
 	[Theory, AutoSubstituteData<WindowManagerCustomization>]

--- a/src/Whim/Context/Context.cs
+++ b/src/Whim/Context/Context.cs
@@ -76,6 +76,7 @@ internal class Context : IContext
 
 		Logger.Debug("Initializing...");
 		_internalContext.PreInitialize();
+		WindowManager.PreInitialize();
 		PluginManager.PreInitialize();
 
 		MonitorManager.Initialize();

--- a/src/Whim/Context/Context.cs
+++ b/src/Whim/Context/Context.cs
@@ -66,6 +66,8 @@ internal class Context : IContext
 			KeybindManager.SetKeybind(name, keybind);
 		}
 
+		FilteredWindows.LoadWindowsIgnoredByWhim(FilterManager);
+
 		// Load the user's config.
 		ConfigLoader configLoader = new(FileManager);
 		DoConfig doConfig = configLoader.LoadConfig();
@@ -76,7 +78,6 @@ internal class Context : IContext
 
 		Logger.Debug("Initializing...");
 		_internalContext.PreInitialize();
-		WindowManager.PreInitialize();
 		PluginManager.PreInitialize();
 
 		MonitorManager.Initialize();

--- a/src/Whim/Router/FilterManager.cs
+++ b/src/Whim/Router/FilterManager.cs
@@ -17,28 +17,18 @@ internal class FilterManager : IFilterManager
 	/// </summary>
 	private readonly List<Filter> _filters = new();
 
-	public FilterManager()
-	{
-		// TODO: Move this somewhere else?
-		IFilterManager.AddDefaultFilters(this);
-	}
-
 	public void Add(Filter filter)
 	{
 		_filters.Add(filter);
 	}
 
-	public void Clear(bool clearDefaults = false)
+	public void Clear()
 	{
-		Logger.Debug($"Clearing filters. Defaults being cleared: {clearDefaults}");
+		Logger.Debug($"Clearing filters");
 		_ignoreWindowClasses.Clear();
 		_ignoreProcessNames.Clear();
 		_ignoreTitles.Clear();
 		_filters.Clear();
-		if (!clearDefaults)
-		{
-			IFilterManager.AddDefaultFilters(this);
-		}
 	}
 
 	public bool ShouldBeIgnored(IWindow window)

--- a/src/Whim/Router/FilterManager.cs
+++ b/src/Whim/Router/FilterManager.cs
@@ -19,6 +19,7 @@ internal class FilterManager : IFilterManager
 
 	public FilterManager()
 	{
+		// TODO: Move this somewhere else?
 		IFilterManager.AddDefaultFilters(this);
 	}
 

--- a/src/Whim/Router/FilteredWindows.cs
+++ b/src/Whim/Router/FilteredWindows.cs
@@ -14,7 +14,7 @@ public static class FilteredWindows
 
 	/// <summary>
 	/// Load the windows which try to set their own locations when the start up.
-	/// See <see cref="IWindowManager.LocationRestoringFilterManager"/>.
+	/// See <see cref="IWindowManager.LocationRestoringFilterManager"/>
 	/// </summary>
 	/// <param name="filterManager"></param>
 	public static void LoadLocationRestoringWindows(IFilterManager filterManager) =>

--- a/src/Whim/Router/FilteredWindows.cs
+++ b/src/Whim/Router/FilteredWindows.cs
@@ -1,0 +1,22 @@
+namespace Whim;
+
+/// <summary>
+/// Defaults for various <see cref="IFilterManager"/>s.
+/// </summary>
+public static class FilteredWindows
+{
+	/// <summary>
+	/// Load the windows which should be ignored by Whim by default.
+	/// </summary>
+	/// <param name="filterManager"></param>
+	public static void LoadWindowsIgnoredByWhim(IFilterManager filterManager) =>
+		filterManager.IgnoreProcessName("SearchUI.exe");
+
+	/// <summary>
+	/// Load the windows which try to set their own locations when the start up.
+	/// See <see cref="IWindowManager.LocationRestoringFilterManager"/>.
+	/// </summary>
+	/// <param name="filterManager"></param>
+	public static void LoadLocationRestoringWindows(IFilterManager filterManager) =>
+		filterManager.IgnoreProcessName("firefox.exe");
+}

--- a/src/Whim/Router/FilteredWindows.cs
+++ b/src/Whim/Router/FilteredWindows.cs
@@ -18,5 +18,5 @@ public static class FilteredWindows
 	/// </summary>
 	/// <param name="filterManager"></param>
 	public static void LoadLocationRestoringWindows(IFilterManager filterManager) =>
-		filterManager.IgnoreProcessName("firefox.exe");
+		filterManager.IgnoreProcessName("firefox.exe").IgnoreProcessName("gateway64.exe");
 }

--- a/src/Whim/Router/IFilterManager.cs
+++ b/src/Whim/Router/IFilterManager.cs
@@ -19,8 +19,7 @@ public interface IFilterManager
 	/// <summary>
 	/// Clears all the filters.
 	/// </summary>
-	/// <param name="clearDefaults">Indicates whether the default filters should be retained.</param>
-	public void Clear(bool clearDefaults = false);
+	public void Clear();
 
 	/// <summary>
 	/// Indicates whether the window should be ignored.
@@ -55,13 +54,4 @@ public interface IFilterManager
 	/// </summary>
 	/// <param name="match"></param>
 	public IFilterManager IgnoreTitleMatch(string match);
-
-	/// <summary>
-	/// Populates the provided <see cref="IFilterManager"/> with the default
-	/// filters.
-	/// </summary>
-	public static void AddDefaultFilters(IFilterManager router)
-	{
-		router.IgnoreProcessName("SearchUI.exe");
-	}
 }

--- a/src/Whim/Window/IWindowManager.cs
+++ b/src/Whim/Window/IWindowManager.cs
@@ -14,11 +14,6 @@ public interface IWindowManager : IDisposable
 	IFilterManager LocationRestoringFilterManager { get; }
 
 	/// <summary>
-	/// Populate the <see cref="LocationRestoringFilterManager"/> with default filters.
-	/// </summary>
-	void PreInitialize();
-
-	/// <summary>
 	/// Initialize the windows event hooks.
 	/// </summary>
 	/// <returns></returns>

--- a/src/Whim/Window/IWindowManager.cs
+++ b/src/Whim/Window/IWindowManager.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using Windows.Win32.Foundation;
 
 namespace Whim;
@@ -10,10 +9,14 @@ namespace Whim;
 public interface IWindowManager : IDisposable
 {
 	/// <summary>
-	/// <see cref="IWindow.ProcessFileName"/>s of processes that will try restore window locations
-	/// after their windows are created.
+	/// Filters for windows that will try restore window locations after their windows are created.
 	/// </summary>
-	HashSet<string> LocationRestoringProcessFileNames { get; }
+	IFilterManager LocationRestoringFilterManager { get; }
+
+	/// <summary>
+	/// Populate the <see cref="LocationRestoringFilterManager"/> with default filters.
+	/// </summary>
+	void PreInitialize();
 
 	/// <summary>
 	/// Initialize the windows event hooks.

--- a/src/Whim/Window/IWindowManager.cs
+++ b/src/Whim/Window/IWindowManager.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using Windows.Win32.Foundation;
 
 namespace Whim;
@@ -8,6 +9,12 @@ namespace Whim;
 /// </summary>
 public interface IWindowManager : IDisposable
 {
+	/// <summary>
+	/// <see cref="IWindow.ProcessFileName"/>s of processes that will try restore window locations
+	/// after their windows are created.
+	/// </summary>
+	HashSet<string> LocationRestoringProcessFileNames { get; }
+
 	/// <summary>
 	/// Initialize the windows event hooks.
 	/// </summary>

--- a/src/Whim/Window/WindowManager.cs
+++ b/src/Whim/Window/WindowManager.cs
@@ -58,11 +58,8 @@ internal class WindowManager : IWindowManager, IInternalWindowManager
 		_context = context;
 		_internalContext = internalContext;
 		_hookDelegate = new WINEVENTPROC(WindowsEventHook);
-	}
 
-	public void PreInitialize()
-	{
-		LocationRestoringFilterManager.IgnoreProcessName("firefox.exe");
+		FilteredWindows.LoadLocationRestoringWindows(LocationRestoringFilterManager);
 	}
 
 	public void Initialize()

--- a/src/Whim/Window/WindowManager.cs
+++ b/src/Whim/Window/WindowManager.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Windows.Win32;
 using Windows.Win32.Foundation;
 using Windows.Win32.UI.Accessibility;
@@ -43,6 +44,14 @@ internal class WindowManager : IWindowManager, IInternalWindowManager
 	/// Indicates whether values have been disposed.
 	/// </summary>
 	private bool _disposedValue;
+
+	public HashSet<string> LocationRestoringProcessFileNames { get; } = new() { "firefox.exe" };
+
+	/// <summary>
+	/// The windows which had their first location change event handled - see <see cref="IWindowManager.LocationRestoringProcessFileNames"/>.
+	/// We maintain a set of the windows that have been handled so that we don't enter an infinite loop of location change events.
+	/// </summary>
+	private readonly HashSet<IWindow> _handledLocationRestoringWindows = new();
 
 	public WindowManager(IContext context, IInternalContext internalContext)
 	{
@@ -386,6 +395,7 @@ internal class WindowManager : IWindowManager, IInternalWindowManager
 	{
 		Logger.Debug($"Window removed: {window}");
 		_windows.TryRemove(window.Handle, out _);
+		_handledLocationRestoringWindows.Remove(window);
 		((IInternalWorkspaceManager)_context.WorkspaceManager).WindowRemoved(window);
 		WindowRemoved?.Invoke(this, new WindowEventArgs() { Window = window });
 	}
@@ -537,7 +547,29 @@ internal class WindowManager : IWindowManager, IInternalWindowManager
 
 		if (!_isMovingWindow)
 		{
-			return;
+			if (
+				window.ProcessFileName != null
+				&& !_handledLocationRestoringWindows.Contains(window)
+				&& LocationRestoringProcessFileNames.Contains(window.ProcessFileName)
+			)
+			{
+				// The window's application tried to restore its position.
+				// Wait, then restore the position.
+				_internalContext.CoreNativeManager.TryEnqueue(async () =>
+				{
+					await Task.Delay(2000).ConfigureAwait(true);
+					if (_context.WorkspaceManager.GetWorkspaceForWindow(window) is IWorkspace workspace)
+					{
+						_handledLocationRestoringWindows.Add(window);
+						workspace.DoLayout();
+					}
+				});
+			}
+			else
+			{
+				// Ignore the window moving event.
+				return;
+			}
 		}
 
 		IPoint<int>? cursorPoint = null;


### PR DESCRIPTION
Added a `IFilterManager` for `IWindowManager` as `IWindowManager.LocationRestoringFilterManager`, to try handle applications which like to restore their window positions when they start. As part of this, the default filters for `IContext.FilterManager` have been moved to the `FilteredWindows.LoadWindowsIgnoredByWhim`.

`IWindowManager.LocationRestoringFilterManager` includes default filters for Firefox and JetBrains Gateway.