### PR TITLE
Let `ILayoutEngine`s perform custom actions 

### DIFF
--- a/src/Whim.Bar.Tests/BarLayoutEngineTests.cs
+++ b/src/Whim.Bar.Tests/BarLayoutEngineTests.cs
@@ -316,10 +316,10 @@ public class BarLayoutEngineTests
 		// Given
 		BarLayoutEngine engine = CreateSut(innerLayoutEngine);
 
-		innerLayoutEngine.PerformCustomAction(actionName, args).Returns(performCustomActionResult);
+		innerLayoutEngine.PerformCustomAction(actionName, args, null).Returns(performCustomActionResult);
 
 		// When
-		ILayoutEngine newEngine = engine.PerformCustomAction(actionName, args);
+		ILayoutEngine newEngine = engine.PerformCustomAction(actionName, args, null);
 
 		// Then
 		Assert.NotSame(engine, newEngine);
@@ -331,10 +331,10 @@ public class BarLayoutEngineTests
 		// Given
 		BarLayoutEngine engine = CreateSut(innerLayoutEngine);
 
-		innerLayoutEngine.PerformCustomAction(actionName, args).Returns(innerLayoutEngine);
+		innerLayoutEngine.PerformCustomAction(actionName, args, null).Returns(innerLayoutEngine);
 
 		// When
-		ILayoutEngine newEngine = engine.PerformCustomAction(actionName, args);
+		ILayoutEngine newEngine = engine.PerformCustomAction(actionName, args, null);
 
 		// Then
 		Assert.Same(engine, newEngine);

--- a/src/Whim.Bar.Tests/BarLayoutEngineTests.cs
+++ b/src/Whim.Bar.Tests/BarLayoutEngineTests.cs
@@ -306,35 +306,42 @@ public class BarLayoutEngineTests
 	}
 
 	[Theory, AutoSubstituteData]
-	public void PerformCustomAction_NotSame(
-		ILayoutEngine innerLayoutEngine,
-		ILayoutEngine performCustomActionResult,
-		string actionName,
-		object args
-	)
+	public void PerformCustomAction_NotSame(ILayoutEngine innerLayoutEngine, ILayoutEngine performCustomActionResult)
 	{
 		// Given
 		BarLayoutEngine engine = CreateSut(innerLayoutEngine);
-
-		innerLayoutEngine.PerformCustomAction(actionName, args, null).Returns(performCustomActionResult);
+		LayoutEngineCustomAction<string> action =
+			new()
+			{
+				Name = "Action",
+				Payload = "payload",
+				Window = null
+			};
+		innerLayoutEngine.PerformCustomAction(action).Returns(performCustomActionResult);
 
 		// When
-		ILayoutEngine newEngine = engine.PerformCustomAction(actionName, args, null);
+		ILayoutEngine newEngine = engine.PerformCustomAction(action);
 
 		// Then
 		Assert.NotSame(engine, newEngine);
 	}
 
 	[Theory, AutoSubstituteData]
-	public void PerformCustomAction_Same(ILayoutEngine innerLayoutEngine, string actionName, object args)
+	public void PerformCustomAction_Same(ILayoutEngine innerLayoutEngine)
 	{
 		// Given
 		BarLayoutEngine engine = CreateSut(innerLayoutEngine);
-
-		innerLayoutEngine.PerformCustomAction(actionName, args, null).Returns(innerLayoutEngine);
+		LayoutEngineCustomAction<string> action =
+			new()
+			{
+				Name = "Action",
+				Payload = "payload",
+				Window = null
+			};
+		innerLayoutEngine.PerformCustomAction(action).Returns(innerLayoutEngine);
 
 		// When
-		ILayoutEngine newEngine = engine.PerformCustomAction(actionName, args, null);
+		ILayoutEngine newEngine = engine.PerformCustomAction(action);
 
 		// Then
 		Assert.Same(engine, newEngine);

--- a/src/Whim.Bar.Tests/BarLayoutEngineTests.cs
+++ b/src/Whim.Bar.Tests/BarLayoutEngineTests.cs
@@ -304,4 +304,39 @@ public class BarLayoutEngineTests
 		// Then
 		innerLayoutEngine.Received(1).DoLayout(Arg.Is<Rectangle<int>>(l => l.Height == 0), monitor);
 	}
+
+	[Theory, AutoSubstituteData]
+	public void PerformCustomAction_NotSame(
+		ILayoutEngine innerLayoutEngine,
+		ILayoutEngine performCustomActionResult,
+		string actionName,
+		object args
+	)
+	{
+		// Given
+		BarLayoutEngine engine = CreateSut(innerLayoutEngine);
+
+		innerLayoutEngine.PerformCustomAction(actionName, args).Returns(performCustomActionResult);
+
+		// When
+		ILayoutEngine newEngine = engine.PerformCustomAction(actionName, args);
+
+		// Then
+		Assert.NotSame(engine, newEngine);
+	}
+
+	[Theory, AutoSubstituteData]
+	public void PerformCustomAction_Same(ILayoutEngine innerLayoutEngine, string actionName, object args)
+	{
+		// Given
+		BarLayoutEngine engine = CreateSut(innerLayoutEngine);
+
+		innerLayoutEngine.PerformCustomAction(actionName, args).Returns(innerLayoutEngine);
+
+		// When
+		ILayoutEngine newEngine = engine.PerformCustomAction(actionName, args);
+
+		// Then
+		Assert.Same(engine, newEngine);
+	}
 }

--- a/src/Whim.Bar/BarLayoutEngine.cs
+++ b/src/Whim.Bar/BarLayoutEngine.cs
@@ -71,4 +71,8 @@ public record BarLayoutEngine : BaseProxyLayoutEngine
 	/// <inheritdoc />
 	public override ILayoutEngine SwapWindowInDirection(Direction direction, IWindow window) =>
 		UpdateInner(InnerLayoutEngine.SwapWindowInDirection(direction, window));
+
+	/// <inheritdoc />
+	public override ILayoutEngine PerformCustomAction<T>(string actionName, T args) =>
+		UpdateInner(InnerLayoutEngine.PerformCustomAction(actionName, args));
 }

--- a/src/Whim.Bar/BarLayoutEngine.cs
+++ b/src/Whim.Bar/BarLayoutEngine.cs
@@ -73,6 +73,6 @@ public record BarLayoutEngine : BaseProxyLayoutEngine
 		UpdateInner(InnerLayoutEngine.SwapWindowInDirection(direction, window));
 
 	/// <inheritdoc />
-	public override ILayoutEngine PerformCustomAction<T>(string actionName, T args) =>
-		UpdateInner(InnerLayoutEngine.PerformCustomAction(actionName, args));
+	public override ILayoutEngine PerformCustomAction<T>(string actionName, T args, IWindow? window) =>
+		UpdateInner(InnerLayoutEngine.PerformCustomAction(actionName, args, window));
 }

--- a/src/Whim.Bar/BarLayoutEngine.cs
+++ b/src/Whim.Bar/BarLayoutEngine.cs
@@ -73,6 +73,6 @@ public record BarLayoutEngine : BaseProxyLayoutEngine
 		UpdateInner(InnerLayoutEngine.SwapWindowInDirection(direction, window));
 
 	/// <inheritdoc />
-	public override ILayoutEngine PerformCustomAction<T>(string actionName, T args, IWindow? window) =>
-		UpdateInner(InnerLayoutEngine.PerformCustomAction(actionName, args, window));
+	public override ILayoutEngine PerformCustomAction<T>(LayoutEngineCustomAction<T> action) =>
+		UpdateInner(InnerLayoutEngine.PerformCustomAction(action));
 }

--- a/src/Whim.FloatingLayout.Tests/FloatingLayoutEngineTests.cs
+++ b/src/Whim.FloatingLayout.Tests/FloatingLayoutEngineTests.cs
@@ -1090,4 +1090,71 @@ public class FloatingLayoutEngineTests
 		newInnerLayoutEngine.Received(1).SwapWindowInDirection(Direction.Left, window);
 	}
 	#endregion
