### PR TITLE
`ILayoutEngine.FocusWindowInDirection` now returns `ILayoutEngine`

### DIFF
--- a/src/Whim.Bar.Tests/BarLayoutEngineTests.cs
+++ b/src/Whim.Bar.Tests/BarLayoutEngineTests.cs
@@ -51,6 +51,8 @@ public class BarLayoutEngineTests
 		// Then
 		Assert.NotSame(engine, newEngine);
 		Assert.Same(newEngine, newEngine2);
+		Assert.IsType<BarLayoutEngine>(newEngine);
+		Assert.IsType<BarLayoutEngine>(newEngine2);
 	}
 
 	[Theory, AutoSubstituteData]
@@ -81,6 +83,7 @@ public class BarLayoutEngineTests
 		// Then
 		innerLayoutEngine.Received(1).FocusWindowInDirection(direction, window);
 		Assert.Same(engine, newEngine);
+		Assert.IsType<BarLayoutEngine>(newEngine);
 	}
 
 	[Theory, AutoSubstituteData]
@@ -101,6 +104,7 @@ public class BarLayoutEngineTests
 
 		// Then
 		Assert.NotSame(engine, newEngine);
+		Assert.IsType<BarLayoutEngine>(newEngine);
 	}
 
 	[Theory, AutoSubstituteData]
@@ -137,6 +141,7 @@ public class BarLayoutEngineTests
 
 		// Then
 		Assert.NotSame(engine, newEngine);
+		Assert.IsType<BarLayoutEngine>(newEngine);
 	}
 
 	[Theory, AutoSubstituteData]
@@ -157,6 +162,7 @@ public class BarLayoutEngineTests
 
 		// Then
 		Assert.Same(engine, newEngine);
+		Assert.IsType<BarLayoutEngine>(newEngine);
 	}
 
 	[Theory, AutoSubstituteData]
@@ -177,6 +183,7 @@ public class BarLayoutEngineTests
 
 		// Then
 		Assert.NotSame(engine, newEngine);
+		Assert.IsType<BarLayoutEngine>(newEngine);
 	}
 
 	[Theory, AutoSubstituteData]
@@ -192,6 +199,7 @@ public class BarLayoutEngineTests
 
 		// Then
 		Assert.Same(engine, newEngine);
+		Assert.IsType<BarLayoutEngine>(newEngine);
 	}
 
 	[Theory, AutoSubstituteData]
@@ -207,6 +215,7 @@ public class BarLayoutEngineTests
 
 		// Then
 		Assert.NotSame(engine, newEngine);
+		Assert.IsType<BarLayoutEngine>(newEngine);
 	}
 
 	[Theory, AutoSubstituteData]
@@ -222,6 +231,7 @@ public class BarLayoutEngineTests
 
 		// Then
 		Assert.Same(engine, newEngine);
+		Assert.IsType<BarLayoutEngine>(newEngine);
 	}
 
 	[Theory, AutoSubstituteData]
@@ -242,6 +252,7 @@ public class BarLayoutEngineTests
 
 		// Then
 		Assert.NotSame(engine, newEngine);
+		Assert.IsType<BarLayoutEngine>(newEngine);
 	}
 
 	[Theory, AutoSubstituteData]
@@ -257,6 +268,7 @@ public class BarLayoutEngineTests
 
 		// Then
 		Assert.Same(engine, newEngine);
+		Assert.IsType<BarLayoutEngine>(newEngine);
 	}
 
 	[Theory, AutoSubstituteData]
@@ -346,6 +358,7 @@ public class BarLayoutEngineTests
 
 		// Then
 		Assert.NotSame(engine, newEngine);
+		Assert.IsType<BarLayoutEngine>(newEngine);
 	}
 
 	[Theory, AutoSubstituteData]
@@ -367,5 +380,6 @@ public class BarLayoutEngineTests
 
 		// Then
 		Assert.Same(engine, newEngine);
+		Assert.IsType<BarLayoutEngine>(newEngine);
 	}
 }

--- a/src/Whim.Bar.Tests/BarLayoutEngineTests.cs
+++ b/src/Whim.Bar.Tests/BarLayoutEngineTests.cs
@@ -73,12 +73,34 @@ public class BarLayoutEngineTests
 	{
 		// Given
 		BarLayoutEngine engine = CreateSut(innerLayoutEngine);
+		innerLayoutEngine.FocusWindowInDirection(direction, window).Returns(innerLayoutEngine);
 
 		// When
-		engine.FocusWindowInDirection(direction, window);
+		ILayoutEngine newEngine = engine.FocusWindowInDirection(direction, window);
 
 		// Then
 		innerLayoutEngine.Received(1).FocusWindowInDirection(direction, window);
+		Assert.Same(engine, newEngine);
+	}
+
+	[Theory, AutoSubstituteData]
+	public void FocusWindowInDirection_NotSame(
+		ILayoutEngine innerLayoutEngine,
+		ILayoutEngine focusWindowInDirectionResult,
+		IWindow window,
+		[Frozen] Direction direction
+	)
+	{
+		// Given
+		BarLayoutEngine engine = CreateSut(innerLayoutEngine);
+
+		innerLayoutEngine.FocusWindowInDirection(direction, window).Returns(focusWindowInDirectionResult);
+
+		// When
+		ILayoutEngine newEngine = engine.FocusWindowInDirection(direction, window);
+
+		// Then
+		Assert.NotSame(engine, newEngine);
 	}
 
 	[Theory, AutoSubstituteData]

--- a/src/Whim.Bar/BarLayoutEngine.cs
+++ b/src/Whim.Bar/BarLayoutEngine.cs
@@ -51,8 +51,8 @@ public record BarLayoutEngine : BaseProxyLayoutEngine
 	}
 
 	/// <inheritdoc />
-	public override void FocusWindowInDirection(Direction direction, IWindow window) =>
-		InnerLayoutEngine.FocusWindowInDirection(direction, window);
+	public override ILayoutEngine FocusWindowInDirection(Direction direction, IWindow window) =>
+		UpdateInner(InnerLayoutEngine.FocusWindowInDirection(direction, window));
 
 	/// <inheritdoc />
 	public override IWindow? GetFirstWindow() => InnerLayoutEngine.GetFirstWindow();

--- a/src/Whim.FloatingLayout.Tests/FloatingLayoutEngineTests.cs
+++ b/src/Whim.FloatingLayout.Tests/FloatingLayoutEngineTests.cs
@@ -1138,7 +1138,7 @@ public class FloatingLayoutEngineTests
 		ILayoutEngine newEngine = engine.PerformCustomAction(action);
 
 		// Then
-		Assert.NotSame(engine, newEngine);
+		Assert.Same(engine, newEngine);
 		innerLayoutEngine.Received(1).PerformCustomAction(action);
 	}
 

