### PR TITLE
FocusLayoutEngine

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,15 @@ Each plugin needs to be added to the `context` object.
 
 ### Layout Engines
 
+#### `FocusLayoutEngine`
+
+`FocusLayoutEngine` is a layout engine that displays one window at a time:
+
+- Calling `SwapWindowInDirection` will swap the current window with the window in the specified direction.
+- Calling `FocusWindowInDirection` will focus the window in the specified direction.
+
+Windows which are not focused are minimized to the taskbar.
+
 #### `SliceLayoutEngine`
 
 `SliceLayoutEngine` is a layout engine that internally stores an ordered list of `IWindow`s. The monitor is divided into a number of `IArea`s. Each `IArea` corresponds to a "slice" of the `IWindow` list.

--- a/src/Whim.Tests/Commands/CoreCommandsTests.cs
+++ b/src/Whim.Tests/Commands/CoreCommandsTests.cs
@@ -437,4 +437,43 @@ public class CoreCommandsTests
 		Assert.Equal(KeyModifiers.LAlt | KeyModifiers.LShift, keybinds[9].Modifiers);
 		Assert.Equal("VK_0", keybinds[9].Key.ToString());
 	}
+
+	[Theory, AutoSubstituteData<CoreCommandsCustomization>]
+	public void FocusLayoutToggleMaximized_NotFocusLayoutEngine(IContext ctx, ILayoutEngine layoutEngine)
+	{
+		// Given
+		CoreCommands commands = new(ctx);
+		PluginCommandsTestUtils testUtils = new(commands);
+
+		ctx.WorkspaceManager.ActiveWorkspace.ActiveLayoutEngine.Returns(layoutEngine);
+
+		ICommand command = testUtils.GetCommand("whim.core.focus_layout.toggle_maximized");
+
+		// When
+		command.TryExecute();
+
+		// Then
+		ctx.WorkspaceManager.ActiveWorkspace.DidNotReceive()
+			.PerformCustomLayoutEngineAction(Arg.Any<LayoutEngineCustomAction>());
+	}
+
+	[Theory, AutoSubstituteData<CoreCommandsCustomization>]
+	public void FocusLayoutToggleMaximized_FocusLayoutEngine(IContext ctx)
+	{
+		// Given
+		CoreCommands commands = new(ctx);
+		PluginCommandsTestUtils testUtils = new(commands);
+
+		FocusLayoutEngine engine = new(new LayoutEngineIdentity());
+		ctx.WorkspaceManager.ActiveWorkspace.ActiveLayoutEngine.Returns(engine);
+
+		ICommand command = testUtils.GetCommand("whim.core.focus_layout.toggle_maximized");
+
+		// When
+		command.TryExecute();
+
+		// Then
+		ctx.WorkspaceManager.ActiveWorkspace.Received(1)
+			.PerformCustomLayoutEngineAction(Arg.Any<LayoutEngineCustomAction>());
+	}
 }

--- a/src/Whim.Tests/Layout/FocusLayoutEngineTests.cs
+++ b/src/Whim.Tests/Layout/FocusLayoutEngineTests.cs
@@ -318,6 +318,29 @@ public class FocusLayoutEngineTests
 		expected.Should().BeEquivalentTo(windowStates);
 	}
 
+	[Theory, AutoSubstituteData]
+	public void PerformCustomAction_UnknownAction(IWindow window1, IWindow window2)
+	{
+		// Given
+		ILayoutEngine sut = new FocusLayoutEngine(_identity);
+		sut = sut.AddWindow(window1);
+		sut = sut.AddWindow(window2);
+
+		// When
+		ILayoutEngine result = sut.PerformCustomAction(
+			new LayoutEngineCustomAction<IWindow?>()
+			{
+				Name = "Focus.unknown",
+				Window = null,
+				Payload = null
+			}
+		);
+
+		// Then
+		Assert.Same(sut, result);
+		Assert.Equal(2, result.Count);
+	}
+
 	#region SwapWindowInDirection
 	[Theory, AutoSubstituteData]
 	public void SwapWindowInDirection_NoWindows(Direction direction, IWindow window)