+
+	#region PerformCustomAction
+	[Theory, AutoSubstituteData<FloatingLayoutEngineCustomization>]
+	internal void PerformCustomAction_UseInner(
+		IContext context,
+		IInternalFloatingLayoutPlugin plugin,
+		ILayoutEngine innerLayoutEngine,
+		string action,
+		object args
+	)
+	{
+		// Given
+		FloatingLayoutEngine engine = new(context, plugin, innerLayoutEngine);
+
+		// When
+		ILayoutEngine newEngine = engine.PerformCustomAction(action, args, null);
+
+		// Then
+		Assert.NotSame(engine, newEngine);
+	}
+
+	[Theory, AutoSubstituteData<FloatingLayoutEngineCustomization>]
+	internal void PerformCustomAction_UseInner_WindowIsDefined(
+		IContext context,
+		IInternalFloatingLayoutPlugin plugin,
+		ILayoutEngine innerLayoutEngine,
+		string action,
+		object args,
+		IWindow window
+	)
+	{
+		// Given
+		FloatingLayoutEngine engine = new(context, plugin, innerLayoutEngine);
+		innerLayoutEngine.PerformCustomAction(action, args, window).Returns(innerLayoutEngine);
+
+		// When
+		ILayoutEngine newEngine = engine.PerformCustomAction(action, args, window);
+
+		// Then
+		Assert.NotSame(engine, newEngine);
+		innerLayoutEngine.Received(1).PerformCustomAction(action, args, window);
+	}
+
+	[Theory, AutoSubstituteData<FloatingLayoutEngineCustomization>]
+	internal void PerformCustomAction_FloatingWindow(
+		IContext context,
+		IInternalFloatingLayoutPlugin plugin,
+		ILayoutEngine innerLayoutEngine,
+		string action,
+		object args,
+		IWindow window
+	)
+	{
+		// Given
+		FloatingLayoutEngine engine = new(context, plugin, innerLayoutEngine);
+		MarkWindowAsFloating(plugin, window, innerLayoutEngine);
+		ILayoutEngine newEngine = engine.AddWindow(window);
+
+		// When
+		ILayoutEngine newEngine2 = newEngine.PerformCustomAction(action, args, window);
+
+		// Then
+		Assert.NotSame(engine, newEngine);
+		Assert.Same(newEngine, newEngine2);
+		innerLayoutEngine.DidNotReceive().PerformCustomAction(action, args, null);
+	}
+	#endregion
 }

--- a/src/Whim.FloatingLayout.Tests/FloatingLayoutEngineTests.cs
+++ b/src/Whim.FloatingLayout.Tests/FloatingLayoutEngineTests.cs
@@ -1096,16 +1096,21 @@ public class FloatingLayoutEngineTests
 	internal void PerformCustomAction_UseInner(
 		IContext context,
 		IInternalFloatingLayoutPlugin plugin,
-		ILayoutEngine innerLayoutEngine,
-		string action,
-		object args
+		ILayoutEngine innerLayoutEngine
 	)
 	{
 		// Given
 		FloatingLayoutEngine engine = new(context, plugin, innerLayoutEngine);
+		LayoutEngineCustomAction<string> action =
+			new()
+			{
+				Name = "Action",
+				Payload = "payload",
+				Window = null
+			};
 
 		// When
-		ILayoutEngine newEngine = engine.PerformCustomAction(action, args, null);
+		ILayoutEngine newEngine = engine.PerformCustomAction(action);
 
 		// Then
 		Assert.NotSame(engine, newEngine);
@@ -1115,22 +1120,26 @@ public class FloatingLayoutEngineTests
 	internal void PerformCustomAction_UseInner_WindowIsDefined(
 		IContext context,
 		IInternalFloatingLayoutPlugin plugin,
-		ILayoutEngine innerLayoutEngine,
-		string action,
-		object args,
-		IWindow window
+		ILayoutEngine innerLayoutEngine
 	)
 	{
 		// Given
 		FloatingLayoutEngine engine = new(context, plugin, innerLayoutEngine);
-		innerLayoutEngine.PerformCustomAction(action, args, window).Returns(innerLayoutEngine);
+		LayoutEngineCustomAction<string> action =
+			new()
+			{
+				Name = "Action",
+				Payload = "payload",
+				Window = Substitute.For<IWindow>()
+			};
+		innerLayoutEngine.PerformCustomAction(action).Returns(innerLayoutEngine);
 
 		// When
-		ILayoutEngine newEngine = engine.PerformCustomAction(action, args, window);
+		ILayoutEngine newEngine = engine.PerformCustomAction(action);
 
 		// Then
 		Assert.NotSame(engine, newEngine);
-		innerLayoutEngine.Received(1).PerformCustomAction(action, args, window);
+		innerLayoutEngine.Received(1).PerformCustomAction(action);
 	}
 
 	[Theory, AutoSubstituteData<FloatingLayoutEngineCustomization>]
@@ -1138,23 +1147,28 @@ public class FloatingLayoutEngineTests
 		IContext context,
 		IInternalFloatingLayoutPlugin plugin,
 		ILayoutEngine innerLayoutEngine,
-		string action,
-		object args,
 		IWindow window
 	)
 	{
 		// Given
 		FloatingLayoutEngine engine = new(context, plugin, innerLayoutEngine);
+		LayoutEngineCustomAction<string> action =
+			new()
+			{
+				Name = "Action",
+				Payload = "payload",
+				Window = window
+			};
 		MarkWindowAsFloating(plugin, window, innerLayoutEngine);
 		ILayoutEngine newEngine = engine.AddWindow(window);
 
 		// When
-		ILayoutEngine newEngine2 = newEngine.PerformCustomAction(action, args, window);
+		ILayoutEngine newEngine2 = newEngine.PerformCustomAction(action);
 
 		// Then
 		Assert.NotSame(engine, newEngine);
 		Assert.Same(newEngine, newEngine2);
-		innerLayoutEngine.DidNotReceive().PerformCustomAction(action, args, null);
+		innerLayoutEngine.DidNotReceive().PerformCustomAction(action);
 	}
 	#endregion
 }

--- a/src/Whim.FloatingLayout/FloatingLayoutEngine.cs
+++ b/src/Whim.FloatingLayout/FloatingLayoutEngine.cs
@@ -248,9 +248,9 @@ internal record FloatingLayoutEngine : BaseProxyLayoutEngine
 		_floatingWindowRects.ContainsKey(window) || InnerLayoutEngine.ContainsWindow(window);
 
 	/// <inheritdoc />
-	public override ILayoutEngine PerformCustomAction<T>(string actionName, T args, IWindow? window)
+	public override ILayoutEngine PerformCustomAction<T>(LayoutEngineCustomAction<T> action)
 	{
-		if (window != null && IsWindowFloating(window))
+		if (action.Window != null && IsWindowFloating(action.Window))
 		{
 			// At this stage, we don't have a way to get the window in a child layout engine at
 			// a given point.
@@ -258,6 +258,6 @@ internal record FloatingLayoutEngine : BaseProxyLayoutEngine
 			return this;
 		}
 
-		return InnerLayoutEngine.PerformCustomAction(actionName, args, window);
+		return InnerLayoutEngine.PerformCustomAction(action);
 	}
 }

--- a/src/Whim.FloatingLayout/FloatingLayoutEngine.cs
+++ b/src/Whim.FloatingLayout/FloatingLayoutEngine.cs
@@ -68,6 +68,15 @@ internal record FloatingLayoutEngine : BaseProxyLayoutEngine
 			: new FloatingLayoutEngine(this, newInnerLayoutEngine, newFloatingWindowRects);
 	}
 
+	/// <summary>
+	/// Returns a new instance of <see cref="FloatingLayoutEngine"/> with the given inner layout engine,
+	/// Only use this for updates that do not involve a window.
+	/// </summary>
+	/// <param name="newInnerLayoutEngine"></param>
+	/// <returns></returns>
+	private FloatingLayoutEngine UpdateInner(ILayoutEngine newInnerLayoutEngine) =>
+		InnerLayoutEngine == newInnerLayoutEngine ? this : new FloatingLayoutEngine(this, newInnerLayoutEngine);
+
 	/// <inheritdoc />
 	public override ILayoutEngine AddWindow(IWindow window)
 	{
@@ -245,4 +254,8 @@ internal record FloatingLayoutEngine : BaseProxyLayoutEngine
 	/// <inheritdoc />
 	public override bool ContainsWindow(IWindow window) =>
 		_floatingWindowRects.ContainsKey(window) || InnerLayoutEngine.ContainsWindow(window);
+
+	/// <inheritdoc />
+	public override ILayoutEngine PerformCustomAction<T>(string actionName, T args) =>
+		UpdateInner(InnerLayoutEngine.PerformCustomAction(actionName, args));
 }

--- a/src/Whim.Gaps.Tests/GapsLayoutEngineTests.cs
+++ b/src/Whim.Gaps.Tests/GapsLayoutEngineTests.cs
@@ -674,4 +674,43 @@ public class GapsLayoutEngineTests
 		Assert.Same(window, firstWindow);
 		innerLayoutEngine.Received(1).GetFirstWindow();
 	}
