### PR TITLE
Update config to prevent floating windows being resized by the gaps plugin

### DIFF
--- a/src/Whim/Template/whim.config.csx
+++ b/src/Whim/Template/whim.config.csx
@@ -47,14 +47,14 @@ void DoConfig(IContext context)
 	BarPlugin barPlugin = new(context, barConfig);
 	context.PluginManager.AddPlugin(barPlugin);
 
-	// Floating window plugin.
-	FloatingLayoutPlugin floatingLayoutPlugin = new(context);
-	context.PluginManager.AddPlugin(floatingLayoutPlugin);
-
 	// Gap plugin.
 	GapsConfig gapsConfig = new() { OuterGap = 0, InnerGap = 10 };
 	GapsPlugin gapsPlugin = new(context, gapsConfig);
 	context.PluginManager.AddPlugin(gapsPlugin);
+
+	// Floating window plugin.
+	FloatingLayoutPlugin floatingLayoutPlugin = new(context);
+	context.PluginManager.AddPlugin(floatingLayoutPlugin);
 
 	// Focus indicator.
 	FocusIndicatorConfig focusIndicatorConfig = new() { Color = new SolidColorBrush(Colors.Red), FadeEnabled = true };


### PR DESCRIPTION
When marking a window as floating or moving a window, the window's size could slightly shrink. This was due to the default having `GapsPlugin` defined after `FloatingLayoutPlugin`. Switching the order fixes this. 