--- a/src/Whim.Tests/Layout/FocusLayoutEngineTests.cs
+++ b/src/Whim.Tests/Layout/FocusLayoutEngineTests.cs
@@ -1,0 +1,320 @@
+using System.Collections;
+using System.Linq;
+using FluentAssertions;
+using NSubstitute;
+using Whim.TestUtils;
+using Xunit;
+
+namespace Whim.Tests;
+
+public class FocusLayoutEngineTests
+{
+	private static readonly LayoutEngineIdentity _identity = new();
+
+	[Fact]
+	public void Name()
+	{
+		// Given
+		FocusLayoutEngine sut = new(_identity);
+
+		// When
+		string name = sut.Name;
+
+		// Then
+		Assert.Equal("Focus", name);
+	}
+
+	[Theory, AutoSubstituteData]
+	public void AddWindow_NewWindow(IWindow window)
+	{
+		// Given
+		FocusLayoutEngine sut = new(_identity);
+
+		// When
+		ILayoutEngine result = sut.AddWindow(window);
+
+		// Then
+		Assert.NotSame(sut, result);
+		Assert.Equal(1, result.Count);
+	}
+
+	[Theory, AutoSubstituteData]
+	public void AddWindow_ExistingWindow(IWindow window)
+	{
+		// Given
+		ILayoutEngine sut = new FocusLayoutEngine(_identity);
+		sut = sut.AddWindow(window);
+
+		// When
+		ILayoutEngine result = sut.AddWindow(window);
+
+		// Then
+		Assert.Same(sut, result);
+		Assert.Equal(1, result.Count);
+	}
+
+	[Theory, AutoSubstituteData]
+	public void RemoveWindow_ExistingWindow(IWindow window)
+	{
+		// Given
+		ILayoutEngine sut = new FocusLayoutEngine(_identity);
+		sut = sut.AddWindow(window);
+
+		// When
+		ILayoutEngine result = sut.RemoveWindow(window);
+
+		// Then
+		Assert.NotSame(sut, result);
+		Assert.Equal(0, result.Count);
+	}
+
+	[Theory, AutoSubstituteData]
+	public void RemoveWindow_NonExistingWindow(IWindow window1, IWindow window2)
+	{
+		// Given
+		ILayoutEngine sut = new FocusLayoutEngine(_identity);
+		sut = sut.AddWindow(window2);
+
+		// When
+		ILayoutEngine result = sut.RemoveWindow(window1);
+
+		// Then
+		Assert.Same(sut, result);
+		Assert.Equal(1, result.Count);
+	}
+
+	[Theory, AutoSubstituteData]
+	public void ContainsWindow_ExistingWindow(IWindow window)
+	{
+		// Given
+		ILayoutEngine sut = new FocusLayoutEngine(_identity);
+		sut = sut.AddWindow(window);
+
+		// When
+		bool result = sut.ContainsWindow(window);
+
+		// Then
+		Assert.True(result);
+	}
+
+	[Theory, AutoSubstituteData]
+	public void ContainsWindow_NonExistingWindow(IWindow window)
+	{
+		// Given
+		ILayoutEngine sut = new FocusLayoutEngine(_identity);
+
+		// When
+		bool result = sut.ContainsWindow(window);
+
+		// Then
+		Assert.False(result);
+	}
+
+	[Theory, AutoSubstituteData]
+	public void GetFirstWindow_ExistingWindow(IWindow window)
+	{
+		// Given
+		ILayoutEngine sut = new FocusLayoutEngine(_identity);
+		sut = sut.AddWindow(window);
+
+		// When
+		IWindow? result = sut.GetFirstWindow();
+
+		// Then
+		Assert.Same(window, result);
+	}
+
+	[Fact]
+	public void GetFirstWindow_Empty()
+	{
+		// Given
+		ILayoutEngine sut = new FocusLayoutEngine(_identity);
+
+		// When
+		IWindow? result = sut.GetFirstWindow();
+
+		// Then
+		Assert.Null(result);
+	}
+
+	[Theory, AutoSubstituteData]
+	public void DoLayout_Empty(Rectangle<int> rectangle, IMonitor monitor)
+	{
+		// Given
+		ILayoutEngine sut = new FocusLayoutEngine(_identity);
+
+		// When
+		IEnumerable result = sut.DoLayout(rectangle, monitor);
+
+		// Then
+		Assert.Empty(result);
+	}
+
+	[Theory, AutoSubstituteData]
+	public void DoLayout_MultipleWindows(
+		Rectangle<int> rectangle,
+		IMonitor monitor,
+		IWindow window1,
+		IWindow window2,
+		IWindow window3
+	)
+	{
+		// Given
+		ILayoutEngine sut = new FocusLayoutEngine(_identity);
+		sut = sut.AddWindow(window1);
+		sut = sut.AddWindow(window2);
+		sut = sut.AddWindow(window3);
+
+		// When
+		IWindowState[] result = sut.DoLayout(rectangle, monitor).ToArray();
+
+		// Then
+		Assert.Equal(3, result.Length);
+
+		IWindowState[] expected = new IWindowState[]
+		{
+			new WindowState()
+			{
+				Window = window1,
+				Rectangle = rectangle,
+				WindowSize = WindowSize.Minimized
+			},
+			new WindowState()
+			{
+				Window = window2,
+				Rectangle = rectangle,
+				WindowSize = WindowSize.Minimized
+			},
+			new WindowState()
+			{
+				Window = window3,
+				Rectangle = rectangle,
+				WindowSize = WindowSize.Normal
+			}
+		};
+
+		expected.Should().BeEquivalentTo(result);
+	}
+
+	[Theory, AutoSubstituteData]
+	public void FocusWindowInDirection_WindowNotInLayout(Direction direction, IWindow window)
+	{
+		// Given
+		ILayoutEngine sut = new FocusLayoutEngine(_identity);
+
+		// When
+		ILayoutEngine result = sut.FocusWindowInDirection(direction, window);
+
+		// Then
+		Assert.Same(sut, result);
+	}
+
+	[Theory]
+	[InlineAutoSubstituteData(0, Direction.Right, 1)]
+	[InlineAutoSubstituteData(0, Direction.Down, 1)]
+	[InlineAutoSubstituteData(0, Direction.Left, 2)]
+	[InlineAutoSubstituteData(0, Direction.Up, 2)]
+	public void FocusWindowInDirection_WindowInLayout(int focusedIndex, Direction direction, int expectedIndex)
+	{
+		// Given
+		IWindow[] windows = Enumerable.Range(0, 3).Select(_ => Substitute.For<IWindow>()).ToArray();
+		ILayoutEngine sut = new FocusLayoutEngine(_identity);
+		sut = sut.AddWindow(windows[0]);
+		sut = sut.AddWindow(windows[1]);
+		sut = sut.AddWindow(windows[2]);
+
+		// When
+		ILayoutEngine result = sut.FocusWindowInDirection(direction, windows[focusedIndex]);
+		IWindowState[] windowStates = result.DoLayout(new Rectangle<int>(), Substitute.For<IMonitor>()).ToArray();
+
+		// Then
+		Assert.NotSame(sut, result);
+		Assert.Equal(sut.Count, result.Count);
+		Assert.Equal(WindowSize.Normal, windowStates[expectedIndex].WindowSize);
+	}
+
+	[Theory, AutoSubstituteData]
+	public void MoveWindowEdgesInDirection(IWindow window)
+	{
+		// Given
+		ILayoutEngine sut = new FocusLayoutEngine(_identity);
+		sut = sut.AddWindow(window);
+
+		// When
+		ILayoutEngine result = sut.MoveWindowEdgesInDirection(Direction.Left, new Point<double>(), window);
+
+		// Then
+		Assert.Same(sut, result);
+	}
+
+	[Theory, AutoSubstituteData]
+	public void MoveWindowToPoint_NewWindow(IWindow window, IPoint<double> point)
+	{
+		// Given
+		ILayoutEngine sut = new FocusLayoutEngine(_identity);
+
+		// When
+		ILayoutEngine result = sut.MoveWindowToPoint(window, point);
+
+		// Then
+		Assert.NotSame(sut, result);
+		Assert.Equal(1, result.Count);
+	}
+
+	[Theory, AutoSubstituteData]
+	public void MoveWindowToPoint_ExistingWindow(IWindow window, IPoint<double> point)
+	{
+		// Given
+		ILayoutEngine sut = new FocusLayoutEngine(_identity);
+		sut = sut.AddWindow(window);
+
+		// When
+		ILayoutEngine result = sut.MoveWindowToPoint(window, point);
+
+		// Then
+		Assert.Same(sut, result);
+		Assert.Equal(1, result.Count);
+	}
+
+	[Theory, AutoSubstituteData]
+	public void PerformCustomAction_ToggleMaximized(IWindow window1, IWindow window2)
+	{
+		// Given
+		ILayoutEngine sut = new FocusLayoutEngine(_identity);
+		sut = sut.AddWindow(window1);
+		sut = sut.AddWindow(window2);
+
+		// When
+		ILayoutEngine result = sut.PerformCustomAction(
+			new LayoutEngineCustomAction<IWindow?>()
+			{
+				Name = "Focus.toggle_maximized",
+				Window = null,
+				Payload = null
+			}
+		);
+		IWindowState[] windowStates = result.DoLayout(new Rectangle<int>(), Substitute.For<IMonitor>()).ToArray();
+
+		// Then
+		Assert.NotSame(sut, result);
+		Assert.Equal(2, result.Count);
+
+		IWindowState[] expected = new IWindowState[]
+		{
+			new WindowState()
+			{
+				Window = window1,
+				Rectangle = new Rectangle<int>(),
+				WindowSize = WindowSize.Maximized
+			},
+			new WindowState()
+			{
+				Window = window2,
+				Rectangle = new Rectangle<int>(),
+				WindowSize = WindowSize.Minimized
+			}
+		};
+
+		expected.Should().BeEquivalentTo(windowStates);
+	}
+}

