### PR TITLE
Consolidate on `IWindow.ProcessFileName`

### DIFF
--- a/src/Whim.Bar.Tests/FocusedWindow/FocusedWindowWidget.test.xaml.cs
+++ b/src/Whim.Bar.Tests/FocusedWindow/FocusedWindowWidget.test.xaml.cs
@@ -49,7 +49,7 @@ public class FocusedWindowWidgetTests
 	public void GetProcessName(IWindow window)
 	{
 		// Given
-		window.ProcessName.Returns("code");
+		window.ProcessFileName.Returns("code");
 
 		// When
 		string? processName = FocusedWindowWidget.GetProcessName(window);

--- a/src/Whim.Bar.Tests/FocusedWindow/FocusedWindowWidget.test.xaml.cs
+++ b/src/Whim.Bar.Tests/FocusedWindow/FocusedWindowWidget.test.xaml.cs
@@ -57,4 +57,17 @@ public class FocusedWindowWidgetTests
 		// Then
 		Assert.Equal("code", processName);
 	}
+
+	[Theory, AutoSubstituteData]
+	public void GetProcessName_Null(IWindow window)
+	{
+		// Given
+		window.ProcessFileName.Returns((string?)null);
+
+		// When
+		string? processName = FocusedWindowWidget.GetProcessName(window);
+
+		// Then
+		Assert.Null(processName);
+	}
 }

--- a/src/Whim.Bar/FocusedWindow/FocusedWindowWidget.xaml.cs
+++ b/src/Whim.Bar/FocusedWindow/FocusedWindowWidget.xaml.cs
@@ -57,5 +57,5 @@ public partial class FocusedWindowWidget : UserControl
 	/// </summary>
 	/// <param name="window"></param>
 	/// <returns></returns>
-	public static string? GetProcessName(IWindow window) => window.ProcessName;
+	public static string? GetProcessName(IWindow window) => window.ProcessFileName?.Replace(".exe", "");
 }

--- a/src/Whim.Bar/FocusedWindow/FocusedWindowWidget.xaml.cs
+++ b/src/Whim.Bar/FocusedWindow/FocusedWindowWidget.xaml.cs
@@ -53,7 +53,7 @@ public partial class FocusedWindowWidget : UserControl
 	}
 
 	/// <summary>
-	/// Returns the process name of the window.
+	/// Returns the process name of the window - e.g., <c>SnippingTool</c>.
 	/// </summary>
 	/// <param name="window"></param>
 	/// <returns></returns>

--- a/src/Whim.Tests/Router/FilterManagerTests.cs
+++ b/src/Whim.Tests/Router/FilterManagerTests.cs
@@ -76,7 +76,7 @@ public class FilterManagerTests
 	{
 		// Given
 		FilterManager filterManager = new();
-		FilteredWindows.LoadWindowsIgnoredByWhim(filterManager);
+		DefaultFilteredWindows.LoadWindowsIgnoredByWhim(filterManager);
 		filterManager.AddWindowClassFilter("Test");
 
 		window.WindowClass.Returns("Test");

--- a/src/Whim.Tests/Router/FilterManagerTests.cs
+++ b/src/Whim.Tests/Router/FilterManagerTests.cs
@@ -33,6 +33,19 @@ public class FilterManagerTests
 	}
 
 	[Theory, AutoSubstituteData]