--- a/src/Whim.FloatingLayout.Tests/FloatingLayoutEngineTests.cs
+++ b/src/Whim.FloatingLayout.Tests/FloatingLayoutEngineTests.cs
@@ -745,12 +745,14 @@ public class FloatingLayoutEngineTests
 		innerLayoutEngine.GetFirstWindow().Returns(window);
 
 		// When
-		engine.FocusWindowInDirection(direction, window);
+		ILayoutEngine newEngine = engine.FocusWindowInDirection(direction, window);
 
 		// Then
 		innerLayoutEngine.Received(1).FocusWindowInDirection(direction, window);
 		innerLayoutEngine.DidNotReceive().GetFirstWindow();
 		window.DidNotReceive().Focus();
+		Assert.NotSame(engine, newEngine);
+		Assert.IsType<FloatingLayoutEngine>(newEngine);
 	}
 
 	[Theory, AutoSubstituteData<FloatingLayoutEngineCustomization>]
@@ -770,7 +772,7 @@ public class FloatingLayoutEngineTests
 		FloatingLayoutEngine engine = new(context, plugin, innerLayoutEngine);
 
 		// When
-		engine.AddWindow(window).FocusWindowInDirection(direction, window);
+		ILayoutEngine newEngine = engine.AddWindow(window).FocusWindowInDirection(direction, window);
 
 		// Then
 		innerLayoutEngine.DidNotReceive().FocusWindowInDirection(direction, window);
@@ -780,6 +782,8 @@ public class FloatingLayoutEngineTests
 		newInnerLayoutEngine.Received(1).GetFirstWindow();
 
 		window.DidNotReceive().Focus();
+		Assert.NotSame(engine, newEngine);
+		Assert.IsType<FloatingLayoutEngine>(newEngine);
 	}
 
 	[Theory, AutoSubstituteData<FloatingLayoutEngineCustomization>]
@@ -801,7 +805,7 @@ public class FloatingLayoutEngineTests
 		newInnerLayoutEngine.GetFirstWindow().Returns(window);
 
 		// When
-		engine.AddWindow(window).FocusWindowInDirection(direction, window);
+		ILayoutEngine newEngine = engine.AddWindow(window).FocusWindowInDirection(direction, window);
 
 		// Then
 		innerLayoutEngine.DidNotReceive().FocusWindowInDirection(direction, window);
@@ -811,6 +815,8 @@ public class FloatingLayoutEngineTests
 		newInnerLayoutEngine.Received(1).GetFirstWindow();
 
 		window.Received(1).Focus();
+		Assert.NotSame(engine, newEngine);
+		Assert.IsType<FloatingLayoutEngine>(newEngine);
 	}
 	#endregion
 
@@ -828,10 +834,12 @@ public class FloatingLayoutEngineTests
 		FloatingLayoutEngine engine = new(context, plugin, innerLayoutEngine);
 
 		// When
-		engine.SwapWindowInDirection(direction, window);
+		ILayoutEngine newEngine = engine.SwapWindowInDirection(direction, window);
 
 		// Then
 		innerLayoutEngine.Received(1).SwapWindowInDirection(direction, window);
+		Assert.NotSame(engine, newEngine);
+		Assert.IsType<FloatingLayoutEngine>(newEngine);
 	}
 
 	[Theory, AutoSubstituteData<FloatingLayoutEngineCustomization>]
@@ -849,10 +857,12 @@ public class FloatingLayoutEngineTests
 		innerLayoutEngine.SwapWindowInDirection(direction, window).Returns(innerLayoutEngine);
 
 		// When
-		engine.SwapWindowInDirection(direction, window);
+		ILayoutEngine newEngine = engine.SwapWindowInDirection(direction, window);
 
 		// Then
 		innerLayoutEngine.Received(1).SwapWindowInDirection(direction, window);
+		Assert.Same(engine, newEngine);
+		Assert.IsType<FloatingLayoutEngine>(newEngine);
 	}
 
 	[Theory, AutoSubstituteData<FloatingLayoutEngineCustomization>]
@@ -872,10 +882,12 @@ public class FloatingLayoutEngineTests
 		FloatingLayoutEngine engine = new(context, plugin, innerLayoutEngine);
 
 		// When
-		engine.AddWindow(window).SwapWindowInDirection(direction, window);
+		ILayoutEngine newEngine = engine.AddWindow(window).SwapWindowInDirection(direction, window);
 
 		// Then
 		innerLayoutEngine.DidNotReceive().SwapWindowInDirection(direction, window);
+		Assert.NotSame(engine, newEngine);
+		Assert.IsType<FloatingLayoutEngine>(newEngine);
 	}
 	#endregion
 
@@ -1114,6 +1126,7 @@ public class FloatingLayoutEngineTests
 
 		// Then
 		Assert.NotSame(engine, newEngine);
+		Assert.IsType<FloatingLayoutEngine>(newEngine);
 	}
 
 	[Theory, AutoSubstituteData<FloatingLayoutEngineCustomization>]
@@ -1140,6 +1153,7 @@ public class FloatingLayoutEngineTests
 		// Then
 		Assert.Same(engine, newEngine);
 		innerLayoutEngine.Received(1).PerformCustomAction(action);
+		Assert.IsType<FloatingLayoutEngine>(newEngine);
 	}
 
 	[Theory, AutoSubstituteData<FloatingLayoutEngineCustomization>]
@@ -1169,6 +1183,7 @@ public class FloatingLayoutEngineTests
 		Assert.NotSame(engine, newEngine);
 		Assert.Same(newEngine, newEngine2);
 		innerLayoutEngine.DidNotReceive().PerformCustomAction(action);
+		Assert.IsType<FloatingLayoutEngine>(newEngine);
 	}
 	#endregion
 }

--- a/src/Whim.FloatingLayout/FloatingLayoutEngine.cs
+++ b/src/Whim.FloatingLayout/FloatingLayoutEngine.cs
@@ -215,7 +215,7 @@ internal record FloatingLayoutEngine : BaseProxyLayoutEngine
 	}
 
 	/// <inheritdoc />
-	public override void FocusWindowInDirection(Direction direction, IWindow window)
+	public override ILayoutEngine FocusWindowInDirection(Direction direction, IWindow window)
 	{
 		if (IsWindowFloating(window))
 		{
@@ -223,10 +223,10 @@ internal record FloatingLayoutEngine : BaseProxyLayoutEngine
 			// a given point.
 			// As a workaround, we just focus the first window.
 			InnerLayoutEngine.GetFirstWindow()?.Focus();
-			return;
+			return this;
 		}
 
-		InnerLayoutEngine.FocusWindowInDirection(direction, window);
+		return UpdateInner(InnerLayoutEngine.FocusWindowInDirection(direction, window), window);
 	}
 
 	/// <inheritdoc />
