### PR TITLE
Account for monitor translation when converting coordinate system

### DIFF
--- a/src/Whim.LayoutPreview/LayoutPreviewPlugin.cs
+++ b/src/Whim.LayoutPreview/LayoutPreviewPlugin.cs
@@ -74,8 +74,7 @@ public class LayoutPreviewPlugin : IPlugin, IDisposable
 			}
 
 			IMonitor monitor = _context.MonitorManager.GetMonitorAtPoint(cursorDraggedPoint);
-			IPoint<int> monitorPoint = monitor.WorkingArea.ToMonitorCoordinates(cursorDraggedPoint);
-			IPoint<double> normalizedPoint = monitor.WorkingArea.ToUnitSquare(monitorPoint);
+			IPoint<double> normalizedPoint = monitor.WorkingArea.ToUnitSquare(cursorDraggedPoint);
 
 			IWorkspace? workspace = _context.WorkspaceManager.GetWorkspaceForMonitor(monitor);
 			if (workspace == null)

--- a/src/Whim.Tests/Monitor/MonitorHelpersTests.cs
+++ b/src/Whim.Tests/Monitor/MonitorHelpersTests.cs
@@ -5,7 +5,7 @@ namespace Whim.Tests;
 
 public class MonitorHelpersTests
 {
-	public static IEnumerable<object[]> IntToUnitSquareData()
+	public static IEnumerable<object[]> ToUnitSquare_Point_Data()
 	{
 		yield return new object[]
 		{
@@ -28,7 +28,7 @@ public class MonitorHelpersTests
 				Width = 1920,
 				Height = 1080
 			},
-			new Point<int>() { X = 192, Y = 108 },
+			new Point<int>() { X = 192 + 100, Y = 108 + 100 },
 			new Point<double>() { X = 0.1, Y = 0.1 }
 		};
 		yield return new object[]
@@ -40,7 +40,7 @@ public class MonitorHelpersTests
 				Width = 1920,
 				Height = 1080
 			},
-			new Point<int>() { X = 960, Y = 270 },
+			new Point<int>() { X = 960 + 100, Y = 270 + 100 },
 			new Point<double>() { X = 0.5, Y = 0.25 }
 		};
 		yield return new object[]
@@ -52,7 +52,7 @@ public class MonitorHelpersTests
 				Width = 1920,
 				Height = 1080
 			},
-			new Point<int>() { X = 192, Y = 108 },
+			new Point<int>() { X = 192 - 100, Y = 108 + 100 },
 			new Point<double>() { X = 0.1, Y = 0.1 }
 		};
 		yield return new object[]
@@ -64,14 +64,14 @@ public class MonitorHelpersTests
 				Width = 1920,
 				Height = 1080
 			},
-			new Point<int>() { X = 960, Y = 270 },
+			new Point<int>() { X = 960 - 100, Y = 270 + 100 },
 			new Point<double>() { X = 0.5, Y = 0.25 }
 		};
 	}
 
 	[Theory]
-	[MemberData(nameof(IntToUnitSquareData))]
-	public void ToUnitSquarePointTheory(IRectangle<int> monitor, IPoint<int> point, IPoint<double> expected)
+	[MemberData(nameof(ToUnitSquare_Point_Data))]
+	public void ToUnitSquare_Point(IRectangle<int> monitor, IPoint<int> point, IPoint<double> expected)
 	{
 		// When
 		IPoint<double> actual = monitor.ToUnitSquare(point);
@@ -81,7 +81,7 @@ public class MonitorHelpersTests
 		Assert.Equal(expected.Y, actual.Y);
 	}
 
-	public static IEnumerable<object[]> IntToUnitSquareRespectSignData()
+	public static IEnumerable<object[]> ToUnitSquare_Point_Data_RespectSign()
 	{
 		yield return new object[]
 		{
@@ -104,7 +104,7 @@ public class MonitorHelpersTests
 				Width = 1920,
 				Height = 1080
 			},
-			new Point<int>() { X = -192, Y = -108 },
+			new Point<int>() { X = -192 + 100, Y = -108 + 100 },
 			new Point<double>() { X = -0.1, Y = -0.1 }
 		};
 		yield return new object[]
