### PR TITLE
Add `INotificationManager` to facilitate toast notifications

### DIFF
--- a/src/Whim.Runner/App.xaml.cs
+++ b/src/Whim.Runner/App.xaml.cs
@@ -39,8 +39,6 @@ public partial class App : Application
 		ProcessLaunchActivationArgs();
 	}
 
-
-
 	private void StartWhim()
 	{
 		try
@@ -81,7 +79,8 @@ public partial class App : Application
 			return;
 		}
 
-		AppNotificationActivatedEventArgs notificationActivatedEventArgs = (AppNotificationActivatedEventArgs)activationArgs.Data;
+		AppNotificationActivatedEventArgs notificationActivatedEventArgs = (AppNotificationActivatedEventArgs)
+			activationArgs.Data;
 		_context?.NotificationManager.ProcessLaunchActivationArgs(notificationActivatedEventArgs);
 	}
 

--- a/src/Whim/Commands/CoreCommands.cs
+++ b/src/Whim/Commands/CoreCommands.cs
@@ -233,6 +233,7 @@ internal class CoreCommands : PluginCommands
 			);
 		}
 
+		// TODO: Remove
 		Add(
 			identifier: "send_test_notification",
 			title: "Send a test notification",
@@ -242,7 +243,10 @@ internal class CoreCommands : PluginCommands
 					.AddText("Whim notification")
 					.AddText("Example message")
 					.AddButton(
-						new AppNotificationButton("Click me").AddArgument("action", "click").AddArgument("key", "value")
+						new AppNotificationButton("Click me")
+							.AddArgument("action", "click")
+							.AddArgument("key", "value")
+							.AddArgument(INotificationManager.NotificationIdKey, "0")
 					)
 					.BuildNotification();
 

--- a/src/Whim/Commands/CoreCommands.cs
+++ b/src/Whim/Commands/CoreCommands.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Linq;
-using Microsoft.Windows.AppNotifications.Builder;
 using Windows.Win32.UI.Input.KeyboardAndMouse;
 
 namespace Whim;
@@ -232,27 +231,6 @@ internal class CoreCommands : PluginCommands
 				keybind: new Keybind(KeyModifiers.LAlt | KeyModifiers.LShift, key: GetVirtualKeyForInt(idx))
 			);
 		}
-
-		// TODO: Remove
-		Add(
-			identifier: "send_test_notification",
-			title: "Send a test notification",
-			callback: () =>
-			{
-				var appNotification = new AppNotificationBuilder()
-					.AddText("Whim notification")
-					.AddText("Example message")
-					.AddButton(
-						new AppNotificationButton("Click me")
-							.AddArgument("action", "click")
-							.AddArgument("key", "value")
-							.AddArgument(INotificationManager.NotificationIdKey, "0")
-					)
-					.BuildNotification();
-
-				_context.NotificationManager.SendToastNotification(appNotification);
-			}
-		);
 	}
 
 	/// <summary>

--- a/src/Whim/Commands/CoreCommands.cs
+++ b/src/Whim/Commands/CoreCommands.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq;
+using Microsoft.Windows.AppNotifications.Builder;
 using Windows.Win32.UI.Input.KeyboardAndMouse;
 
 namespace Whim;
@@ -231,6 +232,23 @@ internal class CoreCommands : PluginCommands
 				keybind: new Keybind(KeyModifiers.LAlt | KeyModifiers.LShift, key: GetVirtualKeyForInt(idx))
 			);
 		}
+
+		Add(
+			identifier: "send_test_notification",
+			title: "Send a test notification",
+			callback: () =>
+			{
+				var appNotification = new AppNotificationBuilder()
+					.AddText("Whim notification")
+					.AddText("Example message")
+					.AddButton(
+						new AppNotificationButton("Click me").AddArgument("action", "click").AddArgument("key", "value")
+					)
+					.BuildNotification();
+
+				_context.NotificationManager.SendToastNotification(appNotification);
+			}
+		);
 	}
 
 	/// <summary>

--- a/src/Whim/Context/Context.cs
+++ b/src/Whim/Context/Context.cs
@@ -27,6 +27,7 @@ internal class Context : IContext
 	public ICommandManager CommandManager => _commandManager;
 	public IPluginManager PluginManager { get; }
 	public IKeybindManager KeybindManager { get; }
+	public INotificationManager NotificationManager { get; }
 
 	public event EventHandler<ExitEventArgs>? Exiting;
 	public event EventHandler<ExitEventArgs>? Exited;
@@ -52,6 +53,7 @@ internal class Context : IContext
 		_commandManager = new CommandManager();
 		PluginManager = new PluginManager(this, _commandManager);
 		KeybindManager = new KeybindManager(this);
+		NotificationManager = new NotificationManager(this);
 	}
 
 	public void Initialize()
@@ -84,6 +86,7 @@ internal class Context : IContext
 		_internalContext.PreInitialize();
 		PluginManager.PreInitialize();
 