+
+	[Theory, AutoSubstituteData]
+	public void PerformCustomAction_NotSame(
+		ILayoutEngine innerLayoutEngine,
+		ILayoutEngine performCustomActionResult,
+		string actionName,
+		object args
+	)
+	{
+		// Given
+		GapsConfig gapsConfig = new() { OuterGap = 10, InnerGap = 5 };
+		innerLayoutEngine.PerformCustomAction(actionName, args, null).Returns(performCustomActionResult);
+
+		GapsLayoutEngine gapsLayoutEngine = new(gapsConfig, innerLayoutEngine);
+
+		// When
+		ILayoutEngine newLayoutEngine = gapsLayoutEngine.PerformCustomAction(actionName, args, null);
+
+		// Then
+		Assert.NotSame(gapsLayoutEngine, newLayoutEngine);
+		innerLayoutEngine.Received(1).PerformCustomAction(actionName, args, null);
+	}
+
+	[Theory, AutoSubstituteData]
+	public void PerformCustomAction_Same(ILayoutEngine innerLayoutEngine, string actionName, object args)
+	{
+		// Given
+		GapsConfig gapsConfig = new() { OuterGap = 10, InnerGap = 5 };
+		innerLayoutEngine.PerformCustomAction(actionName, args, null).Returns(innerLayoutEngine);
+
+		GapsLayoutEngine gapsLayoutEngine = new(gapsConfig, innerLayoutEngine);
+
+		// When
+		ILayoutEngine newLayoutEngine = gapsLayoutEngine.PerformCustomAction(actionName, args, null);
+
+		// Then
+		Assert.Same(gapsLayoutEngine, newLayoutEngine);
+		innerLayoutEngine.Received(1).PerformCustomAction(actionName, args, null);
+	}
 }

--- a/src/Whim.Gaps.Tests/GapsLayoutEngineTests.cs
+++ b/src/Whim.Gaps.Tests/GapsLayoutEngineTests.cs
@@ -676,41 +676,52 @@ public class GapsLayoutEngineTests
 	}
 
 	[Theory, AutoSubstituteData]
-	public void PerformCustomAction_NotSame(
-		ILayoutEngine innerLayoutEngine,
-		ILayoutEngine performCustomActionResult,
-		string actionName,
-		object args
-	)
+	public void PerformCustomAction_NotSame(ILayoutEngine innerLayoutEngine, ILayoutEngine performCustomActionResult)
 	{
 		// Given
 		GapsConfig gapsConfig = new() { OuterGap = 10, InnerGap = 5 };
-		innerLayoutEngine.PerformCustomAction(actionName, args, null).Returns(performCustomActionResult);
+
+		LayoutEngineCustomAction<string> action =
+			new()
+			{
+				Name = "Action",
+				Payload = "payload",
+				Window = Substitute.For<IWindow>()
+			};
+		innerLayoutEngine.PerformCustomAction(action).Returns(performCustomActionResult);
 
 		GapsLayoutEngine gapsLayoutEngine = new(gapsConfig, innerLayoutEngine);
 
 		// When
-		ILayoutEngine newLayoutEngine = gapsLayoutEngine.PerformCustomAction(actionName, args, null);
+		ILayoutEngine newLayoutEngine = gapsLayoutEngine.PerformCustomAction(action);
 
 		// Then
 		Assert.NotSame(gapsLayoutEngine, newLayoutEngine);
-		innerLayoutEngine.Received(1).PerformCustomAction(actionName, args, null);
+		innerLayoutEngine.Received(1).PerformCustomAction(action);
 	}
 
 	[Theory, AutoSubstituteData]
-	public void PerformCustomAction_Same(ILayoutEngine innerLayoutEngine, string actionName, object args)
+	public void PerformCustomAction_Same(ILayoutEngine innerLayoutEngine)
 	{
 		// Given
 		GapsConfig gapsConfig = new() { OuterGap = 10, InnerGap = 5 };
-		innerLayoutEngine.PerformCustomAction(actionName, args, null).Returns(innerLayoutEngine);
+
+		LayoutEngineCustomAction<string> action =
+			new()
+			{
+				Name = "Action",
+				Payload = "payload",
+				Window = Substitute.For<IWindow>()
+			};
+		innerLayoutEngine.PerformCustomAction(action).Returns(innerLayoutEngine);
 
 		GapsLayoutEngine gapsLayoutEngine = new(gapsConfig, innerLayoutEngine);
 
 		// When
-		ILayoutEngine newLayoutEngine = gapsLayoutEngine.PerformCustomAction(actionName, args, null);
+		ILayoutEngine newLayoutEngine = gapsLayoutEngine.PerformCustomAction(action);
 
 		// Then
 		Assert.Same(gapsLayoutEngine, newLayoutEngine);
-		innerLayoutEngine.Received(1).PerformCustomAction(actionName, args, null);
+		innerLayoutEngine.Received(1).PerformCustomAction(action);
 	}
 }

--- a/src/Whim.Gaps/GapsLayoutEngine.cs
+++ b/src/Whim.Gaps/GapsLayoutEngine.cs
@@ -118,6 +118,6 @@ public record GapsLayoutEngine : BaseProxyLayoutEngine
 		UpdateInner(InnerLayoutEngine.SwapWindowInDirection(direction, window));
 
 	/// <inheritdoc />
-	public override ILayoutEngine PerformCustomAction<T>(string actionName, T args) =>
-		UpdateInner(InnerLayoutEngine.PerformCustomAction(actionName, args));
+	public override ILayoutEngine PerformCustomAction<T>(string actionName, T args, IWindow? window) =>
+		UpdateInner(InnerLayoutEngine.PerformCustomAction(actionName, args, window));
 }

--- a/src/Whim.Gaps/GapsLayoutEngine.cs
+++ b/src/Whim.Gaps/GapsLayoutEngine.cs
@@ -116,4 +116,8 @@ public record GapsLayoutEngine : BaseProxyLayoutEngine
 	/// <inheritdoc />
 	public override ILayoutEngine SwapWindowInDirection(Direction direction, IWindow window) =>
 		UpdateInner(InnerLayoutEngine.SwapWindowInDirection(direction, window));
+
+	/// <inheritdoc />
+	public override ILayoutEngine PerformCustomAction<T>(string actionName, T args) =>
+		UpdateInner(InnerLayoutEngine.PerformCustomAction(actionName, args));
 }

--- a/src/Whim.Gaps/GapsLayoutEngine.cs
+++ b/src/Whim.Gaps/GapsLayoutEngine.cs
@@ -118,6 +118,6 @@ public record GapsLayoutEngine : BaseProxyLayoutEngine
 		UpdateInner(InnerLayoutEngine.SwapWindowInDirection(direction, window));
 
 	/// <inheritdoc />
-	public override ILayoutEngine PerformCustomAction<T>(string actionName, T args, IWindow? window) =>
-		UpdateInner(InnerLayoutEngine.PerformCustomAction(actionName, args, window));
+	public override ILayoutEngine PerformCustomAction<T>(LayoutEngineCustomAction<T> action) =>
+		UpdateInner(InnerLayoutEngine.PerformCustomAction(action));
 }

--- a/src/Whim.TestUtils/ProxyLayoutEngineBaseTests.cs
+++ b/src/Whim.TestUtils/ProxyLayoutEngineBaseTests.cs
@@ -186,9 +186,16 @@ public abstract class ProxyLayoutEngineBaseTests
 	{
 		// Given
 		ILayoutEngine layoutEngine = CreateLayoutEngine(inner).AddWindow(window1);
+		LayoutEngineCustomAction<string> action =
+			new()
+			{
+				Name = "Action",
+				Payload = "payload",
+				Window = null
+			};
 
 		// When
-		layoutEngine.PerformCustomAction("action", 1, null);
+		layoutEngine.PerformCustomAction(action);
 
 		// Then it shouldn't throw.
 	}

--- a/src/Whim.TestUtils/ProxyLayoutEngineBaseTests.cs
+++ b/src/Whim.TestUtils/ProxyLayoutEngineBaseTests.cs
@@ -188,7 +188,7 @@ public abstract class ProxyLayoutEngineBaseTests
 		ILayoutEngine layoutEngine = CreateLayoutEngine(inner).AddWindow(window1);
 
 		// When
-		layoutEngine.PerformCustomAction("action", 1);
+		layoutEngine.PerformCustomAction("action", 1, null);
 
 		// Then it shouldn't throw.
 	}

--- a/src/Whim.TestUtils/ProxyLayoutEngineBaseTests.cs
+++ b/src/Whim.TestUtils/ProxyLayoutEngineBaseTests.cs
@@ -3,7 +3,6 @@ using Xunit;
 
 namespace Whim.TestUtils;
 
-#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
 /// <summary>
 /// Tests for <see cref="ILayoutEngine"/> implementations.
 /// </summary>
@@ -181,5 +180,16 @@ public abstract class ProxyLayoutEngineBaseTests
 
 		// Then it shouldn't throw.
 	}
+
+	[Theory, AutoSubstituteData]
+	public void PerformCustomAction_WindowIsPresent(ILayoutEngine inner, IWindow window1)
+	{
+		// Given
+		ILayoutEngine layoutEngine = CreateLayoutEngine(inner).AddWindow(window1);
+
+		// When
+		layoutEngine.PerformCustomAction("action", 1);
+
+		// Then it shouldn't throw.
+	}
 }
-#pragma warning restore CS1591 // Missing XML comment for publicly visible type or member