+	public void AddProcessFileNameFilter(IWindow window)
+	{
+		// Given
+		FilterManager filterManager = new();
+		filterManager.AddProcessFileNameFilter("Test.exe");
+
+		window.ProcessFileName.Returns("Test.exe");
+
+		// Then
+		Assert.True(filterManager.ShouldBeIgnored(window));
+	}
+
+	[Theory, AutoSubstituteData]
 	public void AddTitleFilter(IWindow window)
 	{
 		// Given

--- a/src/Whim.Tests/Router/RouterManagerTests.cs
+++ b/src/Whim.Tests/Router/RouterManagerTests.cs
@@ -29,112 +29,187 @@ public class RouterManagerTests
 	[Theory, AutoSubstituteData<RouterManagerCustomization>]
 	public void AddWindowClassRouteString(IContext ctx, IWindow window)
 	{
+		// Given
 		RouterManager routerManager = new(ctx);
+
+		// When
 		routerManager.AddWindowClassRoute("Test", "Test");
 
+		// Then
 		Assert.Equal("Test", routerManager.RouteWindow(window)?.Name);
 	}
 
 	[Theory, AutoSubstituteData<RouterManagerCustomization>]
 	public void AddWindowClassRoute(IContext ctx, IWindow window, IWorkspace workspace)
 	{
+		// Given
 		RouterManager routerManager = new(ctx);
+
+		// When
 		routerManager.AddWindowClassRoute("Test", workspace);
 
+		// Then
 		Assert.Equal("Test", routerManager.RouteWindow(window)?.Name);
 	}
 
 	[Theory, AutoSubstituteData<RouterManagerCustomization>]
 	public void AddProcessNameRouteString(IContext ctx, IWindow window)
 	{
+		// Given
 		RouterManager routerManager = new(ctx);
+
+		// When
 		routerManager.AddProcessNameRoute("Test", "Test");
 
+		// Then
 		Assert.Equal("Test", routerManager.RouteWindow(window)?.Name);
 	}
 
 	[Theory, AutoSubstituteData<RouterManagerCustomization>]
 	public void AddProcessNameRoute(IContext ctx, IWindow window, IWorkspace workspace)
 	{
+		// Given
 		RouterManager routerManager = new(ctx);
+
+		// When
 		routerManager.AddProcessNameRoute("Test", workspace);
 
+		// Then
 		Assert.Equal("Test", routerManager.RouteWindow(window)?.Name);
 	}
 
 	[Theory, AutoSubstituteData<RouterManagerCustomization>]
 	public void AddProcessFileNameRouteString(IContext ctx, IWindow window)
 	{
+		// Given
+		RouterManager routerManager = new(ctx);
+
+		// When
+		routerManager.AddProcessFileNameRoute("Test.exe", "Test");
+
+		// Then
+		Assert.Equal("Test", routerManager.RouteWindow(window)?.Name);
+	}
+
+	[Theory, AutoSubstituteData<RouterManagerCustomization>]
+	public void AddProcessFileNameRouteString_ProcessFileNameIsNull(IContext ctx, IWindow window)
+	{
+		// Given
 		RouterManager routerManager = new(ctx);
 		routerManager.AddProcessFileNameRoute("Test.exe", "Test");
 
-		Assert.Equal("Test", routerManager.RouteWindow(window)?.Name);
+		// When
+		window.ProcessFileName.Returns((string?)null);
+
+		// Then
+		Assert.Null(routerManager.RouteWindow(window));
 	}
 
 	[Theory, AutoSubstituteData<RouterManagerCustomization>]
 	public void AddProcessFileNameRoute(IContext ctx, IWindow window, IWorkspace workspace)
 	{
+		// Given
 		RouterManager routerManager = new(ctx);
+
+		// When
 		routerManager.AddProcessFileNameRoute("Test.exe", workspace);
 
+		// Then
 		Assert.Equal("Test", routerManager.RouteWindow(window)?.Name);
+	}
+
+	[Theory, AutoSubstituteData<RouterManagerCustomization>]
+	public void AddProcessFileNameRoute_ProcessFileNameIsNull(IContext ctx, IWindow window)
+	{
+		// Given
+		RouterManager routerManager = new(ctx);
+		routerManager.AddProcessFileNameRoute("Test.exe", "Test");
+
+		// When
+		window.ProcessFileName.Returns((string?)null);
+
+		// Then
+		Assert.Null(routerManager.RouteWindow(window));
 	}
 
 	[Theory, AutoSubstituteData<RouterManagerCustomization>]
 	public void AddTitleRouteString(IContext ctx, IWindow window)
 	{
+		// Given
 		RouterManager routerManager = new(ctx);
+
+		// When
 		routerManager.AddTitleRoute("Test", "Test");
 
+		// Then
 		Assert.Equal("Test", routerManager.RouteWindow(window)?.Name);
 	}
 
 	[Theory, AutoSubstituteData<RouterManagerCustomization>]
 	public void AddTitleRoute(IContext ctx, IWindow window, IWorkspace workspace)
 	{
+		// Given
 		RouterManager routerManager = new(ctx);
+
+		// When
 		routerManager.AddTitleRoute("Test", workspace);
 
+		// Then
 		Assert.Equal("Test", routerManager.RouteWindow(window)?.Name);
 	}
 
 	[Theory, AutoSubstituteData<RouterManagerCustomization>]
 	public void AddTitleMatchRouteString(IContext ctx, IWindow window)
 	{
+		// Given
 		RouterManager routerManager = new(ctx);
+
+		// When
 		routerManager.AddTitleMatchRoute("Test", "Test");
 
+		// Then
 		Assert.Equal("Test", routerManager.RouteWindow(window)?.Name);
 	}
 
 	[Theory, AutoSubstituteData<RouterManagerCustomization>]
 	public void AddTitleMatchRoute(IContext ctx, IWindow window, IWorkspace workspace)
 	{
+		// Given
 		RouterManager routerManager = new(ctx);
+
+		// When
 		routerManager.AddTitleMatchRoute("Test", workspace);
 
+		// Then
 		Assert.Equal("Test", routerManager.RouteWindow(window)?.Name);
 	}
 
 	[Theory, AutoSubstituteData<RouterManagerCustomization>]
 	public void Clear(IContext ctx, IWindow window)
 	{
+		// Given
 		RouterManager routerManager = new(ctx);
 		routerManager.AddWindowClassRoute("Test", "Test");
 
+		// When
 		routerManager.Clear();
 
+		// Then
 		Assert.Null(routerManager.RouteWindow(window));
 	}
 
 	[Theory, AutoSubstituteData<RouterManagerCustomization>]
 	public void CustomRouter(IContext ctx, IWindow window, IWorkspace workspace)
 	{
+		// Given
 		RouterManager routerManager = new(ctx);
 
 		routerManager.Add((w) => w.WindowClass == "Not Test" ? Substitute.For<IWorkspace>() : null);
+
+		// When
 		routerManager.Add((w) => w.WindowClass == "Test" ? workspace : null);
 
+		// Then
 		Assert.Equal("Test", routerManager.RouteWindow(window)?.Name);
 	}
 }

