### PR TITLE
Make workspace activation commands part of core

### DIFF
--- a/src/Whim.TestUtils/PluginCommandsTestUtils.cs
+++ b/src/Whim.TestUtils/PluginCommandsTestUtils.cs
@@ -30,4 +30,16 @@ public class PluginCommandsTestUtils
 		Assert.NotNull(command);
 		return command!;
 	}
+
+	/// <summary>
+	/// Get the keybind with the given identifier.
+	/// </summary>
+	/// <param name="id"></param>
+	/// <returns></returns>
+	public IKeybind GetKeybind(string id)
+	{
+		IKeybind? keybind = _pluginCommands.Keybinds.FirstOrDefault(c => c.commandId == id).keybind;
+		Assert.NotNull(keybind);
+		return keybind!;
+	}
 }

--- a/src/Whim.Tests/Commands/CoreCommandsTests.cs
+++ b/src/Whim.Tests/Commands/CoreCommandsTests.cs
@@ -1,5 +1,6 @@
 using AutoFixture;
 using NSubstitute;
+using System.Collections.Generic;
 using Whim.TestUtils;
 using Xunit;
 
@@ -243,5 +244,81 @@ public class CoreCommandsTests
 
 		// Then
 		context.Received(1).Exit(null);
+	}
+
+	private static List<IWorkspace> CreateWorkspaces(int count)
+	{
+		List<IWorkspace> workspaces = new();
+		for (int idx = 0; idx < count; idx++)
+		{
+			workspaces.Add(Substitute.For<IWorkspace>());
+		}
+		return workspaces;
+	}
+
+	[Theory, AutoSubstituteData<CoreCommandsCustomization>]
+	public void ActivateWorkspaceAtIndex_IndexDoesNotExist(IContext context)
+	{
+		// Given
+		CoreCommands commands = new(context);
+		PluginCommandsTestUtils testUtils = new(commands);
+		List<IWorkspace> workspaces = CreateWorkspaces(2);
+		context.WorkspaceManager.GetEnumerator().Returns(workspaces.GetEnumerator());
+
+		int index = 3;
+
+		ICommand command = testUtils.GetCommand($"whim.core.activate_workspace_{index}");
+
+		// When
+		command.TryExecute();
+
+		// Then
+		context.WorkspaceManager.DidNotReceive().Activate(Arg.Any<IWorkspace>());
+	}
+
+	[Theory]
+	[InlineAutoSubstituteData<CoreCommandsCustomization>(1)]
+	[InlineAutoSubstituteData<CoreCommandsCustomization>(2)]
+	[InlineAutoSubstituteData<CoreCommandsCustomization>(10)]
+	public void ActivateWorkspaceAtIndex(int index, IContext context)
+	{
+		// Given
+		CoreCommands commands = new(context);
+		PluginCommandsTestUtils testUtils = new(commands);
+		List<IWorkspace> workspaces = CreateWorkspaces(10);
+		context.WorkspaceManager.GetEnumerator().Returns(workspaces.GetEnumerator());
+
+		ICommand command = testUtils.GetCommand($"whim.core.activate_workspace_{index}");
+
+		// When
+		command.TryExecute();
+
+		// Then
+		context.WorkspaceManager.Received(1).Activate(workspaces[index - 1]);
+	}
+
+	[Theory, AutoSubstituteData<CoreCommandsCustomization>]
+	public void ActivateWorkspaceAtIndex_VerifyKeybinds(IContext context)
+	{
+		// Given
+		CoreCommands commands = new(context);
+		PluginCommandsTestUtils testUtils = new(commands);
+
+		// When
+		IKeybind[] keybinds = new IKeybind[10];
+		for (int idx = 0; idx < 10; idx++)
+		{
+			keybinds[idx] = testUtils.GetKeybind($"whim.core.activate_workspace_{idx + 1}");
+		}
+
+		// Then
+		for (int idx = 0; idx < 9; idx++)
+		{
+			Assert.Equal(KeyModifiers.LAlt | KeyModifiers.LShift, keybinds[idx].Modifiers);
+			Assert.Equal("VK_" + (idx + 1), keybinds[idx].Key.ToString());
+		}
+
+		Assert.Equal(KeyModifiers.LAlt | KeyModifiers.LShift, keybinds[9].Modifiers);
+		Assert.Equal("VK_0", keybinds[9].Key.ToString());
 	}
 }

