### PR TITLE
Allow users to specify `whim.custom` namespace

### DIFF
--- a/src/Whim.Tests/Commands/CommandManagerTests.cs
+++ b/src/Whim.Tests/Commands/CommandManagerTests.cs
@@ -51,14 +51,16 @@ public class CommandManagerTests
 		Assert.Single(commandManager);
 	}
 
-	[Fact]
-	public void Add()
+	[Theory]
+	[InlineData("command")]
+	[InlineData("whim.custom.command")]
+	public void Add(string identifier)
 	{
 		// Given
 		CommandManager commandManager = new();
 
 		// When
-		commandManager.Add("command", "title", () => { });
+		commandManager.Add(identifier, "title", () => { });
 
 		// Then
 		ICommand? command = commandManager.TryGetCommand("whim.custom.command");

--- a/src/Whim/Commands/CommandManager.cs
+++ b/src/Whim/Commands/CommandManager.cs
@@ -25,8 +25,15 @@ internal class CommandManager : ICommandManager
 		_commands.Add(item.Id, item);
 	}
 
-	public void Add(string identifier, string title, Action callback, Func<bool>? condition = null) =>
-		AddPluginCommand(new Command($"whim.custom.{identifier}", title, callback, condition));
+	public void Add(string identifier, string title, Action callback, Func<bool>? condition = null)
+	{
+		if (!identifier.StartsWith(ICommandManager.CustomCommandPrefix))
+		{
+			identifier = $"{ICommandManager.CustomCommandPrefix}.{identifier}";
+		}
+
+		AddPluginCommand(new Command(identifier, title, callback, condition));
+	}
 
 	public ICommand? TryGetCommand(string commandId)
 	{

--- a/src/Whim/Commands/ICommandManager.cs
+++ b/src/Whim/Commands/ICommandManager.cs
@@ -9,9 +9,14 @@ namespace Whim;
 public interface ICommandManager : IEnumerable<ICommand>
 {
 	/// <summary>
+	/// The prefix for all custom commands.
+	/// </summary>
+	const string CustomCommandPrefix = "whim.custom";
+
+	/// <summary>
 	/// Gets the number of commands in the manager.
 	/// </summary>
-	public int Count { get; }
+	int Count { get; }
 
 	/// <summary>
 	/// Adds a new user-defined command to the manager.
@@ -31,12 +36,12 @@ public interface ICommandManager : IEnumerable<ICommand>
 	/// executed.
 	/// If this is null, the command will always be accessible.
 	/// </param>
-	public void Add(string identifier, string title, Action callback, Func<bool>? condition = null);
+	void Add(string identifier, string title, Action callback, Func<bool>? condition = null);
 
 	/// <summary>
 	/// Tries to get the command with the given identifier.
 	/// </summary>
 	/// <param name="commandId">The identifier of the command to get</param>
 	/// <returns>The command with the given identifier, or null if not found.</returns>
-	public ICommand? TryGetCommand(string commandId);
+	ICommand? TryGetCommand(string commandId);
 }

--- a/src/Whim/Plugin/PluginManager.cs
+++ b/src/Whim/Plugin/PluginManager.cs
@@ -90,8 +90,10 @@ internal partial class PluginManager : IPluginManager
 	{
 		switch (plugin.Name)
 		{
-			case "whim.custom":
-				throw new InvalidOperationException("Name 'whim.custom' is reserved for user-defined commands.");
+			case ICommandManager.CustomCommandPrefix:
+				throw new InvalidOperationException(
+					$"Name '{ICommandManager.CustomCommandPrefix}' is reserved for user-defined commands."
+				);
 			case "whim":
 				throw new InvalidOperationException("Name 'whim' is reserved for internal use.");
 			case string name when Contains(name):


### PR DESCRIPTION
Previously, `whim.custom` would _always_ be prefixed. This was a bit confusing, as users could add the `whim.custom` prefix themselves, resulting in `whim.custom.whim.custom.<command>`. We now handle when users specify `whim.custom` themselves.