### PR TITLE
Save and restore workspaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,7 +291,7 @@ As Whim supports more novel layouts, it also has functionality to account for di
 
 #### `ILayoutEngine` Mutability
 
-Implementations of Whim's `ILayoutEngine` should be immutable. This was done to support future functionality like previewing changes to layouts before committing them (see [#425](https://github.com/dalyIsaac/Whim/issues/425)). In comparison, workspacer's `ILayoutEngine` implementations are mutable.
+Implementations of Whim's `ILayoutEngine` should be immutable. This was done to support functionality like previewing changes to layouts before committing them, with the `LayoutPreview` plugin. In comparison, workspacer's `ILayoutEngine` implementations are mutable.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,40 @@ This directory will contain a `whim.config.csx` file which you can edit to custo
 
 The config contains a pre-filled example which you can use as a starting point. You can also find the config [here](src/Whim/Template/whim.config.csx).
 
+### Workspaces
+
+A "workspace" in Whim is a collection of windows. They are displayed on a single monitor. The layouts of workspaces are determined by their layout engines. Each workspace has a single active layout engine, and can cycle through different layout engines. For more, see [Inspiration](#inspiration).
+
+The `WorkspaceManager` object has a customizable `CreateLayoutEngines` property which provides the default layout engines for workspaces. For example, the following config sets up three workspaces, and two layout engines:
+
+```csharp
+// Set up workspaces.
+context.WorkspaceManager.Add("Browser");
+context.WorkspaceManager.Add("IDE");
+context.WorkspaceManager.Add("Alt");
+
+// Set up layout engines.
+context.WorkspaceManager.CreateLayoutEngines = () => new CreateLeafLayoutEngine[]
+{
+    (id) => new TreeLayoutEngine(context, treeLayoutPlugin, id),
+    (id) => new ColumnLayoutEngine(id)
+};
+```
+
+It's also possible to customize the layout engines for a specific workspace:
+
+```csharp
+context.WorkspaceManager.Add(
+    "Alt",
+    new CreateLeafLayoutEngine[]
+    {
+        (id) => new ColumnLayoutEngine(id)
+    }
+);
+```
+
+When Whim exits, it will save the current workspaces and the current positions of each window within them. When Whim is started again, it will attempt to merge the saved workspaces with the workspaces defined in the config.
+
 ### Plugins
 
 Whim is build around plugins. Plugins are referenced using `#r` and `using` statements at the top of the config file. Each plugin generally has a `Config` class, and a `Plugin` class. For example:

--- a/src/Whim.Tests/Context/CoreSavedStateManagerTests.cs
+++ b/src/Whim.Tests/Context/CoreSavedStateManagerTests.cs
@@ -1,0 +1,199 @@
+using System.Collections.Generic;
+using System.Text.Json;
+using NSubstitute;
+using Whim.TestUtils;
+using Windows.Win32.Foundation;
+using Xunit;
+
+namespace Whim.Tests;
+
+[System.Diagnostics.CodeAnalysis.SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope")]
+public class CoreSavedStateManagerTests
+{
+	[Theory, AutoSubstituteData]
+	public void PreInitialize_FileDoesNotExist_DoesNotDeserialize(IContext ctx)
+	{
+		// Given
+		ctx.FileManager.SavedStateDir.Returns("savedStateDir");
+		CoreSavedStateManager sut = new(ctx);
+
+		// When
+		sut.PreInitialize();
+
+		// Then
+		ctx.FileManager.Received(1).EnsureDirExists("savedStateDir");
+		ctx.FileManager.DidNotReceive().ReadAllText(Arg.Any<string>());
+	}
+
+	[Theory, AutoSubstituteData]
+	public void PreInitialize_FileExists_CannotDeserialize(IContext ctx)
+	{
+		// Given
+		ctx.FileManager.SavedStateDir.Returns("savedStateDir");
+		ctx.FileManager.FileExists(Arg.Any<string>()).Returns(true);
+		ctx.FileManager.ReadAllText(Arg.Any<string>()).Returns("invalid json");
+		CoreSavedStateManager sut = new(ctx);
+
+		// When
+		sut.PreInitialize();
+
+		// Then
+		ctx.FileManager.Received(1).ReadAllText("savedStateDir\\core.json");
+	}
+
+	private static CoreSavedState CreateSavedState()
+	{
+		return new CoreSavedState(
+			new List<SavedWorkspace>()
+			{
+				new(
+					"workspace1",
+					new() { new SavedWindow(1, new(0, 0, 100, 100)), new SavedWindow(2, new(100, 100, 100, 100)), }
+				),
+				new(
+					"workspace2",
+					new() { new SavedWindow(3, new(200, 200, 100, 100)), new SavedWindow(4, new(300, 300, 100, 100)), }
+				),
+			}
+		);
+	}
+
+	[Theory, AutoSubstituteData]
+	public void PreInitialize_FileExists_CanDeserialize(IContext ctx)
+	{
+		// Given
+		ctx.FileManager.FileExists(Arg.Any<string>()).Returns(true);
+		ctx.FileManager.ReadAllText(Arg.Any<string>()).Returns(JsonSerializer.Serialize(CreateSavedState()));
+		CoreSavedStateManager sut = new(ctx);
+
+		// When
+		sut.PreInitialize();
+
+		// Then
+		ctx.FileManager.Received(1).ReadAllText(Arg.Any<string>());
+		Assert.NotNull(sut.SavedState);
+		Assert.Equal(2, sut.SavedState!.Workspaces.Count);
+		Assert.Equal(2, sut.SavedState!.Workspaces[0].Windows.Count);
+		Assert.Equal(2, sut.SavedState!.Workspaces[1].Windows.Count);
+	}
+
+	[Theory, AutoSubstituteData]
+	public void PostInitialize(IContext ctx)
+	{
+		// Given
+		ctx.FileManager.SavedStateDir.Returns("savedStateDir");
+		ctx.FileManager.FileExists(Arg.Any<string>()).Returns(true);
+		ctx.FileManager.ReadAllText(Arg.Any<string>()).Returns(JsonSerializer.Serialize(CreateSavedState()));
+		CoreSavedStateManager sut = new(ctx);
+		sut.PreInitialize();
+
+		// When
+		sut.PostInitialize();
+
+		// Then the saved state should be cleared.
+		Assert.Null(sut.SavedState);
+	}
+
+	private static string Setup_ContextState(IContext ctx)
+	{
+		ctx.MonitorManager.PrimaryMonitor.WorkingArea.Returns(new Rectangle<int>(0, 0, 1000, 1000));
+
+		// Create four windows.
+		IWindow[] windows = new IWindow[4];
+		for (int i = 0; i < 4; i++)
+		{
+			windows[i] = Substitute.For<IWindow>();
+			windows[i].Handle.Returns((HWND)(i + 1));
+		}
+
+		// Create two workspaces with two windows each
+		IWorkspace workspace1 = Substitute.For<IWorkspace>();
+		workspace1.Name.Returns("workspace1");
+		workspace1
+			.ActiveLayoutEngine
+			.DoLayout(Arg.Any<IRectangle<int>>(), Arg.Any<IMonitor>())
+			.Returns(
+				new List<IWindowState>()
+				{
+					new WindowState()
+					{
+						Window = windows[0],
+						Rectangle = new Rectangle<int>(0, 0, 100, 100),
+						WindowSize = WindowSize.Normal
+					},
+					new WindowState()
+					{
+						Window = windows[1],
+						Rectangle = new Rectangle<int>(100, 100, 100, 100),
+						WindowSize = WindowSize.Normal
+					},
+				}
+			);
+
+		IWorkspace workspace2 = Substitute.For<IWorkspace>();
+		workspace2.Name.Returns("workspace2");
+		workspace2
+			.ActiveLayoutEngine
+			.DoLayout(Arg.Any<IRectangle<int>>(), Arg.Any<IMonitor>())
+			.Returns(
+				new List<IWindowState>()
+				{
+					new WindowState()
+					{
+						Window = windows[2],
+						Rectangle = new Rectangle<int>(200, 200, 100, 100),
+						WindowSize = WindowSize.Normal
+					},
+					new WindowState()
+					{
+						Window = windows[3],
+						Rectangle = new Rectangle<int>(300, 300, 100, 100),
+						WindowSize = WindowSize.Normal
+					},
+				}
+			);
+
+		// Load the workspaces into the context.
+		ctx.WorkspaceManager
+			.GetEnumerator()
+			.Returns(new List<IWorkspace>() { workspace1, workspace2 }.GetEnumerator());
+
+		// Create the expected JSON.
+		return JsonSerializer.Serialize(
+			new CoreSavedState(
+				new List<SavedWorkspace>()
+				{
+					new(
+						"workspace1",
+						new() { new SavedWindow(1, new(0, 0, 0.1, 0.1)), new SavedWindow(2, new(0.1, 0.1, 0.1, 0.1)), }
+					),
+					new(
+						"workspace2",
+						new()
+						{
+							new SavedWindow(3, new(0.2, 0.2, 0.1, 0.1)),
+							new SavedWindow(4, new(0.3, 0.3, 0.1, 0.1)),
+						}
+					)
+				}
+			)
+		);
+	}
+
+	[Theory, AutoSubstituteData]
+	public void Dispose_SavesState(IContext ctx)
+	{
+		// Given
+		string expectedJson = Setup_ContextState(ctx);
+		ctx.FileManager.SavedStateDir.Returns("savedStateDir");
+
+		CoreSavedStateManager sut = new(ctx);
+		sut.PreInitialize();
+
+		// When
+		sut.Dispose();
+
+		// Then
+		ctx.FileManager.Received(1).WriteAllText("savedStateDir\\core.json", expectedJson);
+	}
+}

--- a/src/Whim.Tests/Location/RectangleTests.cs
+++ b/src/Whim.Tests/Location/RectangleTests.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+using System.Numerics;
 using Xunit;
 
 namespace Whim.Tests;
@@ -116,5 +118,49 @@ public class RectangleTests
 
 		// Then
 		Assert.Equal(hashCode1, hashCode2);
+	}
+
+	public static IEnumerable<object[]> CenterData()
+	{
+		yield return new object[]
+		{
+			new Rectangle<int>() { Width = 10, Height = 10 },
+			new Point<int>() { X = 5, Y = 5 }
+		};
+		yield return new object[]
+		{
+			new Rectangle<double>()
+			{
+				X = 5,
+				Y = 5,
+				Width = 10,
+				Height = 10
+			},
+			new Point<double>() { X = 10, Y = 10 }
+		};
+		yield return new object[]
+		{
+			new Rectangle<double>()
+			{
+				X = -5,
+				Y = -5,
+				Width = 10,
+				Height = 10
+			},
+			new Point<double>() { X = 0, Y = 0 }
+		};
+	}
+
+	[Theory]
+	[MemberData(nameof(CenterData))]
+	public void Center<T>(IRectangle<T> rect, IPoint<T> expected)
+		where T : INumber<T>
+	{
+		// When
+		IPoint<T> actual = rect.Center;
+
+		// Then
+		Assert.Equal(expected.X, actual.X);
+		Assert.Equal(expected.Y, actual.Y);
 	}
 }