--- a/src/Whim.Tests/Layout/FocusLayoutEngineTests.cs
+++ b/src/Whim.Tests/Layout/FocusLayoutEngineTests.cs
@@ -482,4 +482,82 @@ public class FocusLayoutEngineTests
 			.BeEquivalentTo(windowStates);
 	}
 	#endregion
+
+	#region MinimizeWindowEnd
+	[Theory, AutoSubstituteData]
+	public void MinimizeWindowEnd_DoesNotContainWindow(IMonitor monitor, IWindow newWindow)
+	{
+		// Given there are two windows in the layout
+		IWindow[] windows = Enumerable.Range(0, 2).Select(_ => Substitute.For<IWindow>()).ToArray();
+		ILayoutEngine sut = new FocusLayoutEngine(_identity);
+		sut = sut.AddWindow(windows[0]);
+		sut = sut.AddWindow(windows[1]);
+
+		// When a new window is restored
+		ILayoutEngine result = sut.MinimizeWindowEnd(newWindow);
+		IWindowState[] windowStates = result.DoLayout(new Rectangle<int>(), monitor).ToArray();
+
+		// Then the window is added to the layout
+		Assert.NotSame(sut, result);
+		Assert.Equal(3, result.Count);
+		new IWindowState[]
+		{
+			new WindowState()
+			{
+				Window = windows[0],
+				Rectangle = new Rectangle<int>(),
+				WindowSize = WindowSize.Normal
+			},
+			new WindowState()
+			{
+				Window = windows[1],
+				Rectangle = new Rectangle<int>(),
+				WindowSize = WindowSize.Minimized
+			},
+			new WindowState()
+			{
+				Window = newWindow,
+				Rectangle = new Rectangle<int>(),
+				WindowSize = WindowSize.Minimized
+			}
+		}
+			.Should()
+			.BeEquivalentTo(windowStates);
+	}
+
+	[Theory, AutoSubstituteData]
+	public void MinimizeWindowEnd_ExistingWindow(IMonitor monitor)
+	{
+		// Given there are two windows in the layout
+		IWindow[] windows = Enumerable.Range(0, 2).Select(_ => Substitute.For<IWindow>()).ToArray();
+		ILayoutEngine sut = new FocusLayoutEngine(_identity);
+		sut = sut.AddWindow(windows[0]);
+		sut = sut.AddWindow(windows[1]);
+
+		// When a new window is restored
+		ILayoutEngine result = sut.MinimizeWindowEnd(windows[0]);
+		IWindowState[] windowStates = result.DoLayout(new Rectangle<int>(), monitor).ToArray();
+
+		// Then the window is added to the layout
+		Assert.NotSame(sut, result);
+		Assert.Equal(2, result.Count);
+		new IWindowState[]
+		{
+			new WindowState()
+			{
+				Window = windows[0],
+				Rectangle = new Rectangle<int>(),
+				WindowSize = WindowSize.Normal
+			},
+			new WindowState()
+			{
+				Window = windows[1],
+				Rectangle = new Rectangle<int>(),
+				WindowSize = WindowSize.Minimized
+			}
+		}
+			.Should()
+			.BeEquivalentTo(windowStates);
+	}
+	#endregion
 }

