### PR TITLE
Add Command Palette command to find and activate a window

### DIFF
--- a/src/Whim.CommandPalette/CommandPaletteCommands.cs
+++ b/src/Whim.CommandPalette/CommandPaletteCommands.cs
@@ -104,6 +104,22 @@ public class CommandPaletteCommands : PluginCommands
 							ConfirmButtonText = "Remove"
 						}
 					)
+			)
+			.Add(
+				identifier: "find_focus_window",
+				title: "Find and focus window",
+				callback: () =>
+					_commandPalettePlugin.Activate(
+						new MenuVariantConfig()
+						{
+							Hint = "Find window",
+							ConfirmButtonText = "Focus",
+							Commands = _context
+								.WorkspaceManager
+								.SelectMany(w => w.Windows)
+								.Select(w => FocusWindowCommandCreator(w))
+						}
+					)
 			);
 	}
 
@@ -223,7 +239,30 @@ public class CommandPaletteCommands : PluginCommands
 	internal ICommand RemoveWindowCommandCreator(IWindow window) =>
 		new Command(
 			identifier: $"{PluginName}.remove_window.{window.Title}",
-			title: $"Remove \"{window.Title}\"",
+			title: window.Title,
 			callback: () => _context.WorkspaceManager.ActiveWorkspace.RemoveWindow(window)
+		);
+
+	/// <summary>
+	/// Focus window command creator.
+	/// </summary>
+	/// <param name="window"></param>
+	/// <returns></returns>
+	internal ICommand FocusWindowCommandCreator(IWindow window) =>
+		new Command(
+			identifier: $"{PluginName}.focus_window.{window.Title}",
+			title: window.Title,
+			callback: () =>
+			{
+				IWorkspace? workspace = _context.WorkspaceManager.GetWorkspaceForWindow(window);
+				if (workspace == null)
+				{
+					return;
+				}
+
+				// A bit of a dirty hack to focus the window. If the window is minimised, it will
+				// now be shown. It will then be focused.
+				workspace.AddWindow(window);
+			}
 		);
 }

--- a/src/Whim.Tests/Workspace/WorkspaceManagerTests.cs
+++ b/src/Whim.Tests/Workspace/WorkspaceManagerTests.cs
@@ -416,7 +416,7 @@ public class WorkspaceManagerTests
 
 		// Layout is done, and the first window is focused.
 		workspace.Received(1).DoLayout();
-		workspace.Received(1).FocusFirstWindow();
+		workspace.Received(1).FocusLastFocusedWindow();
 	}
 
 	[Theory, AutoSubstituteData<WorkspaceManagerCustomization>]
@@ -452,7 +452,7 @@ public class WorkspaceManagerTests
 		previousWorkspace.Received(1).Deactivate();
 		previousWorkspace.DidNotReceive().DoLayout();
 		currentWorkspace.Received(1).DoLayout();
-		currentWorkspace.Received(1).FocusFirstWindow();
+		currentWorkspace.Received(1).FocusLastFocusedWindow();
 	}
 
 	[Theory, AutoSubstituteData<WorkspaceManagerCustomization>]
@@ -481,11 +481,11 @@ public class WorkspaceManagerTests
 
 		workspaces[0].DidNotReceive().Deactivate();
 		workspaces[0].Received(1).DoLayout();
-		workspaces[0].DidNotReceive().FocusFirstWindow();
+		workspaces[0].DidNotReceive().FocusLastFocusedWindow();
 
 		workspaces[1].DidNotReceive().Deactivate();
 		workspaces[1].Received(1).DoLayout();
-		workspaces[1].Received(1).FocusFirstWindow();
+		workspaces[1].Received(1).FocusLastFocusedWindow();
 	}
 
 	[InlineAutoSubstituteData<WorkspaceManagerCustomization>(0, 2)]
@@ -508,11 +508,11 @@ public class WorkspaceManagerTests
 
 		workspaces[currentIdx].Received(1).Deactivate();
 		workspaces[currentIdx].DidNotReceive().DoLayout();
-		workspaces[currentIdx].DidNotReceive().FocusFirstWindow();
+		workspaces[currentIdx].DidNotReceive().FocusLastFocusedWindow();
 
 		workspaces[prevIdx].DidNotReceive().Deactivate();
 		workspaces[prevIdx].Received(1).DoLayout();
-		workspaces[prevIdx].Received(1).FocusFirstWindow();
+		workspaces[prevIdx].Received(1).FocusLastFocusedWindow();
 	}
 
 	[Theory, AutoSubstituteData<WorkspaceManagerCustomization>]
@@ -534,11 +534,11 @@ public class WorkspaceManagerTests
 
 		workspaces[0].DidNotReceive().Deactivate();
 		workspaces[0].DidNotReceive().DoLayout();