--- a/src/Whim.Tests/Window/WindowManagerTests.cs
+++ b/src/Whim.Tests/Window/WindowManagerTests.cs
@@ -207,7 +207,7 @@ public class WindowManagerTests
 	}
 
 	[Theory, AutoSubstituteData<WindowManagerCustomization>]
-	internal void OnWindowMinimizeStart(IContext ctx, IInternalContext internalCtx, IWindow window)
+	internal void OnWindowMinimizeStart(IContext ctx, IInternalContext internalCtx)
 	{
 		// Given
 		HWND hwnd = new(1);
@@ -225,12 +225,12 @@ public class WindowManagerTests
 		);
 
 		// Then
-		internalCtx.WorkspaceManager.Received(1).WindowMinimizeStart(window);
-		Assert.Equal(window, result.Arguments.Window);
+		internalCtx.WorkspaceManager.Received(1).WindowMinimizeStart(Arg.Any<IWindow>());
+		Assert.Equal((int)_processId, result.Arguments.Window.ProcessId);
 	}
 
 	[Theory, AutoSubstituteData<WindowManagerCustomization>]
-	internal void OnWindowMinimizeEnd(IContext ctx, IInternalContext internalCtx, IWindow window)
+	internal void OnWindowMinimizeEnd(IContext ctx, IInternalContext internalCtx)
 	{
 		// Given
 		HWND hwnd = new(1);
@@ -248,8 +248,8 @@ public class WindowManagerTests
 		);
 
 		// Then
-		internalCtx.WorkspaceManager.Received(1).WindowMinimizeEnd(window);
-		Assert.Equal(window, result.Arguments.Window);
+		internalCtx.WorkspaceManager.Received(1).WindowMinimizeEnd(Arg.Any<IWindow>());
+		Assert.Equal((int)_processId, result.Arguments.Window.ProcessId);
 	}
 
 	private static void InitializeCoreNativeManagerMock(IInternalContext internalCtx)