+		NotificationManager.Initialize();
 		MonitorManager.Initialize();
 		WindowManager.Initialize();
 		WorkspaceManager.Initialize();
@@ -122,6 +125,7 @@ internal class Context : IContext
 		WorkspaceManager.Dispose();
 		WindowManager.Dispose();
 		MonitorManager.Dispose();
+		NotificationManager.Dispose();
 		_internalContext.Dispose();
 
 		Logger.Debug("Mostly exited...");

--- a/src/Whim/Context/IContext.cs
+++ b/src/Whim/Context/IContext.cs
@@ -90,6 +90,11 @@ public interface IContext
 	IFileManager FileManager { get; }
 
 	/// <summary>
+	/// Manager for interacting with notifications.
+	/// </summary>
+	INotificationManager NotificationManager { get; }
+
+	/// <summary>
 	/// This will be called by the Whim Runner.
 	/// You likely won't need to call it yourself.
 	/// </summary>

--- a/src/Whim/Notification/INotificationManager.cs
+++ b/src/Whim/Notification/INotificationManager.cs
@@ -45,4 +45,10 @@ public interface INotificationManager : IDisposable
 	/// </param>
 	/// <returns></returns>
 	bool SendToastNotification(AppNotification appNotification);
+
+	/// <summary>
+	/// Handles a toast notification activation on app launch.
+	/// </summary>
+	/// <param name="args"></param>
+	void ProcessLaunchActivationArgs(AppNotificationActivatedEventArgs args);
 }

--- a/src/Whim/Notification/INotificationManager.cs
+++ b/src/Whim/Notification/INotificationManager.cs
@@ -9,6 +9,11 @@ namespace Whim;
 public interface INotificationManager : IDisposable
 {
 	/// <summary>
+	/// The key used to store the notification id in the notification arguments.
+	/// </summary>
+	public const string NotificationIdKey = "WHIM_NOTIFICATION_ID";
+
+	/// <summary>
 	/// Initialize the notification manager.
 	/// </summary>
 	void Initialize();
@@ -16,20 +21,28 @@ public interface INotificationManager : IDisposable
 	/// <summary>
 	/// Register a notification handler for a given notification id.
 	/// </summary>
-	/// <param name="notificationId"></param>
+	/// <param name="notificationId">
+	/// The notification id to register the handler for. <br/>
+	/// The notificationid should be prefixed by the plugin name to prevent collisions.
+	/// </param>
 	/// <param name="notificationReceived"></param>
-	void Register(int notificationId, Action<AppNotificationActivatedEventArgs> notificationReceived);
+	void Register(string notificationId, Action<AppNotificationActivatedEventArgs> notificationReceived);
 
 	/// <summary>
 	/// Unregister a notification handler for a given notification id.
 	/// </summary>
 	/// <param name="notificationId"></param>
-	void Unregister(int notificationId);
+	void Unregister(string notificationId);
 
 	/// <summary>
 	/// Send a toast notification to the user.
 	/// </summary>
-	/// <param name="appNotification"></param>
+	/// <param name="appNotification">
+	/// The notification to send. <br/>
+	/// Make sure to call <c>SetArgument(INotificationManager.NOTIFICATION_ID_KEY, notificationId)</c>
+	/// to the notification and each component which can be interacted with. <br/>
+	/// Otherwise, the notification will not be handled.
+	/// </param>
 	/// <returns></returns>
 	bool SendToastNotification(AppNotification appNotification);
 }

--- a/src/Whim/Notification/INotificationManager.cs
+++ b/src/Whim/Notification/INotificationManager.cs
@@ -1,0 +1,35 @@
+using System;
+using Microsoft.Windows.AppNotifications;
+
+namespace Whim;
+
+/// <summary>
+/// The notification manager allows the sending of toast notifications to the user.
+/// </summary>
+public interface INotificationManager : IDisposable
+{
+	/// <summary>
+	/// Initialize the notification manager.
+	/// </summary>
+	void Initialize();
+
+	/// <summary>
+	/// Register a notification handler for a given notification id.
+	/// </summary>
+	/// <param name="notificationId"></param>
+	/// <param name="notificationReceived"></param>
+	void Register(int notificationId, Action<AppNotificationActivatedEventArgs> notificationReceived);
+
+	/// <summary>
+	/// Unregister a notification handler for a given notification id.
+	/// </summary>
+	/// <param name="notificationId"></param>
+	void Unregister(int notificationId);
+
+	/// <summary>
+	/// Send a toast notification to the user.
+	/// </summary>
+	/// <param name="appNotification"></param>
+	/// <returns></returns>
+	bool SendToastNotification(AppNotification appNotification);
+}

