### PR TITLE
Catch errors from Windows events

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -262,3 +262,6 @@ dotnet_diagnostic.IDE0045.severity = silent
 
 # IDE0055: Fix formatting
 dotnet_diagnostic.IDE0055.severity = none
+
+# IDE0060: Remove unused parameters
+dotnet_diagnostic.IDE0060.severity = none

--- a/README.md
+++ b/README.md
@@ -337,3 +337,9 @@ The Whim repository includes a `.vscode` directory with a [`launch.json`](.vscod
 Tasks to build, test, and format XAML can be found in [`tasks.json`](.vscode/tasks.json).
 
 To see the recommended extensions, open the Command Palette and run `Extensions: Show Recommended Extensions`.
+
+### Unhandled Exception Handling
+
+`IContext` has an `UncaughtExceptionHandling` property to specify how to handle uncaught exceptions. When developing, it's recommended to set this to `UncaughtExceptionHandling.Shutdown` to shutdown Whim when an uncaught exception occurs. This will make it easier to debug the exception.
+
+All uncaught exceptions will be logged as `Fatal`.

--- a/src/Whim.Runner/App.xaml.cs
+++ b/src/Whim.Runner/App.xaml.cs
@@ -75,6 +75,7 @@ public partial class App : Application
 		Logger.Error(e.Exception.ToString());
 		e.Handled = true;
 
+		_context.HandleUncaughtException("App", e.Exception);
 #if DEBUG
 		_context?.Exit();
 #endif

--- a/src/Whim.Runner/App.xaml.cs
+++ b/src/Whim.Runner/App.xaml.cs
@@ -66,7 +66,7 @@ public partial class App : Application
 		}
 		else
 		{
-			new StartupExceptionWindow(this, e).Activate();
+			new ExceptionWindow(this, e).Activate();
 		}
 	}
 

--- a/src/Whim.Runner/App.xaml.cs
+++ b/src/Whim.Runner/App.xaml.cs
@@ -75,7 +75,8 @@ public partial class App : Application
 		Logger.Error(e.Exception.ToString());
 		e.Handled = true;
 
-		_context.HandleUncaughtException("App", e.Exception);
+		_context?.HandleUncaughtException("App", e.Exception);
+
 #if DEBUG
 		_context?.Exit();
 #endif

--- a/src/Whim.Runner/ExceptionWindow.xaml
+++ b/src/Whim.Runner/ExceptionWindow.xaml
@@ -1,5 +1,5 @@
 ﻿<Window
-	x:Class="Whim.Runner.StartupExceptionWindow"
+	x:Class="Whim.Runner.ExceptionWindow"
 	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"

--- a/src/Whim.Runner/ExceptionWindow.xaml.cs
+++ b/src/Whim.Runner/ExceptionWindow.xaml.cs
@@ -5,7 +5,7 @@ namespace Whim.Runner;
 /// <summary>
 /// Exposes the exception encountered during startup to the user.
 /// </summary>
