### PR TITLE
Fix window edge movement command values

### DIFF
--- a/src/Whim.Tests/Commands/CoreCommandsTests.cs
+++ b/src/Whim.Tests/Commands/CoreCommandsTests.cs
@@ -114,13 +114,8 @@ public class CoreCommandsTests
 		context.WorkspaceManager.ActiveWorkspace.Received(1).SwapWindowInDirection(direction, null);
 	}
 
-	[InlineAutoSubstituteData<CoreCommandsCustomization>("whim.core.move_window_left_edge_left", Direction.Left, 1, 0)]
-	[InlineAutoSubstituteData<CoreCommandsCustomization>(
-		"whim.core.move_window_left_edge_right",
-		Direction.Left,
-		-1,
-		0
-	)]
+	[InlineAutoSubstituteData<CoreCommandsCustomization>("whim.core.move_window_left_edge_left", Direction.Left, -1, 0)]
+	[InlineAutoSubstituteData<CoreCommandsCustomization>("whim.core.move_window_left_edge_right", Direction.Left, 1, 0)]
 	[InlineAutoSubstituteData<CoreCommandsCustomization>(
 		"whim.core.move_window_right_edge_left",
 		Direction.Right,
@@ -133,8 +128,8 @@ public class CoreCommandsTests
 		1,
 		0
 	)]
-	[InlineAutoSubstituteData<CoreCommandsCustomization>("whim.core.move_window_top_edge_up", Direction.Up, 0, 1)]
-	[InlineAutoSubstituteData<CoreCommandsCustomization>("whim.core.move_window_top_edge_down", Direction.Up, 0, -1)]
+	[InlineAutoSubstituteData<CoreCommandsCustomization>("whim.core.move_window_top_edge_up", Direction.Up, 0, -1)]
+	[InlineAutoSubstituteData<CoreCommandsCustomization>("whim.core.move_window_top_edge_down", Direction.Up, 0, 1)]
 	[InlineAutoSubstituteData<CoreCommandsCustomization>("whim.core.move_window_bottom_edge_up", Direction.Down, 0, -1)]
 	[InlineAutoSubstituteData<CoreCommandsCustomization>(
 		"whim.core.move_window_bottom_edge_down",

--- a/src/Whim/Commands/CoreCommands.cs
+++ b/src/Whim/Commands/CoreCommands.cs
@@ -86,7 +86,7 @@ internal class CoreCommands : PluginCommands
 						.WorkspaceManager
 						.MoveWindowEdgesInDirection(
 							Direction.Left,
-							new Point<int>() { X = MoveWindowEdgeDelta, Y = 0 }
+							new Point<int>() { X = -MoveWindowEdgeDelta, Y = 0 }
 						),
 				keybind: new Keybind(IKeybind.WinCtrl, VIRTUAL_KEY.VK_H)
 			)
@@ -98,7 +98,7 @@ internal class CoreCommands : PluginCommands
 						.WorkspaceManager
 						.MoveWindowEdgesInDirection(
 							Direction.Left,
-							new Point<int>() { X = -MoveWindowEdgeDelta, Y = 0 }
+							new Point<int>() { X = MoveWindowEdgeDelta, Y = 0 }
 						),
 				keybind: new Keybind(IKeybind.WinCtrl, VIRTUAL_KEY.VK_J)
 			)
@@ -132,7 +132,7 @@ internal class CoreCommands : PluginCommands
 				callback: () =>
 					_context
 						.WorkspaceManager
-						.MoveWindowEdgesInDirection(Direction.Up, new Point<int>() { Y = MoveWindowEdgeDelta }),
+						.MoveWindowEdgesInDirection(Direction.Up, new Point<int>() { Y = -MoveWindowEdgeDelta }),
 				keybind: new Keybind(IKeybind.WinCtrl, VIRTUAL_KEY.VK_U)
 			)
 			.Add(
@@ -141,7 +141,7 @@ internal class CoreCommands : PluginCommands
 				callback: () =>
 					_context
 						.WorkspaceManager
-						.MoveWindowEdgesInDirection(Direction.Up, new Point<int>() { Y = -MoveWindowEdgeDelta }),
+						.MoveWindowEdgesInDirection(Direction.Up, new Point<int>() { Y = MoveWindowEdgeDelta }),
 				keybind: new Keybind(IKeybind.WinCtrl, VIRTUAL_KEY.VK_I)
 			)
 			.Add(


### PR DESCRIPTION
The following commands would move in the inverse direction from expected:

- `whim.core.move_window_left_edge_left`
- `whim.core.move_window_left_edge_right`
- `whim.core.move_window_top_edge_up`
- `whim.core.move_window_top_edge_down`

This PR fixes the incorrect signs.