--- a/src/Whim.Tests/Layout/FocusLayoutEngineTests.cs
+++ b/src/Whim.Tests/Layout/FocusLayoutEngineTests.cs
@@ -317,4 +317,56 @@ public class FocusLayoutEngineTests
 
 		expected.Should().BeEquivalentTo(windowStates);
 	}
+
+	#region SwapWindowInDirection
+	[Theory, AutoSubstituteData]
+	public void SwapWindowInDirection_NoWindows(Direction direction, IWindow window)
+	{
+		// Given
+		ILayoutEngine sut = new FocusLayoutEngine(_identity);
+
+		// When
+		ILayoutEngine result = sut.SwapWindowInDirection(direction, window);
+
+		// Then
+		Assert.Same(sut, result);
+	}
+
+	[Theory, AutoSubstituteData]
+	public void SwapWindowInDirection_CannotFindWindow(Direction direction, IWindow addedWindow, IWindow swapWindow)
+	{
+		// Given
+		ILayoutEngine sut = new FocusLayoutEngine(_identity);
+		sut = sut.AddWindow(addedWindow);
+
+		// When
+		ILayoutEngine result = sut.SwapWindowInDirection(direction, swapWindow);
+
+		// Then
+		Assert.Same(sut, result);
+	}
+
+	[Theory]
+	[InlineAutoSubstituteData(0, Direction.Right, 1)]
+	[InlineAutoSubstituteData(0, Direction.Down, 1)]
+	[InlineAutoSubstituteData(0, Direction.Left, 2)]
+	[InlineAutoSubstituteData(0, Direction.Up, 2)]
+	public void SwapWindowInDirection_CanFindWindow(int focusedIndex, Direction direction, int expectedIndex)
+	{
+		// Given
+		IWindow[] windows = Enumerable.Range(0, 3).Select(_ => Substitute.For<IWindow>()).ToArray();
+		ILayoutEngine sut = new FocusLayoutEngine(_identity);
+		sut = sut.AddWindow(windows[0]);
+		sut = sut.AddWindow(windows[1]);
+		sut = sut.AddWindow(windows[2]);
+
+		// When
+		ILayoutEngine result = sut.SwapWindowInDirection(direction, windows[focusedIndex]);
+
+		// Then
+		Assert.NotSame(sut, result);
+		Assert.Equal(sut.Count, result.Count);
+		Assert.Equal(windows[expectedIndex], result.GetFirstWindow());
+	}
+	#endregion
 }

--- a/src/Whim.Tests/Layout/FocusLayoutEngineTests.cs
+++ b/src/Whim.Tests/Layout/FocusLayoutEngineTests.cs
@@ -369,4 +369,117 @@ public class FocusLayoutEngineTests
 		Assert.Equal(windows[expectedIndex], result.GetFirstWindow());
 	}
 	#endregion
