### PR TITLE
Hide LayoutPreviewWindow on window focus

### DIFF
--- a/src/Whim.LayoutPreview.Tests/LayoutPreviewPluginTests.cs
+++ b/src/Whim.LayoutPreview.Tests/LayoutPreviewPluginTests.cs
@@ -75,6 +75,7 @@ public class LayoutPreviewPluginTests
 		ctx.WindowManager.Received(1).WindowMoveStart += Arg.Any<EventHandler<WindowMovedEventArgs>>();
 		ctx.WindowManager.Received(1).WindowMoved += Arg.Any<EventHandler<WindowMovedEventArgs>>();
 		ctx.WindowManager.Received(1).WindowMoveEnd += Arg.Any<EventHandler<WindowMovedEventArgs>>();
+		ctx.WindowManager.Received(1).WindowRemoved += Arg.Any<EventHandler<WindowEventArgs>>();
 		ctx.FilterManager.Received(1).AddTitleMatchFilter(LayoutPreviewWindow.WindowTitle);
 	}
 
@@ -303,6 +304,34 @@ public class LayoutPreviewPluginTests
 		plugin.PreInitialize();
 		ctx.WindowManager.WindowMoved += Raise.Event<EventHandler<WindowMovedEventArgs>>(ctx.WindowManager, moveArgs);
 		ctx.WindowManager.WindowRemoved += Raise.Event<EventHandler<WindowEventArgs>>(ctx.WindowManager, removeArgs);
+
+		// Then
+		Assert.Null(plugin.DraggedWindow);
+	}
+
+	[Theory, AutoSubstituteData<LayoutPreviewPluginCustomization>]
+	public void WindowManager_WindowFocused(IContext ctx, IWindow movedWindow)
+	{
+		// Given
+		using LayoutPreviewPlugin plugin = new(ctx);
+
+		WindowMovedEventArgs moveArgs =
+			new()
+			{
+				Window = movedWindow,
+				CursorDraggedPoint = new Location<int>(),
+				MovedEdges = null
+			};
+
+		WindowFocusedEventArgs focusArgs = new() { Window = movedWindow };
+
+		// When
+		plugin.PreInitialize();
+		ctx.WindowManager.WindowMoved += Raise.Event<EventHandler<WindowMovedEventArgs>>(ctx.WindowManager, moveArgs);
+		ctx.WindowManager.WindowFocused += Raise.Event<EventHandler<WindowFocusedEventArgs>>(
+			ctx.WindowManager,
+			focusArgs
+		);
 
 		// Then
 		Assert.Null(plugin.DraggedWindow);

--- a/src/Whim.LayoutPreview/LayoutPreviewPlugin.cs
+++ b/src/Whim.LayoutPreview/LayoutPreviewPlugin.cs
@@ -39,6 +39,7 @@ public class LayoutPreviewPlugin : IPlugin, IDisposable
 		_context.WindowManager.WindowMoved += WindowMoved;
 		_context.WindowManager.WindowMoveEnd += WindowManager_WindowMoveEnd;
 		_context.WindowManager.WindowRemoved += WindowManager_WindowRemoved;
+		_context.WindowManager.WindowFocused += WindowManager_WindowFocused;
 		_context.FilterManager.AddTitleMatchFilter(LayoutPreviewWindow.WindowTitle);
 	}
 
@@ -113,6 +114,15 @@ public class LayoutPreviewPlugin : IPlugin, IDisposable
 				_layoutPreviewWindow?.Hide(_context);
 				DraggedWindow = null;
 			}
+		}
+	}
+
+	private void WindowManager_WindowFocused(object? sender, WindowFocusedEventArgs e)
+	{
+		lock (_previewLock)
+		{
+			_layoutPreviewWindow?.Hide(_context);
+			DraggedWindow = null;
 		}
 	}
 


### PR DESCRIPTION
This is mainly a workaround for when the `LayoutPreviewWindow` remains unexpectedly open.