--- a/src/Whim.TestUtils/TestLayoutEngine.cs
+++ b/src/Whim.TestUtils/TestLayoutEngine.cs
@@ -48,6 +48,6 @@ public record TestLayoutEngine : ILayoutEngine
 		throw new NotImplementedException();
 
 	/// <inheritdoc/>
-	public ILayoutEngine PerformCustomAction<T>(string actionName, T args, IWindow? window) =>
+	public ILayoutEngine PerformCustomAction<T>(LayoutEngineCustomAction<T> action) =>
 		throw new NotImplementedException();
 }

--- a/src/Whim.TestUtils/TestLayoutEngine.cs
+++ b/src/Whim.TestUtils/TestLayoutEngine.cs
@@ -46,4 +46,7 @@ public record TestLayoutEngine : ILayoutEngine
 	/// <inheritdoc/>
 	public ILayoutEngine SwapWindowInDirection(Direction direction, IWindow window) =>
 		throw new NotImplementedException();
+
+	/// <inheritdoc/>
+	public ILayoutEngine PerformCustomAction<T>(string actionName, T args) => throw new NotImplementedException();
 }

--- a/src/Whim.TestUtils/TestLayoutEngine.cs
+++ b/src/Whim.TestUtils/TestLayoutEngine.cs
@@ -48,5 +48,6 @@ public record TestLayoutEngine : ILayoutEngine
 		throw new NotImplementedException();
 
 	/// <inheritdoc/>
-	public ILayoutEngine PerformCustomAction<T>(string actionName, T args) => throw new NotImplementedException();
+	public ILayoutEngine PerformCustomAction<T>(string actionName, T args, IWindow? window) =>
+		throw new NotImplementedException();
 }

--- a/src/Whim.Tests/Layout/ColumnLayoutEngineTests.cs
+++ b/src/Whim.Tests/Layout/ColumnLayoutEngineTests.cs
@@ -881,7 +881,7 @@ public class ColumnLayoutEngineTests
 		ILayoutEngine engine = new ColumnLayoutEngine(identity).AddWindow(window);
 
 		// When
-		ILayoutEngine newEngine = engine.PerformCustomAction("test", 1);
+		ILayoutEngine newEngine = engine.PerformCustomAction("test", 1, null);
 
 		// Then
 		Assert.Same(engine, newEngine);

--- a/src/Whim.Tests/Layout/ColumnLayoutEngineTests.cs
+++ b/src/Whim.Tests/Layout/ColumnLayoutEngineTests.cs
@@ -879,9 +879,16 @@ public class ColumnLayoutEngineTests
 	{
 		// Given
 		ILayoutEngine engine = new ColumnLayoutEngine(identity).AddWindow(window);
+		LayoutEngineCustomAction<string> action =
+			new()
+			{
+				Name = "Action",
+				Payload = "payload",
+				Window = Substitute.For<IWindow>()
+			};
 
 		// When
-		ILayoutEngine newEngine = engine.PerformCustomAction("test", 1, null);
+		ILayoutEngine newEngine = engine.PerformCustomAction(action);
 
 		// Then
 		Assert.Same(engine, newEngine);

--- a/src/Whim.Tests/Layout/ColumnLayoutEngineTests.cs
+++ b/src/Whim.Tests/Layout/ColumnLayoutEngineTests.cs
@@ -873,4 +873,17 @@ public class ColumnLayoutEngineTests
 		Assert.Equal(1, windows.FindIndex(w => w.Window == window));
 	}
 	#endregion
+
+	[Theory, AutoSubstituteData]
+	public void PerformCustomAction(IWindow window)
+	{
+		// Given
+		ILayoutEngine engine = new ColumnLayoutEngine(identity).AddWindow(window);
+
+		// When
+		ILayoutEngine newEngine = engine.PerformCustomAction("test", 1);
+
+		// Then
+		Assert.Same(engine, newEngine);
+	}
 }

--- a/src/Whim.Tests/Workspace/WorkspaceTests.cs
+++ b/src/Whim.Tests/Workspace/WorkspaceTests.cs
@@ -1170,15 +1170,47 @@ public class WorkspaceTests
 
 	#region PerformCustomLayoutEngineAction
 	[Theory, AutoSubstituteData<WorkspaceCustomization>]
+	internal void PerformCustomLayoutEngineAction_PassWindowThroughAsArgs(
+		IContext ctx,
+		IInternalContext internalCtx,
+		WorkspaceManagerTriggers triggers,
+		ILayoutEngine layoutEngine,
+		IWindow window
+	)
+	{
+		// Given
+		layoutEngine
+			.PerformCustomAction(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<IWindow>())
+			.Returns(layoutEngine);
+		Workspace workspace = new(ctx, internalCtx, triggers, "Workspace", new ILayoutEngine[] { layoutEngine });
+
+		string actionName = "Action";
+
+		layoutEngine.ClearReceivedCalls();
+
+		// When PerformCustomLayoutEngineAction is called
+		workspace.PerformCustomLayoutEngineAction(actionName, triggerWindow: window);
+
+		// Then the layout engine is not changed
+		layoutEngine.Received(1).PerformCustomAction(actionName, window, window);
+		layoutEngine.DidNotReceive().DoLayout(Arg.Any<IRectangle<int>>(), Arg.Any<IMonitor>());
+		Assert.Equal(layoutEngine, workspace.ActiveLayoutEngine);
+	}
+	)
+
+	[Theory, AutoSubstituteData<WorkspaceCustomization>]
 	internal void PerformCustomLayoutEngineAction_NoChange(
 		IContext ctx,
 		IInternalContext internalCtx,
 		WorkspaceManagerTriggers triggers,
-		ILayoutEngine layoutEngine
+		ILayoutEngine layoutEngine,
+		IWindow window
 	)
 	{
 		// Given
-		layoutEngine.PerformCustomAction(Arg.Any<string>(), Arg.Any<string>()).Returns(layoutEngine);
+		layoutEngine
+			.PerformCustomAction(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<IWindow>())
+			.Returns(layoutEngine);
 		Workspace workspace = new(ctx, internalCtx, triggers, "Workspace", new ILayoutEngine[] { layoutEngine });
 
 		string actionName = "Action";
@@ -1187,10 +1219,10 @@ public class WorkspaceTests
 		layoutEngine.ClearReceivedCalls();
 
 		// When PerformCustomLayoutEngineAction is called
-		workspace.PerformCustomLayoutEngineAction(actionName, args);
+		workspace.PerformCustomLayoutEngineAction(actionName, args, window);
 
 		// Then the layout engine is not changed
-		layoutEngine.Received(1).PerformCustomAction(actionName, args);
+		layoutEngine.Received(1).PerformCustomAction(actionName, args, window);
 		layoutEngine.DidNotReceive().DoLayout(Arg.Any<IRectangle<int>>(), Arg.Any<IMonitor>());
 		Assert.Equal(layoutEngine, workspace.ActiveLayoutEngine);
 	}
@@ -1202,12 +1234,17 @@ public class WorkspaceTests
 		WorkspaceManagerTriggers triggers,
 		ILayoutEngine layoutEngine,
 		ILayoutEngine layoutEngine1,