--- a/src/Whim.Tests/Window/WindowManagerTests.cs
+++ b/src/Whim.Tests/Window/WindowManagerTests.cs
@@ -570,7 +570,7 @@ public class WindowManagerTests
 		((IInternalWorkspaceManager)ctx.WorkspaceManager)
 			.Received(1)
 			.WindowRemoved(Arg.Any<IWindow>());
-		Assert.Empty(windowManager.Windows);
+		Assert.Empty(windowManager.HandleWindowMap);
 	}
 
 	#region OnWindowMoveStart

--- a/src/Whim.Tests/Workspace/WorkspaceTests.cs
+++ b/src/Whim.Tests/Workspace/WorkspaceTests.cs
@@ -17,7 +17,7 @@ public class WorkspaceCustomization : ICustomization
 		internalContext.CoreNativeManager.IsWindow(Arg.Any<HWND>()).Returns(true);
 
 		// Assume windows are managed.
-		internalContext.WindowManager.Windows.ContainsKey(Arg.Any<HWND>()).Returns(true);
+		internalContext.WindowManager.HandleWindowMap.ContainsKey(Arg.Any<HWND>()).Returns(true);
 
 		// Set up the triggers.
 		WorkspaceManagerTriggers triggers =
@@ -200,7 +200,7 @@ public class WorkspaceTests
 			new(context, internalContext, triggers, "Workspace", new ILayoutEngine[] { layoutEngine });
 
 		internalContext.CoreNativeManager.IsWindow(Arg.Any<HWND>()).Returns(true);
-		internalContext.WindowManager.Windows.ContainsKey(Arg.Any<HWND>()).Returns(false);
+		internalContext.WindowManager.HandleWindowMap.ContainsKey(Arg.Any<HWND>()).Returns(false);
 
 		// When
 		workspace.AddWindow(window);

--- a/src/Whim/Commands/CoreCommands.cs
+++ b/src/Whim/Commands/CoreCommands.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using Windows.Win32.UI.Input.KeyboardAndMouse;
 
 namespace Whim;
@@ -198,6 +199,17 @@ internal class CoreCommands : PluginCommands
 				keybind: new Keybind(IKeybind.WinCtrl, VIRTUAL_KEY.VK_W)
 			)
 			.Add(identifier: "exit_whim", title: "Exit Whim", callback: () => _context.Exit());
+
+		for (int idx = 1; idx <= 10; idx++)
+		{
+			ActivateWorkspaceAtIndex activateWorkspaceAtIndex = new(idx);
+			_ = Add(
+				identifier: $"activate_workspace_{idx}",
+				title: $"Activate workspace {idx}",
+				callback: () => activateWorkspaceAtIndex.Execute(context),
+				keybind: new Keybind(KeyModifiers.LAlt | KeyModifiers.LShift, key: GetVirtualKeyForInt(idx))
+			);
+		}
 	}
 
 	/// <summary>
@@ -223,4 +235,34 @@ internal class CoreCommands : PluginCommands
 		{
 			_context.WorkspaceManager.ActiveWorkspace.SwapWindowInDirection(direction);
 		};
