### PR TITLE
feat: `WorkspaceManager.SwapActiveWorkspaceWithNextMonitor` (#661)

### DIFF
--- a/src/Whim/Workspace/IWorkspaceManager.cs
+++ b/src/Whim/Workspace/IWorkspaceManager.cs
@@ -173,7 +173,7 @@ public interface IWorkspaceManager : IEnumerable<IWorkspace>, IDisposable
 	/// <param name="reverse">
 	/// When <see langword="true"/>, swaps workspace with the previous monitor, otherwise with the next. Defaults to <see langword="false" />.
 	/// </param>
-	void SwapActiveWorkspaceWithNextMonitor(bool reverse = false);
+	void SwapActiveWorkspaceWithAdjacentMonitor(bool reverse = false);
 
 	/// <summary>
 	/// Retrieves the monitor for the active workspace.

--- a/src/Whim/Workspace/IWorkspaceManager.cs
+++ b/src/Whim/Workspace/IWorkspaceManager.cs
@@ -168,6 +168,14 @@ public interface IWorkspaceManager : IEnumerable<IWorkspace>, IDisposable
 	void MoveWindowToAdjacentWorkspace(IWindow? window = null, bool reverse = false, bool skipActive = false);
 
 	/// <summary>
+	/// Swap the currently active workspace with the one active on the next (or previous) monitor.
+	/// </summary>
+	/// <param name="reverse">
+	/// When <see langword="true"/>, swaps workspace with the previous monitor, otherwise with the next. Defaults to <see langword="false" />.
+	/// </param>
+	void SwapActiveWorkspaceWithNextMonitor(bool reverse = false);
+
+	/// <summary>
 	/// Retrieves the monitor for the active workspace.
 	/// </summary>
 	/// <param name="workspace"></param>

--- a/src/Whim/Workspace/IWorkspaceManager.cs
+++ b/src/Whim/Workspace/IWorkspaceManager.cs
@@ -173,7 +173,7 @@ public interface IWorkspaceManager : IEnumerable<IWorkspace>, IDisposable
 	/// <param name="reverse">
 	/// When <see langword="true"/>, swaps workspace with the previous monitor, otherwise with the next. Defaults to <see langword="false" />.
 	/// </param>
-	void SwapActiveWorkspaceWithAdjacentMonitor(bool reverse = false);
+	void SwapActiveWorkspaceWithNextMonitor(bool reverse = false);
 
 	/// <summary>
 	/// Retrieves the monitor for the active workspace.

--- a/src/Whim/Workspace/WorkspaceManager.cs
+++ b/src/Whim/Workspace/WorkspaceManager.cs
@@ -474,24 +474,20 @@ internal class WorkspaceManager : IInternalWorkspaceManager, IWorkspaceManager
 		return null;
 	}
 
-	public void SwapActiveWorkspaceWithAdjacentMonitor(bool reverse = false)
+	public void SwapActiveWorkspaceWithNextMonitor(bool reverse = false)
 	{
 		// Get the next monitor.
 		IMonitor monitor = _context.MonitorManager.ActiveMonitor;
 		IMonitor nextMonitor = reverse
 			? _context.MonitorManager.GetPreviousMonitor(monitor)
 			: _context.MonitorManager.GetNextMonitor(monitor);
-		if (nextMonitor.Equals(monitor))
-		{
-			Logger.Error($"No monitor adjacent to {monitor} found.");
-			return;
-		}
 
 		// Get workspace on next monitor.
 		IWorkspace? nextWorkspace = GetWorkspaceForMonitor(nextMonitor);
 		if (nextWorkspace == null)
 		{
 			Logger.Error($"Monitor {nextMonitor} was not found to correspond to any workspace");
+
 			return;
 		}
 

--- a/src/Whim/Workspace/WorkspaceManager.cs
+++ b/src/Whim/Workspace/WorkspaceManager.cs
@@ -474,20 +474,24 @@ internal class WorkspaceManager : IInternalWorkspaceManager, IWorkspaceManager
 		return null;
 	}
 
-	public void SwapActiveWorkspaceWithNextMonitor(bool reverse = false)
+	public void SwapActiveWorkspaceWithAdjacentMonitor(bool reverse = false)
 	{
 		// Get the next monitor.
 		IMonitor monitor = _context.MonitorManager.ActiveMonitor;
 		IMonitor nextMonitor = reverse
 			? _context.MonitorManager.GetPreviousMonitor(monitor)
 			: _context.MonitorManager.GetNextMonitor(monitor);
+		if (nextMonitor.Equals(monitor))
+		{
+			Logger.Error($"No monitor adjacent to {monitor} found.");
+			return;
+		}
 
 		// Get workspace on next monitor.
 		IWorkspace? nextWorkspace = GetWorkspaceForMonitor(nextMonitor);
 		if (nextWorkspace == null)
 		{
 			Logger.Error($"Monitor {nextMonitor} was not found to correspond to any workspace");
-
 			return;
 		}
 

--- a/src/Whim/Workspace/WorkspaceManager.cs
+++ b/src/Whim/Workspace/WorkspaceManager.cs
@@ -474,6 +474,26 @@ internal class WorkspaceManager : IInternalWorkspaceManager, IWorkspaceManager
 		return null;
 	}
 
+	public void SwapActiveWorkspaceWithNextMonitor(bool reverse = false)
+	{
+		// Get the next monitor.
+		IMonitor monitor = _context.MonitorManager.ActiveMonitor;
+		IMonitor nextMonitor = reverse
+			? _context.MonitorManager.GetPreviousMonitor(monitor)
+			: _context.MonitorManager.GetNextMonitor(monitor);
+
+		// Get workspace on next monitor.
+		IWorkspace? nextWorkspace = GetWorkspaceForMonitor(nextMonitor);
+		if (nextWorkspace == null)
+		{
+			Logger.Error($"Monitor {nextMonitor} was not found to correspond to any workspace");
+
+			return;
+		}
+
+		Activate(nextWorkspace, monitor);
+	}
+
 	public IMonitor? GetMonitorForWorkspace(IWorkspace workspace)
 	{
 		Logger.Debug($"Getting monitor for active workspace {workspace}");

--- a/src/Whim/Workspace/WorkspaceManager.cs
+++ b/src/Whim/Workspace/WorkspaceManager.cs
@@ -474,7 +474,7 @@ internal class WorkspaceManager : IInternalWorkspaceManager, IWorkspaceManager
 		return null;
 	}
 
-	public void SwapActiveWorkspaceWithNextMonitor(bool reverse = false)
+	public void SwapActiveWorkspaceWithAdjacentMonitor(bool reverse = false)
 	{
 		// Get the next monitor.
 		IMonitor monitor = _context.MonitorManager.ActiveMonitor;
@@ -482,12 +482,17 @@ internal class WorkspaceManager : IInternalWorkspaceManager, IWorkspaceManager
 			? _context.MonitorManager.GetPreviousMonitor(monitor)
 			: _context.MonitorManager.GetNextMonitor(monitor);
 
+		if (monitor.Equals(nextMonitor))
+		{
+			Logger.Error($"Monitor {monitor} is already the {(!reverse ? "next" : "previous")} monitor");
+			return;
+		}
+
 		// Get workspace on next monitor.
 		IWorkspace? nextWorkspace = GetWorkspaceForMonitor(nextMonitor);
 		if (nextWorkspace == null)
 		{
 			Logger.Error($"Monitor {nextMonitor} was not found to correspond to any workspace");
-
 			return;
 		}
 


### PR DESCRIPTION
This adds a command to swap the currently active workspace with the one active on the next (or previous) monitor.

c.f. #661.