+
+	#region MinimizeWindowStart
+	[Theory, AutoSubstituteData]
+	public void MinimizeWindowStart_ContainsWindow(IMonitor monitor)
+	{
+		// Given there are two windows in the layout
+		IWindow[] windows = Enumerable.Range(0, 2).Select(_ => Substitute.For<IWindow>()).ToArray();
+		ILayoutEngine sut = new FocusLayoutEngine(_identity);
+		sut = sut.AddWindow(windows[0]);
+		sut = sut.AddWindow(windows[1]);
+
+		// When the focused window is minimized
+		ILayoutEngine result = sut.MinimizeWindowStart(windows[1]);
+		IWindowState[] windowStates = result.DoLayout(new Rectangle<int>(), monitor).ToArray();
+
+		// Then all the windows are minimized
+		Assert.NotSame(sut, result);
+		Assert.Equal(2, result.Count);
+		new IWindowState[]
+		{
+			new WindowState()
+			{
+				Window = windows[0],
+				Rectangle = new Rectangle<int>(),
+				WindowSize = WindowSize.Minimized
+			},
+			new WindowState()
+			{
+				Window = windows[1],
+				Rectangle = new Rectangle<int>(),
+				WindowSize = WindowSize.Minimized
+			}
+		}
+			.Should()
+			.BeEquivalentTo(windowStates);
+	}
+
+	[Theory, AutoSubstituteData]
+	public void MinimizeWindowStart_WindowNotFound(IMonitor monitor, IWindow newWindow)
+	{
+		// Given there are two windows in the layout
+		IWindow[] windows = Enumerable.Range(0, 2).Select(_ => Substitute.For<IWindow>()).ToArray();
+		ILayoutEngine sut = new FocusLayoutEngine(_identity);
+		sut = sut.AddWindow(windows[0]);
+		sut = sut.AddWindow(windows[1]);
+
+		// When a new window is minimized
+		ILayoutEngine result = sut.MinimizeWindowStart(newWindow);
+		IWindowState[] windowStates = result.DoLayout(new Rectangle<int>(), monitor).ToArray();
+
+		// Then the window is added to the layout
+		Assert.NotSame(sut, result);
+		Assert.Equal(3, result.Count);
+		new IWindowState[]
+		{
+			new WindowState()
+			{
+				Window = windows[0],
+				Rectangle = new Rectangle<int>(),
+				WindowSize = WindowSize.Minimized
+			},
+			new WindowState()
+			{
+				Window = windows[1],
+				Rectangle = new Rectangle<int>(),
+				WindowSize = WindowSize.Normal
+			},
+			new WindowState()
+			{
+				Window = newWindow,
+				Rectangle = new Rectangle<int>(),
+				WindowSize = WindowSize.Minimized
+			}
+		}
+			.Should()
+			.BeEquivalentTo(windowStates);
+	}
+
+	[Theory, AutoSubstituteData]
+	public void MinimizeWindowStart_NonFocusedWindowMinimized(IMonitor monitor)
+	{
+		// Given there are two windows in the layout
+		IWindow[] windows = Enumerable.Range(0, 2).Select(_ => Substitute.For<IWindow>()).ToArray();
+		ILayoutEngine sut = new FocusLayoutEngine(_identity);
+		sut = sut.AddWindow(windows[0]);
+		sut = sut.AddWindow(windows[1]);
+
+		// When the non-focused window is minimized
+		ILayoutEngine result = sut.MinimizeWindowStart(windows[0]);
+		IWindowState[] windowStates = result.DoLayout(new Rectangle<int>(), monitor).ToArray();
+
+		// Then the window is added to the layout
+		Assert.Same(sut, result);
+		Assert.Equal(2, result.Count);
+		new IWindowState[]
+		{
+			new WindowState()
+			{
+				Window = windows[0],
+				Rectangle = new Rectangle<int>(),
+				WindowSize = WindowSize.Minimized
+			},
+			new WindowState()
+			{
+				Window = windows[1],
+				Rectangle = new Rectangle<int>(),
+				WindowSize = WindowSize.Normal
+			}
+		}
+			.Should()
+			.BeEquivalentTo(windowStates);
+	}
+	#endregion
 }

--- a/src/Whim.Tests/Workspace/WorkspaceTests.cs
+++ b/src/Whim.Tests/Workspace/WorkspaceTests.cs
@@ -716,8 +716,38 @@ public class WorkspaceTests
 		// When FocusWindowInDirection is called
 		workspace.FocusWindowInDirection(Direction.Up, window);
 
-		// Then the layout engine is told to focus the window
+		// Then the layout engine is told to focus the window, and a layout occurs
 		activeLayoutEngine.Received(1).FocusWindowInDirection(Direction.Up, window);
+		Assert.NotSame(activeLayoutEngine, workspace.ActiveLayoutEngine);
+		activeLayoutEngine.Received(1).DoLayout(Arg.Any<IRectangle<int>>(), Arg.Any<IMonitor>());
+	}
+
+	[Theory, AutoSubstituteData<WorkspaceCustomization>]
+	internal void FocusWindowInDirection_NoLayoutEngineChange(
+		IContext ctx,
+		IInternalContext internalCtx,
+		WorkspaceManagerTriggers triggers,
+		ILayoutEngine layoutEngine1,
+		ILayoutEngine layoutEngine2,
+		IWindow window
+	)
+	{
+		// Given the active layout engine does not change when calling FocusWindowInDirection
+		Workspace workspace =
+			new(ctx, internalCtx, triggers, "Workspace", new ILayoutEngine[] { layoutEngine1, layoutEngine2 });
+		workspace.AddWindow(window);
+
+		ILayoutEngine activeLayoutEngine = workspace.ActiveLayoutEngine;
+		activeLayoutEngine.FocusWindowInDirection(Direction.Up, window).Returns(activeLayoutEngine);
+		activeLayoutEngine.ClearReceivedCalls();
+
+		// When FocusWindowInDirection is called
+		workspace.FocusWindowInDirection(Direction.Up, window);
+
+		// Then the layout engine is told to focus the window, and no layout occurs
+		activeLayoutEngine.Received(1).FocusWindowInDirection(Direction.Up, window);
+		Assert.Same(activeLayoutEngine, workspace.ActiveLayoutEngine);
+		activeLayoutEngine.DidNotReceive().DoLayout(Arg.Any<IRectangle<int>>(), Arg.Any<IMonitor>());
 	}
 
 	[Theory, AutoSubstituteData<WorkspaceCustomization>]

--- a/src/Whim/Commands/Command.cs
+++ b/src/Whim/Commands/Command.cs
@@ -27,6 +27,9 @@ public class Command : ICommand
 	/// <param name="condition">
 	/// A condition to determine if the command should be visible, or able to be
 	/// executed.