-		ILayoutEngine layoutEngine1Result
+		ILayoutEngine layoutEngine1Result,
+		IWindow window
 	)
 	{
 		// Given
-		layoutEngine.PerformCustomAction(Arg.Any<string>(), Arg.Any<string>()).Returns(layoutEngine);
-		layoutEngine1.PerformCustomAction(Arg.Any<string>(), Arg.Any<string>()).Returns(layoutEngine1Result);
+		layoutEngine
+			.PerformCustomAction(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<IWindow>())
+			.Returns(layoutEngine);
+		layoutEngine1
+			.PerformCustomAction(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<IWindow>())
+			.Returns(layoutEngine1Result);
 
 		Workspace workspace =
 			new(ctx, internalCtx, triggers, "Workspace", new ILayoutEngine[] { layoutEngine, layoutEngine1 });
@@ -1218,13 +1255,13 @@ public class WorkspaceTests
 		layoutEngine.ClearReceivedCalls();
 
 		// When PerformCustomLayoutEngineAction is called
-		workspace.PerformCustomLayoutEngineAction(actionName, args);
+		workspace.PerformCustomLayoutEngineAction(actionName, args, window);
 
 		// Then the layout engine is changed
-		layoutEngine.Received(1).PerformCustomAction(actionName, args);
+		layoutEngine.Received(1).PerformCustomAction(actionName, args, window);
 		layoutEngine.DidNotReceive().DoLayout(Arg.Any<IRectangle<int>>(), Arg.Any<IMonitor>());
 
-		layoutEngine1.Received(1).PerformCustomAction(actionName, args);
+		layoutEngine1.Received(1).PerformCustomAction(actionName, args, window);
 		layoutEngine1.DidNotReceive().DoLayout(Arg.Any<IRectangle<int>>(), Arg.Any<IMonitor>());
 		layoutEngine1Result.DidNotReceive().DoLayout(Arg.Any<IRectangle<int>>(), Arg.Any<IMonitor>());
 
@@ -1238,12 +1275,17 @@ public class WorkspaceTests
 		WorkspaceManagerTriggers triggers,
 		ILayoutEngine layoutEngine,
 		ILayoutEngine layoutEngineResult,
-		ILayoutEngine layoutEngine1
+		ILayoutEngine layoutEngine1,
+		IWindow window
 	)
 	{
 		// Given
-		layoutEngine.PerformCustomAction(Arg.Any<string>(), Arg.Any<string>()).Returns(layoutEngineResult);
-		layoutEngine1.PerformCustomAction(Arg.Any<string>(), Arg.Any<string>()).Returns(layoutEngine1);
+		layoutEngine
+			.PerformCustomAction(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<IWindow>())
+			.Returns(layoutEngineResult);
+		layoutEngine1
+			.PerformCustomAction(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<IWindow>())
+			.Returns(layoutEngine1);
 
 		Workspace workspace =
 			new(ctx, internalCtx, triggers, "Workspace", new ILayoutEngine[] { layoutEngine, layoutEngine1 });
@@ -1254,15 +1296,15 @@ public class WorkspaceTests
 		layoutEngine.ClearReceivedCalls();
 
 		// When PerformCustomLayoutEngineAction is called
-		workspace.PerformCustomLayoutEngineAction(actionName, args);
+		workspace.PerformCustomLayoutEngineAction(actionName, args, window);
 
 		// Then the layout engine is changed
-		layoutEngine.Received(1).PerformCustomAction(actionName, args);
+		layoutEngine.Received(1).PerformCustomAction(actionName, args, window);
 		layoutEngine.DidNotReceive().DoLayout(Arg.Any<IRectangle<int>>(), Arg.Any<IMonitor>());
 
 		layoutEngineResult.Received(1).DoLayout(Arg.Any<IRectangle<int>>(), Arg.Any<IMonitor>());
 
-		layoutEngine1.Received(1).PerformCustomAction(actionName, args);
+		layoutEngine1.Received(1).PerformCustomAction(actionName, args, window);
 		layoutEngine1.DidNotReceive().DoLayout(Arg.Any<IRectangle<int>>(), Arg.Any<IMonitor>());
 
 		Assert.Equal(layoutEngineResult, workspace.ActiveLayoutEngine);

--- a/src/Whim.Tests/Workspace/WorkspaceTests.cs
+++ b/src/Whim.Tests/Workspace/WorkspaceTests.cs
@@ -1179,24 +1179,21 @@ public class WorkspaceTests
 	)
 	{
 		// Given
-		layoutEngine
-			.PerformCustomAction(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<IWindow>())
-			.Returns(layoutEngine);
+		layoutEngine.PerformCustomAction(Arg.Any<LayoutEngineCustomAction<IWindow?>>()).Returns(layoutEngine);
 		Workspace workspace = new(ctx, internalCtx, triggers, "Workspace", new ILayoutEngine[] { layoutEngine });
 
-		string actionName = "Action";
+		LayoutEngineCustomAction action = new() { Name = "Action", Window = window };
 
 		layoutEngine.ClearReceivedCalls();
 
 		// When PerformCustomLayoutEngineAction is called
-		workspace.PerformCustomLayoutEngineAction(actionName, triggerWindow: window);
+		workspace.PerformCustomLayoutEngineAction(action);
 
 		// Then the layout engine is not changed
-		layoutEngine.Received(1).PerformCustomAction(actionName, window, window);
+		layoutEngine.Received(1).PerformCustomAction(Arg.Any<LayoutEngineCustomAction<IWindow?>>());
 		layoutEngine.DidNotReceive().DoLayout(Arg.Any<IRectangle<int>>(), Arg.Any<IMonitor>());
 		Assert.Equal(layoutEngine, workspace.ActiveLayoutEngine);
 	}
-	)
 
 	[Theory, AutoSubstituteData<WorkspaceCustomization>]
 	internal void PerformCustomLayoutEngineAction_NoChange(
@@ -1208,21 +1205,24 @@ public class WorkspaceTests
 	)
 	{
 		// Given
-		layoutEngine
-			.PerformCustomAction(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<IWindow>())
-			.Returns(layoutEngine);
+		layoutEngine.PerformCustomAction(Arg.Any<LayoutEngineCustomAction<string>>()).Returns(layoutEngine);
 		Workspace workspace = new(ctx, internalCtx, triggers, "Workspace", new ILayoutEngine[] { layoutEngine });
 
-		string actionName = "Action";
-		string args = "Args";
+		LayoutEngineCustomAction<string> action =
+			new()
+			{
+				Name = "Action",
+				Payload = "payload",
+				Window = window
+			};
 
 		layoutEngine.ClearReceivedCalls();
 
 		// When PerformCustomLayoutEngineAction is called
-		workspace.PerformCustomLayoutEngineAction(actionName, args, window);
+		workspace.PerformCustomLayoutEngineAction(action);
 
 		// Then the layout engine is not changed
-		layoutEngine.Received(1).PerformCustomAction(actionName, args, window);
+		layoutEngine.Received(1).PerformCustomAction(action);
 		layoutEngine.DidNotReceive().DoLayout(Arg.Any<IRectangle<int>>(), Arg.Any<IMonitor>());
 		Assert.Equal(layoutEngine, workspace.ActiveLayoutEngine);
 	}