@@ -240,7 +240,7 @@ internal record FloatingLayoutEngine : BaseProxyLayoutEngine
 			return this;
 		}
 
-		return InnerLayoutEngine.SwapWindowInDirection(direction, window);
+		return UpdateInner(InnerLayoutEngine.SwapWindowInDirection(direction, window), window);
 	}
 
 	/// <inheritdoc />
@@ -258,6 +258,6 @@ internal record FloatingLayoutEngine : BaseProxyLayoutEngine
 			return this;
 		}
 
-		return InnerLayoutEngine.PerformCustomAction(action);
+		return UpdateInner(InnerLayoutEngine.PerformCustomAction(action), action.Window);
 	}
 }

--- a/src/Whim.Gaps.Tests/GapsLayoutEngineTests.cs
+++ b/src/Whim.Gaps.Tests/GapsLayoutEngineTests.cs
@@ -443,18 +443,42 @@ public class GapsLayoutEngineTests
 	}
 
 	[Theory, AutoSubstituteData]
-	public void FocusWindowInDirection(IWindow window, ILayoutEngine innerLayoutEngine)
+	public void FocusWindowInDirection_Same(IWindow window, ILayoutEngine innerLayoutEngine)
 	{
 		// Given
 		Direction direction = Direction.Left;
 		GapsConfig gapsConfig = new() { OuterGap = 10, InnerGap = 5 };
 
 		GapsLayoutEngine gapsLayoutEngine = new(gapsConfig, innerLayoutEngine);
+		innerLayoutEngine.FocusWindowInDirection(direction, window).Returns(innerLayoutEngine);
 
 		// When
-		gapsLayoutEngine.FocusWindowInDirection(direction, window);
+		ILayoutEngine newLayoutEngine = gapsLayoutEngine.FocusWindowInDirection(direction, window);
 
 		// Then
+		Assert.Same(gapsLayoutEngine, newLayoutEngine);
+		innerLayoutEngine.Received(1).FocusWindowInDirection(direction, window);
+	}
+
+	[Theory, AutoSubstituteData]
+	public void FocusWindowInDirection_NotSame(
+		IWindow window,
+		ILayoutEngine innerLayoutEngine,
+		ILayoutEngine newInnerLayoutEngine
+	)
+	{
+		// Given
+		Direction direction = Direction.Left;
+		GapsConfig gapsConfig = new() { OuterGap = 10, InnerGap = 5 };
+		innerLayoutEngine.FocusWindowInDirection(direction, window).Returns(newInnerLayoutEngine);
+
+		GapsLayoutEngine gapsLayoutEngine = new(gapsConfig, innerLayoutEngine);
+
+		// When
+		ILayoutEngine newLayoutEngine = gapsLayoutEngine.FocusWindowInDirection(direction, window);
+
+		// Then
+		Assert.NotSame(gapsLayoutEngine, newLayoutEngine);
 		innerLayoutEngine.Received(1).FocusWindowInDirection(direction, window);
 	}
 

--- a/src/Whim.Gaps.Tests/GapsLayoutEngineTests.cs
+++ b/src/Whim.Gaps.Tests/GapsLayoutEngineTests.cs
@@ -457,6 +457,7 @@ public class GapsLayoutEngineTests
 
 		// Then
 		Assert.Same(gapsLayoutEngine, newLayoutEngine);
+		Assert.IsType<GapsLayoutEngine>(newLayoutEngine);
 		innerLayoutEngine.Received(1).FocusWindowInDirection(direction, window);
 	}
 
@@ -479,6 +480,7 @@ public class GapsLayoutEngineTests
 
 		// Then
 		Assert.NotSame(gapsLayoutEngine, newLayoutEngine);
+		Assert.IsType<GapsLayoutEngine>(newLayoutEngine);
 		innerLayoutEngine.Received(1).FocusWindowInDirection(direction, window);
 	}
 
@@ -497,6 +499,7 @@ public class GapsLayoutEngineTests
 
 		// Then
 		Assert.Same(gapsLayoutEngine, newLayoutEngine);
+		Assert.IsType<GapsLayoutEngine>(newLayoutEngine);
 		innerLayoutEngine.Received(1).AddWindow(window);
 	}
 
@@ -514,6 +517,7 @@ public class GapsLayoutEngineTests
 
 		// Then
 		Assert.NotSame(gapsLayoutEngine, newLayoutEngine);
+		Assert.IsType<GapsLayoutEngine>(newLayoutEngine);
 		innerLayoutEngine.Received(1).AddWindow(window);
 	}
 	#endregion
@@ -533,6 +537,7 @@ public class GapsLayoutEngineTests
 
 		// Then
 		Assert.Same(gapsLayoutEngine, newLayoutEngine);
+		Assert.IsType<GapsLayoutEngine>(newLayoutEngine);
 		innerLayoutEngine.Received(1).RemoveWindow(window);
 	}
 
@@ -550,6 +555,7 @@ public class GapsLayoutEngineTests
 
 		// Then
 		Assert.NotSame(gapsLayoutEngine, newLayoutEngine);
+		Assert.IsType<GapsLayoutEngine>(newLayoutEngine);
 		innerLayoutEngine.Received(1).RemoveWindow(window);
 	}
 	#endregion
@@ -571,6 +577,7 @@ public class GapsLayoutEngineTests
 
 		// Then
 		Assert.Same(gapsLayoutEngine, newLayoutEngine);
+		Assert.IsType<GapsLayoutEngine>(newLayoutEngine);
 		innerLayoutEngine.Received(1).MoveWindowEdgesInDirection(direction, deltas, window);
 	}
 
@@ -594,6 +601,7 @@ public class GapsLayoutEngineTests
 
 		// Then
 		Assert.NotSame(gapsLayoutEngine, newLayoutEngine);
+		Assert.IsType<GapsLayoutEngine>(newLayoutEngine);
 		innerLayoutEngine.Received(1).MoveWindowEdgesInDirection(direction, deltas, window);
 	}
 	#endregion
@@ -614,6 +622,7 @@ public class GapsLayoutEngineTests
 
 		// Then
 		Assert.Same(gapsLayoutEngine, newLayoutEngine);
+		Assert.IsType<GapsLayoutEngine>(newLayoutEngine);
 		innerLayoutEngine.Received(1).MoveWindowToPoint(window, point);
 	}
 
@@ -636,6 +645,7 @@ public class GapsLayoutEngineTests
 
 		// Then
 		Assert.NotSame(gapsLayoutEngine, newLayoutEngine);
+		Assert.IsType<GapsLayoutEngine>(newLayoutEngine);
 		innerLayoutEngine.Received(1).MoveWindowToPoint(window, point);
 	}
 	#endregion