+	///
+	/// When this evaluates to false, the <paramref name="callback"/> will not be executed.
+	///
 	/// If this is null, the command will always be accessible.
 	/// </param>
 	public Command(string identifier, string title, Action callback, Func<bool>? condition = null)

--- a/src/Whim/Commands/CoreCommands.cs
+++ b/src/Whim/Commands/CoreCommands.cs
@@ -206,7 +206,7 @@ internal class CoreCommands : PluginCommands
 			)
 			.Add(
 				identifier: "focus_layout.toggle_maximized",
-				title: "Toggle the maximized state for the FocusLayoutEngine",
+				title: "Toggle the maximized state for the current FocusLayoutEngine",
 				callback: () =>
 				{
 					IWorkspace workspace = _context.WorkspaceManager.ActiveWorkspace;
@@ -233,7 +233,7 @@ internal class CoreCommands : PluginCommands
 					IWorkspace workspace = _context.WorkspaceManager.ActiveWorkspace;
 					ILayoutEngine activeLayoutEngine = workspace.ActiveLayoutEngine;
 					return activeLayoutEngine.GetLayoutEngine<FocusLayoutEngine>()
-						is not FocusLayoutEngine focusLayoutEngine;
+						is FocusLayoutEngine focusLayoutEngine;
 				}
 			)
 			.Add(

--- a/src/Whim/Commands/CoreCommands.cs
+++ b/src/Whim/Commands/CoreCommands.cs
@@ -205,6 +205,38 @@ internal class CoreCommands : PluginCommands
 				callback: FocusMonitorInDirection(getNext: true)
 			)
 			.Add(
+				identifier: "focus_layout.toggle_maximized",
+				title: "Toggle the maximized state for the FocusLayoutEngine",
+				callback: () =>
+				{
+					IWorkspace workspace = _context.WorkspaceManager.ActiveWorkspace;
+					ILayoutEngine activeLayoutEngine = workspace.ActiveLayoutEngine;
+
+					if (
+						activeLayoutEngine.GetLayoutEngine<FocusLayoutEngine>()
+						is not FocusLayoutEngine focusLayoutEngine
+					)
+					{
+						return;
+					}
+
+					workspace.PerformCustomLayoutEngineAction(
+						new LayoutEngineCustomAction()
+						{
+							Name = $"{focusLayoutEngine.Name}.toggle_maximized",
+							Window = null
+						}
+					);
+				},
+				condition: () =>
+				{
+					IWorkspace workspace = _context.WorkspaceManager.ActiveWorkspace;
+					ILayoutEngine activeLayoutEngine = workspace.ActiveLayoutEngine;
+					return activeLayoutEngine.GetLayoutEngine<FocusLayoutEngine>()
+						is not FocusLayoutEngine focusLayoutEngine;
+				}
+			)
+			.Add(
 				identifier: "close_current_workspace",
 				title: "Close the current workspace",
 				callback: () => _context.WorkspaceManager.Remove(_context.WorkspaceManager.ActiveWorkspace),

--- a/src/Whim/Layout/ColumnLayoutEngine.cs
+++ b/src/Whim/Layout/ColumnLayoutEngine.cs
@@ -6,7 +6,7 @@ using System.Linq;
 namespace Whim;
 
 /// <summary>
-/// Column layout engine with a stack data structure.
+/// Layout engine that lays out windows in columns.
 /// </summary>
 public record ColumnLayoutEngine : ILayoutEngine
 {

--- a/src/Whim/Layout/FocusLayoutEngine.cs
+++ b/src/Whim/Layout/FocusLayoutEngine.cs
@@ -117,11 +117,25 @@ public record FocusLayoutEngine : ILayoutEngine
 			}
 			else
 			{
+				WindowSize windowSize;
+				if (maximized)
+				{
+					windowSize = WindowSize.Maximized;
+				}
+				else if (_hideFocusedWindow)
+				{
+					windowSize = WindowSize.Minimized;
+				}
+				else
+				{
+					windowSize = WindowSize.Normal;
+				}
+
 				yield return new WindowState()
 				{
 					Window = window,
 					Rectangle = rectangle,
-					WindowSize = maximized ? WindowSize.Maximized : WindowSize.Normal
+					WindowSize = windowSize,
 				};
 			}
 		}

