### PR TITLE
Add missing documentation

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,5 +1,8 @@
 <Project>
 	<PropertyGroup>
-		<GenerateDocumentationFile>false</GenerateDocumentationFile>
+		<GenerateDocumentationFile>true</GenerateDocumentationFile>
+		<!-- Workaround for IDE0005 (Remove unnecessary usings/imports); see
+		https://github.com/dotnet/roslyn/issues/41640 -->
+		<NoWarn>EnableGenerateDocumentationFile</NoWarn>
 	</PropertyGroup>
 </Project>

--- a/src/Whim.TestUtils/Directory.Build.props
+++ b/src/Whim.TestUtils/Directory.Build.props
@@ -1,0 +1,5 @@
+<Project>
+	<PropertyGroup>
+		<GenerateDocumentationFile>false</GenerateDocumentationFile>
+	</PropertyGroup>
+</Project>

--- a/src/Whim.TreeLayout.Bar/ToggleDirectionCommand.cs
+++ b/src/Whim.TreeLayout.Bar/ToggleDirectionCommand.cs
@@ -10,7 +10,9 @@ public class ToggleDirectionCommand : System.Windows.Input.ICommand
 	private readonly TreeLayoutEngineWidgetViewModel _viewModel;
 
 	/// <inheritdoc/>
+#pragma warning disable CS0067 // The event 'ToggleDirectionCommand.CanExecuteChanged' is never used
 	public event EventHandler? CanExecuteChanged;
+#pragma warning restore CS0067 // The event 'ToggleDirectionCommand.CanExecuteChanged' is never used
 
 	/// <summary>
 	/// Creates a new instance of <see cref="ToggleDirectionCommand"/>.

--- a/src/Whim.TreeLayout.Tests/TreeLayoutCommandsTests.cs
+++ b/src/Whim.TreeLayout.Tests/TreeLayoutCommandsTests.cs
@@ -6,7 +6,7 @@ namespace Whim.TreeLayout.Tests;
 
 public class TreeLayoutCommandsTests
 {
-	private class Wrapper
+	private sealed class Wrapper
 	{
 		public IContext Context { get; } = Substitute.For<IContext>();
 		public IMonitor Monitor { get; } = Substitute.For<IMonitor>();

--- a/src/Whim.TreeLayout.Tests/Utils/LayoutEngineWrapper.cs
+++ b/src/Whim.TreeLayout.Tests/Utils/LayoutEngineWrapper.cs
@@ -2,7 +2,7 @@ using NSubstitute;
 
 namespace Whim.TreeLayout.Tests;
 
-internal class LayoutEngineWrapper
+internal sealed class LayoutEngineWrapper
 {
 	public IContext Context { get; } = Substitute.For<IContext>();
 	public ITreeLayoutPlugin Plugin { get; } = Substitute.For<ITreeLayoutPlugin>();

--- a/src/Whim.TreeLayout.Tests/Utils/SimpleTestTree.cs
+++ b/src/Whim.TreeLayout.Tests/Utils/SimpleTestTree.cs
@@ -26,7 +26,7 @@ namespace Whim.TreeLayout.Tests;
 /// |                      |                      |
 /// -----------------------------------------------
 /// </summary>
-internal class SimpleTestTree
+internal sealed class SimpleTestTree
 {
 	public SplitNode Root;
 	public SplitNode Top;

--- a/src/Whim.TreeLayout.Tests/Utils/TestTree.cs
+++ b/src/Whim.TreeLayout.Tests/Utils/TestTree.cs
@@ -48,7 +48,7 @@ namespace Whim.TreeLayout.Tests;
 /// |                                                                               |                                                                                |
 /// ------------------------------------------------------------------------------------------------------------------------------------------------------------------
 /// </summary>
-internal class TestTree
+internal sealed class TestTree
 {
 	public SplitNode Root;
 	public WindowNode Left;

--- a/src/Whim.TreeLayout/ITreeLayoutPlugin.cs
+++ b/src/Whim.TreeLayout/ITreeLayoutPlugin.cs
@@ -3,8 +3,8 @@ using System;
 namespace Whim.TreeLayout;
 
 /// <summary>
-/// TreeLayoutPlugin provides commands and functionality for the <see cref="TreeLayoutEngine"/>.
-/// TreeLayoutPlugin does not load the <see cref="TreeLayoutEngine"/> - that is done when creating
+/// <see cref="TreeLayoutPlugin"/> provides commands and functionality for the <see cref="TreeLayoutEngine"/>.
+/// <see cref="TreeLayoutPlugin"/> does not load the <see cref="TreeLayoutEngine"/> - that is done when creating
 /// a workspace via <see cref="IWorkspaceManager.Add"/>.
 /// </summary>
 public interface ITreeLayoutPlugin : IPlugin

--- a/src/Whim.TreeLayout/TreeLayoutEngine.cs
+++ b/src/Whim.TreeLayout/TreeLayoutEngine.cs
@@ -685,5 +685,6 @@ public record TreeLayoutEngine : ILayoutEngine
 		return new TreeLayoutEngine(this, currentNode, newWindows);
 	}
 
+	/// <inheritdoc />
 	public ILayoutEngine PerformCustomAction<T>(LayoutEngineCustomAction<T> action) => this;
 }

--- a/src/Whim.Updater.Tests/Directory.Build.props
+++ b/src/Whim.Updater.Tests/Directory.Build.props
@@ -1,0 +1,5 @@
+<Project>
+	<PropertyGroup>
+		<GenerateDocumentationFile>false</GenerateDocumentationFile>
+	</PropertyGroup>
+</Project>

--- a/src/Whim/Layout/ColumnLayoutEngine.cs
+++ b/src/Whim/Layout/ColumnLayoutEngine.cs
@@ -236,5 +236,6 @@ public record ColumnLayoutEngine : ILayoutEngine
 		}
 	}
 
+	/// <inheritdoc/>
 	public ILayoutEngine PerformCustomAction<T>(LayoutEngineCustomAction<T> action) => this;
 }

--- a/src/Whim/Workspace/IWorkspace.cs
+++ b/src/Whim/Workspace/IWorkspace.cs
@@ -170,7 +170,7 @@ public interface IWorkspace : IDisposable
 	/// For more, see <see cref="ILayoutEngine.PerformCustomAction{T}" />.
 	/// </remarks>
 	/// <typeparam name="T">
-	/// The type of <paramref name="args" />'s payload.
+	/// The type of <paramref name="action" />'s payload.
 	/// </typeparam>
 	/// <param name="action">
 	/// Metadata about the action to perform, and the payload to perform it with.


### PR DESCRIPTION
Addressed a bunch of warnings, and turned `GenerateDocumentationFile` back on.