--- a/src/Whim.Tests/Window/WindowManagerTests.cs
+++ b/src/Whim.Tests/Window/WindowManagerTests.cs
@@ -27,6 +27,10 @@ internal class WindowManagerCustomization : ICustomization
 		IContext context = fixture.Freeze<IContext>();
 		context.WorkspaceManager.Returns(workspaceManager);
 		context.MonitorManager.Returns(monitorManager);
+
+		IInternalContext internalCtx = fixture.Freeze<IInternalContext>();
+		internalCtx.WorkspaceManager.Returns((IInternalWorkspaceManager)workspaceManager);
+		internalCtx.MonitorManager.Returns((IInternalMonitorManager)monitorManager);
 	}
 }
 
@@ -157,18 +161,12 @@ public class WindowManagerTests
 		// Given
 		WindowManager windowManager = new(ctx, internalCtx);
 
-		// When
+		// Then
 		var result = Assert.Raises<WindowEventArgs>(
 			eh => windowManager.WindowAdded += eh,
 			eh => windowManager.WindowAdded -= eh,
 			() => windowManager.OnWindowAdded(window)
 		);
-
-		// Then
-		((IInternalWorkspaceManager)ctx.WorkspaceManager)
-			.Received(1)
-			.WindowAdded(window);
-		Assert.Equal(window, result.Arguments.Window);
 	}
 
 	[Theory, AutoSubstituteData<WindowManagerCustomization>]
@@ -185,10 +183,8 @@ public class WindowManagerTests
 		);
 
 		// Then
-		((IInternalWorkspaceManager)ctx.WorkspaceManager)
-			.Received(1)
-			.WindowFocused(window);
-		((IInternalMonitorManager)ctx.MonitorManager).Received(1).WindowFocused(window);
+		internalCtx.WorkspaceManager.Received(1).WindowFocused(window);
+		internalCtx.MonitorManager.Received(1).WindowFocused(window);
 		Assert.Equal(window, result.Arguments.Window);
 	}
 
@@ -206,9 +202,7 @@ public class WindowManagerTests
 		);
 
 		// Then
-		((IInternalWorkspaceManager)ctx.WorkspaceManager)
-			.Received(1)
-			.WindowRemoved(window);
+		internalCtx.WorkspaceManager.Received(1).WindowRemoved(window);
 		Assert.Equal(window, result.Arguments.Window);
 	}
 
@@ -216,19 +210,22 @@ public class WindowManagerTests
 	internal void OnWindowMinimizeStart(IContext ctx, IInternalContext internalCtx, IWindow window)
 	{
 		// Given
+		HWND hwnd = new(1);
 		WindowManager windowManager = new(ctx, internalCtx);
+		CaptureWinEventProc capture = CaptureWinEventProc.Create(internalCtx);
+		AllowWindowCreation(ctx, internalCtx, hwnd);
+
+		windowManager.Initialize();
 
 		// When
 		var result = Assert.Raises<WindowEventArgs>(
 			eh => windowManager.WindowMinimizeStart += eh,
 			eh => windowManager.WindowMinimizeStart -= eh,
-			() => windowManager.OnWindowMinimizeStart(window)
+			() => capture.WinEventProc!.Invoke((HWINEVENTHOOK)0, PInvoke.EVENT_SYSTEM_MINIMIZESTART, hwnd, 0, 0, 0, 0)
 		);
 
 		// Then
-		((IInternalWorkspaceManager)ctx.WorkspaceManager)
-			.Received(1)
-			.WindowMinimizeStart(window);
+		internalCtx.WorkspaceManager.Received(1).WindowMinimizeStart(window);
 		Assert.Equal(window, result.Arguments.Window);
 	}
 
@@ -236,19 +233,22 @@ public class WindowManagerTests
 	internal void OnWindowMinimizeEnd(IContext ctx, IInternalContext internalCtx, IWindow window)
 	{
 		// Given
+		HWND hwnd = new(1);
 		WindowManager windowManager = new(ctx, internalCtx);
+		CaptureWinEventProc capture = CaptureWinEventProc.Create(internalCtx);
+		AllowWindowCreation(ctx, internalCtx, hwnd);
+
+		windowManager.Initialize();
 
 		// When
 		var result = Assert.Raises<WindowEventArgs>(
 			eh => windowManager.WindowMinimizeEnd += eh,
 			eh => windowManager.WindowMinimizeEnd -= eh,
-			() => windowManager.OnWindowMinimizeEnd(window)
+			() => capture.WinEventProc!.Invoke((HWINEVENTHOOK)0, PInvoke.EVENT_SYSTEM_MINIMIZEEND, hwnd, 0, 0, 0, 0)
 		);
 
 		// Then
-		((IInternalWorkspaceManager)ctx.WorkspaceManager)
-			.Received(1)
-			.WindowMinimizeEnd(window);
+		internalCtx.WorkspaceManager.Received(1).WindowMinimizeEnd(window);
 		Assert.Equal(window, result.Arguments.Window);
 	}
 
@@ -346,9 +346,7 @@ public class WindowManagerTests
 			);
 
 		// Then
-		((IInternalWorkspaceManager)ctx.WorkspaceManager)
-			.DidNotReceive()
-			.WindowAdded(Arg.Any<IWindow>());
+		internalCtx.WorkspaceManager.DidNotReceive().WindowAdded(Arg.Any<IWindow>());
 	}
 
 	[InlineAutoSubstituteData<WindowManagerCustomization>(true, false, true, true)]
@@ -403,9 +401,7 @@ public class WindowManagerTests
 		capture.WinEventProc!.Invoke((HWINEVENTHOOK)0, PInvoke.EVENT_OBJECT_SHOW, hwnd, 0, 0, 0, 0);
 
 		// Then
-		((IInternalWorkspaceManager)ctx.WorkspaceManager)
-			.DidNotReceive()
-			.WindowAdded(Arg.Any<IWindow>());
+		internalCtx.WorkspaceManager.DidNotReceive().WindowAdded(Arg.Any<IWindow>());
 		ctx.FilterManager.DidNotReceive().ShouldBeIgnored(Arg.Any<IWindow>());
 	}
 
@@ -426,9 +422,7 @@ public class WindowManagerTests
 		capture.WinEventProc!.Invoke((HWINEVENTHOOK)0, PInvoke.EVENT_OBJECT_SHOW, hwnd, 0, 0, 0, 0);
 
 		// Then