@@ -116,7 +116,7 @@ public class MonitorHelpersTests
 				Width = 1920,
 				Height = 1080
 			},
-			new Point<int>() { X = -960, Y = 270 },
+			new Point<int>() { X = -960 + 100, Y = 270 + 100 },
 			new Point<double>() { X = -0.5, Y = 0.25 }
 		};
 		yield return new object[]
@@ -128,7 +128,7 @@ public class MonitorHelpersTests
 				Width = 1920,
 				Height = 1080
 			},
-			new Point<int>() { X = 192, Y = -108 },
+			new Point<int>() { X = 192 - 100, Y = -108 + 100 },
 			new Point<double>() { X = 0.1, Y = -0.1 }
 		};
 		yield return new object[]
@@ -140,14 +140,14 @@ public class MonitorHelpersTests
 				Width = 1920,
 				Height = 1080
 			},
-			new Point<int>() { X = -960, Y = -270 },
+			new Point<int>() { X = -960 - 100, Y = -270 + 100 },
 			new Point<double>() { X = -0.5, Y = -0.25 }
 		};
 	}
 
 	[Theory]
-	[MemberData(nameof(IntToUnitSquareRespectSignData))]
-	public void ToUnitSquarePointRespectSignTheory(IRectangle<int> monitor, IPoint<int> point, IPoint<double> expected)
+	[MemberData(nameof(ToUnitSquare_Point_Data_RespectSign))]
+	public void ToUnitSquare_PointRespectSignTheory(IRectangle<int> monitor, IPoint<int> point, IPoint<double> expected)
 	{
 		// When
 		IPoint<double> actual = monitor.ToUnitSquare(point, respectSign: true);
@@ -157,7 +157,7 @@ public class MonitorHelpersTests
 		Assert.Equal(expected.Y, actual.Y);
 	}
 
-	public static IEnumerable<object[]> DoubleToUnitSquareData()
+	public static IEnumerable<object[]> ToUnitSquare_Rectangle_Data_Double()
 	{
 		yield return new object[]
 		{
@@ -188,8 +188,8 @@ public class MonitorHelpersTests
 			},
 			new Rectangle<int>()
 			{
-				X = 192,
-				Y = 108,
+				X = 192 + 100,
+				Y = 108 + 100,
 				Width = 192,
 				Height = 108
 			},
@@ -212,8 +212,8 @@ public class MonitorHelpersTests
 			},
 			new Rectangle<int>()
 			{
-				X = 192,
-				Y = 108,
+				X = 192 - 100,
+				Y = 108 - 100,
 				Width = 192,
 				Height = 108
 			},
@@ -228,8 +228,12 @@ public class MonitorHelpersTests
 	}
 
 	[Theory]
-	[MemberData(nameof(DoubleToUnitSquareData))]
-	public void ToUnitSquareRectangleTheory(IRectangle<int> monitor, IRectangle<int> rect, IRectangle<double> expected)
+	[MemberData(nameof(ToUnitSquare_Rectangle_Data_Double))]
+	public void ToUnitSquare_Rectangle_Theory(
+		IRectangle<int> monitor,
+		IRectangle<int> rect,
+		IRectangle<double> expected
+	)
 	{
 		// When
 		IRectangle<double> actual = monitor.ToUnitSquare(rect);
@@ -239,7 +243,7 @@ public class MonitorHelpersTests
 		Assert.Equal(expected.Y, actual.Y);
 	}
 