--- a/src/Whim/Notification/NotificationManager.cs
+++ b/src/Whim/Notification/NotificationManager.cs
@@ -1,0 +1,114 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.Windows.AppNotifications;
+using Microsoft.Windows.AppNotifications.Builder;
+
+namespace Whim;
+
+internal class NotificationManager : INotificationManager
+{
+	public const string NOTIFICATION_ID_KEY = "notificationId";
+
+	private bool _disposedValue;
+	private bool _initialized;
+
+	private readonly IContext _context;
+	private readonly Dictionary<int, Action<AppNotificationActivatedEventArgs>> _notificationHandlers = new();
+
+	public NotificationManager(IContext context)
+	{
+		_context = context;
+	}
+
+	private void OnNotificationInvoked(AppNotificationManager sender, AppNotificationActivatedEventArgs args)
+	{
+		try
+		{
+			int notificationId = int.Parse(args.UserInput[NOTIFICATION_ID_KEY]);
+			_notificationHandlers[notificationId]?.Invoke(args);
+		}
+		catch (Exception e)
+		{
+			_context.HandleUncaughtException(nameof(OnNotificationInvoked), e);
+		}
+	}
+
+	public void Initialize()
+	{
+		// To ensure all Notification handling happens in this process instance, register for
+		// NotificationInvoked before calling Register(). Without this a new process will
+		// be launched to handle the notification.
+		AppNotificationManager notificationManager = AppNotificationManager.Default;
+		notificationManager.NotificationInvoked += OnNotificationInvoked;
+		notificationManager.Register();
+		_initialized = true;
+
+		RegisterNotification(_context);
+	}
+
+	int NOTIFICATION_ID = 0;
+
+	void RegisterNotification(IContext context)
+	{
+		context
+			.NotificationManager
+			.Register(
+				NOTIFICATION_ID,
+				(a) =>
+				{
+					Logger.Debug("Notification clicked");
+				}
+			);
+	}
+
+	public void Register(int notificationId, Action<AppNotificationActivatedEventArgs> notificationReceived)
+	{
+		_notificationHandlers.Add(notificationId, notificationReceived);
+	}
+
+	public void Unregister(int notificationId)
+	{
+		_notificationHandlers.Remove(notificationId);
+	}
+
+	public bool SendToastNotification(AppNotification appNotification)
+	{
+		if (!_initialized)
+		{
+			throw new InvalidOperationException(
+				"Notification manager must be initialized before sending notifications."
+			);
+		}
+
+		AppNotificationManager.Default.Show(appNotification);
+
+		return appNotification.Id != 0;
+	}
+
+	protected virtual void Dispose(bool disposing)
+	{
+		if (!_disposedValue)
+		{
+			if (_initialized)
+			{
+				AppNotificationManager.Default.Unregister();
+			}
+
+			_disposedValue = true;
+		}
+	}
+
+	// Free unmanaged resources
+	~NotificationManager()
+	{
+		// Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+		Dispose(disposing: false);
+	}
+
+	public void Dispose()
+	{
+		// Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+		Dispose(disposing: true);
+		GC.SuppressFinalize(this);
+	}
+}

--- a/src/Whim/Notification/NotificationManager.cs
+++ b/src/Whim/Notification/NotificationManager.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using Microsoft.Windows.AppNotifications;
-using Microsoft.Windows.AppNotifications.Builder;
 
 namespace Whim;
 
@@ -45,6 +44,11 @@ internal class NotificationManager : INotificationManager
 		{
 			_context.HandleUncaughtException(nameof(AppNotificationManager_NotificationInvoked), e);
 		}
+	}
+
+	public void ProcessLaunchActivationArgs(AppNotificationActivatedEventArgs args)
+	{
+		AppNotificationManager_NotificationInvoked(AppNotificationManager.Default, args);
 	}
 
 	// TODO: Remove

--- a/src/Whim/Notification/NotificationManager.cs
+++ b/src/Whim/Notification/NotificationManager.cs
@@ -26,8 +26,6 @@ internal class NotificationManager : INotificationManager
 		notificationManager.NotificationInvoked += AppNotificationManager_NotificationInvoked;
 		notificationManager.Register();
 		_initialized = true;
-
-		RegisterNotification(_context);
 	}
 
 	private void AppNotificationManager_NotificationInvoked(
@@ -49,21 +47,6 @@ internal class NotificationManager : INotificationManager
 	public void ProcessLaunchActivationArgs(AppNotificationActivatedEventArgs args)
 	{
 		AppNotificationManager_NotificationInvoked(AppNotificationManager.Default, args);
-	}
-
-	// TODO: Remove
-
-	void RegisterNotification(IContext context)
-	{
-		context
-			.NotificationManager
-			.Register(
-				"0",
-				(a) =>
-				{
-					Logger.Debug("Notification clicked");
-				}
-			);
 	}
 
 	public void Register(string notificationId, Action<AppNotificationActivatedEventArgs> notificationReceived)


### PR DESCRIPTION
Added `INotificationManager` to facilitate toast notifications. The core and plugins can display notifications and register listeners to handle user interaction with the notifications. This is a bit of a tricky API, as _all_ interactions need to set the `WHIM_NOTIFICATION_ID` argument in order for Whim to route the interaction to the correct listener.

This will be used by the `Whim.Updater` in #141.