--- a/src/Whim/Layout/FocusLayoutEngine.cs
+++ b/src/Whim/Layout/FocusLayoutEngine.cs
@@ -1,0 +1,192 @@
+using System.Collections.Generic;
+using System.Collections.Immutable;
+
+namespace Whim;
+
+// TODO: Describe SwapWindowInDirection and FocusWindowInDirection
+public record FocusLayoutEngine : ILayoutEngine
+{
+	private readonly ImmutableList<IWindow> _list;
+	private readonly int _focusedIndex;
+	private readonly bool _maximized;
+
+	/// <inheritdoc/>
+	public string Name { get; init; } = "Focus";
+
+	/// <inheritdoc/>
+	public int Count => _list.Count;
+
+	/// <inheritdoc/>
+	public LayoutEngineIdentity Identity { get; }
+
+	/// <summary>
+	/// Creates a new instance of the <see cref="FocusLayoutEngine"/> class.
+	/// </summary>
+	/// <param name="identity">The identity of the layout engine.</param>
+	public FocusLayoutEngine(LayoutEngineIdentity identity)
+	{
+		Identity = identity;
+		_list = ImmutableList<IWindow>.Empty;
+	}
+
+	private FocusLayoutEngine(
+		FocusLayoutEngine layoutEngine,
+		ImmutableList<IWindow> list,
+		int focusedIndex,
+		bool maximized
+	)
+	{
+		Name = layoutEngine.Name;
+		Identity = layoutEngine.Identity;
+		_list = list;
+		_focusedIndex = focusedIndex < 0 || focusedIndex >= _list.Count ? 0 : focusedIndex;
+		_maximized = maximized;
+	}
+
+	/// <inheritdoc/>
+	public ILayoutEngine AddWindow(IWindow window)
+	{
+		Logger.Debug($"Adding window {window} to layout engine {Name}");
+
+		if (_list.Contains(window))
+		{
+			Logger.Debug($"Window {window} already exists in layout engine {Name}");
+			return this;
+		}
+
+		ImmutableList<IWindow> newList = _list.Add(window);
+		return new FocusLayoutEngine(this, newList, newList.Count - 1, _maximized);
+	}
+
+	/// <inheritdoc/>
+	public ILayoutEngine RemoveWindow(IWindow window)
+	{
+		Logger.Debug($"Removing window {window} from layout engine {Name}");
+
+		if (!_list.Contains(window))
+		{
+			Logger.Debug($"Window {window} does not exist in layout engine {Name}");
+			return this;
+		}
+
+		return new FocusLayoutEngine(this, _list.Remove(window), _focusedIndex, _maximized);
+	}
+
+	/// <inheritdoc/>
+	public bool ContainsWindow(IWindow window)
+	{
+		Logger.Debug($"Checking if layout engine {Name} contains window {window}");
+		return _list.Contains(window);
+	}
+
+	/// <inheritdoc/>
+	public IWindow? GetFirstWindow()
+	{
+		Logger.Debug($"Getting first window in layout engine {Name}");
+		return _list.Count == 0 ? null : _list[0];
+	}
+
+	/// <inheritdoc/>
+	public IEnumerable<IWindowState> DoLayout(IRectangle<int> rectangle, IMonitor monitor)
+	{
+		Logger.Debug($"Performing a focus layout");
+
+		if (_list.Count == 0)
+		{
+			yield break;
+		}
+
+		for (int idx = 0; idx < _list.Count; idx++)
+		{
+			IWindow window = _list[idx];
+			bool focused = idx == _focusedIndex;
+			bool maximized = _maximized && focused;
+
+			if (!focused)
+			{
+				yield return new WindowState()
+				{
+					Window = window,
+					Rectangle = rectangle,
+					WindowSize = WindowSize.Minimized
+				};
+			}
+			else
+			{
+				yield return new WindowState()
+				{
+					Window = window,
+					Rectangle = rectangle,
+					WindowSize = maximized ? WindowSize.Maximized : WindowSize.Normal
+				};
+			}
+		}
+	}
+
+	/// <inheritdoc/>
+	public ILayoutEngine FocusWindowInDirection(Direction direction, IWindow window)
+	{
+		Logger.Debug($"Focusing window {window} in direction {direction} in layout engine {Name}");
+
+		if (!_list.Contains(window))
+		{
+			Logger.Debug($"Window {window} does not exist in layout engine {Name}");
+			return this;
+		}
+
+		int index = _list.IndexOf(window);
+		int newIndex = direction switch
+		{
+			Direction.Left => index - 1,
+			Direction.Up => index - 1,
+			_ => index + 1
+		};
+		newIndex = newIndex.Mod(_list.Count);
+
+		return new FocusLayoutEngine(this, _list, newIndex, _maximized);
+	}
+
+	/// <inheritdoc/>
+	public ILayoutEngine SwapWindowInDirection(Direction direction, IWindow window)
+	{
+		Logger.Debug($"Swapping window {window} in direction {direction} in layout engine {Name}");
+
+		if (!_list.Contains(window))
+		{
+			Logger.Debug($"Window {window} does not exist in layout engine {Name}");
+			return this;
+		}
+
+		int index = _list.IndexOf(window);
+		int newIndex = direction switch
+		{
+			Direction.Left => index - 1,
+			Direction.Up => index - 1,
+			_ => index + 1
+		};
+		newIndex = newIndex.Mod(_list.Count);
+
+		IWindow oldWindow = _list[index];
+		IWindow newWindow = _list[newIndex];
+
+		ImmutableList<IWindow> newList = _list.SetItem(index, newWindow).SetItem(newIndex, oldWindow);
+		return new FocusLayoutEngine(this, newList, newIndex, _maximized);
+	}
+
+	/// <inheritdoc/>
+	public ILayoutEngine MoveWindowEdgesInDirection(Direction edges, IPoint<double> deltas, IWindow window) => this;
+
+	/// <inheritdoc/>
+	public ILayoutEngine MoveWindowToPoint(IWindow window, IPoint<double> point) => AddWindow(window);
+
+	/// <inheritdoc/>
+	public ILayoutEngine PerformCustomAction<T>(LayoutEngineCustomAction<T> action)
+	{
+		if (action.Name == $"{Name}.toggle_maximized")
+		{
+			return new FocusLayoutEngine(this, _list, _focusedIndex, !_maximized);
+		}
+
+		return this;
+	}
+}

--- a/src/Whim/Layout/FocusLayoutEngine.cs
+++ b/src/Whim/Layout/FocusLayoutEngine.cs
@@ -4,12 +4,33 @@ using System.Collections.Immutable;
 namespace Whim;
 
 /// <summary>