-		((IInternalWorkspaceManager)ctx.WorkspaceManager)
-			.DidNotReceive()
-			.WindowAdded(Arg.Any<IWindow>());
+		internalCtx.WorkspaceManager.DidNotReceive().WindowAdded(Arg.Any<IWindow>());
 		ctx.FilterManager.Received(1).ShouldBeIgnored(Arg.Any<IWindow>());
 	}
 
@@ -449,11 +443,9 @@ public class WindowManagerTests
 		capture.WinEventProc!.Invoke((HWINEVENTHOOK)0, PInvoke.EVENT_OBJECT_SHOW, hwnd, 0, 0, 0, 0);
 
 		// Then
-		((IInternalWorkspaceManager)ctx.WorkspaceManager)
-			.DidNotReceive()
-			.WindowAdded(Arg.Any<IWindow>());
+		internalCtx.WorkspaceManager.DidNotReceive().WindowAdded(Arg.Any<IWindow>());
 		ctx.FilterManager.Received(1).ShouldBeIgnored(Arg.Any<IWindow>());
-		((IInternalWorkspaceManager)ctx.WorkspaceManager).DidNotReceive().WindowAdded(Arg.Any<IWindow>());
+		internalCtx.WorkspaceManager.DidNotReceive().WindowAdded(Arg.Any<IWindow>());
 	}
 
 	[InlineAutoSubstituteData<WindowManagerCustomization>(PInvoke.EVENT_SYSTEM_FOREGROUND)]
@@ -477,10 +469,8 @@ public class WindowManagerTests
 		);
 
 		// Then
-		((IInternalMonitorManager)ctx.MonitorManager)
-			.Received(1)
-			.WindowFocused(Arg.Any<IWindow>());
-		((IInternalWorkspaceManager)ctx.WorkspaceManager).Received(1).WindowFocused(Arg.Any<IWindow>());
+		internalCtx.MonitorManager.Received(1).WindowFocused(Arg.Any<IWindow>());
+		internalCtx.WorkspaceManager.Received(1).WindowFocused(Arg.Any<IWindow>());
 	}
 
 	[InlineAutoSubstituteData<WindowManagerCustomization>(PInvoke.EVENT_SYSTEM_FOREGROUND)]
@@ -508,10 +498,8 @@ public class WindowManagerTests
 		);
 
 		// Then
-		((IInternalMonitorManager)ctx.MonitorManager)
-			.Received(1)
-			.WindowFocused(Arg.Any<IWindow>());
-		((IInternalWorkspaceManager)ctx.WorkspaceManager).Received(1).WindowFocused(Arg.Any<IWindow>());
+		internalCtx.MonitorManager.Received(1).WindowFocused(Arg.Any<IWindow>());
+		internalCtx.WorkspaceManager.Received(1).WindowFocused(Arg.Any<IWindow>());
 	}
 
 	[Theory, AutoSubstituteData<WindowManagerCustomization>]
@@ -553,9 +541,7 @@ public class WindowManagerTests
 		);
 
 		// Then
-		((IInternalWorkspaceManager)ctx.WorkspaceManager)
-			.Received(1)
-			.WindowRemoved(Arg.Any<IWindow>());
+		internalCtx.WorkspaceManager.Received(1).WindowRemoved(Arg.Any<IWindow>());
 	}
 
 	[InlineAutoSubstituteData<WindowManagerCustomization>(PInvoke.EVENT_OBJECT_DESTROY)]
@@ -579,9 +565,7 @@ public class WindowManagerTests
 		);
 
 		// Then
-		((IInternalWorkspaceManager)ctx.WorkspaceManager)
-			.Received(1)
-			.WindowRemoved(Arg.Any<IWindow>());
+		internalCtx.WorkspaceManager.Received(1).WindowRemoved(Arg.Any<IWindow>());
 		Assert.Empty(windowManager.HandleWindowMap);
 	}
 
@@ -1005,9 +989,7 @@ public class WindowManagerTests
 		);
 
 		// Then
-		((IInternalWorkspaceManager)ctx.WorkspaceManager)
-			.Received(1)
-			.WindowMinimizeStart(Arg.Any<IWindow>());
+		internalCtx.WorkspaceManager.Received(1).WindowMinimizeStart(Arg.Any<IWindow>());
 	}
 
 	[Theory, AutoSubstituteData<WindowManagerCustomization>]
@@ -1029,9 +1011,7 @@ public class WindowManagerTests
 		);
 
 		// Then
-		((IInternalWorkspaceManager)ctx.WorkspaceManager)
-			.Received(1)
-			.WindowMinimizeEnd(Arg.Any<IWindow>());
+		internalCtx.WorkspaceManager.Received(1).WindowMinimizeEnd(Arg.Any<IWindow>());
 	}
 
 	#region OnWindowMoveEnd
@@ -1455,26 +1435,6 @@ public class WindowManagerTests
 			.DidNotReceive()
 			.MoveWindowEdgesInDirection(Arg.Any<Direction>(), Arg.Any<IPoint<int>>(), Arg.Any<IWindow>());
 		ctx.WorkspaceManager.DidNotReceive().MoveWindowToWorkspace(Arg.Any<IWorkspace>(), Arg.Any<IWindow>());
-	}
-
-	[Theory]
-	[InlineAutoSubstituteData<WindowManagerCustomization>(false)]
-	[InlineAutoSubstituteData<WindowManagerCustomization>(true)]
-	internal void PostInitialize(bool routeToActiveWorkspace, IContext ctx, IInternalContext internalCtx)
-	{
-		// Given
-		ctx.RouterManager.RouteToActiveWorkspace.Returns(routeToActiveWorkspace);
-		internalCtx.CoreNativeManager.GetAllWindows().Returns(new List<HWND>() { new(1), new(2), new(3) });
-
-		WindowManager windowManager = new(ctx, internalCtx);
-
-		// When
-		windowManager.PostInitialize();
-
-		// Then RouteToActiveWorkspace was get and set
-		internalCtx.CoreNativeManager.Received(3).IsSplashScreen(Arg.Any<HWND>());
-		_ = ctx.RouterManager.Received(1).RouteToActiveWorkspace;
-		ctx.RouterManager.Received().RouteToActiveWorkspace = routeToActiveWorkspace;
 	}
 
 	#region Dispose