+
+	// This record is necessary, otherwise the index captured is the last one (11)
+	// The index here is 1-based.
+	private record ActivateWorkspaceAtIndex(int Index)
+	{
+		public void Execute(IContext context)
+		{
+			IWorkspace[] workspaces = context.WorkspaceManager.ToArray();
+			if (Index <= workspaces.Length)
+			{
+				context.WorkspaceManager.Activate(workspaces[Index - 1]);
+			}
+		}
+	}
+
+	/// <summary>
+	/// Convert the given integer to a <see cref="VIRTUAL_KEY"/>.
+	/// This converts the integer 0 - 9 to <see cref="VIRTUAL_KEY.VK_1"/> - <see cref="VIRTUAL_KEY.VK_0"/>.
+	/// </summary>
+	/// <param name="idx">The integer to convert, 0 - 9.</param>
+	/// <returns>The <see cref="VIRTUAL_KEY"/> corresponding to the given integer</returns>
+	private static VIRTUAL_KEY GetVirtualKeyForInt(int idx)
+	{
+		if (idx == 10)
+		{
+			return VIRTUAL_KEY.VK_0;
+		}
+
+		return (VIRTUAL_KEY)((int)VIRTUAL_KEY.VK_1 + (idx - 1));
+	}
 }

--- a/src/Whim/Window/IInternalWindowManager.cs
+++ b/src/Whim/Window/IInternalWindowManager.cs
@@ -14,5 +14,5 @@ internal interface IInternalWindowManager
 	/// <summary>
 	/// Map of <see cref="HWND"/> to <see cref="IWindow"/> for easy <see cref="IWindow"/> lookup.
 	/// </summary>
-	IReadOnlyDictionary<HWND, IWindow> Windows { get; }
+	IReadOnlyDictionary<HWND, IWindow> HandleWindowMap { get; }
 }

--- a/src/Whim/Window/IWindowManager.cs
+++ b/src/Whim/Window/IWindowManager.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using Windows.Win32.Foundation;
 
 namespace Whim;
@@ -6,7 +7,7 @@ namespace Whim;
 /// <summary>
 /// The manager for <see cref="IWindow"/>s.
 /// </summary>
-public interface IWindowManager : IDisposable
+public interface IWindowManager : IEnumerable<IWindow>, IDisposable
 {
 	/// <summary>
 	/// Filters for windows that will try restore window locations after their windows are created.

--- a/src/Whim/Window/WindowManager.cs
+++ b/src/Whim/Window/WindowManager.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -24,7 +25,7 @@ internal class WindowManager : IWindowManager, IInternalWindowManager
 	public event EventHandler<WindowEventArgs>? WindowMinimizeEnd;
 
 	private readonly ConcurrentDictionary<HWND, IWindow> _windows = new();
-	public IReadOnlyDictionary<HWND, IWindow> Windows => _windows;
+	public IReadOnlyDictionary<HWND, IWindow> HandleWindowMap => _windows;
 
 	/// <summary>
 	/// All the hooks added with <see cref="ICoreNativeManager.SetWinEventHook"/>.
@@ -604,4 +605,8 @@ internal class WindowManager : IWindowManager, IInternalWindowManager
 		((IInternalWorkspaceManager)_context.WorkspaceManager).WindowMinimizeEnd(window);
 		WindowMinimizeEnd?.Invoke(this, new WindowEventArgs() { Window = window });
 	}
+
+	public IEnumerator<IWindow> GetEnumerator() => _windows.Values.GetEnumerator();
+
+	IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 }

--- a/src/Whim/Workspace/Workspace.cs
+++ b/src/Whim/Workspace/Workspace.cs
@@ -587,7 +587,7 @@ internal class Workspace : IWorkspace, IInternalWorkspace
 				Logger.Debug($"Window {window.Handle} is no longer a window.");
 				removeWindow = true;
 			}
-			else if (!_internalContext.WindowManager.Windows.ContainsKey(window.Handle))
+			else if (!_internalContext.WindowManager.HandleWindowMap.ContainsKey(window.Handle))
 			{
 				Logger.Debug($"Window {window.Handle} is somehow no longer managed.");
 				removeWindow = true;


### PR DESCRIPTION
Previously they were an example in the README. They are now supported commands in Whim, and a new example command/keybind has replaced them in the README.