--- a/src/Whim.Tests/Router/RouterManagerTests.cs
+++ b/src/Whim.Tests/Router/RouterManagerTests.cs
@@ -119,11 +119,11 @@ public class RouterManagerTests
 	}
 
 	[Theory, AutoSubstituteData<RouterManagerCustomization>]
-	public void AddProcessFileNameRoute_ProcessFileNameIsNull(IContext ctx, IWindow window)
+	public void AddProcessFileNameRoute_ProcessFileNameIsNull(IContext ctx, IWindow window, IWorkspace workspace)
 	{
 		// Given
 		RouterManager routerManager = new(ctx);
-		routerManager.AddProcessFileNameRoute("Test.exe", "Test");
+		routerManager.AddProcessFileNameRoute("Test.exe", workspace);
 
 		// When
 		window.ProcessFileName.Returns((string?)null);

--- a/src/Whim.Tests/Router/RouterManagerTests.cs
+++ b/src/Whim.Tests/Router/RouterManagerTests.cs
@@ -19,6 +19,7 @@ public class RouterManagerCustomization : ICustomization
 		IWindow window = fixture.Freeze<IWindow>();
 		window.WindowClass.Returns("Test");
 		window.ProcessName.Returns("Test");
+		window.ProcessFileName.Returns("Test.exe");
 		window.Title.Returns("Test");
 	}
 }
@@ -57,6 +58,24 @@ public class RouterManagerTests
 	{
 		RouterManager routerManager = new(ctx);
 		routerManager.AddProcessNameRoute("Test", workspace);
+
+		Assert.Equal("Test", routerManager.RouteWindow(window)?.Name);
+	}
+
+	[Theory, AutoSubstituteData<RouterManagerCustomization>]
+	public void AddProcessFileNameRouteString(IContext ctx, IWindow window)
+	{
+		RouterManager routerManager = new(ctx);
+		routerManager.AddProcessFileNameRoute("Test.exe", "Test");
+
+		Assert.Equal("Test", routerManager.RouteWindow(window)?.Name);
+	}
+
+	[Theory, AutoSubstituteData<RouterManagerCustomization>]
+	public void AddProcessFileNameRoute(IContext ctx, IWindow window, IWorkspace workspace)
+	{
+		RouterManager routerManager = new(ctx);
+		routerManager.AddProcessFileNameRoute("Test.exe", workspace);
 
 		Assert.Equal("Test", routerManager.RouteWindow(window)?.Name);
 	}

--- a/src/Whim/Context/Context.cs
+++ b/src/Whim/Context/Context.cs
@@ -69,7 +69,7 @@ internal class Context : IContext
 			KeybindManager.SetKeybind(name, keybind);
 		}
 
-		FilteredWindows.LoadWindowsIgnoredByWhim(FilterManager);
+		DefaultFilteredWindows.LoadWindowsIgnoredByWhim(FilterManager);
 
 		// Load the user's config.
 		ConfigLoader configLoader = new(FileManager);