--- a/src/Whim/Context/CoreSavedStateManager.cs
+++ b/src/Whim/Context/CoreSavedStateManager.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+
+namespace Whim;
+
+internal class CoreSavedStateManager : ICoreSavedStateManager
+{
+	private readonly IContext _context;
+	private readonly string _savedStateFilePath;
+	private bool _disposedValue;
+
+	public CoreSavedState? SavedState { get; private set; }
+
+	public CoreSavedStateManager(IContext context)
+	{
+		_context = context;
+		_savedStateFilePath = Path.Combine(_context.FileManager.SavedStateDir, "core.json");
+	}
+
+	public void PreInitialize()
+	{
+		_context.FileManager.EnsureDirExists(_context.FileManager.SavedStateDir);
+
+		// If the saved plugin state file doesn't yet exist, we don't need to load anything.
+		if (!_context.FileManager.FileExists(_savedStateFilePath))
+		{
+			return;
+		}
+
+		try
+		{
+			SavedState = JsonSerializer.Deserialize<CoreSavedState>(
+				_context.FileManager.ReadAllText(_savedStateFilePath)
+			);
+		}
+		catch (Exception e)
+		{
+			Logger.Error($"Failed to deserialize saved state: {e}");
+		}
+	}
+
+	public void PostInitialize()
+	{
+		SavedState = null;
+	}
+
+	#region Save state on dispose
+	protected virtual void Dispose(bool disposing)
+	{
+		if (!_disposedValue)
+		{
+			if (disposing)
+			{
+				// dispose managed state (managed objects)
+				SaveState();
+			}
+
+			_disposedValue = true;
+		}
+	}
+
+	public void Dispose()
+	{
+		// Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+		Dispose(disposing: true);
+		GC.SuppressFinalize(this);
+	}
+
+	private void SaveState()
+	{
+		List<SavedWorkspace> savedWorkspaces = new();
+		IMonitor monitor = _context.MonitorManager.PrimaryMonitor;
+		IRectangle<int> fakeMonitorRect = new Rectangle<int>() { Height = 1000, Width = 1000 };
+
+		foreach (IWorkspace workspace in _context.WorkspaceManager)
+		{
+			List<SavedWindow> savedWindows = new();
+
+			foreach (IWindowState windowState in workspace.ActiveLayoutEngine.DoLayout(fakeMonitorRect, monitor))
+			{
+				Rectangle<double> scaled =
+					(Rectangle<double>)MonitorHelpers.ToUnitSquare(fakeMonitorRect, windowState.Rectangle);
+				savedWindows.Add(new SavedWindow(windowState.Window.Handle, scaled));
+			}
+
+			savedWorkspaces.Add(new SavedWorkspace(workspace.Name, savedWindows));
+		}
+
+		CoreSavedState coreSavedState = new(savedWorkspaces);
+		_context.FileManager.WriteAllText(_savedStateFilePath, JsonSerializer.Serialize(coreSavedState));
+	}
+	#endregion
+}

--- a/src/Whim/Context/CoreSavedStateManager.cs
+++ b/src/Whim/Context/CoreSavedStateManager.cs
@@ -46,7 +46,6 @@ internal class CoreSavedStateManager : ICoreSavedStateManager
 		SavedState = null;
 	}
 
-	#region Save state on dispose
 	protected virtual void Dispose(bool disposing)
 	{
 		if (!_disposedValue)
@@ -91,5 +90,4 @@ internal class CoreSavedStateManager : ICoreSavedStateManager
 		CoreSavedState coreSavedState = new(savedWorkspaces);
 		_context.FileManager.WriteAllText(_savedStateFilePath, JsonSerializer.Serialize(coreSavedState));
 	}
-	#endregion
 }

--- a/src/Whim/Context/ICoreSavedStateManager.cs
+++ b/src/Whim/Context/ICoreSavedStateManager.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Collections.Generic;
+
+namespace Whim;
+
+internal record SavedWindow(long Handle, Rectangle<double> Rectangle);
+
+internal record SavedWorkspace(string Name, List<SavedWindow> Windows);
+
+internal record CoreSavedState(List<SavedWorkspace> Workspaces);
+
+internal interface ICoreSavedStateManager : IDisposable
+{
+	/// <summary>
+	/// The loaded saved state.
+	/// </summary>
+	CoreSavedState? SavedState { get; }
+
+	/// <summary>
+	/// Load the saved state. Each manager is responsible for loading its own state.
+	/// </summary>
+	void PreInitialize();
+
+	/// <summary>
+	/// Clears the saved state.
+	/// </summary>
+	void PostInitialize();
+}

--- a/src/Whim/Context/ICoreSavedStateManager.cs
+++ b/src/Whim/Context/ICoreSavedStateManager.cs
@@ -3,12 +3,29 @@ using System.Collections.Generic;
 
 namespace Whim;
 
+/// <summary>
+/// A window's handle, and it's rectangle in its last active <see cref="ILayoutEngine"/>.
+/// </summary>
+/// <param name="Handle"></param>
+/// <param name="Rectangle"></param>
 internal record SavedWindow(long Handle, Rectangle<double> Rectangle);
 
+/// <summary>
+/// A workspace's name, and the windows it contains.
+/// </summary>
+/// <param name="Name"></param>
+/// <param name="Windows"></param>
 internal record SavedWorkspace(string Name, List<SavedWindow> Windows);
 
+/// <summary>
+/// The saved state for Whim's core.
+/// </summary>
+/// <param name="Workspaces">The workspaces that were saved.</param>
 internal record CoreSavedState(List<SavedWorkspace> Workspaces);
 
+/// <summary>
+/// Saves and restores the state for Whim's core.
+/// </summary>
 internal interface ICoreSavedStateManager : IDisposable
 {
 	/// <summary>
@@ -22,7 +39,7 @@ internal interface ICoreSavedStateManager : IDisposable
 	void PreInitialize();
 
 	/// <summary>
-	/// Clears the saved state.
+	/// Clears the saved state, as it is no longer needed.
 	/// </summary>
 	void PostInitialize();
 }