-public sealed partial class StartupExceptionWindow : Microsoft.UI.Xaml.Window
+public sealed partial class ExceptionWindow : Microsoft.UI.Xaml.Window
 {
 	private readonly App _app;
 
@@ -19,7 +19,7 @@ public sealed partial class StartupExceptionWindow : Microsoft.UI.Xaml.Window
 	/// </summary>
 	/// <param name="app"></param>
 	/// <param name="exitEventArgs"></param>
-	public StartupExceptionWindow(App app, ExitEventArgs exitEventArgs)
+	public ExceptionWindow(App app, ExitEventArgs exitEventArgs)
 	{
 		InitializeComponent();
 		_app = app;

--- a/src/Whim.Runner/Whim.Runner.csproj
+++ b/src/Whim.Runner/Whim.Runner.csproj
@@ -68,7 +68,7 @@
 		<DefineConstants>DISABLE_XAML_GENERATED_MAIN</DefineConstants>
 	</PropertyGroup>
 	<ItemGroup>
-		<None Remove="StartupExceptionWindow.xaml" />
+		<None Remove="ExceptionWindow.xaml" />
 	</ItemGroup>
 
 	<ItemGroup>
@@ -90,8 +90,7 @@
 	<!-- Defining the "Msix" ProjectCapability here allows the Single-project MSIX Packaging
 		Tools extension to be activated for this project even if the Windows App SDK Nuget
 		package has not yet been restored -->
-	<ItemGroup
-		Condition="'$(DisableMsixProjectCapabilityAddedByProject)'!='true' and '$(EnablePreviewMsixTooling)'=='true'">
+	<ItemGroup Condition="'$(DisableMsixProjectCapabilityAddedByProject)'!='true' and '$(EnablePreviewMsixTooling)'=='true'">
 		<ProjectCapability Include="Msix" />
 	</ItemGroup>
 
@@ -104,8 +103,7 @@
 		<ProjectReference Include="..\Whim.LayoutPreview\Whim.LayoutPreview.csproj" />
 		<ProjectReference Include="..\Whim.TreeLayout\Whim.TreeLayout.csproj" />
 		<ProjectReference Include="..\Whim.TreeLayout.Bar\Whim.TreeLayout.Bar.csproj" />
-		<ProjectReference
-			Include="..\Whim.TreeLayout.CommandPalette\Whim.TreeLayout.CommandPalette.csproj" />
+		<ProjectReference Include="..\Whim.TreeLayout.CommandPalette\Whim.TreeLayout.CommandPalette.csproj" />
 		<ProjectReference Include="..\Whim.TreeLayout\Whim.TreeLayout.csproj" />
 		<ProjectReference Include="..\Whim\Whim.csproj" />
 	</ItemGroup>
@@ -118,7 +116,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<Page Update="StartupExceptionWindow.xaml">
+		<Page Update="ExceptionWindow.xaml">
 			<Generator>MSBuild:Compile</Generator>
 		</Page>
 	</ItemGroup>
@@ -127,96 +125,69 @@
 	<Target Name="CopyBarAfterBuild" AfterTargets="Build;Publish">
 		<ItemGroup>
 			<BarSourceFile Include="$(SolutionDir)\src\Whim.Bar\$(OutDir)\Whim.Bar\**\*" />
-			<BarDestinationFile
-				Include="@(BarSourceFile->'$(TargetDir)plugins\Whim.Bar\%(RecursiveDir)%(Filename)%(Extension)')" />
+			<BarDestinationFile Include="@(BarSourceFile->'$(TargetDir)plugins\Whim.Bar\%(RecursiveDir)%(Filename)%(Extension)')" />
 		</ItemGroup>
-		<Copy SourceFiles="@(BarSourceFile)" DestinationFiles="@(BarDestinationFile)"
-			SkipUnchangedFiles="true" />
-		<Copy SourceFiles="$(SolutionDir)src\Whim.Bar\$(OutDir)Whim.Bar.dll"
-			DestinationFolder="$(TargetDir)plugins\Whim.Bar\" SkipUnchangedFiles="true" />
+		<Copy SourceFiles="@(BarSourceFile)" DestinationFiles="@(BarDestinationFile)" SkipUnchangedFiles="true" />
+		<Copy SourceFiles="$(SolutionDir)src\Whim.Bar\$(OutDir)Whim.Bar.dll" DestinationFolder="$(TargetDir)plugins\Whim.Bar\" SkipUnchangedFiles="true" />
 	</Target>
 
 	<!--Whim.CommandPalette-->
 	<Target Name="CopyCommandPaletteAfterBuild" AfterTargets="Build;Publish">
 		<ItemGroup>
-			<CommandPaletteSourceFile
-				Include="$(SolutionDir)\src\Whim.CommandPalette\$(OutDir)\Whim.CommandPalette\**\*" />
-			<CommandPaletteDestinationFile
-				Include="@(CommandPaletteSourceFile->'$(TargetDir)plugins\Whim.CommandPalette\%(RecursiveDir)%(Filename)%(Extension)')" />
+			<CommandPaletteSourceFile Include="$(SolutionDir)\src\Whim.CommandPalette\$(OutDir)\Whim.CommandPalette\**\*" />
+			<CommandPaletteDestinationFile Include="@(CommandPaletteSourceFile->'$(TargetDir)plugins\Whim.CommandPalette\%(RecursiveDir)%(Filename)%(Extension)')" />
 		</ItemGroup>
-		<Copy SourceFiles="@(CommandPaletteSourceFile)"
-			DestinationFiles="@(CommandPaletteDestinationFile)" SkipUnchangedFiles="true" />
-		<Copy SourceFiles="$(SolutionDir)src\Whim.CommandPalette\$(OutDir)Whim.CommandPalette.dll"
-			DestinationFolder="$(TargetDir)plugins\Whim.CommandPalette\" SkipUnchangedFiles="true" />
+		<Copy SourceFiles="@(CommandPaletteSourceFile)" DestinationFiles="@(CommandPaletteDestinationFile)" SkipUnchangedFiles="true" />
+		<Copy SourceFiles="$(SolutionDir)src\Whim.CommandPalette\$(OutDir)Whim.CommandPalette.dll" DestinationFolder="$(TargetDir)plugins\Whim.CommandPalette\" SkipUnchangedFiles="true" />
 	</Target>
 
 	<!--Whim.FloatingLayout-->
 	<Target Name="CopyFloatingLayoutAfterBuild" AfterTargets="Build;Publish">
-		<Copy SourceFiles="$(SolutionDir)src\Whim.FloatingLayout\$(OutDir)Whim.FloatingLayout.dll"
-			DestinationFolder="$(TargetDir)plugins\Whim.FloatingLayout\" SkipUnchangedFiles="true" />
+		<Copy SourceFiles="$(SolutionDir)src\Whim.FloatingLayout\$(OutDir)Whim.FloatingLayout.dll" DestinationFolder="$(TargetDir)plugins\Whim.FloatingLayout\" SkipUnchangedFiles="true" />
 	</Target>
 
 	<!--Whim.FocusIndicator-->
 	<Target Name="CopyFocusIndicatorAfterBuild" AfterTargets="Build;Publish">
 		<ItemGroup>
-			<FocusIndicatorSourceFile
-				Include="$(SolutionDir)\src\Whim.FocusIndicator\$(OutDir)\Whim.FocusIndicator\**\*" />
-			<FocusIndicatorDestinationFile
-				Include="@(FocusIndicatorSourceFile->'$(TargetDir)plugins\Whim.FocusIndicator\%(RecursiveDir)%(Filename)%(Extension)')" />
+			<FocusIndicatorSourceFile Include="$(SolutionDir)\src\Whim.FocusIndicator\$(OutDir)\Whim.FocusIndicator\**\*" />
+			<FocusIndicatorDestinationFile Include="@(FocusIndicatorSourceFile->'$(TargetDir)plugins\Whim.FocusIndicator\%(RecursiveDir)%(Filename)%(Extension)')" />
 		</ItemGroup>
-		<Copy SourceFiles="@(FocusIndicatorSourceFile)"
-			DestinationFiles="@(FocusIndicatorDestinationFile)" SkipUnchangedFiles="true" />
-		<Copy SourceFiles="$(SolutionDir)src\Whim.FocusIndicator\$(OutDir)Whim.FocusIndicator.dll"
-			DestinationFolder="$(TargetDir)plugins\Whim.FocusIndicator\" SkipUnchangedFiles="true" />
+		<Copy SourceFiles="@(FocusIndicatorSourceFile)" DestinationFiles="@(FocusIndicatorDestinationFile)" SkipUnchangedFiles="true" />
+		<Copy SourceFiles="$(SolutionDir)src\Whim.FocusIndicator\$(OutDir)Whim.FocusIndicator.dll" DestinationFolder="$(TargetDir)plugins\Whim.FocusIndicator\" SkipUnchangedFiles="true" />
 	</Target>
 
 	<!--Whim.Gaps-->
 	<Target Name="CopyGapsAfterBuild" AfterTargets="Build;Publish">
-		<Copy SourceFiles="$(SolutionDir)src\Whim.Gaps\$(OutDir)Whim.Gaps.dll"
-			DestinationFolder="$(TargetDir)plugins\Whim.Gaps\" SkipUnchangedFiles="true" />
+		<Copy SourceFiles="$(SolutionDir)src\Whim.Gaps\$(OutDir)Whim.Gaps.dll" DestinationFolder="$(TargetDir)plugins\Whim.Gaps\" SkipUnchangedFiles="true" />
 	</Target>
 
 	<!--Whim.LayoutPreview-->
 	<Target Name="CopyLayoutPreviewAfterBuild" AfterTargets="Build;Publish">
 		<ItemGroup>
-			<LayoutPreviewSourceFile
-				Include="$(SolutionDir)\src\Whim.LayoutPreview\$(OutDir)\Whim.LayoutPreview\**\*" />
-			<LayoutPreviewDestinationFile
-				Include="@(LayoutPreviewSourceFile->'$(TargetDir)plugins\Whim.LayoutPreview\%(RecursiveDir)%(Filename)%(Extension)')" />
+			<LayoutPreviewSourceFile Include="$(SolutionDir)\src\Whim.LayoutPreview\$(OutDir)\Whim.LayoutPreview\**\*" />
+			<LayoutPreviewDestinationFile Include="@(LayoutPreviewSourceFile->'$(TargetDir)plugins\Whim.LayoutPreview\%(RecursiveDir)%(Filename)%(Extension)')" />
 		</ItemGroup>
-		<Copy SourceFiles="@(LayoutPreviewSourceFile)"
-			DestinationFiles="@(LayoutPreviewDestinationFile)" SkipUnchangedFiles="true" />
-		<Copy SourceFiles="$(SolutionDir)src\Whim.LayoutPreview\$(OutDir)Whim.LayoutPreview.dll"
-			DestinationFolder="$(TargetDir)plugins\Whim.LayoutPreview\" SkipUnchangedFiles="true" />
+		<Copy SourceFiles="@(LayoutPreviewSourceFile)" DestinationFiles="@(LayoutPreviewDestinationFile)" SkipUnchangedFiles="true" />
+		<Copy SourceFiles="$(SolutionDir)src\Whim.LayoutPreview\$(OutDir)Whim.LayoutPreview.dll" DestinationFolder="$(TargetDir)plugins\Whim.LayoutPreview\" SkipUnchangedFiles="true" />
 	</Target>
 
 	<!--Whim.TreeLayout-->
 	<Target Name="CopyTreeLayoutAfterBuild" AfterTargets="Build;Publish">
-		<Copy SourceFiles="$(SolutionDir)src\Whim.TreeLayout\$(OutDir)Whim.TreeLayout.dll"
-			DestinationFolder="$(TargetDir)plugins\Whim.TreeLayout\" SkipUnchangedFiles="true" />
+		<Copy SourceFiles="$(SolutionDir)src\Whim.TreeLayout\$(OutDir)Whim.TreeLayout.dll" DestinationFolder="$(TargetDir)plugins\Whim.TreeLayout\" SkipUnchangedFiles="true" />
 	</Target>
 
 	<!--Whim.TreeLayout.Bar-->
-	<Target Name="CopyTreeLayoutBarAfterBuild"
-		AfterTargets="Build;Publish;CopyBarAfterBuild;CopyTreeLayoutAfterBuild">
+	<Target Name="CopyTreeLayoutBarAfterBuild" AfterTargets="Build;Publish;CopyBarAfterBuild;CopyTreeLayoutAfterBuild">
 		<ItemGroup>
-			<TreeLayoutBarSourceFile
-				Include="$(SolutionDir)\src\Whim.TreeLayout.Bar\$(OutDir)\Whim.TreeLayout.Bar\**\*" />
-			<TreeLayoutBarDestinationFile
-				Include="@(TreeLayoutBarSourceFile->'$(TargetDir)plugins\Whim.TreeLayout.Bar\%(RecursiveDir)%(Filename)%(Extension)')" />
+			<TreeLayoutBarSourceFile Include="$(SolutionDir)\src\Whim.TreeLayout.Bar\$(OutDir)\Whim.TreeLayout.Bar\**\*" />
+			<TreeLayoutBarDestinationFile Include="@(TreeLayoutBarSourceFile->'$(TargetDir)plugins\Whim.TreeLayout.Bar\%(RecursiveDir)%(Filename)%(Extension)')" />
 		</ItemGroup>
-		<Copy SourceFiles="@(TreeLayoutBarSourceFile)"
-			DestinationFiles="@(TreeLayoutBarDestinationFile)" SkipUnchangedFiles="true" />
-		<Copy SourceFiles="$(SolutionDir)src\Whim.TreeLayout.Bar\$(OutDir)Whim.TreeLayout.Bar.dll"
-			DestinationFolder="$(TargetDir)plugins\Whim.TreeLayout.Bar\" SkipUnchangedFiles="true" />
+		<Copy SourceFiles="@(TreeLayoutBarSourceFile)" DestinationFiles="@(TreeLayoutBarDestinationFile)" SkipUnchangedFiles="true" />
+		<Copy SourceFiles="$(SolutionDir)src\Whim.TreeLayout.Bar\$(OutDir)Whim.TreeLayout.Bar.dll" DestinationFolder="$(TargetDir)plugins\Whim.TreeLayout.Bar\" SkipUnchangedFiles="true" />
 	</Target>
 
 	<!--Whim.TreeLayout.CommandPalette-->
-	<Target Name="CopyTreeLayoutCommandPaletteAfterBuild"
-		AfterTargets="Build;Publish;CopyCommandPaletteAfterBuild;CopyTreeLayoutAfterBuild">
-		<Copy
-			SourceFiles="$(SolutionDir)src\Whim.TreeLayout.CommandPalette\$(OutDir)Whim.TreeLayout.CommandPalette.dll"
-			DestinationFolder="$(TargetDir)plugins\Whim.TreeLayout.CommandPalette\"
-			SkipUnchangedFiles="true" />
+	<Target Name="CopyTreeLayoutCommandPaletteAfterBuild" AfterTargets="Build;Publish;CopyCommandPaletteAfterBuild;CopyTreeLayoutAfterBuild">
+		<Copy SourceFiles="$(SolutionDir)src\Whim.TreeLayout.CommandPalette\$(OutDir)Whim.TreeLayout.CommandPalette.dll" DestinationFolder="$(TargetDir)plugins\Whim.TreeLayout.CommandPalette\" SkipUnchangedFiles="true" />
 	</Target>
 </Project>

--- a/src/Whim.Tests/Commands/CoreCommandsTests.cs
+++ b/src/Whim.Tests/Commands/CoreCommandsTests.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.Collections.Generic;
 using AutoFixture;
 using NSubstitute;
 using Whim.TestUtils;

--- a/src/Whim.Tests/Native/MouseHookTests.cs
+++ b/src/Whim.Tests/Native/MouseHookTests.cs
@@ -167,6 +167,29 @@ public class MouseHookTests
 	}
 
 	[Theory, AutoSubstituteData]
+	internal void HandleException(IInternalContext internalCtx)
+	{
+		// Given
+		CaptureMouseHook capture = CaptureMouseHook.Create(internalCtx);
+		System.Drawing.Point point = new(1, 2);
+		MSLLHOOKSTRUCT msllhookstruct = new() { pt = point };
+		internalCtx.CoreNativeManager.PtrToStructure<MSLLHOOKSTRUCT>(Arg.Any<nint>()).Returns(msllhookstruct);
+		using MouseHook mouseHook = new(internalCtx);
+
+		mouseHook.PostInitialize();
+
+		// When
+		internalCtx
+			.CoreNativeManager
+			.PtrToStructure<MSLLHOOKSTRUCT>(Arg.Any<nint>())
+			.Returns(_ => throw new System.Exception("Test exception"));
+		capture.MouseHook!.Invoke(0, (WPARAM)PInvoke.WM_LBUTTONDOWN, 1);
+
+		// The
+		Assert.Equal(0, capture.Handle?.Calls);
+	}
+
+	[Theory, AutoSubstituteData]
 	internal void Dispose(IInternalContext internalCtx)
 	{
 		// Given

--- a/src/Whim.Tests/Native/MouseHookTests.cs
+++ b/src/Whim.Tests/Native/MouseHookTests.cs
@@ -45,11 +45,11 @@ public class MouseHookTests
 	}
 
 	[Theory, AutoSubstituteData]
-	internal void PostInitialize(IInternalContext internalCtx)
+	internal void PostInitialize(IContext ctx, IInternalContext internalCtx)
 	{
 		// Given
 		CaptureMouseHook capture = CaptureMouseHook.Create(internalCtx);
-		using MouseHook mouseHook = new(internalCtx);
+		using MouseHook mouseHook = new(ctx, internalCtx);
 
 		// When
 		mouseHook.PostInitialize();
@@ -59,11 +59,11 @@ public class MouseHookTests
 	}
 
 	[Theory, AutoSubstituteData]
-	internal void OnMouseTriggerEvent_LParamIsZero(IInternalContext internalCtx)
+	internal void OnMouseTriggerEvent_LParamIsZero(IContext ctx, IInternalContext internalCtx)
 	{
 		// Given
 		CaptureMouseHook capture = CaptureMouseHook.Create(internalCtx);
-		using MouseHook mouseHook = new(internalCtx);
+		using MouseHook mouseHook = new(ctx, internalCtx);
 
 		// When
 		mouseHook.PostInitialize();
@@ -77,12 +77,12 @@ public class MouseHookTests
 	}
 
 	[Theory, AutoSubstituteData]
-	internal void OnMouseTriggerEvent_NotMSLLHOOKSTRUCT(IInternalContext internalCtx)
+	internal void OnMouseTriggerEvent_NotMSLLHOOKSTRUCT(IContext ctx, IInternalContext internalCtx)
 	{
 		// Given
 		CaptureMouseHook capture = CaptureMouseHook.Create(internalCtx);
 		internalCtx.CoreNativeManager.PtrToStructure<MSLLHOOKSTRUCT>(Arg.Any<nint>()).Returns((MSLLHOOKSTRUCT?)null);
-		using MouseHook mouseHook = new(internalCtx);
+		using MouseHook mouseHook = new(ctx, internalCtx);
 
 		// When
 		mouseHook.PostInitialize();
@@ -96,14 +96,14 @@ public class MouseHookTests
 	}
 
 	[Theory, AutoSubstituteData]
-	internal void OnMouseTriggerEvent_Success_WM_LBUTTONDOWN(IInternalContext internalCtx)
+	internal void OnMouseTriggerEvent_Success_WM_LBUTTONDOWN(IContext ctx, IInternalContext internalCtx)
 	{
 		// Given
 		CaptureMouseHook capture = CaptureMouseHook.Create(internalCtx);
 		System.Drawing.Point point = new(1, 2);
 		MSLLHOOKSTRUCT msllhookstruct = new() { pt = point };
 		internalCtx.CoreNativeManager.PtrToStructure<MSLLHOOKSTRUCT>(Arg.Any<nint>()).Returns(msllhookstruct);
-		using MouseHook mouseHook = new(internalCtx);
+		using MouseHook mouseHook = new(ctx, internalCtx);
 
 		// When
 		mouseHook.PostInitialize();
@@ -119,14 +119,14 @@ public class MouseHookTests
 	}
 
 	[Theory, AutoSubstituteData]
-	internal void OnMouseTriggerEvent_Success_WM_LBUTTONUP(IInternalContext internalCtx)
+	internal void OnMouseTriggerEvent_Success_WM_LBUTTONUP(IContext ctx, IInternalContext internalCtx)
 	{
 		// Given
 		CaptureMouseHook capture = CaptureMouseHook.Create(internalCtx);
 		System.Drawing.Point point = new(1, 2);
 		MSLLHOOKSTRUCT msllhookstruct = new() { pt = point };
 		internalCtx.CoreNativeManager.PtrToStructure<MSLLHOOKSTRUCT>(Arg.Any<nint>()).Returns(msllhookstruct);
-		using MouseHook mouseHook = new(internalCtx);
+		using MouseHook mouseHook = new(ctx, internalCtx);
 
 		// When
 		mouseHook.PostInitialize();
@@ -142,12 +142,12 @@ public class MouseHookTests
 	}
 
 	[Theory, AutoSubstituteData]
-	internal void OtherKey(IInternalContext internalCtx)
+	internal void OtherKey(IContext ctx, IInternalContext internalCtx)
 	{
 		// Given
 		CaptureMouseHook capture = CaptureMouseHook.Create(internalCtx);
 		internalCtx.CoreNativeManager.PtrToStructure<MSLLHOOKSTRUCT>(Arg.Any<nint>()).Returns(new MSLLHOOKSTRUCT());
-		using MouseHook mouseHook = new(internalCtx);
+		using MouseHook mouseHook = new(ctx, internalCtx);
 
 		// When
 		mouseHook.PostInitialize();
@@ -167,14 +167,14 @@ public class MouseHookTests
 	}
 
 	[Theory, AutoSubstituteData]
-	internal void HandleException(IInternalContext internalCtx)
+	internal void HandleException(IContext ctx, IInternalContext internalCtx)
 	{
 		// Given
 		CaptureMouseHook capture = CaptureMouseHook.Create(internalCtx);
 		System.Drawing.Point point = new(1, 2);
 		MSLLHOOKSTRUCT msllhookstruct = new() { pt = point };
 		internalCtx.CoreNativeManager.PtrToStructure<MSLLHOOKSTRUCT>(Arg.Any<nint>()).Returns(msllhookstruct);
-		using MouseHook mouseHook = new(internalCtx);
+		using MouseHook mouseHook = new(ctx, internalCtx);
 
 		mouseHook.PostInitialize();
 
@@ -190,11 +190,11 @@ public class MouseHookTests
 	}
 
 	[Theory, AutoSubstituteData]
-	internal void Dispose(IInternalContext internalCtx)
+	internal void Dispose(IContext ctx, IInternalContext internalCtx)
 	{
 		// Given
 		CaptureMouseHook capture = CaptureMouseHook.Create(internalCtx);
-		using MouseHook mouseHook = new(internalCtx);
+		using MouseHook mouseHook = new(ctx, internalCtx);
 		mouseHook.PostInitialize();
 
 		// When
@@ -205,11 +205,11 @@ public class MouseHookTests
 	}
 
 	[Theory, AutoSubstituteData]
-	internal void AlreadyDisposed(IInternalContext internalCtx)
+	internal void AlreadyDisposed(IContext ctx, IInternalContext internalCtx)
 	{
 		// Given
 		CaptureMouseHook capture = CaptureMouseHook.Create(internalCtx);
-		using MouseHook mouseHook = new(internalCtx);
+		using MouseHook mouseHook = new(ctx, internalCtx);
 		mouseHook.PostInitialize();
 		mouseHook.Dispose();
 

--- a/src/Whim.Tests/Native/MouseHookTests.cs
+++ b/src/Whim.Tests/Native/MouseHookTests.cs
@@ -183,7 +183,11 @@ public class MouseHookTests
 			.CoreNativeManager
 			.PtrToStructure<MSLLHOOKSTRUCT>(Arg.Any<nint>())
 			.Returns(_ => throw new System.Exception("Test exception"));
-		capture.MouseHook!.Invoke(0, (WPARAM)PInvoke.WM_LBUTTONDOWN, 1);
+		CustomAssert.DoesNotRaise<MouseEventArgs>(
+			h => mouseHook.MouseLeftButtonDown += h,
+			h => mouseHook.MouseLeftButtonDown -= h,
+			() => capture.MouseHook!.Invoke(0, (WPARAM)PInvoke.WM_LBUTTONDOWN, 1)
+		);
 
 		// The
 		Assert.Equal(0, capture.Handle?.Calls);

--- a/src/Whim.Tests/Window/WindowManagerTests.cs
+++ b/src/Whim.Tests/Window/WindowManagerTests.cs
@@ -1,12 +1,8 @@
 using System;
-using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Collections.Generic;
-using System.ComponentModel;
 using System.ComponentModel;
 using System.Linq;
-using System.Threading.Tasks;
 using System.Threading.Tasks;
 using AutoFixture;
 using FluentAssertions;
@@ -323,7 +319,7 @@ public class WindowManagerTests
 	[InlineAutoSubstituteData<WindowManagerCustomization>(PInvoke.CHILDID_SELF, 0, null)]
 #pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
 	[Theory]
-	internal void WindowsEventHook_IsEventWindowValid_False(
+	internal void WinEventProc_IsEventWindowValid_False(
 		int idObject,
 		int idChild,
 		int? hwndValue,
@@ -360,7 +356,7 @@ public class WindowManagerTests
 	[InlineAutoSubstituteData<WindowManagerCustomization>(false, false, false, true)]
 	[InlineAutoSubstituteData<WindowManagerCustomization>(false, false, true, false)]
 	[Theory]
-	internal void WindowsEventHook_AddWindow_Fail(
+	internal void WinEventProc_AddWindow_Fail(
 		bool isSplashScreen,
 		bool isCloakedWindow,
 		bool isStandardWindow,
@@ -388,7 +384,7 @@ public class WindowManagerTests
 	}
 
 	[Theory, AutoSubstituteData<WindowManagerCustomization>]
-	internal void WindowsEventHook_CreateWindow_Null(IContext ctx, IInternalContext internalCtx)
+	internal void WinEventProc_CreateWindow_Null(IContext ctx, IInternalContext internalCtx)
 	{
 		// Given
 		HWND hwnd = new(1);
@@ -414,7 +410,7 @@ public class WindowManagerTests
 	}
 
 	[Theory, AutoSubstituteData<WindowManagerCustomization>]
-	internal void WindowsEventHook_IgnoreWindow(IContext ctx, IInternalContext internalCtx)
+	internal void WinEventProc_IgnoreWindow(IContext ctx, IInternalContext internalCtx)
 	{
 		// Given
 		HWND hwnd = new(1);
@@ -437,7 +433,7 @@ public class WindowManagerTests
 	}
 
 	[Theory, AutoSubstituteData<WindowManagerCustomization>]
-	internal void WindowsEventHook_WindowIsMinimized(IContext ctx, IInternalContext internalCtx)
+	internal void WinEventProc_WindowIsMinimized(IContext ctx, IInternalContext internalCtx)
 	{
 		// Given
 		HWND hwnd = new(1);
@@ -463,7 +459,7 @@ public class WindowManagerTests
 	[InlineAutoSubstituteData<WindowManagerCustomization>(PInvoke.EVENT_SYSTEM_FOREGROUND)]
 	[InlineAutoSubstituteData<WindowManagerCustomization>(PInvoke.EVENT_OBJECT_UNCLOAKED)]
 	[Theory]
-	internal void WindowsEventHook_OnWindowFocused(uint eventType, IContext ctx, IInternalContext internalCtx)
+	internal void WinEventProc_OnWindowFocused(uint eventType, IContext ctx, IInternalContext internalCtx)
 	{
 		// Given
 		HWND hwnd = new(1);
@@ -490,11 +486,7 @@ public class WindowManagerTests
 	[InlineAutoSubstituteData<WindowManagerCustomization>(PInvoke.EVENT_SYSTEM_FOREGROUND)]
 	[InlineAutoSubstituteData<WindowManagerCustomization>(PInvoke.EVENT_OBJECT_UNCLOAKED)]
 	[Theory]
-	internal void WindowsEventHook_OnWindowFocused_IgnoredWindow(
-		uint eventType,
-		IContext ctx,
-		IInternalContext internalCtx
-	)
+	internal void WinEventProc_OnWindowFocused_IgnoredWindow(uint eventType, IContext ctx, IInternalContext internalCtx)
 	{
 		// Given
 		HWND hwnd = new(1);
@@ -523,7 +515,7 @@ public class WindowManagerTests
 	}
 
 	[Theory, AutoSubstituteData<WindowManagerCustomization>]
-	internal void WindowsEventHook_OnWindowHidden_IgnoreWindow(IContext ctx, IInternalContext internalCtx)
+	internal void WinEventProc_OnWindowHidden_IgnoreWindow(IContext ctx, IInternalContext internalCtx)
 	{
 		// Given
 		HWND hwnd = new(1);
@@ -543,7 +535,7 @@ public class WindowManagerTests
 	}
 
 	[Theory, AutoSubstituteData<WindowManagerCustomization>]
-	internal void WindowsEventHook_OnWindowHidden(IContext ctx, IInternalContext internalCtx)
+	internal void WinEventProc_OnWindowHidden(IContext ctx, IInternalContext internalCtx)
 	{
 		// Given
 		HWND hwnd = new(1);
@@ -569,7 +561,7 @@ public class WindowManagerTests
 	[InlineAutoSubstituteData<WindowManagerCustomization>(PInvoke.EVENT_OBJECT_DESTROY)]
 	[InlineAutoSubstituteData<WindowManagerCustomization>(PInvoke.EVENT_OBJECT_CLOAKED)]
 	[Theory]
-	internal void WindowsEventHook_OnWindowRemoved(uint eventType, IContext ctx, IInternalContext internalCtx)
+	internal void WinEventProc_OnWindowRemoved(uint eventType, IContext ctx, IInternalContext internalCtx)
 	{
 		// Given
 		HWND hwnd = new(1);
@@ -595,7 +587,7 @@ public class WindowManagerTests
 
 	#region OnWindowMoveStart
 	[Theory, AutoSubstituteData<WindowManagerCustomization>]
-	internal void WindowsEventHook_OnWindowMoveStart(IContext ctx, IInternalContext internalCtx, IWorkspace workspace)
+	internal void WinEventProc_OnWindowMoveStart(IContext ctx, IInternalContext internalCtx, IWorkspace workspace)
 	{
 		// Given
 		HWND hwnd = new(1);
@@ -630,7 +622,7 @@ public class WindowManagerTests
 	}
 
 	[Theory, AutoSubstituteData<WindowManagerCustomization>]
-	internal void WindowsEventHook_OnWindowMoveStart_GetCursorPos(IContext ctx, IInternalContext internalCtx)
+	internal void WinEventProc_OnWindowMoveStart_GetCursorPos(IContext ctx, IInternalContext internalCtx)
 	{
 		// Given
 		HWND hwnd = new(1);
@@ -659,7 +651,7 @@ public class WindowManagerTests
 	[MemberData(nameof(MoveEdgesSuccessData))]
 #pragma warning disable IDE0060 // Remove unused parameter
 #pragma warning disable xUnit1026 // Theory methods should use all of their parameter
-	internal void WindowsEventHook_OnWindowMoveStart_MovedEdges(
+	internal void WinEventProc_OnWindowMoveStart_MovedEdges(
 		ILocation<int> originalLocation,
 		ILocation<int> newLocation,
 		Direction _direction,
@@ -729,7 +721,7 @@ public class WindowManagerTests
 	}
 
 	[Theory, AutoSubstituteData<WindowManagerCustomization>]
-	internal void WindowsEventHook_OnWindowMoved_DoesNotRaise_ProcessFileNameIsNull(
+	internal void WinEventProc_OnWindowMoved_DoesNotRaise_ProcessFileNameIsNull(
 		IContext ctx,
 		IInternalContext internalCtx
 	)
@@ -751,7 +743,7 @@ public class WindowManagerTests
 	}
 
 	[Theory, AutoSubstituteData<WindowManagerCustomization>]
-	internal void WindowsEventHook_OnWindowMoved_DoesNotRaise_WindowDoesNotRestore(
+	internal void WinEventProc_OnWindowMoved_DoesNotRaise_WindowDoesNotRestore(
 		IContext ctx,
 		IInternalContext internalCtx
 	)
@@ -796,7 +788,7 @@ public class WindowManagerTests
 	}
 
 	[Theory, AutoSubstituteData<WindowManagerCustomization>]
-	internal async void WindowsEventHook_OnWindowMoved_Raises_CannotFindWorkspaceForWindow(
+	internal async void WinEventProc_OnWindowMoved_Raises_CannotFindWorkspaceForWindow(
 		IContext ctx,
 		IInternalContext internalCtx
 	)
@@ -825,7 +817,7 @@ public class WindowManagerTests
 	}
 
 	[Theory, AutoSubstituteData<WindowManagerCustomization>]
-	internal async void WindowsEventHook_OnWindowMoved_Raises_DoLayout(IContext ctx, IInternalContext internalCtx)
+	internal async void WinEventProc_OnWindowMoved_Raises_DoLayout(IContext ctx, IInternalContext internalCtx)
 	{
 		// Given the window is registered as restoring, and a workspace is found for it
 		(CaptureWinEventProc capture, WindowManager windowManager, HWND hwnd) = Setup_LocationRestoring(
@@ -850,7 +842,7 @@ public class WindowManagerTests
 	}
 
 	[Theory, AutoSubstituteData<WindowManagerCustomization>]
-	internal async void WindowsEventHook_OnWindowMoved_DoesNotRaise_WindowAlreadyHandled(
+	internal async void WinEventProc_OnWindowMoved_DoesNotRaise_WindowAlreadyHandled(
 		IContext ctx,
 		IInternalContext internalCtx
 	)
@@ -876,7 +868,7 @@ public class WindowManagerTests
 	}
 
 	[Theory, AutoSubstituteData<WindowManagerCustomization>]
-	internal async void WindowsEventHook_OnWindowMoved_WindowGetsRemoved(IContext ctx, IInternalContext internalCtx)
+	internal async void WinEventProc_OnWindowMoved_WindowGetsRemoved(IContext ctx, IInternalContext internalCtx)
 	{
 		// Given the window has been been handled, but is removed
 		(CaptureWinEventProc capture, WindowManager windowManager, HWND hwnd) = Setup_LocationRestoring(
@@ -900,7 +892,7 @@ public class WindowManagerTests
 	}
 
 	[Theory, AutoSubstituteData<WindowManagerCustomization>]
-	internal void WindowsEventHook_OnWindowMoved_DoesNotRaise(IContext ctx, IInternalContext internalCtx)
+	internal void WinEventProc_OnWindowMoved_DoesNotRaise(IContext ctx, IInternalContext internalCtx)
 	{
 		// Given
 		HWND hwnd = new(1);
@@ -921,7 +913,7 @@ public class WindowManagerTests
 	}
 
 	[Theory, AutoSubstituteData<WindowManagerCustomization>]
-	internal void WindowsEventHook_OnWindowMoved_DoesNotRaise_MouseIsUp(IContext ctx, IInternalContext internalCtx)
+	internal void WinEventProc_OnWindowMoved_DoesNotRaise_MouseIsUp(IContext ctx, IInternalContext internalCtx)
 	{
 		// Given the window has not had OnWindowMoveStart called
 		HWND hwnd = new(1);
@@ -945,7 +937,7 @@ public class WindowManagerTests
 	}
 
 	[Theory, AutoSubstituteData<WindowManagerCustomization>]
-	internal void WindowsEventHook_OnWindowMoved_GetCursorPos(IContext ctx, IInternalContext internalCtx)
+	internal void WinEventProc_OnWindowMoved_GetCursorPos(IContext ctx, IInternalContext internalCtx)
 	{
 		// Given
 		HWND hwnd = new(1);
@@ -973,7 +965,7 @@ public class WindowManagerTests
 	}
 
 	[Theory, AutoSubstituteData<WindowManagerCustomization>]
-	internal void WindowsEventHook_OnWindowMoved(IContext ctx, IInternalContext internalCtx, IWorkspace workspace)
+	internal void WinEventProc_OnWindowMoved(IContext ctx, IInternalContext internalCtx, IWorkspace workspace)
 	{
 		// Given
 		CaptureWinEventProc capture = CaptureWinEventProc.Create(internalCtx);
@@ -1015,7 +1007,7 @@ public class WindowManagerTests
 	#endregion
 
 	[Theory, AutoSubstituteData<WindowManagerCustomization>]
-	internal void WindowsEventHook_OnWindowMinimizeStart(IContext ctx, IInternalContext internalCtx)
+	internal void WinEventProc_OnWindowMinimizeStart(IContext ctx, IInternalContext internalCtx)
 	{
 		// Given
 		HWND hwnd = new(1);
@@ -1039,7 +1031,7 @@ public class WindowManagerTests
 	}
 
 	[Theory, AutoSubstituteData<WindowManagerCustomization>]
-	internal void WindowsEventHook_OnWindowMinimizeEnd(IContext ctx, IInternalContext internalCtx)
+	internal void WinEventProc_OnWindowMinimizeEnd(IContext ctx, IInternalContext internalCtx)
 	{
 		// Given
 		HWND hwnd = new(1);
@@ -1064,7 +1056,7 @@ public class WindowManagerTests
 
 	#region OnWindowMoveEnd
 	[Theory, AutoSubstituteData<WindowManagerCustomization>]
-	internal void WindowsEventHook_OnWindowMoveEnd_WindowNotMoving(IContext ctx, IInternalContext internalCtx)
+	internal void WinEventProc_OnWindowMoveEnd_WindowNotMoving(IContext ctx, IInternalContext internalCtx)
 	{
 		// Given
 		HWND hwnd = new(1);
@@ -1083,7 +1075,7 @@ public class WindowManagerTests
 	}
 
 	[Theory, AutoSubstituteData<WindowManagerCustomization>]
-	internal void WindowsEventHook_OnWindowMoveEnd_GetMovedEdges_NoWorkspace(IContext ctx, IInternalContext internalCtx)
+	internal void WinEventProc_OnWindowMoveEnd_GetMovedEdges_NoWorkspace(IContext ctx, IInternalContext internalCtx)
 	{
 		// Given
 		HWND hwnd = new(1);
@@ -1105,7 +1097,7 @@ public class WindowManagerTests
 	}
 
 	[Theory, AutoSubstituteData<WindowManagerCustomization>]
-	internal void WindowsEventHook_OnWindowMoveEnd_GetMovedEdges_DoesNotContainWindowState(
+	internal void WinEventProc_OnWindowMoveEnd_GetMovedEdges_DoesNotContainWindowState(
 		IContext ctx,
 		IInternalContext internalCtx,
 		IWorkspace workspace
@@ -1142,7 +1134,7 @@ public class WindowManagerTests
 	}
 
 	[Theory, AutoSubstituteData<WindowManagerCustomization>]
-	internal void WindowsEventHook_OnWindowMoveEnd_MoveWindowToPoint(
+	internal void WinEventProc_OnWindowMoveEnd_MoveWindowToPoint(
 		IContext ctx,
 		IInternalContext internalCtx,
 		IWorkspace workspace
@@ -1179,7 +1171,7 @@ public class WindowManagerTests
 	#endregion
 
 	[Theory, AutoSubstituteData<WindowManagerCustomization>]
-	internal void WindowsEventHook_OnWindowMoved_GetMovedEdges_CannotGetNewWindowLocation(
+	internal void WinEventProc_OnWindowMoved_GetMovedEdges_CannotGetNewWindowLocation(
 		IContext ctx,
 		IInternalContext internalCtx,
 		IWorkspace workspace
@@ -1220,7 +1212,7 @@ public class WindowManagerTests
 	[InlineAutoSubstituteData<WindowManagerCustomization>(0, 1, 1, 0)]
 	[InlineAutoSubstituteData<WindowManagerCustomization>(1, 1, 1, 1)]
 	[Theory]
-	internal void WindowsEventHook_OnWindowMoveEnd_GetMovedEdges_MoveTooManyEdges(
+	internal void WinEventProc_OnWindowMoveEnd_GetMovedEdges_MoveTooManyEdges(
 		int newX,
 		int newY,
 		int newWidth,
@@ -1350,7 +1342,7 @@ public class WindowManagerTests
 
 	[Theory]
 	[MemberData(nameof(MoveEdgesSuccessData))]
-	internal void WindowsEventHook_OnWindowMoveEnd_Success(
+	internal void WinEventProc_OnWindowMoveEnd_Success(
 		ILocation<int> originalLocation,
 		ILocation<int> newLocation,
 		Direction direction,
@@ -1399,7 +1391,7 @@ public class WindowManagerTests
 	}
 
 	[Theory, AutoSubstituteData<WindowManagerCustomization>]
-	internal void WindowsEventHook_OnWindowMoveEnd_GetCursorPos(
+	internal void WinEventProc_OnWindowMoveEnd_GetCursorPos(
 		IContext ctx,
 		IInternalContext internalCtx,
 		IWorkspace workspace
@@ -1459,7 +1451,7 @@ public class WindowManagerTests
 	}
 
 	[Theory, AutoSubstituteData<WindowManagerCustomization>]
-	internal void WindowsEventHook_InvalidEvent(IContext ctx, IInternalContext internalCtx)
+	internal void WinEventProc_InvalidEvent(IContext ctx, IInternalContext internalCtx)
 	{
 		// Given
 		HWND hwnd = new(1);

--- a/src/Whim/Context/Context.cs
+++ b/src/Whim/Context/Context.cs
@@ -103,11 +103,7 @@ internal class Context : IContext
 				// TODO
 				throw new NotImplementedException();
 
-			case UncaughtExceptionHandling.ShutdownSilently:
-				Exit(new ExitEventArgs() { Reason = ExitReason.Error, Message = exception.ToString() });
-				break;
-
-			case UncaughtExceptionHandling.ShutdownWithMessage:
+			case UncaughtExceptionHandling.Shutdown:
 				Exit(new ExitEventArgs() { Reason = ExitReason.Error, Message = exception.ToString() });
 				break;
 

--- a/src/Whim/Context/Context.cs
+++ b/src/Whim/Context/Context.cs
@@ -103,7 +103,11 @@ internal class Context : IContext
 				// TODO
 				throw new NotImplementedException();
 
-			case UncaughtExceptionHandling.Shutdown:
+			case UncaughtExceptionHandling.ShutdownSilently:
+				Exit(new ExitEventArgs() { Reason = ExitReason.Error, Message = exception.ToString() });
+				break;
+
+			case UncaughtExceptionHandling.ShutdownWithMessage:
 				Exit(new ExitEventArgs() { Reason = ExitReason.Error, Message = exception.ToString() });
 				break;
 

--- a/src/Whim/Context/Context.cs
+++ b/src/Whim/Context/Context.cs
@@ -99,10 +99,6 @@ internal class Context : IContext
 
 		switch (UncaughtExceptionHandling)
 		{
-			case UncaughtExceptionHandling.Notify:
-				// TODO
-				throw new NotImplementedException();
-
 			case UncaughtExceptionHandling.Shutdown:
 				Exit(new ExitEventArgs() { Reason = ExitReason.Error, Message = exception.ToString() });
 				break;

--- a/src/Whim/Context/Context.cs
+++ b/src/Whim/Context/Context.cs
@@ -16,6 +16,7 @@ internal class Context : IContext
 	private readonly IInternalContext _internalContext;
 	public IFileManager FileManager { get; }
 	public Logger Logger { get; }
+	public ExceptionHandling ExceptionHandling { get; set; } = ExceptionHandling.Log;
 	public INativeManager NativeManager { get; }
 	public IWorkspaceManager WorkspaceManager { get; }
 	public IWindowManager WindowManager { get; }

--- a/src/Whim/Context/Context.cs
+++ b/src/Whim/Context/Context.cs
@@ -16,7 +16,7 @@ internal class Context : IContext
 	private readonly IInternalContext _internalContext;
 	public IFileManager FileManager { get; }
 	public Logger Logger { get; }
-	public ExceptionHandling ExceptionHandling { get; set; } = ExceptionHandling.Log;
+	public UncaughtExceptionHandling UncaughtExceptionHandling { get; set; } = UncaughtExceptionHandling.Log;
 	public INativeManager NativeManager { get; }
 	public IWorkspaceManager WorkspaceManager { get; }
 	public IWindowManager WindowManager { get; }
@@ -91,6 +91,26 @@ internal class Context : IContext
 		_internalContext.PostInitialize();
 
 		Logger.Debug("Completed initialization");
+	}
+
+	public void HandleUncaughtException(string procName, Exception exception)
+	{
+		Logger.Fatal($"Unhandled exception in {procName}: {exception}");
+
+		switch (UncaughtExceptionHandling)
+		{
+			case UncaughtExceptionHandling.Notify:
+				// TODO
+				throw new NotImplementedException();
+
+			case UncaughtExceptionHandling.Shutdown:
+				Exit(new ExitEventArgs() { Reason = ExitReason.Error, Message = exception.ToString() });
+				break;
+
+			case UncaughtExceptionHandling.Log:
+			default:
+				break;
+		}
 	}
 
 	public void Exit(ExitEventArgs? args = null)

--- a/src/Whim/Context/IContext.cs
+++ b/src/Whim/Context/IContext.cs
@@ -100,6 +100,8 @@ public interface IContext
 
 	/// <summary>
 	/// Handles an uncaught exception, according to <see cref="UncaughtExceptionHandling"/>.
+	/// Place this in a <c>catch</c> block where re-entry can occur - for example, in a
+	/// Win32 hook.
 	/// </summary>
 	/// <param name="procName"></param>
 	/// <param name="exception"></param>

--- a/src/Whim/Context/IContext.cs
+++ b/src/Whim/Context/IContext.cs
@@ -13,11 +13,6 @@ public enum UncaughtExceptionHandling
 	Log,
 
 	/// <summary>
-	/// Send a notification to the user and continue.
-	/// </summary>
-	Notify,
-
-	/// <summary>
 	/// Shutdown and show the user an error message.
 	/// </summary>
 	Shutdown

--- a/src/Whim/Context/IContext.cs
+++ b/src/Whim/Context/IContext.cs
@@ -18,9 +18,14 @@ public enum UncaughtExceptionHandling
 	Notify,
 
 	/// <summary>
+	/// Shutdown silently.
+	/// </summary>
+	ShutdownSilently,
+
+	/// <summary>
 	/// Shutdown and show the user an error message.
 	/// </summary>
-	Shutdown,
+	ShutdownWithMessage
 }
 
 /// <summary>

--- a/src/Whim/Context/IContext.cs
+++ b/src/Whim/Context/IContext.cs
@@ -5,7 +5,7 @@ namespace Whim;
 /// <summary>
 /// Ways to handle uncaught exceptions.
 /// </summary>
-public enum ExceptionHandling
+public enum UncaughtExceptionHandling
 {
 	/// <summary>
 	/// Log the error and continue.
@@ -40,9 +40,9 @@ public interface IContext
 	Logger Logger { get; }
 
 	/// <summary>
-	/// How to handle uncaught exceptions. Defaults to <see cref="ExceptionHandling.Log"/>.
+	/// How to handle uncaught exceptions. Defaults to <see cref="UncaughtExceptionHandling.Log"/>.
 	/// </summary>
-	ExceptionHandling ExceptionHandling { get; set; }
+	UncaughtExceptionHandling UncaughtExceptionHandling { get; set; }
 
 	/// <summary>
 	/// Whim's <see cref="IWorkspaceManager"/> instances.
@@ -102,6 +102,13 @@ public interface IContext
 	/// Thrown if the user's config could not be loaded.
 	/// </exception>
 	void Initialize();
+
+	/// <summary>
+	/// Handles an uncaught exception, according to <see cref="UncaughtExceptionHandling"/>.
+	/// </summary>
+	/// <param name="procName"></param>
+	/// <param name="exception"></param>
+	void HandleUncaughtException(string procName, Exception exception);
 
 	/// <summary>
 	/// This event is fired when the context is shutting down.

--- a/src/Whim/Context/IContext.cs
+++ b/src/Whim/Context/IContext.cs
@@ -18,14 +18,9 @@ public enum UncaughtExceptionHandling
 	Notify,
 
 	/// <summary>
-	/// Shutdown silently.
-	/// </summary>
-	ShutdownSilently,
-
-	/// <summary>
 	/// Shutdown and show the user an error message.
 	/// </summary>
-	ShutdownWithMessage
+	Shutdown
 }
 
 /// <summary>

--- a/src/Whim/Context/IContext.cs
+++ b/src/Whim/Context/IContext.cs
@@ -3,6 +3,27 @@ using System;
 namespace Whim;
 
 /// <summary>
+/// Ways to handle uncaught exceptions.
+/// </summary>
+public enum ExceptionHandling
+{
+	/// <summary>
+	/// Log the error and continue.
+	/// </summary>
+	Log,
+
+	/// <summary>
+	/// Send a notification to the user and continue.
+	/// </summary>
+	Notify,
+
+	/// <summary>
+	/// Shutdown and show the user an error message.
+	/// </summary>
+	Shutdown,
+}
+
+/// <summary>
 /// This is the core of Whim. <br/>
 ///
 /// <c>IContext</c> consists of managers which contain and control Whim's state, and thus
@@ -17,6 +38,11 @@ public interface IContext
 	/// Whim's <see cref="Logger"/> instances.
 	/// </summary>
 	Logger Logger { get; }
+
+	/// <summary>
+	/// How to handle uncaught exceptions. Defaults to <see cref="ExceptionHandling.Log"/>.
+	/// </summary>
+	ExceptionHandling ExceptionHandling { get; set; }
 
 	/// <summary>
 	/// Whim's <see cref="IWorkspaceManager"/> instances.

--- a/src/Whim/Context/InternalContext.cs
+++ b/src/Whim/Context/InternalContext.cs
@@ -24,7 +24,7 @@ internal class InternalContext : IInternalContext
 		CoreNativeManager = new CoreNativeManager(context);
 		WindowMessageMonitor = new WindowMessageMonitor(context, this);
 		KeybindHook = new KeybindHook(context, this);
-		MouseHook = new MouseHook(this);
+		MouseHook = new MouseHook(context, this);
 		DeferWindowPosManager = new DeferWindowPosManager(context, this);
 	}
 

--- a/src/Whim/Keybinds/KeybindHook.cs
+++ b/src/Whim/Keybinds/KeybindHook.cs
@@ -38,7 +38,7 @@ internal class KeybindHook : IKeybindHook
 		}
 		catch (Exception e)
 		{
-			Logger.Error($"Error in LowLevelKeyboardProc: {e}");
+			Logger.Fatal($"Error in LowLevelKeyboardProc: {e}");
 			return _internalContext.CoreNativeManager.CallNextHookEx(nCode, wParam, lParam);
 		}
 	}

--- a/src/Whim/Keybinds/KeybindHook.cs
+++ b/src/Whim/Keybinds/KeybindHook.cs
@@ -13,6 +13,7 @@ internal class KeybindHook : IKeybindHook
 {
 	private readonly IContext _context;
 	private readonly IInternalContext _internalContext;
+	private readonly HOOKPROC _lowLevelKeyboardProc;
 	private UnhookWindowsHookExSafeHandle? _unhookKeyboardHook;
 	private bool _disposedValue;
 
@@ -20,6 +21,7 @@ internal class KeybindHook : IKeybindHook
 	{
 		_context = context;
 		_internalContext = internalContext;
+		_lowLevelKeyboardProc = LowLevelKeyboardProcWrapper;
 	}
 
 	public void PostInitialize()
@@ -27,7 +29,7 @@ internal class KeybindHook : IKeybindHook
 		Logger.Debug("Initializing keybind manager...");
 		_unhookKeyboardHook = _internalContext
 			.CoreNativeManager
-			.SetWindowsHookEx(WINDOWS_HOOK_ID.WH_KEYBOARD_LL, LowLevelKeyboardProcWrapper, null, 0);
+			.SetWindowsHookEx(WINDOWS_HOOK_ID.WH_KEYBOARD_LL, _lowLevelKeyboardProc, null, 0);
 	}
 
 	private LRESULT LowLevelKeyboardProcWrapper(int nCode, WPARAM wParam, LPARAM lParam)

--- a/src/Whim/Keybinds/KeybindHook.cs
+++ b/src/Whim/Keybinds/KeybindHook.cs
@@ -13,7 +13,6 @@ internal class KeybindHook : IKeybindHook
 {
 	private readonly IContext _context;
 	private readonly IInternalContext _internalContext;
-	private readonly HOOKPROC _lowLevelKeyboardProc;
 	private UnhookWindowsHookExSafeHandle? _unhookKeyboardHook;
 	private bool _disposedValue;
 
@@ -21,7 +20,6 @@ internal class KeybindHook : IKeybindHook
 	{
 		_context = context;
 		_internalContext = internalContext;
-		_lowLevelKeyboardProc = LowLevelKeyboardProc;
 	}
 
 	public void PostInitialize()
@@ -29,7 +27,20 @@ internal class KeybindHook : IKeybindHook
 		Logger.Debug("Initializing keybind manager...");
 		_unhookKeyboardHook = _internalContext
 			.CoreNativeManager
-			.SetWindowsHookEx(WINDOWS_HOOK_ID.WH_KEYBOARD_LL, _lowLevelKeyboardProc, null, 0);
+			.SetWindowsHookEx(WINDOWS_HOOK_ID.WH_KEYBOARD_LL, LowLevelKeyboardProcWrapper, null, 0);
+	}
+
+	private LRESULT LowLevelKeyboardProcWrapper(int nCode, WPARAM wParam, LPARAM lParam)
+	{
+		try
+		{
+			return LowLevelKeyboardProc(nCode, wParam, lParam);
+		}
+		catch (Exception e)
+		{
+			Logger.Error($"Error in LowLevelKeyboardProc: {e}");
+			return _internalContext.CoreNativeManager.CallNextHookEx(nCode, wParam, lParam);
+		}
 	}
 
 	/// <summary>

--- a/src/Whim/Keybinds/KeybindHook.cs
+++ b/src/Whim/Keybinds/KeybindHook.cs
@@ -40,7 +40,7 @@ internal class KeybindHook : IKeybindHook
 		}
 		catch (Exception e)
 		{
-			Logger.Fatal($"Error in LowLevelKeyboardProc: {e}");
+			_context.HandleUncaughtException(nameof(LowLevelKeyboardProc), e);
 			return _internalContext.CoreNativeManager.CallNextHookEx(nCode, wParam, lParam);
 		}
 	}

--- a/src/Whim/Native/DeferWindowPosManager.cs
+++ b/src/Whim/Native/DeferWindowPosManager.cs
@@ -38,7 +38,7 @@ internal class DeferWindowPosManager : IDeferWindowPosManager
 		for (int i = 0; i < stackTrace.FrameCount; i++)
 		{
 			StackFrame? frame = stackTrace.GetFrame(i);
-			if (frame?.GetMethod() == typeof(WindowManager).GetMethod(nameof(WindowManager.WindowsEventHook)))
+			if (frame?.GetMethod() == typeof(WindowManager).GetMethod(nameof(WindowManager.WinEventProcWrapper)))
 			{
 				entryCount++;
 

--- a/src/Whim/Native/MouseHook.cs
+++ b/src/Whim/Native/MouseHook.cs
@@ -10,6 +10,7 @@ namespace Whim;
 /// </summary>
 internal class MouseHook : IMouseHook
 {
+	private readonly IContext _context;
 	private readonly IInternalContext _internalContext;
 	private readonly HOOKPROC _lowLevelMouseProc;
 	private UnhookWindowsHookExSafeHandle? _unhookMouseHook;
@@ -17,8 +18,9 @@ internal class MouseHook : IMouseHook
 	public event EventHandler<MouseEventArgs>? MouseLeftButtonDown;
 	public event EventHandler<MouseEventArgs>? MouseLeftButtonUp;
 
-	public MouseHook(IInternalContext internalContext)
+	public MouseHook(IContext context, IInternalContext internalContext)
 	{
+		_context = context;
 		_internalContext = internalContext;
 		_lowLevelMouseProc = LowLevelMouseProcWrapper;
 	}
@@ -39,7 +41,7 @@ internal class MouseHook : IMouseHook
 		}
 		catch (Exception e)
 		{
-			Logger.Fatal($"Error in LowLevelMouseProc: {e}");
+			_context.HandleUncaughtException(nameof(LowLevelMouseProc), e);
 			return _internalContext.CoreNativeManager.CallNextHookEx(nCode, wParam, lParam);
 		}
 	}

--- a/src/Whim/Native/MouseHook.cs
+++ b/src/Whim/Native/MouseHook.cs
@@ -11,6 +11,7 @@ namespace Whim;
 internal class MouseHook : IMouseHook
 {
 	private readonly IInternalContext _internalContext;
+	private readonly HOOKPROC _lowLevelMouseProc;
 	private UnhookWindowsHookExSafeHandle? _unhookMouseHook;
 	private bool disposedValue;
 	public event EventHandler<MouseEventArgs>? MouseLeftButtonDown;
@@ -19,6 +20,7 @@ internal class MouseHook : IMouseHook
 	public MouseHook(IInternalContext internalContext)
 	{
 		_internalContext = internalContext;
+		_lowLevelMouseProc = LowLevelMouseProcWrapper;
 	}
 
 	public void PostInitialize()
@@ -26,7 +28,7 @@ internal class MouseHook : IMouseHook
 		Logger.Debug("Initializing mouse manager...");
 		_unhookMouseHook = _internalContext
 			.CoreNativeManager
-			.SetWindowsHookEx(WINDOWS_HOOK_ID.WH_MOUSE_LL, LowLevelMouseProcWrapper, null, 0);
+			.SetWindowsHookEx(WINDOWS_HOOK_ID.WH_MOUSE_LL, _lowLevelMouseProc, null, 0);
 	}
 
 	private LRESULT LowLevelMouseProcWrapper(int nCode, WPARAM wParam, LPARAM lParam)

--- a/src/Whim/Native/MouseHook.cs
+++ b/src/Whim/Native/MouseHook.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Runtime.CompilerServices;
 using Windows.Win32;
 using Windows.Win32.Foundation;
 using Windows.Win32.UI.WindowsAndMessaging;
@@ -50,7 +49,6 @@ internal class MouseHook : IMouseHook
 	/// <param name="wParam"></param>
 	/// <param name="lParam"></param>
 	/// <returns></returns>
-	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 	private LRESULT LowLevelMouseProc(int nCode, WPARAM wParam, LPARAM lParam)
 	{
 		switch ((uint)wParam)

--- a/src/Whim/Native/MouseHook.cs
+++ b/src/Whim/Native/MouseHook.cs
@@ -38,7 +38,7 @@ internal class MouseHook : IMouseHook
 		}
 		catch (Exception e)
 		{
-			Logger.Error($"Error in LowLevelMouseProc: {e}");
+			Logger.Fatal($"Error in LowLevelMouseProc: {e}");
 			return _internalContext.CoreNativeManager.CallNextHookEx(nCode, wParam, lParam);
 		}
 	}

--- a/src/Whim/Window/WindowManager.cs
+++ b/src/Whim/Window/WindowManager.cs
@@ -212,7 +212,7 @@ internal class WindowManager : IWindowManager, IInternalWindowManager
 		}
 		catch (Exception e)
 		{
-			Logger.Error($"Caught error in WinEventProc: {e}");
+			Logger.Fatal($"Caught error in WinEventProc: {e}");
 		}
 	}
 

--- a/src/Whim/Window/WindowManager.cs
+++ b/src/Whim/Window/WindowManager.cs
@@ -213,7 +213,7 @@ internal class WindowManager : IWindowManager, IInternalWindowManager
 		}
 		catch (Exception e)
 		{
-			Logger.Fatal($"Caught error in WinEventProc: {e}");
+			_context.HandleUncaughtException(nameof(WinEventProc), e);
 		}
 	}
 

--- a/src/Whim/Window/WindowManager.cs
+++ b/src/Whim/Window/WindowManager.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Windows.Win32;
 using Windows.Win32.Foundation;
@@ -228,7 +227,6 @@ internal class WindowManager : IWindowManager, IInternalWindowManager
 	/// <param name="idChild"></param>
 	/// <param name="_idEventThread"></param>
 	/// <param name="_dwmsEventTime"></param>
-	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 	private void WinEventProc(
 		HWINEVENTHOOK _hWinEventHook,
 		uint eventType,


### PR DESCRIPTION
Handles top-level exceptions from `KeybindHook`, `MouseHook`, and `WindowManager`, using the new `UncaughtExceptionHandling` enum and `IContext.HandleUncaughtException` method.

`StartupExceptionWindow` has been renamed to `ExceptionWindow`, as it can now show exceptions whenever `UncaughtExceptionHandling` is set to `Shutdown`.