@@ -656,6 +666,7 @@ public class GapsLayoutEngineTests
 
 		// Then
 		Assert.Same(gapsLayoutEngine, newLayoutEngine);
+		Assert.IsType<GapsLayoutEngine>(newLayoutEngine);
 		innerLayoutEngine.Received(1).SwapWindowInDirection(direction, window);
 	}
 
@@ -678,6 +689,7 @@ public class GapsLayoutEngineTests
 
 		// Then
 		Assert.NotSame(gapsLayoutEngine, newLayoutEngine);
+		Assert.IsType<GapsLayoutEngine>(newLayoutEngine);
 		innerLayoutEngine.Received(1).SwapWindowInDirection(direction, window);
 	}
 	#endregion
@@ -721,6 +733,7 @@ public class GapsLayoutEngineTests
 
 		// Then
 		Assert.NotSame(gapsLayoutEngine, newLayoutEngine);
+		Assert.IsType<GapsLayoutEngine>(newLayoutEngine);
 		innerLayoutEngine.Received(1).PerformCustomAction(action);
 	}
 
@@ -746,6 +759,7 @@ public class GapsLayoutEngineTests
 
 		// Then
 		Assert.Same(gapsLayoutEngine, newLayoutEngine);
+		Assert.IsType<GapsLayoutEngine>(newLayoutEngine);
 		innerLayoutEngine.Received(1).PerformCustomAction(action);
 	}
 }

--- a/src/Whim.Gaps/GapsLayoutEngine.cs
+++ b/src/Whim.Gaps/GapsLayoutEngine.cs
@@ -96,8 +96,8 @@ public record GapsLayoutEngine : BaseProxyLayoutEngine
 	}
 
 	/// <inheritdoc />
-	public override void FocusWindowInDirection(Direction direction, IWindow window) =>
-		InnerLayoutEngine.FocusWindowInDirection(direction, window);
+	public override ILayoutEngine FocusWindowInDirection(Direction direction, IWindow window) =>
+		UpdateInner(InnerLayoutEngine.FocusWindowInDirection(direction, window));
 
 	/// <inheritdoc />
 	public override IWindow? GetFirstWindow() => InnerLayoutEngine.GetFirstWindow();

--- a/src/Whim.SliceLayout.Tests/SliceLayoutEngine/FocusWindowInDirectionTests.cs
+++ b/src/Whim.SliceLayout.Tests/SliceLayoutEngine/FocusWindowInDirectionTests.cs
@@ -51,11 +51,13 @@ public class FocusWindowInDirectionTests
 			sut = sut.AddWindow(window);
 		}
 
-		sut.FocusWindowInDirection(direction, windows[focusedWindowIdx]);
-		sut.FocusWindowInDirection(direction, windows[focusedWindowIdx]);
+		ILayoutEngine newEngine1 = sut.FocusWindowInDirection(direction, windows[focusedWindowIdx]);
+		ILayoutEngine newEngine2 = sut.FocusWindowInDirection(direction, windows[focusedWindowIdx]);
 
 		// Then
 		windows[expectedWindowIdx].Received(2).Focus();
+		Assert.Same(sut, newEngine1);
+		Assert.Same(newEngine1, newEngine2);
 	}
 
 	public static IEnumerable<object[]> FocusWindowInDirection_NoWindowInDirection_Data()

--- a/src/Whim.SliceLayout/SliceLayoutEngine.cs
+++ b/src/Whim.SliceLayout/SliceLayoutEngine.cs
@@ -147,10 +147,11 @@ public partial record SliceLayoutEngine : ILayoutEngine
 	}
 
 	/// <inheritdoc />
-	public void FocusWindowInDirection(Direction direction, IWindow window)
+	public ILayoutEngine FocusWindowInDirection(Direction direction, IWindow window)
 	{
 		Logger.Debug($"Focusing window in direction {direction} from {window}");
 		GetWindowInDirection(direction, window)?.Focus();
+		return this;
 	}
 
 	/// <inheritdoc />

--- a/src/Whim.TestUtils/TestLayoutEngine.cs
+++ b/src/Whim.TestUtils/TestLayoutEngine.cs
@@ -31,7 +31,8 @@ public record TestLayoutEngine : ILayoutEngine
 		throw new NotImplementedException();
 
 	/// <inheritdoc/>
-	public ILayoutEngine FocusWindowInDirection(Direction direction, IWindow window) => throw new NotImplementedException();
+	public ILayoutEngine FocusWindowInDirection(Direction direction, IWindow window) =>
+		throw new NotImplementedException();
 
 	/// <inheritdoc/>
 	public IWindow? GetFirstWindow() => throw new NotImplementedException();

--- a/src/Whim.TestUtils/TestLayoutEngine.cs
+++ b/src/Whim.TestUtils/TestLayoutEngine.cs
@@ -31,7 +31,7 @@ public record TestLayoutEngine : ILayoutEngine
 		throw new NotImplementedException();
 
 	/// <inheritdoc/>
-	public void FocusWindowInDirection(Direction direction, IWindow window) => throw new NotImplementedException();
+	public ILayoutEngine FocusWindowInDirection(Direction direction, IWindow window) => throw new NotImplementedException();
 
 	/// <inheritdoc/>
 	public IWindow? GetFirstWindow() => throw new NotImplementedException();

--- a/src/Whim.Tests/Workspace/WorkspaceTests.cs
+++ b/src/Whim.Tests/Workspace/WorkspaceTests.cs
@@ -749,11 +749,13 @@ public class WorkspaceTests
 		Workspace workspace = new(ctx, internalCtx, triggers, "Workspace", new ILayoutEngine[] { layoutEngine });
 		workspace.AddWindow(window);
 
+		ILayoutEngine focusLayoutEngine = workspace.ActiveLayoutEngine;
+
 		// When FocusWindowInDirection is called
 		workspace.FocusWindowInDirection(Direction.Up, window);
 
 		// Then the layout engine is told to focus the window
-		workspace.ActiveLayoutEngine.Received(1).FocusWindowInDirection(Direction.Up, window);
+		focusLayoutEngine.Received(1).FocusWindowInDirection(Direction.Up, window);
 	}
 
 	[Theory, AutoSubstituteData<WorkspaceCustomization>]

--- a/src/Whim.Tests/Workspace/WorkspaceTests.cs
+++ b/src/Whim.Tests/Workspace/WorkspaceTests.cs
@@ -72,12 +72,14 @@ public class WorkspaceTests
 	{
 		// Given
 		Workspace workspace = new(ctx, internalCtx, triggers, "Workspace", new ILayoutEngine[] { layoutEngine });
+		ILayoutEngine activeLayoutEngine = workspace.ActiveLayoutEngine;
 
 		// When
 		bool result = workspace.TrySetLayoutEngine("Layout2");
 
 		// Then
 		Assert.False(result);
+		Assert.Same(activeLayoutEngine, workspace.ActiveLayoutEngine);
 	}
 
 	[Theory, AutoSubstituteData<WorkspaceCustomization>]