--- a/src/Whim/Context/IInternalContext.cs
+++ b/src/Whim/Context/IInternalContext.cs
@@ -7,6 +7,8 @@ namespace Whim;
 /// </summary>
 internal interface IInternalContext : IDisposable
 {
+	ICoreSavedStateManager CoreSavedStateManager { get; }
+
 	ICoreNativeManager CoreNativeManager { get; }
 
 	IWindowMessageMonitor WindowMessageMonitor { get; }

--- a/src/Whim/Context/IInternalContext.cs
+++ b/src/Whim/Context/IInternalContext.cs
@@ -11,6 +11,10 @@ internal interface IInternalContext : IDisposable
 
 	IWindowMessageMonitor WindowMessageMonitor { get; }
 
+	IInternalWorkspaceManager WorkspaceManager { get; }
+
+	IInternalMonitorManager MonitorManager { get; }
+
 	IInternalWindowManager WindowManager { get; }
 
 	IKeybindHook KeybindHook { get; }

--- a/src/Whim/Context/InternalContext.cs
+++ b/src/Whim/Context/InternalContext.cs
@@ -10,6 +10,10 @@ internal class InternalContext : IInternalContext
 
 	public IWindowMessageMonitor WindowMessageMonitor { get; }
 
+	public IInternalWorkspaceManager WorkspaceManager => (IInternalWorkspaceManager)_context.WorkspaceManager;
+
+	public IInternalMonitorManager MonitorManager => (IInternalMonitorManager)_context.MonitorManager;
+
 	public IInternalWindowManager WindowManager => (IInternalWindowManager)_context.WindowManager;
 
 	public IKeybindHook KeybindHook { get; }

--- a/src/Whim/Context/InternalContext.cs
+++ b/src/Whim/Context/InternalContext.cs
@@ -6,6 +6,8 @@ internal class InternalContext : IInternalContext
 
 	private readonly IContext _context;
 
+	public ICoreSavedStateManager CoreSavedStateManager { get; }
+
 	public ICoreNativeManager CoreNativeManager { get; }
 
 	public IWindowMessageMonitor WindowMessageMonitor { get; }
@@ -25,6 +27,7 @@ internal class InternalContext : IInternalContext
 	public InternalContext(IContext context)
 	{
 		_context = context;
+		CoreSavedStateManager = new CoreSavedStateManager(context);
 		CoreNativeManager = new CoreNativeManager(context);
 		WindowMessageMonitor = new WindowMessageMonitor(context, this);
 		KeybindHook = new KeybindHook(context, this);
@@ -35,10 +38,12 @@ internal class InternalContext : IInternalContext
 	public void PreInitialize()
 	{
 		WindowMessageMonitor.PreInitialize();
+		CoreSavedStateManager.PreInitialize();
 	}
 
 	public void PostInitialize()
 	{
+		CoreSavedStateManager.PostInitialize();
 		KeybindHook.PostInitialize();
 		MouseHook.PostInitialize();
 	}
@@ -50,6 +55,7 @@ internal class InternalContext : IInternalContext
 			if (disposing)
 			{
 				// dispose managed state (managed objects)
+				CoreSavedStateManager.Dispose();
 				WindowMessageMonitor.Dispose();
 				KeybindHook.Dispose();
 				MouseHook.Dispose();

--- a/src/Whim/Location/IRectangle.cs
+++ b/src/Whim/Location/IRectangle.cs
@@ -11,12 +11,17 @@ public interface IRectangle<T> : IPoint<T>
 	/// <summary>
 	/// The width, in pixels.
 	/// </summary>
-	public T Width { get; }
+	T Width { get; }
 
 	/// <summary>
 	/// The height, in pixels.
 	/// </summary>
-	public T Height { get; }
+	T Height { get; }
+
+	/// <summary>
+	/// The center of the rectangle.
+	/// </summary>
+	IPoint<T> Center { get; }
 
 	/// <summary>
 	/// Indicates whether the specified point is inside this item's bounding box.
@@ -30,5 +35,5 @@ public interface IRectangle<T> : IPoint<T>
 	/// <see langword="true"/> if the location given by <paramref name="point"/> is inside this
 	/// <see cref="IRectangle{T}"/>'s bounding box; otherwise, <see langword="false"/>.
 	/// </returns>
-	public bool ContainsPoint(IPoint<T> point);
+	bool ContainsPoint(IPoint<T> point);
 }

--- a/src/Whim/Location/Rectangle.cs
+++ b/src/Whim/Location/Rectangle.cs
@@ -33,6 +33,9 @@ public record Rectangle<T> : IRectangle<T>, IEquatable<Rectangle<T>>
 	/// <inheritdoc />
 	public T Height { get; set; } = T.Zero;
 
+	/// <inheritdoc />
+	public IPoint<T> Center => new Point<T>() { X = X + (Width / (T.One + T.One)), Y = Y + (Height / (T.One + T.One)) };
+
 	/// <summary>
 	/// Creates a new <see cref="Rectangle{T}"/> with zero values.
 	/// </summary>

--- a/src/Whim/Location/Rectangle.cs
+++ b/src/Whim/Location/Rectangle.cs
@@ -53,6 +53,21 @@ public record Rectangle<T> : IRectangle<T>, IEquatable<Rectangle<T>>
 		Height = rectangle.Height;
 	}
 
+	/// <summary>
+	/// Creates a new <see cref="Rectangle{T}"/> with the given values.
+	/// </summary>
+	/// <param name="x"></param>
+	/// <param name="y"></param>
+	/// <param name="width"></param>
+	/// <param name="height"></param>
+	public Rectangle(T x, T y, T width, T height)
+	{
+		X = x;
+		Y = y;
+		Width = width;
+		Height = height;
+	}
+
 	/// <inheritdoc />
 	public bool ContainsPoint(IPoint<T> point) =>
 		point.X >= X && point.X < X + Width && point.Y >= Y && point.Y < Y + Height;

--- a/src/Whim/Window/IInternalWindowManager.cs
+++ b/src/Whim/Window/IInternalWindowManager.cs
@@ -5,11 +5,38 @@ namespace Whim;
 
 internal interface IInternalWindowManager
 {
+	/// <summary>
+	/// Add the given <see cref="HWND"/> as an <see cref="IWindow"/> inside this
+	/// <see cref="IWindowManager"/>.
+	/// </summary>
+	/// <param name="hwnd"></param>
+	/// <returns>The newly added <see cref="IWindow"/>, or <see langword="null"/> if the <see cref="HWND"/> was ignored.</returns>
+	IWindow? AddWindow(HWND hwnd);
+
+	/// <summary>
+	/// Fire the <see cref="IWindowManager.WindowAdded"/> event.
+	/// </summary>
+	/// <param name="window"></param>
 	void OnWindowAdded(IWindow window);
+
+	/// <summary>
+	/// Handles when the given window is focused.
+	/// This can be called by <see cref="Workspace.AddWindow"/>, as an already focused window may
+	/// have switched to a different workspace.
+	/// </summary>
+	/// <param name="window"></param>
 	void OnWindowFocused(IWindow? window);
+
+	/// <summary>
+	/// Removes the given window from the <see cref="IWindowManager"/>, and fires:
+	///
+	/// <list type="bullet">
+	/// <item><description><see cref="IInternalWorkspaceManager.WindowRemoved(IWindow)" /></description></item>
+	/// <item><description><see cref="IWindowManager.WindowRemoved"/></description></item>
+	/// </list>
+	/// </summary>
+	/// <param name="window"></param>
 	void OnWindowRemoved(IWindow window);
-	void OnWindowMinimizeStart(IWindow window);
-	void OnWindowMinimizeEnd(IWindow window);
 
 	/// <summary>
 	/// Map of <see cref="HWND"/> to <see cref="IWindow"/> for easy <see cref="IWindow"/> lookup.

--- a/src/Whim/Window/IWindow.cs
+++ b/src/Whim/Window/IWindow.cs
@@ -37,6 +37,7 @@ public interface IWindow
 	/// <summary>
 	/// The center of the window.
 	/// </summary>
+	[Obsolete("Use Rectangle.Center instead.")]
 	IPoint<int> Center { get; }
 
 	/// <summary>

--- a/src/Whim/Window/IWindowManager.cs
+++ b/src/Whim/Window/IWindowManager.cs
@@ -27,6 +27,7 @@ public interface IWindowManager : IEnumerable<IWindow>, IDisposable
 
 	/// <summary>
 	/// Creates a new window. If the window cannot be created, <see langword="null"/> is returned.
+	/// This will try reuse existing <see cref="IWindow"/>s if possible.
 	/// </summary>
 	/// <remarks>
 	/// This does not add the window to the <see cref="IWindowManager"/> or to the <see cref="IWorkspaceManager"/>.

--- a/src/Whim/Window/Window.cs
+++ b/src/Whim/Window/Window.cs
@@ -184,7 +184,7 @@ internal class Window : IWindow
 		return Handle.GetHashCode();
 	}
 
-	public override string ToString() => $"{Title} ({ProcessName}) [{ProcessId}] <{WindowClass}> {{{Handle.Value}}}";
+	public override string ToString() => $"{Title} ({ProcessName}) [{ProcessId}] <{WindowClass}> {{{Handle}}}";
 
 	public BitmapImage? GetIcon() => this.GetIcon(_context, _internalContext);
 }