-	public static IEnumerable<object[]> ToMonitorData()
+	public static IEnumerable<object[]> ToMonitor_Data()
 	{
 		yield return new object[]
 		{
@@ -286,8 +290,8 @@ public class MonitorHelpersTests
 	}
 
 	[Theory]
-	[MemberData(nameof(ToMonitorData))]
-	public void ToMonitorTheory(IRectangle<int> monitor, IRectangle<double> rect, IRectangle<int> expected)
+	[MemberData(nameof(ToMonitor_Data))]
+	public void ToMonitor_Theory(IRectangle<int> monitor, IRectangle<double> rect, IRectangle<int> expected)
 	{
 		// When
 		IRectangle<int> actual = monitor.ToMonitor(rect);
@@ -297,7 +301,7 @@ public class MonitorHelpersTests
 		Assert.Equal(expected.Y, actual.Y);
 	}
 
-	public static IEnumerable<object[]> ToMonitorCoordinatesData()
+	public static IEnumerable<object[]> ToMonitorCoordinates_Data()
 	{
 		yield return new object[]
 		{
@@ -320,8 +324,8 @@ public class MonitorHelpersTests
 	}
 
 	[Theory]
-	[MemberData(nameof(ToMonitorCoordinatesData))]
-	public void ToMonitorCoordinatesTheory(IRectangle<int> monitor, IPoint<int> point, IPoint<int> expected)
+	[MemberData(nameof(ToMonitorCoordinates_Data))]
+	public void ToMonitorCoordinates_Theory(IRectangle<int> monitor, IPoint<int> point, IPoint<int> expected)
 	{
 		// When
 		IPoint<int> actual = monitor.ToMonitorCoordinates(point);

--- a/src/Whim/Monitor/IMonitor.cs
+++ b/src/Whim/Monitor/IMonitor.cs
@@ -44,7 +44,7 @@ public interface IMonitor
 public static class MonitorHelpers
 {
 	/// <summary>
-	/// Translated the <paramref name="point"/> from the system's coordinate system to the
+	/// Converts the <paramref name="point"/> from the system's coordinate system to the
 	/// <paramref name="monitor"/>'s coordinate system.
 	/// The <paramref name="monitor"/>'s coordinate system is defined in terms of the monitor's
 	/// width and height, <b>not</b> the unit square.
@@ -61,7 +61,7 @@ public static class MonitorHelpers
 	}
 
 	/// <summary>
-	/// Translate the <paramref name="point"/> from the <paramref name="monitor"/>'s coordinate
+	/// Converts the <paramref name="point"/> from the <paramref name="monitor"/>'s coordinate
 	/// system to the unit square.
 	/// </summary>
 	/// <param name="monitor"></param>
@@ -74,8 +74,12 @@ public static class MonitorHelpers
 	{
 		Debug.Assert(monitor.Width != 0);
 		Debug.Assert(monitor.Height != 0);
-		double x = (double)point.X / monitor.Width;
-		double y = (double)point.Y / monitor.Height;
+
+		int translatedX = point.X - monitor.X;
+		int translatedY = point.Y - monitor.Y;
+
+		double x = (double)translatedX / monitor.Width;
+		double y = (double)translatedY / monitor.Height;
 
 		return respectSign
 			? new Point<double>() { X = x, Y = y }
@@ -83,7 +87,7 @@ public static class MonitorHelpers
 	}
 
 	/// <summary>
-	/// Translate the <paramref name="rectangle"/> from the unit square to the
+	/// Converts the <paramref name="rectangle"/> from the unit square to the
 	/// <paramref name="monitor"/>'s coordinate system.
 	/// </summary>
 	/// <param name="monitor"></param>
@@ -93,8 +97,12 @@ public static class MonitorHelpers
 	{
 		Debug.Assert(monitor.Width != 0);
 		Debug.Assert(monitor.Height != 0);
-		double x = Math.Abs((double)rectangle.X / monitor.Width);
-		double y = Math.Abs((double)rectangle.Y / monitor.Height);
+
+		int translatedX = rectangle.X - monitor.X;
+		int translatedY = rectangle.Y - monitor.Y;
+
+		double x = Math.Abs((double)translatedX / monitor.Width);
+		double y = Math.Abs((double)translatedY / monitor.Height);
 		double width = Math.Abs((double)rectangle.Width / monitor.Width);
 		double height = Math.Abs((double)rectangle.Height / monitor.Height);
 		return new Rectangle<double>()
@@ -107,7 +115,7 @@ public static class MonitorHelpers
 	}
 
 	/// <summary>
-	/// Translate the <paramref name="rectangle"/> from the unit square to the
+	/// Converts the <paramref name="rectangle"/> from the unit square to the
 	/// <paramref name="monitor"/>'s coordinate system.
 	/// </summary>
 	/// <param name="monitor"></param>


### PR DESCRIPTION
Fixed #754, which was caused by `IRectangle<int>.ToUnitSquare` not account for monitor $x$ offsets.