-		workspaces[0].DidNotReceive().FocusFirstWindow();
+		workspaces[0].DidNotReceive().FocusLastFocusedWindow();
 
 		workspaces[1].DidNotReceive().Deactivate();
 		workspaces[1].DidNotReceive().DoLayout();
-		workspaces[1].DidNotReceive().FocusFirstWindow();
+		workspaces[1].DidNotReceive().FocusLastFocusedWindow();
 	}
 
 	[InlineAutoSubstituteData<WorkspaceManagerCustomization>(0, 1)]
@@ -561,11 +561,11 @@ public class WorkspaceManagerTests
 
 		workspaces[currentIdx].Received(1).Deactivate();
 		workspaces[currentIdx].DidNotReceive().DoLayout();
-		workspaces[currentIdx].DidNotReceive().FocusFirstWindow();
+		workspaces[currentIdx].DidNotReceive().FocusLastFocusedWindow();
 
 		workspaces[nextIdx].DidNotReceive().Deactivate();
 		workspaces[nextIdx].Received(1).DoLayout();
-		workspaces[nextIdx].Received(1).FocusFirstWindow();
+		workspaces[nextIdx].Received(1).FocusLastFocusedWindow();
 	}
 
 	[Theory, AutoSubstituteData<WorkspaceManagerCustomization>]
@@ -587,11 +587,11 @@ public class WorkspaceManagerTests
 
 		workspaces[0].DidNotReceive().Deactivate();
 		workspaces[0].DidNotReceive().DoLayout();
-		workspaces[0].DidNotReceive().FocusFirstWindow();
+		workspaces[0].DidNotReceive().FocusLastFocusedWindow();
 
 		workspaces[1].DidNotReceive().Deactivate();
 		workspaces[1].DidNotReceive().DoLayout();
-		workspaces[1].DidNotReceive().FocusFirstWindow();
+		workspaces[1].DidNotReceive().FocusLastFocusedWindow();
 	}
 	#endregion
 

--- a/src/Whim.Tests/Workspace/WorkspaceTests.cs
+++ b/src/Whim.Tests/Workspace/WorkspaceTests.cs
@@ -359,6 +359,49 @@ public class WorkspaceTests
 	}
 
 	[Theory, AutoSubstituteData<WorkspaceCustomization>]
+	internal void FocusLastFocusedWindow_NoLastFocusedWindow(
+		IContext context,
+		IInternalContext internalContext,
+		WorkspaceManagerTriggers triggers,
+		ILayoutEngine layoutEngine
+	)
+	{
+		// Given
+		Workspace workspace =
+			new(context, internalContext, triggers, "Workspace", new ILayoutEngine[] { layoutEngine });
+
+		// When FocusLastFocusedWindow is called
+		workspace.FocusLastFocusedWindow();
+
+		// Then the LayoutEngine's GetFirstWindow method is called
+		layoutEngine.Received(1).GetFirstWindow();
+	}
+
+	[Theory, AutoSubstituteData<WorkspaceCustomization>]
+	internal void FocusLastFocusedWindow_LastFocusedWindow(
+		IContext context,
+		IInternalContext internalContext,
+		WorkspaceManagerTriggers triggers,
+		ILayoutEngine layoutEngine,
+		IWindow window
+	)
+	{
+		// Given the window is in the workspace
+		Workspace workspace =
+			new(context, internalContext, triggers, "Workspace", new ILayoutEngine[] { layoutEngine });
+		workspace.AddWindow(window);
+
+		window.ClearReceivedCalls();
+
+		// When FocusLastFocusedWindow is called
+		workspace.FocusLastFocusedWindow();
+
+		// Then the LayoutEngine's GetFirstWindow method is called
+		layoutEngine.DidNotReceive().GetFirstWindow();
+		window.Received(1).Focus();
+	}
+
+	[Theory, AutoSubstituteData<WorkspaceCustomization>]
 	internal void NextLayoutEngine(
 		IContext context,
 		IInternalContext internalContext,

--- a/src/Whim.Tests/Workspace/WorkspaceTests.cs
+++ b/src/Whim.Tests/Workspace/WorkspaceTests.cs
@@ -460,6 +460,7 @@ public class WorkspaceTests
 		// Then the window is added to the layout engine
 		layoutEngine.Received(1).AddWindow(window);
 		context.WorkspaceManager.Received(1).GetMonitorForWorkspace(workspace);
+		window.Received(2).Focus();
 	}
 
 	[Theory, AutoSubstituteData<WorkspaceCustomization>]
@@ -481,6 +482,31 @@ public class WorkspaceTests
 		// Then the window is added to the layout engine
 		layoutEngine.Received(1).AddWindow(window);
 		context.WorkspaceManager.Received(1).GetMonitorForWorkspace(workspace);