@@ -93,12 +95,14 @@ public class WorkspaceTests
 		layoutEngine.Name.Returns("Layout");
 
 		Workspace workspace = new(ctx, internalCtx, triggers, "Workspace", new ILayoutEngine[] { layoutEngine });
+		ILayoutEngine activeLayoutEngine = workspace.ActiveLayoutEngine;
 
 		// When
 		bool result = workspace.TrySetLayoutEngine("Layout");
 
 		// Then
 		Assert.True(result);
+		Assert.Same(activeLayoutEngine, workspace.ActiveLayoutEngine);
 	}
 
 	[Theory, AutoSubstituteData<WorkspaceCustomization>]
@@ -115,12 +119,14 @@ public class WorkspaceTests
 
 		Workspace workspace =
 			new(ctx, internalCtx, triggers, "Workspace", new ILayoutEngine[] { layoutEngine, layoutEngine2 });
+		ILayoutEngine activeLayoutEngine = workspace.ActiveLayoutEngine;
 
 		// When
 		bool result = workspace.TrySetLayoutEngine("Layout2");
 
 		// Then
 		Assert.True(result);
+		Assert.NotSame(activeLayoutEngine, workspace.ActiveLayoutEngine);
 	}
 
 	[Theory, AutoSubstituteData<WorkspaceCustomization>]
@@ -423,12 +429,14 @@ public class WorkspaceTests
 		// Given
 		Workspace workspace =
 			new(ctx, internalCtx, triggers, "Workspace", new ILayoutEngine[] { layoutEngine, layoutEngine2 });
+		ILayoutEngine givenEngine = workspace.ActiveLayoutEngine;
 
 		// When NextLayoutEngine is called
 		workspace.NextLayoutEngine();
 
 		// Then the active layout engine is set to the next one
 		Assert.True(Object.ReferenceEquals(layoutEngine2, workspace.ActiveLayoutEngine));
+		Assert.NotSame(givenEngine, workspace.ActiveLayoutEngine);
 	}
 
 	[Theory, AutoSubstituteData<WorkspaceCustomization>]
@@ -444,12 +452,15 @@ public class WorkspaceTests
 		Workspace workspace =
 			new(ctx, internalCtx, triggers, "Workspace", new ILayoutEngine[] { layoutEngine, layoutEngine2 });
 
+		ILayoutEngine givenEngine = workspace.ActiveLayoutEngine;
+
 		// When NextLayoutEngine is called
 		workspace.NextLayoutEngine();
 		workspace.NextLayoutEngine();
 
 		// Then the active layout engine is set to the first one
 		Assert.True(Object.ReferenceEquals(layoutEngine, workspace.ActiveLayoutEngine));
+		Assert.Same(givenEngine, workspace.ActiveLayoutEngine);
 	}
 
 	[Theory, AutoSubstituteData<WorkspaceCustomization>]
@@ -464,12 +475,14 @@ public class WorkspaceTests
 		// Given
 		Workspace workspace =
 			new(ctx, internalCtx, triggers, "Workspace", new ILayoutEngine[] { layoutEngine, layoutEngine2 });
+		ILayoutEngine givenEngine = workspace.ActiveLayoutEngine;
 
 		// When PreviousLayoutEngine is called
 		workspace.PreviousLayoutEngine();
 
 		// Then the active layout engine is set to the previous one
 		Assert.True(Object.ReferenceEquals(layoutEngine2, workspace.ActiveLayoutEngine));
+		Assert.NotSame(givenEngine, workspace.ActiveLayoutEngine);
 	}
 
 	[Theory, AutoSubstituteData<WorkspaceCustomization>]
@@ -484,6 +497,7 @@ public class WorkspaceTests
 		// Given
 		Workspace workspace =
 			new(ctx, internalCtx, triggers, "Workspace", new ILayoutEngine[] { layoutEngine, layoutEngine2 });
+		ILayoutEngine givenEngine = workspace.ActiveLayoutEngine;
 
 		// When PreviousLayoutEngine is called
 		workspace.PreviousLayoutEngine();
@@ -491,6 +505,7 @@ public class WorkspaceTests
 
 		// Then the active layout engine is set to the last one
 		Assert.True(Object.ReferenceEquals(layoutEngine, workspace.ActiveLayoutEngine));
+		Assert.Same(givenEngine, workspace.ActiveLayoutEngine);
 	}
 
 	[Theory, AutoSubstituteData<WorkspaceCustomization>]
@@ -526,6 +541,7 @@ public class WorkspaceTests
 	{
 		// Given
 		Workspace workspace = new(ctx, internalCtx, triggers, "Workspace", new ILayoutEngine[] { layoutEngine });
+		ILayoutEngine givenEngine = workspace.ActiveLayoutEngine;
 
 		// When AddWindow is called
 		workspace.AddWindow(window);
@@ -534,6 +550,7 @@ public class WorkspaceTests
 		layoutEngine.Received(1).AddWindow(window);
 		ctx.WorkspaceManager.Received(1).GetMonitorForWorkspace(workspace);
 		window.Received(1).Focus();
+		Assert.NotSame(givenEngine, workspace.ActiveLayoutEngine);
 	}
 
 	[Theory, AutoSubstituteData<WorkspaceCustomization>]
@@ -549,6 +566,7 @@ public class WorkspaceTests
 		Workspace workspace = new(ctx, internalCtx, triggers, "Workspace", new ILayoutEngine[] { layoutEngine });
 		workspace.AddWindow(window);
 		workspace.WindowMinimizeStart(window);
+		ILayoutEngine givenEngine = workspace.ActiveLayoutEngine;
 
 		// When AddWindow is called
 		workspace.AddWindow(window);
@@ -557,6 +575,7 @@ public class WorkspaceTests
 		layoutEngine.Received(1).AddWindow(window);
 		ctx.WorkspaceManager.Received(3).GetMonitorForWorkspace(workspace);
 		window.Received(2).Focus();
+		Assert.NotSame(givenEngine, workspace.ActiveLayoutEngine);
 	}
 
 	#region RemoveWindow
@@ -574,12 +593,14 @@ public class WorkspaceTests
 
 		// When RemoveWindow is called
 		workspace.RemoveWindow(window);
+		ILayoutEngine givenEngine = workspace.ActiveLayoutEngine;
 		bool result = workspace.RemoveWindow(window);
 
 		// Then the window is removed from the layout engine
 		Assert.False(result);
 		layoutEngine.DidNotReceive().RemoveWindow(window);
 		internalCtx.CoreNativeManager.DidNotReceive().IsWindow(Arg.Any<HWND>());
