### PR TITLE
Try to route to the active workspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,6 +330,8 @@ context.RouterManager.Add((window) =>
 });
 ```
 
+`IRouterManager` has a `RouterOptions` property which can configure how new windows are routed - see [`RouterOptions`](src/Whim/Router/RouterOptions.cs).
+
 ### Filtering
 
 [`IFilterManager`](src/Whim/Filter/IFilterManager.cs) tells Whim to ignore windows based on `Filter` delegates. A common use case is for plugins to filter out windows they manage themselves and want Whim to not lay out. For example, the bars and command palette are filtered out.

--- a/src/Whim.Tests/Router/RouterManagerTests.cs
+++ b/src/Whim.Tests/Router/RouterManagerTests.cs
@@ -26,6 +26,18 @@ public class RouterManagerCustomization : ICustomization
 
 public class RouterManagerTests
 {
+	[Theory]
+	[InlineAutoSubstituteData(true, RouterOptions.RouteToActiveWorkspace)]
+	[InlineAutoSubstituteData(false, RouterOptions.RouteToLaunchedWorkspace)]
+	public void RouteToActiveWorkspace(bool routeToActiveWorkspace, RouterOptions routerOptions, IContext ctx)
+	{
+		// Given
+		RouterManager routerManager = new(ctx) { RouterOptions = routerOptions };
+
+		// Then
+		Assert.Equal(routeToActiveWorkspace, routerManager.RouteToActiveWorkspace);
+	}
+
 	[Theory, AutoSubstituteData<RouterManagerCustomization>]
 	public void AddWindowClassRouteString(IContext ctx, IWindow window)
 	{

--- a/src/Whim.Tests/Router/RouterManagerTests.cs
+++ b/src/Whim.Tests/Router/RouterManagerTests.cs
@@ -29,13 +29,25 @@ public class RouterManagerTests
 	[Theory]
 	[InlineAutoSubstituteData(true, RouterOptions.RouteToActiveWorkspace)]
 	[InlineAutoSubstituteData(false, RouterOptions.RouteToLaunchedWorkspace)]
-	public void RouteToActiveWorkspace(bool routeToActiveWorkspace, RouterOptions routerOptions, IContext ctx)
+	public void RouteToActiveWorkspace_Get(bool routeToActiveWorkspace, RouterOptions routerOptions, IContext ctx)
 	{
 		// Given
 		RouterManager routerManager = new(ctx) { RouterOptions = routerOptions };
 
 		// Then
 		Assert.Equal(routeToActiveWorkspace, routerManager.RouteToActiveWorkspace);
+	}
+
+	[Theory]
+	[InlineAutoSubstituteData(true, RouterOptions.RouteToActiveWorkspace)]
+	[InlineAutoSubstituteData(false, RouterOptions.RouteToLaunchedWorkspace)]
+	public void RouteToActiveWorkspace_Set(bool routeToActiveWorkspace, RouterOptions routerOptions, IContext ctx)
+	{
+		// Given
+		RouterManager routerManager = new(ctx) { RouteToActiveWorkspace = routeToActiveWorkspace };
+
+		// Then
+		Assert.Equal(routerOptions, routerManager.RouterOptions);
 	}
 
 	[Theory, AutoSubstituteData<RouterManagerCustomization>]

--- a/src/Whim.Tests/Workspace/WorkspaceManagerTests.cs
+++ b/src/Whim.Tests/Workspace/WorkspaceManagerTests.cs
@@ -1134,7 +1134,7 @@ public class WorkspaceManagerTests
 	}
 
 	[Theory, AutoSubstituteData<WorkspaceManagerCustomization>]
-	internal void WindowAdded_RouterToActive(
+	internal void WindowAdded_RouteToActiveWorkspace(
 		IContext ctx,
 		IInternalContext internalCtx,
 		IMonitor[] monitors,
@@ -1144,13 +1144,76 @@ public class WorkspaceManagerTests
 		// Given
 		IWorkspace[] workspaces = CreateWorkspaces(2);
 		WorkspaceManagerTestWrapper workspaceManager = CreateSut(ctx, internalCtx, workspaces);
+		workspaceManager.Activate(workspaces[0], monitors[0]);
 
 		ActivateWorkspacesOnMonitors(workspaceManager, workspaces, monitors);
 		ClearWorkspaceReceivedCalls(workspaces);
 
 		// There is a router which routes the window to the active workspace
 		ctx.RouterManager.RouteWindow(window).Returns((IWorkspace?)null);
-		ctx.RouterManager.RouteToActiveWorkspace.Returns(true);
+		ctx.RouterManager.RouterOptions.Returns(RouterOptions.RouteToActiveWorkspace);
+
+		// When a window is added
+		Assert.RaisedEvent<RouteEventArgs> routeEvent = Assert.Raises<RouteEventArgs>(
+			h => workspaceManager.WindowRouted += h,
+			h => workspaceManager.WindowRouted -= h,
+			() => workspaceManager.WindowAdded(window)
+		);
+
+		// Then the window is added to the active workspace
+		Assert_WindowAddedToWorkspace1(workspaces, window, routeEvent);
+	}
+
+	[Theory, AutoSubstituteData<WorkspaceManagerCustomization>]
+	internal void WindowAdded_RouteToLastTrackedActiveWorkspace(
+		IContext ctx,
+		IInternalContext internalCtx,
+		IMonitor[] monitors,
+		IWindow window
+	)
+	{
+		// Given
+		IWorkspace[] workspaces = CreateWorkspaces(2);
+		WorkspaceManagerTestWrapper workspaceManager = CreateSut(ctx, internalCtx, workspaces);
+		workspaceManager.Activate(workspaces[0], monitors[0]);
+
+		ActivateWorkspacesOnMonitors(workspaceManager, workspaces, monitors);
+		ClearWorkspaceReceivedCalls(workspaces);
+
+		// There is a router which routes the window to the last tracked active workspace
+		ctx.RouterManager.RouteWindow(window).Returns((IWorkspace?)null);
+		ctx.RouterManager.RouterOptions.Returns(RouterOptions.RouteToLastTrackedActiveWorkspace);
+
+		// When a window is added
+		Assert.RaisedEvent<RouteEventArgs> routeEvent = Assert.Raises<RouteEventArgs>(
+			h => workspaceManager.WindowRouted += h,
+			h => workspaceManager.WindowRouted -= h,
+			() => workspaceManager.WindowAdded(window)
+		);
+
+		// Then the window is added to the active workspace
+		Assert_WindowAddedToWorkspace1(workspaces, window, routeEvent);
+	}
+
+	[Theory, AutoSubstituteData<WorkspaceManagerCustomization>]
+	internal void WindowAdded_RouteToLaunchedWorkspace(
+		IContext ctx,
+		IInternalContext internalCtx,
+		IMonitor[] monitors,
+		IWindow window
+	)
+	{
+		// Given
+		IWorkspace[] workspaces = CreateWorkspaces(2);
+		WorkspaceManagerTestWrapper workspaceManager = CreateSut(ctx, internalCtx, workspaces);
+		workspaceManager.Activate(workspaces[0], monitors[0]);
+
+		ActivateWorkspacesOnMonitors(workspaceManager, workspaces, monitors);
+		ClearWorkspaceReceivedCalls(workspaces);
+
+		// There is a router which routes the window to the last tracked active workspace
+		ctx.RouterManager.RouteWindow(window).Returns((IWorkspace?)null);
+		ctx.RouterManager.RouterOptions.Returns(RouterOptions.RouteToLaunchedWorkspace);
 
 		// When a window is added
 		Assert.RaisedEvent<RouteEventArgs> routeEvent = Assert.Raises<RouteEventArgs>(

--- a/src/Whim/Monitor/IInternalMonitorManager.cs
+++ b/src/Whim/Monitor/IInternalMonitorManager.cs
@@ -3,6 +3,11 @@ namespace Whim;
 internal interface IInternalMonitorManager
 {
 	/// <summary>
+	/// The last <see cref="IMonitor"/> which received an event sent by Windows which Whim did not ignore.
+	/// </summary>
+	IMonitor LastWhimActiveMonitor { get; set; }
+
+	/// <summary>
 	/// Called when the window has been focused.
 	/// </summary>
 	/// <param name="window"></param>

--- a/src/Whim/Monitor/MonitorManager.cs
+++ b/src/Whim/Monitor/MonitorManager.cs
@@ -25,12 +25,11 @@ internal class MonitorManager : IInternalMonitorManager, IMonitorManager
 	private Monitor[] _monitors = Array.Empty<Monitor>();
 	private bool _disposedValue;
 
-	/// <summary>
-	/// The <see cref="IMonitor"/> which currently has focus.
-	/// </summary>
 	public IMonitor ActiveMonitor { get; private set; }
 
 	public IMonitor PrimaryMonitor { get; private set; }
+
+	public IMonitor LastWhimActiveMonitor { get; set; }
 
 	public int Length => _monitors.Length;
 
@@ -61,6 +60,7 @@ internal class MonitorManager : IInternalMonitorManager, IMonitorManager
 			(_monitors?.FirstOrDefault(m => m.IsPrimary)) ?? throw new Exception("No primary monitor found.");
 		ActiveMonitor = primaryMonitor;
 		PrimaryMonitor = primaryMonitor;
+		LastWhimActiveMonitor = primaryMonitor;
 	}
 
 	public void Initialize()
@@ -89,6 +89,11 @@ internal class MonitorManager : IInternalMonitorManager, IMonitorManager
 				Logger.Debug($"Setting active monitor to {monitor}");
 
 				ActiveMonitor = monitor;
+
+				if (window is not null)
+				{
+					LastWhimActiveMonitor = monitor;
+				}
 				break;
 			}
 		}

--- a/src/Whim/Monitor/MonitorManager.cs
+++ b/src/Whim/Monitor/MonitorManager.cs
@@ -74,9 +74,9 @@ internal class MonitorManager : IInternalMonitorManager, IMonitorManager
 
 	public void WindowFocused(IWindow? window)
 	{
-		Logger.Debug($"Focusing on {window}");
-
 		HWND hwnd = window?.Handle ?? _internalContext.CoreNativeManager.GetForegroundWindow();
+		Logger.Debug($"Focusing hwnd {hwnd}");
+
 		HMONITOR hMONITOR = _internalContext.CoreNativeManager.MonitorFromWindow(
 			hwnd,
 			MONITOR_FROM_FLAGS.MONITOR_DEFAULTTONEAREST

--- a/src/Whim/Router/IRouterManager.cs
+++ b/src/Whim/Router/IRouterManager.cs
@@ -8,36 +8,6 @@ namespace Whim;
 public delegate IWorkspace? Router(IWindow window);
 
 /// <summary>
-/// Describes how to route windows when they are added to Whim.
-/// </summary>
-public enum RouterOptions
-{
-	/// <summary>
-	/// Routes windows to the workspace which is currently active on the monitor the window is on.
-	/// </summary>
-	RouteToLaunchedWorkspace,
-
-	/// <summary>
-	/// Routes windows to the active workspace. This may lead to unexpected results, as the
-	/// <see cref="IMonitorManager.ActiveMonitor"/> and thus <see cref="IWorkspaceManager.ActiveWorkspace"/>
-	/// will be updated by every window event sent by Windows - even those which Whim ignores.
-	///
-	/// <br/>
-	///
-	/// For example, launching an app from the taskbar on Windows 11 will cause <c>Shell_TrayWnd</c>
-	/// to focus on the main monitor, overriding the <see cref="IMonitorManager.ActiveMonitor"/>.
-	/// As a result, the window will be routed to the workspace on the main monitor.
-	/// </summary>
-	RouteToActiveWorkspace,
-
-	/// <summary>
-	/// Routes windows to the workspace which last received an event sent by Windows which Whim
-	/// did not ignore.
-	/// </summary>
-	RouteToLastTrackedActiveWorkspace
-}
-
-/// <summary>
 /// Manages routers for <see cref="IWindow"/>s.
 /// </summary>
 public interface IRouterManager

--- a/src/Whim/Router/IRouterManager.cs
+++ b/src/Whim/Router/IRouterManager.cs
@@ -8,6 +8,36 @@ namespace Whim;
 public delegate IWorkspace? Router(IWindow window);
 
 /// <summary>
+/// Describes how to route windows when they are added to Whim.
+/// </summary>
+public enum RouterOptions
+{
+	/// <summary>
+	/// Routes windows to the workspace which is currently active on the monitor the window is on.
+	/// </summary>
+	RouteToLaunchedWorkspace,
+
+	/// <summary>
+	/// Routes windows to the active workspace. This may lead to unexpected results, as the
+	/// <see cref="IMonitorManager.ActiveMonitor"/> and thus <see cref="IWorkspaceManager.ActiveWorkspace"/>
+	/// will be updated by every window event sent by Windows - even those which Whim ignores.
+	///
+	/// <br/>
+	///
+	/// For example, launching an app from the taskbar on Windows 11 will cause <c>Shell_TrayWnd</c>
+	/// to focus on the main monitor, overriding the <see cref="IMonitorManager.ActiveMonitor"/>.
+	/// As a result, the window will be routed to the workspace on the main monitor.
+	/// </summary>
+	RouteToActiveWorkspace,
+
+	/// <summary>
+	/// Routes windows to the workspace which last received an event sent by Windows which Whim
+	/// did not ignore.
+	/// </summary>
+	RouteToLastTrackedActiveWorkspace
+}
+
+/// <summary>
 /// Manages routers for <see cref="IWindow"/>s.
 /// </summary>
 public interface IRouterManager
@@ -18,7 +48,14 @@ public interface IRouterManager
 	/// Defaults to <see langword="false"/>.
 	/// This is overridden by any other routers in this <see cref="IRouterManager"/>.
 	/// </summary>
+	[Obsolete("Use RouterOptions instead")]
 	bool RouteToActiveWorkspace { get; set; }
+
+	/// <summary>
+	/// Describes how to route windows when they are added to Whim. <see cref="RouteWindow(IWindow)"/>
+	/// takes precedence over this.
+	/// </summary>
+	RouterOptions RouterOptions { get; set; }
 
 	/// <summary>
 	/// Routes a window to a workspace.

--- a/src/Whim/Router/RouterManager.cs
+++ b/src/Whim/Router/RouterManager.cs
@@ -8,7 +8,13 @@ internal class RouterManager : IRouterManager
 	private readonly IContext _context;
 	private readonly List<Router> _routers = new();
 
-	public bool RouteToActiveWorkspace { get; set; }
+	public bool RouteToActiveWorkspace
+	{
+		get => RouterOptions == RouterOptions.RouteToActiveWorkspace;
+		set => RouterOptions = value ? RouterOptions.RouteToActiveWorkspace : RouterOptions.RouteToLaunchedWorkspace;
+	}
+
+	public RouterOptions RouterOptions { get; set; } = RouterOptions.RouteToLaunchedWorkspace;
 
 	public RouterManager(IContext context)
 	{

--- a/src/Whim/Router/RouterOptions.cs
+++ b/src/Whim/Router/RouterOptions.cs
@@ -1,0 +1,31 @@
+namespace Whim;
+
+/// <summary>
+/// Describes how to route windows when they are added to Whim.
+/// </summary>
+public enum RouterOptions
+{
+	/// <summary>
+	/// Routes windows to the workspace which is currently active on the monitor the window is on.
+	/// </summary>
+	RouteToLaunchedWorkspace,
+
+	/// <summary>
+	/// Routes windows to the active workspace. This may lead to unexpected results, as the
+	/// <see cref="IMonitorManager.ActiveMonitor"/> and thus <see cref="IWorkspaceManager.ActiveWorkspace"/>
+	/// will be updated by every window event sent by Windows - even those which Whim ignores.
+	///
+	/// <br/>
+	///
+	/// For example, launching an app from the taskbar on Windows 11 will cause <c>Shell_TrayWnd</c>
+	/// to focus on the main monitor, overriding the <see cref="IMonitorManager.ActiveMonitor"/>.
+	/// As a result, the window will be routed to the workspace on the main monitor.
+	/// </summary>
+	RouteToActiveWorkspace,
+
+	/// <summary>
+	/// Routes windows to the workspace which last received an event sent by Windows which Whim
+	/// did not ignore.
+	/// </summary>
+	RouteToLastTrackedActiveWorkspace
+}


### PR DESCRIPTION
This marks `IRouterManager.RouteToActiveWorkspace` as obsolete, and replaces it with `IRouterManager.RouterOptions`. `RouterOptions` adds the following options:

- `RouteToLaunchedWorkspace` - this routes windows to the workspace which is currently active on the monitor the window is on. This is the default behavior.
- `RouteToActiveWorkspace` - this routes windows to the active workspace. This may lead to unexpected results, as the `IMonitorManager.ActiveMonitor` and thus `IWorkspaceManager.ActiveWorkspace` will be updated by every window event sent by Windows - even those which Whim ignores. For example, launching an app from the taskbar on Windows 11 will cause `Shell_TrayWnd` to focus on the main monitor, overriding the `IMonitorManager.ActiveMonitor`. As a result, the window will be routed to the workspace on the main monitor.
- `RouteToLastTrackedActiveWorkspace` - this routes windows to the workspace which last received an event sent by Windows which Whim did not ignore.
  