--- a/src/Whim/Router/DefaultFilteredWindows.cs
+++ b/src/Whim/Router/DefaultFilteredWindows.cs
@@ -3,7 +3,7 @@ namespace Whim;
 /// <summary>
 /// Defaults for various <see cref="IFilterManager"/>s.
 /// </summary>
-public static class FilteredWindows
+public static class DefaultFilteredWindows
 {
 	/// <summary>
 	/// Load the windows which should be ignored by Whim by default.

--- a/src/Whim/Router/FilterManager.cs
+++ b/src/Whim/Router/FilterManager.cs
@@ -9,6 +9,7 @@ internal class FilterManager : IFilterManager
 	#region Filters for specific properties
 	private readonly HashSet<string> _ignoreWindowClasses = new();
 	private readonly HashSet<string> _ignoreProcessNames = new();
+	private readonly HashSet<string> _ignoreProcessFileNames = new();
 	private readonly HashSet<string> _ignoreTitles = new();
 	#endregion
 
@@ -31,13 +32,15 @@ internal class FilterManager : IFilterManager
 		_filters.Clear();
 	}
 
-	public bool ShouldBeIgnored(IWindow window)
-	{
-		return _ignoreWindowClasses.Contains(window.WindowClass.ToLower())
-			|| (window.ProcessName is string processName && _ignoreProcessNames.Contains(processName.ToLower()))
-			|| _ignoreTitles.Contains(window.Title.ToLower())
-			|| _filters.Any(f => f(window));
-	}
+	public bool ShouldBeIgnored(IWindow window) =>
+		_ignoreWindowClasses.Contains(window.WindowClass.ToLower())
+		|| (
+			window.ProcessFileName is string processFileName
+			&& _ignoreProcessFileNames.Contains(processFileName.ToLower())
+		)
+		|| (window.ProcessName is string processName && _ignoreProcessNames.Contains(processName.ToLower()))
+		|| _ignoreTitles.Contains(window.Title.ToLower())
+		|| _filters.Any(f => f(window));
 
 	public IFilterManager AddWindowClassFilter(string windowClass)
 	{
@@ -50,6 +53,12 @@ internal class FilterManager : IFilterManager
 	public IFilterManager AddProcessNameFilter(string processName)
 	{
 		_ignoreProcessNames.Add(processName.ToLower());
+		return this;
+	}
+
+	public IFilterManager AddProcessFileNameFilter(string processFileName)
+	{
+		_ignoreProcessFileNames.Add(processFileName.ToLower());
 		return this;
 	}
 

--- a/src/Whim/Router/FilteredWindows.cs
+++ b/src/Whim/Router/FilteredWindows.cs
@@ -10,7 +10,7 @@ public static class FilteredWindows
 	/// </summary>
 	/// <param name="filterManager"></param>
 	public static void LoadWindowsIgnoredByWhim(IFilterManager filterManager) =>
-		filterManager.AddProcessNameFilter("SearchUI.exe");
+		filterManager.AddProcessFileNameFilter("SearchUI.exe");
 
 	/// <summary>
 	/// Load the windows which try to set their own locations when the start up.
@@ -18,5 +18,5 @@ public static class FilteredWindows
 	/// </summary>
 	/// <param name="filterManager"></param>
 	public static void LoadLocationRestoringWindows(IFilterManager filterManager) =>
-		filterManager.AddProcessNameFilter("firefox.exe").AddProcessNameFilter("gateway64.exe");
+		filterManager.AddProcessFileNameFilter("firefox.exe").AddProcessFileNameFilter("gateway64.exe");
 }

--- a/src/Whim/Router/IFilterManager.cs
+++ b/src/Whim/Router/IFilterManager.cs
@@ -69,11 +69,19 @@ public interface IFilterManager
 	IFilterManager AddWindowClassFilter(string windowClass);
 
 	/// <summary>
-	/// Ignores the process name. Case insensitive.
+	/// Ignores the process name - see <see cref="IWindow.ProcessName"/>. Case insensitive.
 	/// </summary>
 	/// <param name="processName"></param>
 	/// <returns></returns>
+	[Obsolete("Use AddProcessFileNameFilter instead")]
 	IFilterManager AddProcessNameFilter(string processName);
+
+	/// <summary>
+	/// Ignores the process name - see <see cref="IWindow.ProcessFileName"/>. Case insensitive.
+	/// </summary>
+	/// <param name="processName"></param>
+	/// <returns></returns>
+	IFilterManager AddProcessFileNameFilter(string processName);
 
 	/// <summary>
 	/// Ignores the title. Case insensitive.