+		Assert.Same(givenEngine, workspace.ActiveLayoutEngine);
 	}
 
 	[Theory, AutoSubstituteData<WorkspaceCustomization>]
@@ -608,6 +629,7 @@ public class WorkspaceTests
 		givenEngine.Received(1).RemoveWindow(window);
 		internalCtx.CoreNativeManager.DidNotReceive().IsWindow(Arg.Any<HWND>());
 		Assert.Null(workspace.LastFocusedWindow);
+		Assert.Same(givenEngine, workspace.ActiveLayoutEngine);
 	}
 
 	[Theory, AutoSubstituteData<WorkspaceCustomization>]
@@ -636,6 +658,7 @@ public class WorkspaceTests
 		givenEngine.Received(1).RemoveWindow(window);
 		ctx.WorkspaceManager.Received(1).GetMonitorForWorkspace(workspace);
 		Assert.Null(workspace.LastFocusedWindow);
+		Assert.NotSame(givenEngine, workspace.ActiveLayoutEngine);
 	}
 
 	[Theory, AutoSubstituteData<WorkspaceCustomization>]
@@ -666,6 +689,7 @@ public class WorkspaceTests
 		givenEngine.Received(1).RemoveWindow(window);
 		ctx.WorkspaceManager.Received(1).GetMonitorForWorkspace(workspace);
 		Assert.Equal(window2, workspace.LastFocusedWindow);
+		Assert.NotSame(givenEngine, workspace.ActiveLayoutEngine);
 	}
 
 	[Theory, AutoSubstituteData<WorkspaceCustomization>]
@@ -685,6 +709,7 @@ public class WorkspaceTests
 
 		ctx.WorkspaceManager.ClearReceivedCalls();
 		internalCtx.CoreNativeManager.ClearReceivedCalls();
+		ILayoutEngine givenEngine = workspace.ActiveLayoutEngine;
 
 		// When RemoveWindow is called
 		bool result = workspace.RemoveWindow(window);
@@ -693,6 +718,7 @@ public class WorkspaceTests
 		Assert.True(result);
 		layoutEngine.DidNotReceive().RemoveWindow(window);
 		ctx.WorkspaceManager.Received(1).GetMonitorForWorkspace(workspace);
+		Assert.Same(givenEngine, workspace.ActiveLayoutEngine);
 	}
 	#endregion
 
@@ -707,12 +733,14 @@ public class WorkspaceTests
 	{
 		// Given
 		Workspace workspace = new(ctx, internalCtx, triggers, "Workspace", new ILayoutEngine[] { layoutEngine });
+		ILayoutEngine activeLayoutEngine = workspace.ActiveLayoutEngine;
 
 		// When FocusWindowInDirection is called
 		workspace.FocusWindowInDirection(Direction.Up, window);
 
 		// Then the layout engine is not told to focus the window
 		layoutEngine.DidNotReceive().FocusWindowInDirection(Direction.Up, window);
+		Assert.Same(activeLayoutEngine, workspace.ActiveLayoutEngine);
 	}
 
 	[Theory, AutoSubstituteData<WorkspaceCustomization>]
@@ -728,12 +756,14 @@ public class WorkspaceTests
 		Workspace workspace = new(ctx, internalCtx, triggers, "Workspace", new ILayoutEngine[] { layoutEngine });
 		workspace.AddWindow(window);
 		workspace.WindowMinimizeStart(window);
+		ILayoutEngine activeLayoutEngine = workspace.ActiveLayoutEngine;
 
 		// When FocusWindowInDirection is called
 		workspace.FocusWindowInDirection(Direction.Up, window);
 
 		// Then the layout engine is not told to focus the window
 		layoutEngine.DidNotReceive().FocusWindowInDirection(Direction.Up, window);
+		Assert.Same(activeLayoutEngine, workspace.ActiveLayoutEngine);
 	}
 
 	[Theory, AutoSubstituteData<WorkspaceCustomization>]
@@ -748,14 +778,13 @@ public class WorkspaceTests
 		// Given
 		Workspace workspace = new(ctx, internalCtx, triggers, "Workspace", new ILayoutEngine[] { layoutEngine });
 		workspace.AddWindow(window);
-
-		ILayoutEngine focusLayoutEngine = workspace.ActiveLayoutEngine;
+		ILayoutEngine activeLayoutEngine = workspace.ActiveLayoutEngine;
 
 		// When FocusWindowInDirection is called
 		workspace.FocusWindowInDirection(Direction.Up, window);
 
 		// Then the layout engine is told to focus the window
-		focusLayoutEngine.Received(1).FocusWindowInDirection(Direction.Up, window);
+		activeLayoutEngine.Received(1).FocusWindowInDirection(Direction.Up, window);
 	}
 
 	[Theory, AutoSubstituteData<WorkspaceCustomization>]
@@ -768,12 +797,14 @@ public class WorkspaceTests
 	{
 		// Given
 		Workspace workspace = new(ctx, internalCtx, triggers, "Workspace", new ILayoutEngine[] { layoutEngine });
+		ILayoutEngine activeLayoutEngine = workspace.ActiveLayoutEngine;
 
 		// When SwapWindowInDirection is called
 		workspace.SwapWindowInDirection(Direction.Up, null);
 
 		// Then the layout engine is not told to swap the window
 		layoutEngine.DidNotReceive().SwapWindowInDirection(Direction.Up, Arg.Any<IWindow>());
+		Assert.Same(activeLayoutEngine, workspace.ActiveLayoutEngine);
 	}
 
 	[Theory, AutoSubstituteData<WorkspaceCustomization>]
@@ -787,12 +818,14 @@ public class WorkspaceTests
 	{
 		// Given
 		Workspace workspace = new(ctx, internalCtx, triggers, "Workspace", new ILayoutEngine[] { layoutEngine });
+		ILayoutEngine activeLayoutEngine = workspace.ActiveLayoutEngine;
 
 		// When SwapWindowInDirection is called
 		workspace.SwapWindowInDirection(Direction.Up, window);
 
 		// Then the layout engine is not told to swap the window
 		layoutEngine.DidNotReceive().SwapWindowInDirection(Direction.Up, window);
+		Assert.Same(activeLayoutEngine, workspace.ActiveLayoutEngine);
 	}
 
 	[Theory, AutoSubstituteData<WorkspaceCustomization>]
@@ -807,6 +840,7 @@ public class WorkspaceTests
 		// Given
 		Workspace workspace = new(ctx, internalCtx, triggers, "Workspace", new ILayoutEngine[] { layoutEngine });
 		workspace.AddWindow(window);
+		ILayoutEngine activeLayoutEngine = workspace.ActiveLayoutEngine;
 
 		ILayoutEngine givenEngine = workspace.ActiveLayoutEngine;
 