-/// A layout engine that displays one window at a time.
+/// A layout engine that displays one window at a time. <see cref="FocusLayoutEngine"/> supports showing windows as:
+///
+/// <list type="bullet">
+/// <item>
+/// <description>
+/// <see cref="WindowSize.Normal"/>: The focused window is shown in its normal size.
+/// </description>
+/// </item>
+///
+/// <item>
+/// <description>
+/// <see cref="WindowSize.Maximized"/>: The focused window is shown in its maximized size.
+/// </description>
+/// </item>
+///
+/// <item>
+/// <description>
+/// <see cref="WindowSize.Minimized"/>: The focused window can be hidden. Additionally, all non-focused windows are shown as minimized
+/// (minimized to the taskbar).
+/// </description>
+/// </item>
+/// </list>
 ///
 /// <br />
 ///
-/// The behaviour <see cref="SwapWindowInDirection(Direction, IWindow)"/> and <see cref="FocusWindowInDirection(Direction, IWindow)"/>
-/// are a bit different to other layout engines:
+/// The <see cref="SwapWindowInDirection(Direction, IWindow)"/> and <see cref="FocusWindowInDirection(Direction, IWindow)"/>
+/// behaviour are a bit different to other layout engines:
 ///
 /// <list type="bullet">
 /// <item>

--- a/src/Whim/Layout/FocusLayoutEngine.cs
+++ b/src/Whim/Layout/FocusLayoutEngine.cs
@@ -25,9 +25,11 @@ public record FocusLayoutEngine : ILayoutEngine
 	/// Creates a new instance of the <see cref="FocusLayoutEngine"/> class.
 	/// </summary>
 	/// <param name="identity">The identity of the layout engine.</param>
-	public FocusLayoutEngine(LayoutEngineIdentity identity)
+	/// <param name="maximized">Whether the focused window should be maximized.</param>
+	public FocusLayoutEngine(LayoutEngineIdentity identity, bool maximized = false)
 	{
 		Identity = identity;
+		_maximized = maximized;
 		_list = ImmutableList<IWindow>.Empty;
 	}
 

--- a/src/Whim/Layout/FocusLayoutEngine.cs
+++ b/src/Whim/Layout/FocusLayoutEngine.cs
@@ -3,8 +3,30 @@ using System.Collections.Immutable;
 
 namespace Whim;
 
-// TODO: Describe SwapWindowInDirection and FocusWindowInDirection
-// NOTE: This LayoutEngine can have 0 or 1 windows shown
+/// <summary>
+/// A layout engine that displays one window at a time.
+///
+/// <br />
+///
+/// The behaviour <see cref="SwapWindowInDirection(Direction, IWindow)"/> and <see cref="FocusWindowInDirection(Direction, IWindow)"/>
+/// are a bit different to other layout engines:
+///
+/// <list type="bullet">
+/// <item>
+/// <description>
+/// When <see cref="SwapWindowInDirection(Direction, IWindow)"/> is called, the window in the direction of the given window
+/// will be swapped with the given window in the list of windows. This does not change the focused window.
+/// </description>
+/// </item>
+///
+/// <item>
+/// <description>
+/// When <see cref="FocusWindowInDirection(Direction, IWindow)"/> is called, the focused window will be changed to the window
+/// in the direction of the given window. This does not change the order of the windows.
+/// </description>
+/// </item>
+/// </list>
+/// </summary>
 public record FocusLayoutEngine : ILayoutEngine
 {
 	private readonly ImmutableList<IWindow> _list;

--- a/src/Whim/Template/whim.config.csx
+++ b/src/Whim/Template/whim.config.csx
@@ -108,6 +108,7 @@ void DoConfig(IContext context)
 		(id) => SliceLayouts.CreateMultiColumnLayout(context, sliceLayoutPlugin, id, 1, 2, 0),
 		(id) => SliceLayouts.CreatePrimaryStackLayout(context, sliceLayoutPlugin, id),
 		(id) => SliceLayouts.CreateSecondaryPrimaryLayout(context, sliceLayoutPlugin, id),
+		(id) => new FocusLayoutEngine(id),
 		(id) => new TreeLayoutEngine(context, treeLayoutPlugin, id),
 		(id) => new ColumnLayoutEngine(id)
 	};

--- a/src/Whim/Workspace/Workspace.cs
+++ b/src/Whim/Workspace/Workspace.cs
@@ -414,12 +414,17 @@ internal class Workspace : IWorkspace, IInternalWorkspace
 
 		lock (_workspaceLock)
 		{
-			if (GetValidVisibleWindow(window) is IWindow validWindow)
+			if (GetValidVisibleWindow(window) is not IWindow validWindow)
 			{
-				_layoutEngines[_activeLayoutEngineIndex] = ActiveLayoutEngine.FocusWindowInDirection(
-					direction,
-					validWindow
-				);
+				return;
+			}
+
+			ILayoutEngine newEngine = ActiveLayoutEngine.FocusWindowInDirection(direction, validWindow);
+
+			if (ActiveLayoutEngine != newEngine)
+			{
+				_layoutEngines[_activeLayoutEngineIndex] = newEngine;
+				DoLayout();
 			}
 		}
 	}


### PR DESCRIPTION
Added a new core layout engine `FocusLayoutEngine`, which shows one or zero windows at a time. The window that is shown is the one that has focus. Minimized windows are shown in the taskbar.
