### PR TITLE
Fix window minimization and focus behavior

### DIFF
--- a/src/Whim.Tests/Commands/CoreCommandsTests.cs
+++ b/src/Whim.Tests/Commands/CoreCommandsTests.cs
@@ -214,13 +214,17 @@ public class CoreCommandsTests
 	}
 
 	[Theory, AutoSubstituteData<CoreCommandsCustomization>]
-	public void MinimizeWindow(IContext context, IWindow window)
+	public void MinimizeWindow(IContext context, IWindow window1, IWindow window2, IWindow window3)
 	{
 		// Given
 		CoreCommands commands = new(context);
 		PluginCommandsTestUtils testUtils = new(commands);
 
-		context.WorkspaceManager.ActiveWorkspace.LastFocusedWindow.Returns(window);
+		window3.IsMinimized.Returns(false);
+
+		IWorkspace activeWorkspace = context.WorkspaceManager.ActiveWorkspace;
+		activeWorkspace.LastFocusedWindow.Returns(window1);
+		activeWorkspace.Windows.GetEnumerator().Returns(new List<IWindow>() { window2, window3 }.GetEnumerator());
 
 		ICommand command = testUtils.GetCommand("whim.core.minimize_window");
 
@@ -228,7 +232,8 @@ public class CoreCommandsTests
 		command.TryExecute();
 
 		// Then
-		window.Received(1).ShowMinimized();
+		window1.Received(1).ShowMinimized();
+		window3.Received(1).Focus();
 	}
 
 	[InlineAutoSubstituteData<CoreCommandsCustomization>("whim.core.focus_previous_monitor")]

--- a/src/Whim.Tests/Commands/CoreCommandsTests.cs
+++ b/src/Whim.Tests/Commands/CoreCommandsTests.cs
@@ -213,6 +213,7 @@ public class CoreCommandsTests
 		window.Received(1).ShowMaximized();
 	}
 
+	#region MinimizeWindow
 	[Theory, AutoSubstituteData<CoreCommandsCustomization>]
 	public void MinimizeWindow(IContext context, IWindow window1, IWindow window2, IWindow window3)
 	{
@@ -235,6 +236,50 @@ public class CoreCommandsTests
 		window1.Received(1).ShowMinimized();
 		window3.Received(1).Focus();
 	}
+
+	[Theory, AutoSubstituteData<CoreCommandsCustomization>]
+	public void MinimizeWindow_NoLastFocusedWindow(IContext context, IWindow window1, IWindow window2)
+	{
+		// Given
+		CoreCommands commands = new(context);
+		PluginCommandsTestUtils testUtils = new(commands);
+
+		window2.IsMinimized.Returns(false);
+
+		IWorkspace activeWorkspace = context.WorkspaceManager.ActiveWorkspace;
+		activeWorkspace.LastFocusedWindow.Returns((IWindow?)null);
+		activeWorkspace.Windows.GetEnumerator().Returns(new List<IWindow>() { window1, window2 }.GetEnumerator());
+
+		ICommand command = testUtils.GetCommand("whim.core.minimize_window");
+
+		// When
+		command.TryExecute();
+
+		// Then
+		window2.Received(1).Focus();
+	}
+
+	[Theory, AutoSubstituteData<CoreCommandsCustomization>]
+	public void MinimizeWindow_FocusFirstWindow(IContext context, IWindow window1, IWindow window2, IWindow window3)
+	{
+		// Given
+		CoreCommands commands = new(context);
+		PluginCommandsTestUtils testUtils = new(commands);
+
+		IWorkspace activeWorkspace = context.WorkspaceManager.ActiveWorkspace;
+		activeWorkspace.LastFocusedWindow.Returns(window1);
+		activeWorkspace.Windows.GetEnumerator().Returns(new List<IWindow>() { window2, window3 }.GetEnumerator());
+
+		ICommand command = testUtils.GetCommand("whim.core.minimize_window");
+
+		// When
+		command.TryExecute();
+
+		// Then
+		window1.Received(1).ShowMinimized();
+		window2.Received(1).Focus();
+	}
+	#endregion
 
 	[InlineAutoSubstituteData<CoreCommandsCustomization>("whim.core.focus_previous_monitor")]
 	[InlineAutoSubstituteData<CoreCommandsCustomization>("whim.core.focus_next_monitor")]

--- a/src/Whim/Commands/CoreCommands.cs
+++ b/src/Whim/Commands/CoreCommands.cs
@@ -182,7 +182,21 @@ internal class CoreCommands : PluginCommands
 			.Add(
 				identifier: "minimize_window",
 				title: "Minimize the current window",
-				callback: () => _context.WorkspaceManager.ActiveWorkspace.LastFocusedWindow?.ShowMinimized()
+				callback: () =>
+				{
+					IWorkspace workspace = _context.WorkspaceManager.ActiveWorkspace;
+					workspace.LastFocusedWindow?.ShowMinimized();
+
+					// Find the first non-minimized window and focus it
+					foreach (IWindow window in workspace.Windows)
+					{
+						if (!window.IsMinimized)
+						{
+							window.Focus();
+							break;
+						}
+					}
+				}
 			)
 			.Add(
 				identifier: "focus_previous_monitor",


### PR DESCRIPTION
When using `whim.core.minimize_window`, try focus a window in the workspace after minimizing the window.