+		window.Received(1).Focus();
+	}
+
+	[Theory, AutoSubstituteData<WorkspaceCustomization>]
+	internal void AddWindow_Success_WindowWasMinimized(
+		IContext context,
+		IInternalContext internalContext,
+		WorkspaceManagerTriggers triggers,
+		ILayoutEngine layoutEngine,
+		IWindow window
+	)
+	{
+		// Given the window has already been added but was since minimized
+		Workspace workspace =
+			new(context, internalContext, triggers, "Workspace", new ILayoutEngine[] { layoutEngine });
+		workspace.AddWindow(window);
+		workspace.WindowMinimizeStart(window);
+
+		// When AddWindow is called
+		workspace.AddWindow(window);
+
+		// Then the window is added to the layout engine
+		layoutEngine.Received(1).AddWindow(window);
+		context.WorkspaceManager.Received(3).GetMonitorForWorkspace(workspace);
+		window.Received(2).Focus();
 	}
 
 	[Theory, AutoSubstituteData<WorkspaceCustomization>]

--- a/src/Whim/Context/Context.cs
+++ b/src/Whim/Context/Context.cs
@@ -42,9 +42,6 @@ internal class Context : IContext
 
 		NativeManager = new NativeManager(this, _internalContext);
 
-		// Initialize just the logger.
-		Logger.Initialize(FileManager);
-
 		RouterManager = new RouterManager(this);
 		FilterManager = new FilterManager();
 		WindowManager = new WindowManager(this, _internalContext);
@@ -76,6 +73,9 @@ internal class Context : IContext
 		ConfigLoader configLoader = new(FileManager);
 		DoConfig doConfig = configLoader.LoadConfig();
 		doConfig(this);
+
+		// Initialize the logger first.
+		Logger.Initialize(FileManager);
 
 		// Initialize the managers.
 		Logger.Debug("Initializing...");

--- a/src/Whim/Workspace/IWorkspace.cs
+++ b/src/Whim/Workspace/IWorkspace.cs
@@ -105,7 +105,14 @@ public interface IWorkspace : IDisposable
 	/// <summary>
 	/// Focuses on the first window in the workspace.
 	/// </summary>
+	[Obsolete("Use FocusLastFocusedWindow instead.")]
 	void FocusFirstWindow();
+
+	/// <summary>
+	/// Focuses on the last window in the workspace. If <see cref="LastFocusedWindow"/> is null,
+	/// then we try focus the first window.
+	/// </summary>
+	void FocusLastFocusedWindow();
 
 	/// <summary>
 	/// Focuses the <paramref name="window"/> in the <paramref name="direction"/>.

--- a/src/Whim/Workspace/Workspace.cs
+++ b/src/Whim/Workspace/Workspace.cs
@@ -270,7 +270,14 @@ internal class Workspace : IWorkspace, IInternalWorkspace
 			if (_normalWindows.Contains(window))
 			{
 				Logger.Error($"Window {window} already exists in workspace {Name}");
+				window.Focus();
 				return;
+			}
+
+			if (_minimizedWindows.Contains(window))
+			{
+				Logger.Debug($"Window {window} is minimized in workspace {Name}, unminimizing");
+				_minimizedWindows.Remove(window);
 			}
 
 			_normalWindows.Add(window);

--- a/src/Whim/Workspace/Workspace.cs
+++ b/src/Whim/Workspace/Workspace.cs
@@ -174,6 +174,20 @@ internal class Workspace : IWorkspace, IInternalWorkspace
 		ActiveLayoutEngine.GetFirstWindow()?.Focus();
 	}
 
+	public void FocusLastFocusedWindow()
+	{
+		Logger.Debug($"Focusing last focused window in workspace {Name}");
+		if (LastFocusedWindow != null)
+		{
+			LastFocusedWindow.Focus();
+		}
+		else
+		{
+			Logger.Debug($"No last focused window in workspace {Name}, focusing first window");
+			ActiveLayoutEngine.GetFirstWindow()?.Focus();
+		}
+	}
+
 	private void UpdateLayoutEngine(int delta)
 	{
 		ILayoutEngine prevLayoutEngine;
@@ -289,6 +303,7 @@ internal class Workspace : IWorkspace, IInternalWorkspace
 
 		DoLayout();
 		window.Focus();
+		LastFocusedWindow = window;
 	}
 
 	public bool RemoveWindow(IWindow window)

--- a/src/Whim/Workspace/WorkspaceManager.cs
+++ b/src/Whim/Workspace/WorkspaceManager.cs
@@ -303,7 +303,7 @@ internal class WorkspaceManager : IInternalWorkspaceManager, IWorkspaceManager
 
 		// Layout the new workspace.
 		workspace.DoLayout();
-		workspace.FocusFirstWindow();
+		workspace.FocusLastFocusedWindow();
 		MonitorWorkspaceChanged?.Invoke(
 			this,
 			new MonitorWorkspaceChangedEventArgs()


### PR DESCRIPTION
- Added a Command Palette command to find and focus a window.
- `Workspace` now handles minimized windows being added to it again, by restoring them.
- When activating a workspace, focus the last focused window instead of the first window.
