### PR TITLE
New `matching strategies` for auto-app-rules

### DIFF
--- a/app_rules/generate_app_rules.py
+++ b/app_rules/generate_app_rules.py
@@ -44,7 +44,7 @@ namespace Whim;
 internal static class DefaultFilteredWindowsKomorebi
 {
 	/// <summary>
-	/// Load the windows ignored by <see href="https://github.com/LGUG2Z/komorebi-application-specific-configuration"/>.
+	/// Load the windows ignored by Komorebi <see href="https://github.com/LGUG2Z/komorebi-application-specific-configuration"/>.
 	/// </summary>
 	/// <param name="filterManager"></param>
 	public static void LoadWindowsIgnoredByKomorebi(IFilterManager filterManager)
@@ -85,7 +85,7 @@ class GenerateRules:
 	def generate_all_rules(self):
 		for app in self.komorebi_rules:
 			if "float_identifiers" in app:
-				# windows matching `float_identifiers` are ignored by komorebi
+				# windows with matching `float_identifiers` are ignored by komorebi
 				Application(app["float_identifiers"], app["name"]).generate_rules()
 
 
@@ -142,12 +142,12 @@ with open(OUTFILE, 'w') as o:
 # Keep track of already generated rules to filter out duplicates
 _processed = {"Class": [], "Exe": [], "Title": []}
 
-# Load komorebi rules
+# Load Komorebi rules
 komorebi_rules = GetRules(URL)
 komorebi_rules.download()
 komorebi_rules.load_yaml()
 
-# Generate rules
+# Generate Whim rules
 GenerateRules(komorebi_rules.rules).generate_all_rules()
 
 # Add footer


### PR DESCRIPTION
This starts the work on #685,  implementing some of the new matching strategies introduced by Komorebi for its app rules.

- [x] refactor `generate_app_rules.py` to support multiple matching strategies
- [x] no longer raise an error for not yet implemented matching rules (there will be a comment in the generated file to inform about not implemented rules)
- [x] implement `matching strategies for  `Legacy`, `Equals`, `StartsWith`, `EndsWith`, `Contains`
- [ ] `Regex` is left open for a later PR (as of now, no rule in the Komorebi repo uses the `Regex` matching strategy)

A test run of the new script is here: https://github.com/urob/Whim/pull/3/files