--- a/src/Whim/Window/WindowManager.cs
+++ b/src/Whim/Window/WindowManager.cs
@@ -364,7 +364,7 @@ internal class WindowManager : IWindowManager, IInternalWindowManager
 	public void OnWindowAdded(IWindow window)
 	{
 		Logger.Debug($"Window added: {window}");
-		((IInternalWorkspaceManager)_context.WorkspaceManager).WindowAdded(window);
+		_internalContext.WorkspaceManager.WindowAdded(window);
 		WindowAdded?.Invoke(this, new WindowEventArgs() { Window = window });
 	}
 
@@ -377,8 +377,8 @@ internal class WindowManager : IWindowManager, IInternalWindowManager
 	public void OnWindowFocused(IWindow? window)
 	{
 		Logger.Debug($"Window focused: {window}");
-		((IInternalMonitorManager)_context.MonitorManager).WindowFocused(window);
-		((IInternalWorkspaceManager)_context.WorkspaceManager).WindowFocused(window);
+		_internalContext.MonitorManager.WindowFocused(window);
+		_internalContext.WorkspaceManager.WindowFocused(window);
 		WindowFocused?.Invoke(this, new WindowFocusedEventArgs() { Window = window });
 	}
 
@@ -407,7 +407,7 @@ internal class WindowManager : IWindowManager, IInternalWindowManager
 		Logger.Debug($"Window removed: {window}");
 		_windows.TryRemove(window.Handle, out _);
 		_handledLocationRestoringWindows.Remove(window);
-		((IInternalWorkspaceManager)_context.WorkspaceManager).WindowRemoved(window);
+		_internalContext.WorkspaceManager.WindowRemoved(window);
 		WindowRemoved?.Invoke(this, new WindowEventArgs() { Window = window });
 	}
 
@@ -604,14 +604,14 @@ internal class WindowManager : IWindowManager, IInternalWindowManager
 	public void OnWindowMinimizeStart(IWindow window)
 	{
 		Logger.Debug($"Window minimize started: {window}");
-		((IInternalWorkspaceManager)_context.WorkspaceManager).WindowMinimizeStart(window);
+		_internalContext.WorkspaceManager.WindowMinimizeStart(window);
 		WindowMinimizeStart?.Invoke(this, new WindowEventArgs() { Window = window });
 	}
 
 	public void OnWindowMinimizeEnd(IWindow window)
 	{
 		Logger.Debug($"Window minimize ended: {window}");
-		((IInternalWorkspaceManager)_context.WorkspaceManager).WindowMinimizeEnd(window);
+		_internalContext.WorkspaceManager.WindowMinimizeEnd(window);
 		WindowMinimizeEnd?.Invoke(this, new WindowEventArgs() { Window = window });
 	}
 

--- a/src/Whim/Workspace/WorkspaceManager.cs
+++ b/src/Whim/Workspace/WorkspaceManager.cs
@@ -168,6 +168,10 @@ internal class WorkspaceManager : IInternalWorkspaceManager, IWorkspaceManager
 		}
 	}
 