@@ -815,6 +849,7 @@ public class WorkspaceTests
 
 		// Then the layout engine is told to swap the window
 		givenEngine.Received(1).SwapWindowInDirection(Direction.Up, window);
+		Assert.NotSame(activeLayoutEngine, workspace.ActiveLayoutEngine);
 	}
 
 	[Theory, AutoSubstituteData<WorkspaceCustomization>]
@@ -828,12 +863,14 @@ public class WorkspaceTests
 		// Given
 		Workspace workspace = new(ctx, internalCtx, triggers, "Workspace", new ILayoutEngine[] { layoutEngine });
 		IPoint<double> deltas = new Point<double>() { X = 0.3, Y = 0 };
+		ILayoutEngine activeLayoutEngine = workspace.ActiveLayoutEngine;
 
 		// When MoveWindowEdgesInDirection is called
 		workspace.MoveWindowEdgesInDirection(Direction.Up, deltas, null);
 
 		// Then the layout engine is not told to move the window
 		layoutEngine.DidNotReceive().MoveWindowEdgesInDirection(Direction.Up, deltas, Arg.Any<IWindow>());
+		Assert.Same(activeLayoutEngine, workspace.ActiveLayoutEngine);
 	}
 
 	[Theory, AutoSubstituteData<WorkspaceCustomization>]
@@ -848,12 +885,14 @@ public class WorkspaceTests
 		// Given
 		Workspace workspace = new(ctx, internalCtx, triggers, "Workspace", new ILayoutEngine[] { layoutEngine });
 		IPoint<double> deltas = new Point<double>() { X = 0.3, Y = 0 };
+		ILayoutEngine activeLayoutEngine = workspace.ActiveLayoutEngine;
 
 		// When MoveWindowEdgesInDirection is called
 		workspace.MoveWindowEdgesInDirection(Direction.Up, deltas, window);
 
 		// Then the layout engine is not told to move the window
 		layoutEngine.DidNotReceive().MoveWindowEdgesInDirection(Direction.Up, deltas, window);
+		Assert.Same(activeLayoutEngine, workspace.ActiveLayoutEngine);
 	}
 
 	[Theory, AutoSubstituteData<WorkspaceCustomization>]
@@ -870,12 +909,14 @@ public class WorkspaceTests
 		workspace.AddWindow(window);
 		IPoint<double> deltas = new Point<double>() { X = 0.3, Y = 0 };
 		ILayoutEngine givenEngine = workspace.ActiveLayoutEngine;
+		ILayoutEngine activeLayoutEngine = workspace.ActiveLayoutEngine;
 
 		// When MoveWindowEdgesInDirection is called
 		workspace.MoveWindowEdgesInDirection(Direction.Up, deltas, window);
 
 		// Then the layout engine is told to move the window
 		givenEngine.Received(1).MoveWindowEdgesInDirection(Direction.Up, deltas, window);
+		Assert.NotSame(activeLayoutEngine, workspace.ActiveLayoutEngine);
 	}
 
 	[Theory, AutoSubstituteData<WorkspaceCustomization>]
@@ -891,6 +932,7 @@ public class WorkspaceTests
 		Workspace workspace = new(ctx, internalCtx, triggers, "Workspace", new ILayoutEngine[] { layoutEngine });
 		IPoint<double> point = new Point<double>() { X = 0.3, Y = 0.3 };
 		window.ClearReceivedCalls();
+		ILayoutEngine activeLayoutEngine = workspace.ActiveLayoutEngine;
 
 		// When MoveWindowToPoint is called
 		workspace.MoveWindowToPoint(window, point);
@@ -899,6 +941,7 @@ public class WorkspaceTests
 		layoutEngine.Received(1).MoveWindowToPoint(window, point);
 		layoutEngine.DidNotReceive().RemoveWindow(window);
 		window.Received(1).Focus();
+		Assert.NotSame(activeLayoutEngine, workspace.ActiveLayoutEngine);
 	}
 
 	[Theory, AutoSubstituteData<WorkspaceCustomization>]
@@ -920,6 +963,8 @@ public class WorkspaceTests
 		ILayoutEngine givenEngine = workspace.ActiveLayoutEngine;
 		window.ClearReceivedCalls();
 
+		ILayoutEngine activeLayoutEngine = workspace.ActiveLayoutEngine;
+
 		// When MoveWindowToPoint is called
 		workspace.MoveWindowToPoint(window, point);
 
@@ -927,6 +972,7 @@ public class WorkspaceTests
 		givenEngine.Received(1).MoveWindowToPoint(window, point);
 		givenEngine.DidNotReceive().RemoveWindow(window);
 		window.Received(1).Focus();
+		Assert.NotSame(activeLayoutEngine, workspace.ActiveLayoutEngine);
 	}
 
 	[Theory, AutoSubstituteData<WorkspaceCustomization>]
@@ -946,12 +992,15 @@ public class WorkspaceTests
 		ILayoutEngine givenEngine = workspace.ActiveLayoutEngine;
 		window.ClearReceivedCalls();
 
+		ILayoutEngine activeLayoutEngine = workspace.ActiveLayoutEngine;
+
 		// When MoveWindowToPoint is called
 		workspace.MoveWindowToPoint(window, point);
 
 		// Then the layout engine is told to remove and add the window
 		givenEngine.Received(1).MoveWindowToPoint(window, point);
 		window.Received(1).Focus();
+		Assert.NotSame(activeLayoutEngine, workspace.ActiveLayoutEngine);
 	}
 
 	[Theory, AutoSubstituteData<WorkspaceCustomization>]
@@ -1098,6 +1147,7 @@ public class WorkspaceTests
 
 		// Then
 		givenEngine.Received(1).RemoveWindow(window);
+		Assert.NotSame(givenEngine, workspace.ActiveLayoutEngine);
 	}
 
 	[Theory, AutoSubstituteData<WorkspaceCustomization>]
@@ -1145,6 +1195,7 @@ public class WorkspaceTests
 
 		// Then
 		givenEngine.Received(1).AddWindow(window);
+		Assert.NotSame(givenEngine, workspace.ActiveLayoutEngine);
 	}
 
 	[Theory, AutoSubstituteData<WorkspaceCustomization>]
@@ -1167,6 +1218,7 @@ public class WorkspaceTests
 
 		// Then
 		givenEngine.DidNotReceive().AddWindow(window);
+		Assert.Same(givenEngine, workspace.ActiveLayoutEngine);
 	}
 	#endregion
 
@@ -1194,7 +1246,7 @@ public class WorkspaceTests
 		// Then the layout engine is not changed
 		layoutEngine.Received(1).PerformCustomAction(Arg.Any<LayoutEngineCustomAction<IWindow?>>());
 		layoutEngine.DidNotReceive().DoLayout(Arg.Any<IRectangle<int>>(), Arg.Any<IMonitor>());