--- a/src/Whim/Router/IRouterManager.cs
+++ b/src/Whim/Router/IRouterManager.cs
@@ -1,4 +1,6 @@
-﻿namespace Whim;
+﻿using System;
+
+namespace Whim;
 
 /// <summary>
 /// Delegate which is called to route a <see cref="IWindow"/>.
@@ -16,7 +18,7 @@ public interface IRouterManager
 	/// Defaults to <see langword="false"/>.
 	/// This is overridden by any other routers in this <see cref="IRouterManager"/>.
 	/// </summary>
-	public bool RouteToActiveWorkspace { get; set; }
+	bool RouteToActiveWorkspace { get; set; }
 
 	/// <summary>
 	/// Routes a window to a workspace.
@@ -26,18 +28,18 @@ public interface IRouterManager
 	/// <see langword="null"/> when the window should be ignored, otherwise the
 	/// <see cref="IWorkspace"/> to route the window to.
 	/// </returns>
-	public IWorkspace? RouteWindow(IWindow window);
+	IWorkspace? RouteWindow(IWindow window);
 
 	/// <summary>
 	/// Clear all the routes.
 	/// </summary>
-	public void Clear();
+	void Clear();
 
 	/// <summary>
 	/// Add a router.
 	/// </summary>
 	/// <param name="router"></param>
-	public void Add(Router router);
+	void Add(Router router);
 
 	#region Routers helper methods
 	/// <summary>
@@ -46,7 +48,7 @@ public interface IRouterManager
 	/// </summary>
 	/// <param name="windowClass"></param>
 	/// <param name="workspaceName"></param>
-	public IRouterManager AddWindowClassRoute(string windowClass, string workspaceName);
+	IRouterManager AddWindowClassRoute(string windowClass, string workspaceName);
 
 	/// <summary>
 	/// Adds a router which moves windows matching <paramref name="windowClass"/> to the
@@ -54,23 +56,41 @@ public interface IRouterManager
 	/// </summary>
 	/// <param name="windowClass"></param>
 	/// <param name="workspace"></param>
-	public IRouterManager AddWindowClassRoute(string windowClass, IWorkspace workspace);
+	IRouterManager AddWindowClassRoute(string windowClass, IWorkspace workspace);
 
 	/// <summary>
-	/// Adds a router which moves processes matching <paramref name="processName"/> to the
+	/// Adds a router which moves processes matching <see cref="IWindow.ProcessName"/> to the
 	/// <paramref name="workspaceName"/>.
 	/// </summary>
 	/// <param name="processName"></param>
 	/// <param name="workspaceName"></param>
-	public IRouterManager AddProcessNameRoute(string processName, string workspaceName);
+	[Obsolete("Use AddProcessFileNameRoute instead")]
+	IRouterManager AddProcessNameRoute(string processName, string workspaceName);
 
 	/// <summary>
-	/// Adds a router which moves processes matching <paramref name="processName"/> to the
+	/// Adds a router which moves processes matching <see cref="IWindow.ProcessName"/> to the
 	/// <paramref name="workspace"/>.
 	/// </summary>
 	/// <param name="processName"></param>
 	/// <param name="workspace"></param>
-	public IRouterManager AddProcessNameRoute(string processName, IWorkspace workspace);
+	[Obsolete("Use AddProcessFileNameRoute instead")]
+	IRouterManager AddProcessNameRoute(string processName, IWorkspace workspace);
+
+	/// <summary>
+	/// Adds a router which moves windows matching <see cref="IWindow.ProcessFileName"/> to the
+	/// <paramref name="workspaceName"/>.
+	/// </summary>
+	/// <param name="processFileName"></param>
+	/// <param name="workspaceName"></param>
+	IRouterManager AddProcessFileNameRoute(string processFileName, string workspaceName);
+
+	/// <summary>
+	/// Adds a router which moves windows matching <see cref="IWindow.ProcessFileName"/> to the
+	/// <paramref name="workspace"/>.
+	/// </summary>
+	/// <param name="processFileName"></param>
+	/// <param name="workspace"></param>
+	IRouterManager AddProcessFileNameRoute(string processFileName, IWorkspace workspace);
 
 	/// <summary>
 	/// Adds a router which moves windows matching <paramref name="title"/> to the workspace
@@ -78,7 +98,7 @@ public interface IRouterManager
 	/// </summary>
 	/// <param name="title"></param>
 	/// <param name="workspaceName"></param>