+	/// <summary>
+	/// Add the saved windows at their saved locations inside their saved workspaces.
+	/// Other windows are routed to the monitor they're on.
+	/// </summary>
 	private void InitializeWindows()
 	{
 		List<HWND> processedWindows = new();

--- a/src/Whim/Workspace/WorkspaceManager.cs
+++ b/src/Whim/Workspace/WorkspaceManager.cs
@@ -132,7 +132,7 @@ internal class WorkspaceManager : IInternalWorkspaceManager, IWorkspaceManager
 		)
 		{
 			int workspaceIdx = _workspacesToCreate.FindIndex(w => w.Name == savedWorkspace.Name);
-			if (workspaceIdx != -1)
+			if (workspaceIdx >= 0)
 			{
 				// Since we don't preserve the layout engines, use the ones provided by the user.
 				WorkspaceToCreate workspaceToCreate = _workspacesToCreate[workspaceIdx];

--- a/src/Whim/Workspace/WorkspaceManager.cs
+++ b/src/Whim/Workspace/WorkspaceManager.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using Windows.Win32.Foundation;
 
 namespace Whim;
 
@@ -15,6 +16,8 @@ internal record WorkspaceManagerTriggers
 	public required Action<WorkspaceEventArgs> WorkspaceLayoutStarted { get; init; }
 	public required Action<WorkspaceEventArgs> WorkspaceLayoutCompleted { get; init; }
 }
+
+internal record WorkspaceToCreate(string Name, IEnumerable<CreateLeafLayoutEngine>? LayoutEngines);
 
 /// <summary>
 /// Implementation of <see cref="IWorkspaceManager"/>.
@@ -41,8 +44,7 @@ internal class WorkspaceManager : IInternalWorkspaceManager, IWorkspaceManager
 	/// Stores the workspaces to create, when <see cref="Initialize"/> is called.
 	/// The workspaces will have been created prior to <see cref="Initialize"/>.
 	/// </summary>
-	private readonly List<(string Name, IEnumerable<CreateLeafLayoutEngine>? LayoutEngines)> _workspacesToCreate =
-		new();
+	private readonly List<WorkspaceToCreate> _workspacesToCreate = new();
 
 	/// <summary>
 	/// Maps monitors to their active workspace.
@@ -106,8 +108,48 @@ internal class WorkspaceManager : IInternalWorkspaceManager, IWorkspaceManager
 	{
 		Logger.Debug("Initializing workspace manager...");
 
+		InitializeWorkspaces();
+
+		_initialized = true;
+		_context.MonitorManager.MonitorsChanged += MonitorManager_MonitorsChanged;
+
+		InitializeWindows();
+
+		Logger.Debug("Workspace manager initialized");
+	}
+
+	/// <summary>
+	/// Load the saved workspaces and merge them with the user-specified workspaces.
+	/// </summary>
+	/// <exception cref="InvalidOperationException"></exception>
+	private void InitializeWorkspaces()
+	{
+		List<WorkspaceToCreate> workspaces = new();
+
+		// Merge the saved state with the workspaces to create.
+		foreach (
+			SavedWorkspace savedWorkspace in _internalContext.CoreSavedStateManager.SavedState?.Workspaces ?? new()
+		)
+		{
+			int workspaceIdx = _workspacesToCreate.FindIndex(w => w.Name == savedWorkspace.Name);
+			if (workspaceIdx != -1)
+			{
+				// Since we don't preserve the layout engines, use the ones provided by the user.
+				WorkspaceToCreate workspaceToCreate = _workspacesToCreate[workspaceIdx];
+				_workspacesToCreate.RemoveAt(workspaceIdx);
+				workspaces.Add(new(workspaceToCreate.Name, workspaceToCreate.LayoutEngines));
+			}
+			else
+			{
+				workspaces.Add(new(savedWorkspace.Name, null));
+			}
+		}
+
+		// Add the remaining workspaces to create.
+		workspaces.AddRange(_workspacesToCreate);
+
 		// Create the workspaces.
-		foreach ((string name, IEnumerable<CreateLeafLayoutEngine>? createLayoutEngines) in _workspacesToCreate)
+		foreach ((string name, IEnumerable<CreateLeafLayoutEngine>? createLayoutEngines) in workspaces)
 		{
 			CreateWorkspace(name, createLayoutEngines);
 		}
@@ -124,11 +166,61 @@ internal class WorkspaceManager : IInternalWorkspaceManager, IWorkspaceManager
 			Activate(workspace, monitor);
 			idx++;
 		}
+	}
 
-		_initialized = true;
-		_context.MonitorManager.MonitorsChanged += MonitorManager_MonitorsChanged;
+	private void InitializeWindows()
+	{
+		List<HWND> processedWindows = new();
 
-		Logger.Debug("Workspace manager initialized");
+		// Route windows to their saved workspaces.
+		foreach (
+			SavedWorkspace savedWorkspace in _internalContext.CoreSavedStateManager.SavedState?.Workspaces ?? new()
+		)
+		{
+			IWorkspace? workspace = TryGet(savedWorkspace.Name);
+			if (workspace == null)
+			{
+				Logger.Error($"Could not find workspace {savedWorkspace.Name}");
+				continue;
+			}
+
+			foreach (SavedWindow savedWindow in savedWorkspace.Windows)
+			{
+				HWND hwnd = (HWND)savedWindow.Handle;
+				IWindow? window = _context.WindowManager.CreateWindow(hwnd);
+				if (window == null)
+				{
+					Logger.Error($"Could not find window with handle {savedWindow.Handle}");
+					continue;
+				}
+
+				_windowWorkspaceMap[window] = workspace;
+				workspace.MoveWindowToPoint(window, savedWindow.Rectangle.Center);
+				processedWindows.Add(hwnd);
+
+				// Fire the window added event.
+				_internalContext.WindowManager.OnWindowAdded(window);
+			}
+		}
+
+		// Route the rest of the windows to the monitor they're on.
+		// Don't route to the active workspace while we're adding all the windows.
+		bool routeToActiveWorkspace = _context.RouterManager.RouteToActiveWorkspace;
+		_context.RouterManager.RouteToActiveWorkspace = false;
+
+		// Add all existing windows.
+		foreach (HWND hwnd in _internalContext.CoreNativeManager.GetAllWindows())
+		{
+			if (processedWindows.Contains(hwnd))
+			{
+				continue;
+			}
+
+			_internalContext.WindowManager.AddWindow(hwnd);
+		}
+
+		// Restore the route to active workspace setting.
+		_context.RouterManager.RouteToActiveWorkspace = routeToActiveWorkspace;
 	}
 
 	#region Workspaces
@@ -182,7 +274,7 @@ internal class WorkspaceManager : IInternalWorkspaceManager, IWorkspaceManager
 		}
 		else
 		{
-			_workspacesToCreate.Add((name ?? $"Workspace {_workspaces.Count + 1}", createLayoutEngines));
+			_workspacesToCreate.Add(new(name ?? $"Workspace {_workspaces.Count + 1}", createLayoutEngines));
 		}
 	}
 
@@ -400,7 +492,7 @@ internal class WorkspaceManager : IInternalWorkspaceManager, IWorkspaceManager
 
 		if (workspace == null && !_context.RouterManager.RouteToActiveWorkspace)
 		{
-			IMonitor? monitor = _context.MonitorManager.GetMonitorAtPoint(window.Center);
+			IMonitor? monitor = _context.MonitorManager.GetMonitorAtPoint(window.Rectangle.Center);
 			if (monitor is not null)
 			{
 				workspace = GetWorkspaceForMonitor(monitor);


### PR DESCRIPTION
Saves workspaces and the window positions for the active layout engine within each workspace.

Workspaces and window positions are restored on startup. This relies on window handles being constant, so this does not work when starting Whim after restarting Windows.

Other changes:

- `IWindow.Center` has been marked as obsolete, and replaced by `IRectangle.Center`.
- Improved documentation and removed unused methods from `IInternalWindowManager`.
- Format a window's handle properly in `Window.ToString()`.