@@ -1239,29 +1239,30 @@ public class WorkspaceTests
 	)
 	{
 		// Given
-		layoutEngine
-			.PerformCustomAction(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<IWindow>())
-			.Returns(layoutEngine);
-		layoutEngine1
-			.PerformCustomAction(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<IWindow>())
-			.Returns(layoutEngine1Result);
+		layoutEngine.PerformCustomAction(Arg.Any<LayoutEngineCustomAction<string>>()).Returns(layoutEngine);
+		layoutEngine1.PerformCustomAction(Arg.Any<LayoutEngineCustomAction<string>>()).Returns(layoutEngine1Result);
 
 		Workspace workspace =
 			new(ctx, internalCtx, triggers, "Workspace", new ILayoutEngine[] { layoutEngine, layoutEngine1 });
 
-		string actionName = "Action";
-		string args = "Args";
+		LayoutEngineCustomAction<string> action =
+			new()
+			{
+				Name = "Action",
+				Payload = "payload",
+				Window = window
+			};
 
 		layoutEngine.ClearReceivedCalls();
 
 		// When PerformCustomLayoutEngineAction is called
-		workspace.PerformCustomLayoutEngineAction(actionName, args, window);
+		workspace.PerformCustomLayoutEngineAction(action);
 
 		// Then the layout engine is changed
-		layoutEngine.Received(1).PerformCustomAction(actionName, args, window);
+		layoutEngine.Received(1).PerformCustomAction(action);
 		layoutEngine.DidNotReceive().DoLayout(Arg.Any<IRectangle<int>>(), Arg.Any<IMonitor>());
 
-		layoutEngine1.Received(1).PerformCustomAction(actionName, args, window);
+		layoutEngine1.Received(1).PerformCustomAction(action);
 		layoutEngine1.DidNotReceive().DoLayout(Arg.Any<IRectangle<int>>(), Arg.Any<IMonitor>());
 		layoutEngine1Result.DidNotReceive().DoLayout(Arg.Any<IRectangle<int>>(), Arg.Any<IMonitor>());
 
@@ -1280,31 +1281,32 @@ public class WorkspaceTests
 	)
 	{
 		// Given
-		layoutEngine
-			.PerformCustomAction(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<IWindow>())
-			.Returns(layoutEngineResult);
-		layoutEngine1
-			.PerformCustomAction(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<IWindow>())
-			.Returns(layoutEngine1);
+		layoutEngine.PerformCustomAction(Arg.Any<LayoutEngineCustomAction<string>>()).Returns(layoutEngineResult);
+		layoutEngine1.PerformCustomAction(Arg.Any<LayoutEngineCustomAction<string>>()).Returns(layoutEngine1);
 
 		Workspace workspace =
 			new(ctx, internalCtx, triggers, "Workspace", new ILayoutEngine[] { layoutEngine, layoutEngine1 });
 
-		string actionName = "Action";
-		string args = "Args";
+		LayoutEngineCustomAction<string> action =
+			new()
+			{
+				Name = "Action",
+				Payload = "payload",
+				Window = window
+			};
 
 		layoutEngine.ClearReceivedCalls();
 
 		// When PerformCustomLayoutEngineAction is called
-		workspace.PerformCustomLayoutEngineAction(actionName, args, window);
+		workspace.PerformCustomLayoutEngineAction(action);
 
 		// Then the layout engine is changed
-		layoutEngine.Received(1).PerformCustomAction(actionName, args, window);
+		layoutEngine.Received(1).PerformCustomAction(action);
 		layoutEngine.DidNotReceive().DoLayout(Arg.Any<IRectangle<int>>(), Arg.Any<IMonitor>());
 
 		layoutEngineResult.Received(1).DoLayout(Arg.Any<IRectangle<int>>(), Arg.Any<IMonitor>());
 
-		layoutEngine1.Received(1).PerformCustomAction(actionName, args, window);
+		layoutEngine1.Received(1).PerformCustomAction(action);
 		layoutEngine1.DidNotReceive().DoLayout(Arg.Any<IRectangle<int>>(), Arg.Any<IMonitor>());
 
 		Assert.Equal(layoutEngineResult, workspace.ActiveLayoutEngine);

--- a/src/Whim.TreeLayout.Tests/LayoutEngine/PerformCustomActionTests.cs
+++ b/src/Whim.TreeLayout.Tests/LayoutEngine/PerformCustomActionTests.cs
@@ -6,15 +6,21 @@ namespace Whim.TreeLayout.Tests;
 public class PerformCustomActionTests
 {
 	[Theory, AutoSubstituteData]
-	public void PerformCustomAction(string actionName, object args, IWindow window)
+	public void PerformCustomAction(IWindow window)
 	{
 		// Given
 		LayoutEngineWrapper wrapper = new LayoutEngineWrapper().SetAsLastFocusedWindow(null);
-
+		LayoutEngineCustomAction<string> action =
+			new()
+			{
+				Name = "Action",
+				Payload = "payload",
+				Window = window
+			};
 		ILayoutEngine engine = new TreeLayoutEngine(wrapper.Context, wrapper.Plugin, wrapper.Identity);
 
 		// When
-		ILayoutEngine newEngine = engine.PerformCustomAction(actionName, args, window);
+		ILayoutEngine newEngine = engine.PerformCustomAction(action);
 
 		// Then
 		Assert.Same(engine, newEngine);

--- a/src/Whim.TreeLayout.Tests/LayoutEngine/PerformCustomActionTests.cs
+++ b/src/Whim.TreeLayout.Tests/LayoutEngine/PerformCustomActionTests.cs
@@ -1,0 +1,22 @@
+using Whim.TestUtils;
+using Xunit;
+
+namespace Whim.TreeLayout.Tests;
+
+public class PerformCustomActionTests
+{
+	[Theory, AutoSubstituteData]
+	public void PerformCustomAction(string actionName, object args, IWindow window)
+	{
+		// Given
+		LayoutEngineWrapper wrapper = new LayoutEngineWrapper().SetAsLastFocusedWindow(null);
+
+		ILayoutEngine engine = new TreeLayoutEngine(wrapper.Context, wrapper.Plugin, wrapper.Identity);
+
+		// When
+		ILayoutEngine newEngine = engine.PerformCustomAction(actionName, args, window);
+
+		// Then
+		Assert.Same(engine, newEngine);
+	}
+}

--- a/src/Whim.TreeLayout/TreeLayoutEngine.cs
+++ b/src/Whim.TreeLayout/TreeLayoutEngine.cs
@@ -685,5 +685,5 @@ public record TreeLayoutEngine : ILayoutEngine
 		return new TreeLayoutEngine(this, currentNode, newWindows);
 	}
 
-	public ILayoutEngine PerformCustomAction<T>(string actionName, T args, IWindow? window) => this;
+	public ILayoutEngine PerformCustomAction<T>(LayoutEngineCustomAction<T> action) => this;
 }

--- a/src/Whim.TreeLayout/TreeLayoutEngine.cs
+++ b/src/Whim.TreeLayout/TreeLayoutEngine.cs
@@ -684,4 +684,6 @@ public record TreeLayoutEngine : ILayoutEngine
 		);
 		return new TreeLayoutEngine(this, currentNode, newWindows);
 	}
+
+	public ILayoutEngine PerformCustomAction<T>(string actionName, T args) => this;
 }

--- a/src/Whim.TreeLayout/TreeLayoutEngine.cs
+++ b/src/Whim.TreeLayout/TreeLayoutEngine.cs
@@ -685,5 +685,5 @@ public record TreeLayoutEngine : ILayoutEngine
 		return new TreeLayoutEngine(this, currentNode, newWindows);
 	}
 
-	public ILayoutEngine PerformCustomAction<T>(string actionName, T args) => this;
+	public ILayoutEngine PerformCustomAction<T>(string actionName, T args, IWindow? window) => this;
 }

--- a/src/Whim/Layout/BaseProxyLayoutEngine.cs
+++ b/src/Whim/Layout/BaseProxyLayoutEngine.cs
@@ -76,6 +76,7 @@ public abstract record BaseProxyLayoutEngine : ILayoutEngine
 	/// <inheritdoc/>
 	public abstract IEnumerable<IWindowState> DoLayout(IRectangle<int> rectangle, IMonitor monitor);
 
+	/// <inheritdoc/>
 	public abstract ILayoutEngine PerformCustomAction<T>(string actionName, T args);
 
 	/// <summary>

--- a/src/Whim/Layout/BaseProxyLayoutEngine.cs
+++ b/src/Whim/Layout/BaseProxyLayoutEngine.cs
@@ -77,7 +77,7 @@ public abstract record BaseProxyLayoutEngine : ILayoutEngine
 	public abstract IEnumerable<IWindowState> DoLayout(IRectangle<int> rectangle, IMonitor monitor);
 
 	/// <inheritdoc/>
-	public abstract ILayoutEngine PerformCustomAction<T>(string actionName, T args, IWindow? window);
+	public abstract ILayoutEngine PerformCustomAction<T>(LayoutEngineCustomAction<T> action);
 
 	/// <summary>
 	/// Checks to see if this <cref name="IImmutableLayoutEngine"/>

--- a/src/Whim/Layout/BaseProxyLayoutEngine.cs
+++ b/src/Whim/Layout/BaseProxyLayoutEngine.cs
@@ -76,6 +76,8 @@ public abstract record BaseProxyLayoutEngine : ILayoutEngine
 	/// <inheritdoc/>
 	public abstract IEnumerable<IWindowState> DoLayout(IRectangle<int> rectangle, IMonitor monitor);
 
+	public abstract ILayoutEngine PerformCustomAction<T>(string actionName, T args);
+
 	/// <summary>
 	/// Checks to see if this <cref name="IImmutableLayoutEngine"/>
 	/// or a child layout engine is type <typeparamref name="T"/>.

--- a/src/Whim/Layout/BaseProxyLayoutEngine.cs
+++ b/src/Whim/Layout/BaseProxyLayoutEngine.cs
@@ -77,7 +77,7 @@ public abstract record BaseProxyLayoutEngine : ILayoutEngine
 	public abstract IEnumerable<IWindowState> DoLayout(IRectangle<int> rectangle, IMonitor monitor);
 
 	/// <inheritdoc/>
-	public abstract ILayoutEngine PerformCustomAction<T>(string actionName, T args);
+	public abstract ILayoutEngine PerformCustomAction<T>(string actionName, T args, IWindow? window);
 
 	/// <summary>
 	/// Checks to see if this <cref name="IImmutableLayoutEngine"/>

--- a/src/Whim/Layout/ColumnLayoutEngine.cs
+++ b/src/Whim/Layout/ColumnLayoutEngine.cs
@@ -235,4 +235,6 @@ public record ColumnLayoutEngine : ILayoutEngine
 			return direction == Direction.Left ? 1 : -1;
 		}
 	}
+
+	public ILayoutEngine PerformCustomAction<T>(string actionName, T args) => this;
 }

--- a/src/Whim/Layout/ColumnLayoutEngine.cs
+++ b/src/Whim/Layout/ColumnLayoutEngine.cs
@@ -236,5 +236,5 @@ public record ColumnLayoutEngine : ILayoutEngine
 		}
 	}
 
-	public ILayoutEngine PerformCustomAction<T>(string actionName, T args) => this;
+	public ILayoutEngine PerformCustomAction<T>(string actionName, T args, IWindow? window) => this;
 }

--- a/src/Whim/Layout/ColumnLayoutEngine.cs
+++ b/src/Whim/Layout/ColumnLayoutEngine.cs
@@ -236,5 +236,5 @@ public record ColumnLayoutEngine : ILayoutEngine
 		}
 	}
 
-	public ILayoutEngine PerformCustomAction<T>(string actionName, T args, IWindow? window) => this;
+	public ILayoutEngine PerformCustomAction<T>(LayoutEngineCustomAction<T> action) => this;
 }

--- a/src/Whim/Layout/ILayoutEngine.cs
+++ b/src/Whim/Layout/ILayoutEngine.cs
@@ -119,8 +119,7 @@ public interface ILayoutEngine
 	ILayoutEngine MoveWindowEdgesInDirection(Direction edges, IPoint<double> deltas, IWindow window);
 
 	/// <summary>
-	/// A custom action handler for the given <paramref name="args"/>.
-	/// Each layout engine should handle the <paramref name="args"/> appropriately.
+	/// Attempts to trigger a custom action in a layout engine.
 	/// </summary>
 	/// <remarks>
 	/// This method is used to handle custom actions that are not part of the