-	public IRouterManager AddTitleRoute(string title, string workspaceName);
+	IRouterManager AddTitleRoute(string title, string workspaceName);
 
 	/// <summary>
 	/// Adds a router which moves windows matching <paramref name="title"/> to the
@@ -86,7 +106,7 @@ public interface IRouterManager
 	/// </summary>
 	/// <param name="title"></param>
 	/// <param name="workspace"></param>
-	public IRouterManager AddTitleRoute(string title, IWorkspace workspace);
+	IRouterManager AddTitleRoute(string title, IWorkspace workspace);
 
 	/// <summary>
 	/// Adds a router which moves windows matching regex <paramref name="match"/> string to the
@@ -94,7 +114,7 @@ public interface IRouterManager
 	/// </summary>
 	/// <param name="match"></param>
 	/// <param name="workspaceName"></param>
-	public IRouterManager AddTitleMatchRoute(string match, string workspaceName);
+	IRouterManager AddTitleMatchRoute(string match, string workspaceName);
 
 	/// <summary>
 	/// Adds a router which moves windows matching regex <paramref name="match"/> string to the
@@ -102,6 +122,6 @@ public interface IRouterManager
 	/// </summary>
 	/// <param name="match"></param>
 	/// <param name="workspace"></param>
-	public IRouterManager AddTitleMatchRoute(string match, IWorkspace workspace);
+	IRouterManager AddTitleMatchRoute(string match, IWorkspace workspace);
 	#endregion
 }

--- a/src/Whim/Router/RouterManager.cs
+++ b/src/Whim/Router/RouterManager.cs
@@ -57,6 +57,36 @@ internal class RouterManager : IRouterManager
 		return this;
 	}
 
+	public IRouterManager AddProcessFileNameRoute(string processFileName, string workspaceName)
+	{
+		processFileName = processFileName.ToLower();
+		Logger.Debug($"Routing process file name {processFileName} to workspace {workspaceName}");
+		Add(window =>
+		{
+			if (window.ProcessFileName?.ToLower() == processFileName)
+			{
+				return _context.WorkspaceManager.TryGet(workspaceName);
+			}
+			return null;
+		});
+		return this;
+	}
+
+	public IRouterManager AddProcessFileNameRoute(string processFileName, IWorkspace workspace)
+	{
+		processFileName = processFileName.ToLower();
+		Logger.Debug($"Routing process file name: {processFileName} to workspace {workspace}");
+		Add(window =>
+		{
+			if (window.ProcessFileName?.ToLower() == processFileName)
+			{
+				return workspace;
+			}
+			return null;
+		});
+		return this;
+	}
+
 	public IRouterManager AddTitleRoute(string title, string workspaceName)
 	{
 		title = title.ToLower();

--- a/src/Whim/Window/IWindow.cs
+++ b/src/Whim/Window/IWindow.cs
@@ -1,3 +1,4 @@
+using System;
 using Microsoft.UI.Xaml.Media.Imaging;
 using Windows.Win32.Foundation;
 
@@ -45,6 +46,7 @@ public interface IWindow
 
 	/// <summary>
 	/// The file name of the module.
+	/// For example, <c>SnippingTool.exe</c>.
 	/// </summary>
 	string? ProcessFileName { get; }
 
@@ -55,7 +57,9 @@ public interface IWindow
 
 	/// <summary>
 	/// The name that the system uses to identify the process to the user.
+	/// For example, <c>SnippingTool</c>.
 	/// </summary>
+	[Obsolete("Use ProcessFileName instead.")]
 	string? ProcessName { get; }
 
 	/// <summary>

--- a/src/Whim/Window/WindowManager.cs
+++ b/src/Whim/Window/WindowManager.cs
@@ -60,7 +60,7 @@ internal class WindowManager : IWindowManager, IInternalWindowManager
 		_internalContext = internalContext;
 		_hookDelegate = new WINEVENTPROC(WinEventProcWrapper);
 
-		FilteredWindows.LoadLocationRestoringWindows(LocationRestoringFilterManager);
+		DefaultFilteredWindows.LoadLocationRestoringWindows(LocationRestoringFilterManager);
 	}
 
 	public void Initialize()


### PR DESCRIPTION
Consolidated on `IWindow.ProcessFileName` to reduce the confusion between it and `IWindow.ProcessName`. `ProcessFileName` and associated methods have been marked as obsolete.

New methods have been created for filtering and routing on `IWindow.ProcessFileName`.

Also renamed `FilteredWindows` to `DefaultFilteredWindows`.