### PR TITLE
Whim can now add minimized windows again

### DIFF
--- a/src/Whim/Native/NativeManager.cs
+++ b/src/Whim/Native/NativeManager.cs
@@ -32,14 +32,14 @@ public partial class NativeManager : INativeManager
 	/// <inheritdoc/>
 	public void QuitWindow(HWND hwnd)
 	{
-		Logger.Debug($"Quitting application with HWND {hwnd.Value}");
+		Logger.Debug($"Quitting application with HWND {hwnd}");
 		PInvoke.SendNotifyMessage(hwnd, PInvoke.WM_SYSCOMMAND, new WPARAM(PInvoke.SC_CLOSE), 0);
 	}
 
 	/// <inheritdoc/>
 	public void ForceForegroundWindow(HWND hwnd)
 	{
-		Logger.Debug($"Forcing window HWND {hwnd.Value} to foreground");
+		Logger.Debug($"Forcing window HWND {hwnd} to foreground");
 		// Implementation courtesy of https://github.com/workspacer/workspacer/commit/1c02613cea485f1ae97f70d6399f7124aeb31297
 		// keybd_event synthesizes a keystroke - see https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-keybd_event
 		PInvoke.keybd_event(0, 0, 0, 0);
@@ -49,35 +49,35 @@ public partial class NativeManager : INativeManager
 	/// <inheritdoc/>
 	public bool HideWindow(HWND hwnd)
 	{
-		Logger.Debug($"Hiding window HWND {hwnd.Value}");
+		Logger.Debug($"Hiding window HWND {hwnd}");
 		return (bool)PInvoke.ShowWindow(hwnd, SHOW_WINDOW_CMD.SW_HIDE);
 	}
 
 	/// <inheritdoc/>
 	public bool ShowWindowMaximized(HWND hwnd)
 	{
-		Logger.Debug($"Showing window HWND {hwnd.Value} maximized");
+		Logger.Debug($"Showing window HWND {hwnd} maximized");
 		return (bool)PInvoke.ShowWindow(hwnd, SHOW_WINDOW_CMD.SW_SHOWMAXIMIZED);
 	}
 
 	/// <inheritdoc/>
 	public bool ShowWindowMinimized(HWND hwnd)
 	{
-		Logger.Debug($"Showing window HWND {hwnd.Value} minimized");
+		Logger.Debug($"Showing window HWND {hwnd} minimized");
 		return (bool)PInvoke.ShowWindow(hwnd, SHOW_WINDOW_CMD.SW_SHOWMINIMIZED);
 	}
 
 	/// <inheritdoc/>
 	public bool MinimizeWindow(HWND hwnd)
 	{
-		Logger.Debug($"Minimizing window HWND {hwnd.Value}");
+		Logger.Debug($"Minimizing window HWND {hwnd}");
 		return (bool)PInvoke.ShowWindow(hwnd, SHOW_WINDOW_CMD.SW_MINIMIZE);
 	}
 
 	/// <inheritdoc/>
 	public bool ShowWindowNoActivate(HWND hwnd)
 	{
-		Logger.Debug($"Showing window HWND {hwnd.Value} no activate");
+		Logger.Debug($"Showing window HWND {hwnd} no activate");
 		return (bool)PInvoke.ShowWindow(hwnd, SHOW_WINDOW_CMD.SW_SHOWNOACTIVATE);
 	}
 
@@ -121,7 +121,7 @@ public partial class NativeManager : INativeManager
 	{
 		if (!PInvoke.GetWindowRect(hwnd, out RECT windowRect))
 		{
-			Logger.Error($"Could not get the window rect for {hwnd.Value}");
+			Logger.Error($"Could not get the window rect for {hwnd}");
 			return null;
 		}
 
@@ -156,7 +156,7 @@ public partial class NativeManager : INativeManager
 
 			if (res.Failed)
 			{
-				Logger.Error($"Could not get the extended frame rect for {hwnd.Value}");
+				Logger.Error($"Could not get the extended frame rect for {hwnd}");
 				return null;
 			}
 
@@ -186,7 +186,7 @@ public partial class NativeManager : INativeManager
 			);
 			if (res.Failed)
 			{
-				Logger.Error($"Failed to set window corners for {hwnd.Value}");
+				Logger.Error($"Failed to set window corners for {hwnd}");
 			}
 		}
 	}

--- a/src/Whim/Window/WindowManager.cs
+++ b/src/Whim/Window/WindowManager.cs
@@ -118,7 +118,7 @@ internal class WindowManager : IWindowManager, IInternalWindowManager
 
 		if (Window.CreateWindow(_context, _internalContext, hwnd) is IWindow newWindow)
 		{
-			_windows[hwnd] = newWindow;
+			Logger.Debug($"Created window {newWindow}");
 			return newWindow;
 		}
 

--- a/src/Whim/Window/WindowManager.cs
+++ b/src/Whim/Window/WindowManager.cs
@@ -240,7 +240,7 @@ internal class WindowManager : IWindowManager, IInternalWindowManager
 		// Try get the window
 		if (!_windows.TryGetValue(hwnd, out IWindow? window) || window == null)
 		{
-			Logger.Verbose($"Window {hwnd.Value} is not added, event type 0x{eventType:X4}");
+			Logger.Verbose($"Window {hwnd} is not added, event type 0x{eventType:X4}");
 			window = AddWindow(hwnd);
 
 			if (
@@ -303,29 +303,29 @@ internal class WindowManager : IWindowManager, IInternalWindowManager
 
 	public IWindow? AddWindow(HWND hwnd)
 	{
-		Logger.Debug($"Adding window {hwnd.Value}");
+		Logger.Debug($"Adding window {hwnd}");
 
 		if (_internalContext.CoreNativeManager.IsSplashScreen(hwnd))
 		{
-			Logger.Verbose($"Window {hwnd.Value} is a splash screen, ignoring");
+			Logger.Verbose($"Window {hwnd} is a splash screen, ignoring");
 			return null;
 		}
 
 		if (_internalContext.CoreNativeManager.IsCloakedWindow(hwnd))
 		{
-			Logger.Verbose($"Window {hwnd.Value} is cloaked, ignoring");
+			Logger.Verbose($"Window {hwnd} is cloaked, ignoring");
 			return null;
 		}
 
 		if (!_internalContext.CoreNativeManager.IsStandardWindow(hwnd))
 		{
-			Logger.Verbose($"Window {hwnd.Value} is not a standard window, ignoring");
+			Logger.Verbose($"Window {hwnd} is not a standard window, ignoring");
 			return null;
 		}
 
 		if (!_internalContext.CoreNativeManager.HasNoVisibleOwner(hwnd))
 		{
-			Logger.Verbose($"Window {hwnd.Value} has a visible owner, ignoring");
+			Logger.Verbose($"Window {hwnd} has a visible owner, ignoring");
 			return null;
 		}
 


### PR DESCRIPTION
This was due to the handle already being registered during startup but not being added to any workspaces. As a result, further events were ignored.

Also fixed the formatting of handles in `NativeManager`.
