### PR TITLE
Force window focus (don't be nice and let windows dawdle)

### DIFF
--- a/src/Whim.CommandPalette/CommandPaletteWindow.xaml.cs
+++ b/src/Whim.CommandPalette/CommandPaletteWindow.xaml.cs
@@ -78,7 +78,7 @@ internal sealed partial class CommandPaletteWindow : Microsoft.UI.Xaml.Window
 		TextEntry.SelectAll();
 		Activate();
 		TextEntry.Focus(FocusState.Programmatic);
-		_window.FocusForceForeground();
+		_window.Focus();
 	}
 
 	/// <summary>

--- a/src/Whim.Tests/Window/WindowTests.cs
+++ b/src/Whim.Tests/Window/WindowTests.cs
@@ -270,21 +270,6 @@ public class WindowTests
 
 		// Then
 		internalCtx.CoreNativeManager.Received(1).SetForegroundWindow(Arg.Any<HWND>());
-	}
-
-	[Theory, AutoSubstituteData<WindowCustomization>]
-	internal void FocusForceForeground(IContext ctx, IInternalContext internalCtx)
-	{
-		// Given
-		internalCtx.CoreNativeManager.SetForegroundWindow(Arg.Any<HWND>());
-
-		IWindow window = Window.CreateWindow(ctx, internalCtx, new HWND(123))!;
-
-		// When
-		window.FocusForceForeground();
-
-		// Then
-		internalCtx.CoreNativeManager.Received(1).SetForegroundWindow(Arg.Any<HWND>());
 		// The following code doesn't work because SendInput accepts a Span.
 		internalCtx.CoreNativeManager.Received(1).SendInput(Arg.Any<INPUT[]>(), Arg.Any<int>());
 	}

--- a/src/Whim/Window/IWindow.cs
+++ b/src/Whim/Window/IWindow.cs
@@ -74,14 +74,9 @@ public interface IWindow
 	bool IsMaximized { get; }
 
 	/// <summary>
-	/// Moves the focus to this window.
-	/// </summary>
-	void Focus();
-
-	/// <summary>
 	/// Forces the window to the foreground and to be focused.
 	/// </summary>
-	void FocusForceForeground();
+	void Focus();
 
 	/// <summary>
 	/// Hides this window.

--- a/src/Whim/Window/Window.cs
+++ b/src/Whim/Window/Window.cs
@@ -66,19 +66,6 @@ internal class Window : IWindow
 	public void Focus()
 	{
 		Logger.Debug(ToString());
-		if (!IsFocused)
-		{
-			_internalContext.CoreNativeManager.SetForegroundWindow(Handle);
-		}
-
-		// We manually call OnWindowFocused as an already focused window may have switched to a
-		// different workspace.
-		((IInternalWindowManager)_context.WindowManager).OnWindowFocused(this);
-	}
-
-	public void FocusForceForeground()
-	{
-		Logger.Debug(ToString());
 		// Use SendInput hack to allow Activate to work - required to resolve focus issue https://github.com/microsoft/PowerToys/issues/4270
 		unsafe
 		{
@@ -91,7 +78,7 @@ internal class Window : IWindow
 
 		// We manually call OnWindowFocused as an already focused window may have switched to a
 		// different workspace.
-		((IInternalWindowManager)_context.WindowManager).OnWindowFocused(this);
+		_internalContext.WindowManager.OnWindowFocused(this);
 	}
 
 	public void Hide()


### PR DESCRIPTION
As reported in Discord, sometimes the focused window could get out of sync between Whim and Windows. While I haven't been able to reproduce this, I suspect that it's related to the PowerToys issue linked.

As a result, now we _always_ try force windows to focus.

To learn more, I recommend poking through the linked PowerToys issue and its related PRs.