### PR TITLE
Add restart support

### DIFF
--- a/src/Whim.Runner/App.xaml.cs
+++ b/src/Whim.Runner/App.xaml.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using Microsoft.UI.Xaml;
+using Microsoft.Windows.AppLifecycle;
+using Windows.ApplicationModel.Core;
 
 // To learn more about WinUI, the WinUI project structure,
 // and more about our project templates, see: http://aka.ms/winui-project-info.
@@ -64,10 +66,34 @@ public partial class App : Application
 		{
 			Exit();
 		}
+		else if (e.Reason == ExitReason.Restart)
+		{
+			Restart();
+		}
 		else
 		{
 			new ExceptionWindow(this, e).Activate();
 		}
+	}
+
+	private void Restart()
+	{
+		AppRestartFailureReason reason = AppInstance.Restart("");
+
+		switch (reason)
+		{
+			case AppRestartFailureReason.RestartPending:
+				Logger.Debug("Another restart is currently pending.");
+				break;
+			case AppRestartFailureReason.InvalidUser:
+				Logger.Fatal("Current user is not signed in or not a valid user.");
+				break;
+			case AppRestartFailureReason.Other:
+				Logger.Fatal("Failure restarting.");
+				break;
+		}
+
+		Exit();
 	}
 
 	private void Application_UnhandledException(object sender, Microsoft.UI.Xaml.UnhandledExceptionEventArgs e)

--- a/src/Whim.Tests/Commands/CoreCommandsTests.cs
+++ b/src/Whim.Tests/Commands/CoreCommandsTests.cs
@@ -327,6 +327,22 @@ public class CoreCommandsTests
 		context.Received(1).Exit(null);
 	}
 
+	[Theory, AutoSubstituteData<CoreCommandsCustomization>]
+	public void RestartWhim(IContext context)
+	{
+		// Given
+		CoreCommands commands = new(context);
+		PluginCommandsTestUtils testUtils = new(commands);
+
+		ICommand command = testUtils.GetCommand("whim.core.restart_whim");
+
+		// When
+		command.TryExecute();
+
+		// Then
+		context.Received(1).Exit(Arg.Is<ExitEventArgs>(args => args.Reason == ExitReason.Restart));
+	}
+
 	private static List<IWorkspace> CreateWorkspaces(int count)
 	{
 		List<IWorkspace> workspaces = new();

--- a/src/Whim/Commands/CoreCommands.cs
+++ b/src/Whim/Commands/CoreCommands.cs
@@ -226,7 +226,12 @@ internal class CoreCommands : PluginCommands
 				callback: () => _context.WorkspaceManager.Remove(_context.WorkspaceManager.ActiveWorkspace),
 				keybind: new Keybind(IKeybind.WinCtrl, VIRTUAL_KEY.VK_W)
 			)
-			.Add(identifier: "exit_whim", title: "Exit Whim", callback: () => _context.Exit());
+			.Add(identifier: "exit_whim", title: "Exit Whim", callback: () => _context.Exit())
+			.Add(
+				identifier: "restart_whim",
+				title: "Restart Whim",
+				callback: () => _context.Exit(new ExitEventArgs() { Reason = ExitReason.Restart })
+			);
 
 		for (int idx = 1; idx <= 10; idx++)
 		{


### PR DESCRIPTION
Whim can now restart itself. This is exposed available via the existing `IContext.Exit`, and the new `whim.core.restart_whim` command.