@@ -129,23 +128,15 @@ public interface ILayoutEngine
 	/// window stack.
 	/// </remarks>
 	/// <typeparam name="T">
-	/// The type of <paramref name="args"/>.
+	/// The type of the <paramref name="action"/>'s payload.
 	/// </typeparam>
-	/// <param name="actionName">
-	/// The name of the action. This should be unique to the layout engine type.
-	/// </param>
-	/// <param name="args">
-	/// The payload of the action, which the handler can use to perform the action.
-	/// </param>
-	/// <param name="triggerWindow">
-	/// The window that triggered the action, if any. Proxy layout engines may use this to.
-	/// This deliberately does not set the default value to null, so that the caller must
-	/// explicitly pass null if they do not have a trigger window.
+	/// <param name="action">
+	/// Metadata about the action to perform, and the payload to perform it with.
 	/// </param>
 	/// <returns>
 	/// A new layout engine if the action is handled, otherwise it returns the current layout engine.
 	/// </returns>
-	ILayoutEngine PerformCustomAction<T>(string actionName, T args, IWindow? triggerWindow);
+	ILayoutEngine PerformCustomAction<T>(LayoutEngineCustomAction<T> action);
 
 	/// <summary>
 	/// Checks to see if this <see cref="ILayoutEngine"/> or a child layout engine is type

--- a/src/Whim/Layout/ILayoutEngine.cs
+++ b/src/Whim/Layout/ILayoutEngine.cs
@@ -119,6 +119,30 @@ public interface ILayoutEngine
 	ILayoutEngine MoveWindowEdgesInDirection(Direction edges, IPoint<double> deltas, IWindow window);
 
 	/// <summary>
+	/// A custom action handler for the given <paramref name="args"/>.
+	/// Each layout engine should handle the <paramref name="args"/> appropriately.
+	/// </summary>
+	/// <remarks>
+	/// This method is used to handle custom actions that are not part of the
+	/// <see cref="ILayoutEngine"/> interface.
+	/// For example, the SliceLayoutEngine uses this method to promote/demote windows in the
+	/// window stack.
+	/// </remarks>
+	/// <typeparam name="T">
+	/// The type of <paramref name="args"/>.
+	/// </typeparam>
+	/// <param name="actionName">
+	/// The name of the action. This should be unique to the layout engine type.
+	/// </param>
+	/// <param name="args">
+	/// The payload of the action, which the handler can use to perform the action.
+	/// </param>
+	/// <returns>
+	/// A new layout engine if the action is handled, otherwise it returns the current layout engine.
+	/// </returns>
+	ILayoutEngine PerformCustomAction<T>(string actionName, T args);
+
+	/// <summary>
 	/// Checks to see if this <see cref="ILayoutEngine"/> or a child layout engine is type
 	/// <typeparamref name="T"/>.
 	/// </summary>

--- a/src/Whim/Layout/ILayoutEngine.cs
+++ b/src/Whim/Layout/ILayoutEngine.cs
@@ -137,10 +137,15 @@ public interface ILayoutEngine
 	/// <param name="args">
 	/// The payload of the action, which the handler can use to perform the action.
 	/// </param>
+	/// <param name="triggerWindow">
+	/// The window that triggered the action, if any. Proxy layout engines may use this to.
+	/// This deliberately does not set the default value to null, so that the caller must
+	/// explicitly pass null if they do not have a trigger window.
+	/// </param>
 	/// <returns>
 	/// A new layout engine if the action is handled, otherwise it returns the current layout engine.
 	/// </returns>
-	ILayoutEngine PerformCustomAction<T>(string actionName, T args);
+	ILayoutEngine PerformCustomAction<T>(string actionName, T args, IWindow? triggerWindow);
 
 	/// <summary>
 	/// Checks to see if this <see cref="ILayoutEngine"/> or a child layout engine is type

--- a/src/Whim/Layout/LayoutEngineCustomAction.cs
+++ b/src/Whim/Layout/LayoutEngineCustomAction.cs
@@ -1,0 +1,34 @@
+namespace Whim;
+
+/// <summary>
+/// The payload for a custom action for a layout engine to perform, via <see cref="ILayoutEngine.PerformCustomAction{T}"/>.
+/// </summary>
+public record LayoutEngineCustomAction
+{
+	/// <summary>
+	/// The name of the action. This should be unique to the layout engine type.
+	/// </summary>
+	public required string Name { get; init; }
+
+	/// <summary>
+	/// The window that triggered the action, if any. Proxy layout engines may use this for their
+	/// own purposes - for example, the FloatingLayoutEngine.
+	///
+	/// This is deliberately set to required to force the specification of the triggering window, where possible.
+	/// </summary>
+	public required IWindow? Window { get; init; }
+}
+
+/// <summary>
+/// The payload for a custom action for a layout engine to perform, via <see cref="ILayoutEngine.PerformCustomAction{T}"/>.
+/// </summary>
+/// <typeparam name="T">
+/// The type of <see cref="Payload"/>.
+/// </typeparam>
+public record LayoutEngineCustomAction<T> : LayoutEngineCustomAction
+{
+	/// <summary>
+	/// The payload of the action, which the handler can use to perform the action.
+	/// </summary>
+	public required T Payload { get; init; }
+}

--- a/src/Whim/Workspace/IWorkspace.cs
+++ b/src/Whim/Workspace/IWorkspace.cs
@@ -154,39 +154,26 @@ public interface IWorkspace : IDisposable
 	/// Performs a custom action in a layout engine.
 	/// </summary>
 	/// <remarks>
-	/// Layout engines need to handle the custom action in <see cref="ILayoutEngine.PerformCustomAction{T}(string, T)"/>.
-	/// For more, see <see cref="ILayoutEngine.PerformCustomAction{T}(string, T)"/>.
+	/// Layout engines need to handle the custom action in <see cref="ILayoutEngine.PerformCustomAction{T}" />.
+	/// For more, see <see cref="ILayoutEngine.PerformCustomAction{T}" />.
 	/// </remarks>
-	/// <param name="actionName">
-	/// The name of the action. This should be unique to the layout engine type.
+	/// <param name="action">
+	/// Metadata about the action to perform, and the payload to perform it with.
 	/// </param>
-	/// <param name="triggerWindow">
-	/// The window that triggered the action, if any. Proxy layout engines may use this to.
-	/// This deliberately does not set the default value to null, so that the caller must
-	/// explicitly pass null if they do not have a trigger window.
-	/// </param>
-	void PerformCustomLayoutEngineAction<T>(string actionName, IWindow? triggerWindow);
+	void PerformCustomLayoutEngineAction(LayoutEngineCustomAction action);
 
 	/// <summary>
 	/// Performs a custom action in a layout engine.
 	/// </summary>
 	/// <remarks>
-	/// Layout engines need to handle the custom action in <see cref="ILayoutEngine.PerformCustomAction{T}(string, T)"/>.
-	/// For more, see <see cref="ILayoutEngine.PerformCustomAction{T}(string, T)"/>.
+	/// Layout engines need to handle the custom action in <see cref="ILayoutEngine.PerformCustomAction{T}" />.
+	/// For more, see <see cref="ILayoutEngine.PerformCustomAction{T}" />.
 	/// </remarks>
 	/// <typeparam name="T">
-	/// The type of <paramref name="args"/>.
+	/// The type of <paramref name="args" />'s payload.
 	/// </typeparam>
-	/// <param name="actionName">
-	/// The name of the action. This should be unique to the layout engine type.
+	/// <param name="action">
+	/// Metadata about the action to perform, and the payload to perform it with.
 	/// </param>
-	/// <param name="args">
-	/// The payload of the action, which the handler can use to perform the action.
-	/// </param>
-	/// <param name="triggerWindow">
-	/// The window that triggered the action, if any. Proxy layout engines may use this to.
-	/// This deliberately does not set the default value to null, so that the caller must
-	/// explicitly pass null if they do not have a trigger window.
-	/// </param>
-	void PerformCustomLayoutEngineAction<T>(string actionName, T args, IWindow? triggerWindow);
+	void PerformCustomLayoutEngineAction<T>(LayoutEngineCustomAction<T> action);
 }

--- a/src/Whim/Workspace/IWorkspace.cs
+++ b/src/Whim/Workspace/IWorkspace.cs
@@ -149,4 +149,22 @@ public interface IWorkspace : IDisposable
 	/// <param name="point">The point to move the window to.</param>
 	void MoveWindowToPoint(IWindow window, IPoint<double> point);
 	#endregion