-		Assert.Equal(layoutEngine, workspace.ActiveLayoutEngine);
+		Assert.Same(layoutEngine, workspace.ActiveLayoutEngine);
 	}
 
 	[Theory, AutoSubstituteData<WorkspaceCustomization>]
@@ -1226,7 +1278,7 @@ public class WorkspaceTests
 		// Then the layout engine is not changed
 		layoutEngine.Received(1).PerformCustomAction(action);
 		layoutEngine.DidNotReceive().DoLayout(Arg.Any<IRectangle<int>>(), Arg.Any<IMonitor>());
-		Assert.Equal(layoutEngine, workspace.ActiveLayoutEngine);
+		Assert.Same(layoutEngine, workspace.ActiveLayoutEngine);
 	}
 
 	[Theory, AutoSubstituteData<WorkspaceCustomization>]
@@ -1268,7 +1320,7 @@ public class WorkspaceTests
 		layoutEngine1.DidNotReceive().DoLayout(Arg.Any<IRectangle<int>>(), Arg.Any<IMonitor>());
 		layoutEngine1Result.DidNotReceive().DoLayout(Arg.Any<IRectangle<int>>(), Arg.Any<IMonitor>());
 
-		Assert.Equal(layoutEngine, workspace.ActiveLayoutEngine);
+		Assert.Same(layoutEngine, workspace.ActiveLayoutEngine);
 	}
 
 	[Theory, AutoSubstituteData<WorkspaceCustomization>]
@@ -1311,7 +1363,7 @@ public class WorkspaceTests
 		layoutEngine1.Received(1).PerformCustomAction(action);
 		layoutEngine1.DidNotReceive().DoLayout(Arg.Any<IRectangle<int>>(), Arg.Any<IMonitor>());
 
-		Assert.Equal(layoutEngineResult, workspace.ActiveLayoutEngine);
+		Assert.Same(layoutEngineResult, workspace.ActiveLayoutEngine);
 	}
 	#endregion
 }

--- a/src/Whim.TreeLayout/TreeLayoutEngine.cs
+++ b/src/Whim.TreeLayout/TreeLayoutEngine.cs
@@ -296,20 +296,20 @@ public record TreeLayoutEngine : ILayoutEngine
 	}
 
 	/// <inheritdoc />
-	public void FocusWindowInDirection(Direction direction, IWindow window)
+	public ILayoutEngine FocusWindowInDirection(Direction direction, IWindow window)
 	{
 		Logger.Debug($"Focusing window {window} in direction {direction}");
 
 		if (_root is null)
 		{
 			Logger.Error($"Root is null, cannot focus window {window}");
-			return;
+			return this;
 		}
 
 		if (!_windows.TryGetValue(window, out ImmutableArray<int> path))
 		{
 			Logger.Error($"Window {window} not found in layout engine {Name}");
-			return;
+			return this;
 		}
 
 		WindowNodeStateAtPoint? adjacentNodeResult = TreeHelpers.GetAdjacentWindowNode(
@@ -320,6 +320,7 @@ public record TreeLayoutEngine : ILayoutEngine
 		);
 
 		adjacentNodeResult?.WindowNode.Focus();
+		return this;
 	}
 
 	/// <inheritdoc />

--- a/src/Whim/Layout/BaseProxyLayoutEngine.cs
+++ b/src/Whim/Layout/BaseProxyLayoutEngine.cs
@@ -62,7 +62,7 @@ public abstract record BaseProxyLayoutEngine : ILayoutEngine
 	public abstract IWindow? GetFirstWindow();
 
 	/// <inheritdoc/>
-	public abstract void FocusWindowInDirection(Direction direction, IWindow window);
+	public abstract ILayoutEngine FocusWindowInDirection(Direction direction, IWindow window);
 
 	/// <inheritdoc/>
 	public abstract ILayoutEngine SwapWindowInDirection(Direction direction, IWindow window);

--- a/src/Whim/Layout/ColumnLayoutEngine.cs
+++ b/src/Whim/Layout/ColumnLayoutEngine.cs
@@ -138,13 +138,13 @@ public record ColumnLayoutEngine : ILayoutEngine
 	public IWindow? GetFirstWindow() => _stack.FirstOrDefault();
 
 	/// <inheritdoc/>
-	public void FocusWindowInDirection(Direction direction, IWindow window)
+	public ILayoutEngine FocusWindowInDirection(Direction direction, IWindow window)
 	{
 		Logger.Debug($"Focusing window {window} in layout engine {Name}");
 
 		if (direction != Direction.Left && direction != Direction.Right)
 		{
-			return;
+			return this;
 		}
 
 		// Find the index of the window in the stack
@@ -152,7 +152,7 @@ public record ColumnLayoutEngine : ILayoutEngine
 		if (windowIndex == -1)
 		{
 			Logger.Error($"Window {window} not found in layout engine {Name}");
-			return;
+			return this;
 		}
 
 		int delta = GetDelta(LeftToRight, direction);
@@ -160,6 +160,7 @@ public record ColumnLayoutEngine : ILayoutEngine
 
 		IWindow adjWindow = _stack[adjIndex];
 		adjWindow.Focus();
+		return this;
 	}
 
 	/// <inheritdoc/>

--- a/src/Whim/Layout/ILayoutEngine.cs
+++ b/src/Whim/Layout/ILayoutEngine.cs
@@ -94,7 +94,7 @@ public interface ILayoutEngine
 	/// </summary>
 	/// <param name="direction">The direction to focus in.</param>
 	/// <param name="window">The origin window</param>
-	void FocusWindowInDirection(Direction direction, IWindow window);
+	ILayoutEngine FocusWindowInDirection(Direction direction, IWindow window);
 
 	/// <summary>
 	/// Swaps the <paramref name="window"/> in the <paramref name="direction"/>.

--- a/src/Whim/Workspace/Workspace.cs
+++ b/src/Whim/Workspace/Workspace.cs
@@ -431,7 +431,10 @@ internal class Workspace : IWorkspace, IInternalWorkspace
 		{
 			if (GetValidVisibleWindow(window) is IWindow validWindow)
 			{
-				ActiveLayoutEngine.FocusWindowInDirection(direction, validWindow);
+				_layoutEngines[_activeLayoutEngineIndex] = ActiveLayoutEngine.FocusWindowInDirection(
+					direction,
+					validWindow
+				);
 			}
 		}
 	}


### PR DESCRIPTION
`ILayoutEngine.FocusWindowInDirection` now returns `ILayoutEngine`. This is in support of #588.

Additionally, fixed a bug in `FloatingLayoutEngine` which would lose the `FloatingLayoutEngine` for some operations.

Added tests to check that `ILayoutEngine`s are replaced correctly in `Workspace`.