+
+	/// <summary>
+	/// Performs a custom action in a layout engine.
+	/// </summary>
+	/// <remarks>
+	/// Layout engines need to handle the custom action in <see cref="ILayoutEngine.PerformCustomAction{T}(string, T)"/>.
+	/// For more, see <see cref="ILayoutEngine.PerformCustomAction{T}(string, T)"/>.
+	/// </remarks>
+	/// <typeparam name="T">
+	/// The type of <paramref name="args"/>.
+	/// </typeparam>
+	/// <param name="actionName">
+	/// The name of the action. This should be unique to the layout engine type.
+	/// </param>
+	/// <param name="args">
+	/// The payload of the action, which the handler can use to perform the action.
+	/// </param>
+	void PerformCustomLayoutEngineAction<T>(string actionName, T args);
 }

--- a/src/Whim/Workspace/IWorkspace.cs
+++ b/src/Whim/Workspace/IWorkspace.cs
@@ -157,6 +157,23 @@ public interface IWorkspace : IDisposable
 	/// Layout engines need to handle the custom action in <see cref="ILayoutEngine.PerformCustomAction{T}(string, T)"/>.
 	/// For more, see <see cref="ILayoutEngine.PerformCustomAction{T}(string, T)"/>.
 	/// </remarks>
+	/// <param name="actionName">
+	/// The name of the action. This should be unique to the layout engine type.
+	/// </param>
+	/// <param name="triggerWindow">
+	/// The window that triggered the action, if any. Proxy layout engines may use this to.
+	/// This deliberately does not set the default value to null, so that the caller must
+	/// explicitly pass null if they do not have a trigger window.
+	/// </param>
+	void PerformCustomLayoutEngineAction<T>(string actionName, IWindow? triggerWindow);
+
+	/// <summary>
+	/// Performs a custom action in a layout engine.
+	/// </summary>
+	/// <remarks>
+	/// Layout engines need to handle the custom action in <see cref="ILayoutEngine.PerformCustomAction{T}(string, T)"/>.
+	/// For more, see <see cref="ILayoutEngine.PerformCustomAction{T}(string, T)"/>.
+	/// </remarks>
 	/// <typeparam name="T">
 	/// The type of <paramref name="args"/>.
 	/// </typeparam>
@@ -166,5 +183,10 @@ public interface IWorkspace : IDisposable
 	/// <param name="args">
 	/// The payload of the action, which the handler can use to perform the action.
 	/// </param>
-	void PerformCustomLayoutEngineAction<T>(string actionName, T args);
+	/// <param name="triggerWindow">
+	/// The window that triggered the action, if any. Proxy layout engines may use this to.
+	/// This deliberately does not set the default value to null, so that the caller must
+	/// explicitly pass null if they do not have a trigger window.
+	/// </param>
+	void PerformCustomLayoutEngineAction<T>(string actionName, T args, IWindow? triggerWindow);
 }

--- a/src/Whim/Workspace/Workspace.cs
+++ b/src/Whim/Workspace/Workspace.cs
@@ -657,6 +657,37 @@ internal class Workspace : IWorkspace, IInternalWorkspace
 		return garbageCollected;
 	}
 
+	public void PerformCustomLayoutEngineAction<T>(string actionname, T args)
+	{
+		Logger.Debug($"Attempting to perform custom layout engine action {actionname} for workspace {Name}");
+
+		bool doLayout = false;
+		for (int idx = 0; idx < _layoutEngines.Length; idx++)
+		{
+			ILayoutEngine oldEngine = _layoutEngines[idx];
+			ILayoutEngine newEngine = oldEngine.PerformCustomAction(actionname, args);
+
+			if (newEngine.Equals(oldEngine))
+			{
+				Logger.Debug($"Layout engine {oldEngine} could not perform action {actionname}");
+			}
+			else
+			{
+				_layoutEngines[idx] = newEngine;
+
+				if (oldEngine == ActiveLayoutEngine)
+				{
+					doLayout = true;
+				}
+			}
+		}
+
+		if (doLayout)
+		{
+			DoLayout();
+		}
+	}
+
 	protected virtual void Dispose(bool disposing)
 	{
 		if (!_disposedValue)

--- a/src/Whim/Workspace/Workspace.cs
+++ b/src/Whim/Workspace/Workspace.cs
@@ -657,7 +657,12 @@ internal class Workspace : IWorkspace, IInternalWorkspace
 		return garbageCollected;
 	}
 
-	public void PerformCustomLayoutEngineAction<T>(string actionname, T args)
+	public void PerformCustomLayoutEngineAction<T>(string actionname, IWindow? triggerWindow)
+	{
+		PerformCustomLayoutEngineAction(actionname, triggerWindow, triggerWindow);
+	}
+
+	public void PerformCustomLayoutEngineAction<T>(string actionname, T args, IWindow? triggerWindow)
 	{
 		Logger.Debug($"Attempting to perform custom layout engine action {actionname} for workspace {Name}");
 
@@ -670,7 +675,7 @@ internal class Workspace : IWorkspace, IInternalWorkspace
 		for (int idx = 0; idx < _layoutEngines.Length; idx++)
 		{
 			ILayoutEngine oldEngine = _layoutEngines[idx];
-			ILayoutEngine newEngine = oldEngine.PerformCustomAction(actionname, args);
+			ILayoutEngine newEngine = oldEngine.PerformCustomAction(actionname, args, triggerWindow);
 
 			if (newEngine.Equals(oldEngine))
 			{

--- a/src/Whim/Workspace/Workspace.cs
+++ b/src/Whim/Workspace/Workspace.cs
@@ -657,14 +657,21 @@ internal class Workspace : IWorkspace, IInternalWorkspace
 		return garbageCollected;
 	}
 
-	public void PerformCustomLayoutEngineAction<T>(string actionname, IWindow? triggerWindow)
+	public void PerformCustomLayoutEngineAction(LayoutEngineCustomAction action)
 	{
-		PerformCustomLayoutEngineAction(actionname, triggerWindow, triggerWindow);
+		PerformCustomLayoutEngineAction(
+			new LayoutEngineCustomAction<IWindow?>()
+			{
+				Name = action.Name,
+				Payload = action.Window,
+				Window = action.Window
+			}
+		);
 	}
 
-	public void PerformCustomLayoutEngineAction<T>(string actionname, T args, IWindow? triggerWindow)
+	public void PerformCustomLayoutEngineAction<T>(LayoutEngineCustomAction<T> action)
 	{
-		Logger.Debug($"Attempting to perform custom layout engine action {actionname} for workspace {Name}");
+		Logger.Debug($"Attempting to perform custom layout engine action {action.Name} for workspace {Name}");
 
 		bool doLayout = false;
 
@@ -675,11 +682,11 @@ internal class Workspace : IWorkspace, IInternalWorkspace
 		for (int idx = 0; idx < _layoutEngines.Length; idx++)
 		{
 			ILayoutEngine oldEngine = _layoutEngines[idx];
-			ILayoutEngine newEngine = oldEngine.PerformCustomAction(actionname, args, triggerWindow);
+			ILayoutEngine newEngine = oldEngine.PerformCustomAction(action);
 
 			if (newEngine.Equals(oldEngine))
 			{
-				Logger.Debug($"Layout engine {oldEngine} could not perform action {actionname}");
+				Logger.Debug($"Layout engine {oldEngine} could not perform action {action.Name}");
 			}
 			else
 			{

--- a/src/Whim/Workspace/Workspace.cs
+++ b/src/Whim/Workspace/Workspace.cs
@@ -54,7 +54,7 @@ internal class Workspace : IWorkspace, IInternalWorkspace
 		}
 	}
 
-	private readonly ILayoutEngine[] _layoutEngines;
+	protected readonly ILayoutEngine[] _layoutEngines;
 	private int _activeLayoutEngineIndex;
 	private bool _disposedValue;
 
@@ -662,6 +662,11 @@ internal class Workspace : IWorkspace, IInternalWorkspace
 		Logger.Debug($"Attempting to perform custom layout engine action {actionname} for workspace {Name}");
 
 		bool doLayout = false;
+
+		// Update the layout engine for a given index can change ActiveLayoutEngine, which breaks the
+		// doLayout test.
+		ILayoutEngine prevActiveLayoutEngine = ActiveLayoutEngine;
+
 		for (int idx = 0; idx < _layoutEngines.Length; idx++)
 		{
 			ILayoutEngine oldEngine = _layoutEngines[idx];
@@ -675,7 +680,7 @@ internal class Workspace : IWorkspace, IInternalWorkspace
 			{
 				_layoutEngines[idx] = newEngine;
 
-				if (oldEngine == ActiveLayoutEngine)
+				if (oldEngine == prevActiveLayoutEngine)
 				{
 					doLayout = true;
 				}


### PR DESCRIPTION
This PR adds the ability for layout engines to perform non-standard actions, and still have their resulting layouts be saved to `Workspace` instances. This was needed for #634, where the `SliceLayoutPlugin` tries to perform operations on the `SliceLayoutEngine`, but was unable to save the resulting `ILayoutEngine` instance to the `Workspace`.

The `PerformCustomAction` method can be used by `ILayoutEngine` implementations to perform non-standard actions.
