### PR TITLE
Last active layout

### DIFF
--- a/src/Whim.Bar.Tests/ActiveLayout/NextLayoutEngineCommandTests.cs
+++ b/src/Whim.Bar.Tests/ActiveLayout/NextLayoutEngineCommandTests.cs
@@ -21,7 +21,7 @@ public class NextLayoutEngineCommandTests
 
 		// Then
 		context.WorkspaceManager.Received(1).GetWorkspaceForMonitor(Arg.Any<IMonitor>());
-		context.WorkspaceManager.GetWorkspaceForMonitor(monitor)!.Received(1).NextLayoutEngine();
+		context.WorkspaceManager.GetWorkspaceForMonitor(monitor)!.Received(1).CycleLayoutEngine(false);
 	}
 
 	[Theory, AutoSubstituteData]

--- a/src/Whim.Bar/ActiveLayout/NextLayoutEngineCommand.cs
+++ b/src/Whim.Bar/ActiveLayout/NextLayoutEngineCommand.cs
@@ -31,6 +31,6 @@ internal class NextLayoutEngineCommand : System.Windows.Input.ICommand
 	public void Execute(object? parameter)
 	{
 		Logger.Debug("Switching to next layout engine");
-		_context.WorkspaceManager.GetWorkspaceForMonitor(_viewModel.Monitor)?.NextLayoutEngine();
+		_context.WorkspaceManager.GetWorkspaceForMonitor(_viewModel.Monitor)?.CycleLayoutEngine(false);
 	}
 }

--- a/src/Whim.Tests/Workspace/WorkspaceManagerTests.cs
+++ b/src/Whim.Tests/Workspace/WorkspaceManagerTests.cs
@@ -2037,7 +2037,7 @@ public class WorkspaceManagerTests
 		// Then changing the layout engine should trigger the event
 		try
 		{
-			workspace.NextLayoutEngine();
+			workspace.CycleLayoutEngine(false);
 		}
 		catch
 		{

--- a/src/Whim.Tests/Workspace/WorkspaceTests.cs
+++ b/src/Whim.Tests/Workspace/WorkspaceTests.cs
@@ -63,7 +63,7 @@ public class WorkspaceTests
 	}
 
 	[Theory, AutoSubstituteData<WorkspaceCustomization>]
-	internal void SetLayoutEngineFromName_CannotFindEngine(
+	internal void TrySetLayoutEngineFromName_CannotFindEngine(
 		IContext ctx,
 		IInternalContext internalCtx,
 		WorkspaceManagerTriggers triggers,
@@ -75,7 +75,7 @@ public class WorkspaceTests
 		ILayoutEngine activeLayoutEngine = workspace.ActiveLayoutEngine;
 
 		// When
-		bool result = workspace.SetLayoutEngineFromName("Layout2");
+		bool result = workspace.TrySetLayoutEngineFromName("Layout2");
 
 		// Then
 		Assert.False(result);
@@ -83,7 +83,7 @@ public class WorkspaceTests
 	}
 
 	[Theory, AutoSubstituteData<WorkspaceCustomization>]
-	internal void SetLayoutEngineFromName_AlreadyActive(
+	internal void TrySetLayoutEngineFromName_AlreadyActive(
 		IContext ctx,
 		IInternalContext internalCtx,
 		WorkspaceManagerTriggers triggers,
@@ -98,7 +98,7 @@ public class WorkspaceTests
 		ILayoutEngine activeLayoutEngine = workspace.ActiveLayoutEngine;
 
 		// When
-		bool result = workspace.SetLayoutEngineFromName("Layout");
+		bool result = workspace.TrySetLayoutEngineFromName("Layout");
 
 		// Then
 		Assert.True(result);
@@ -106,7 +106,7 @@ public class WorkspaceTests
 	}
 
 	[Theory, AutoSubstituteData<WorkspaceCustomization>]
-	internal void SetLayoutEngineFromName_Success(
+	internal void TrySetLayoutEngineFromName_Success(
 		IContext ctx,
 		IInternalContext internalCtx,
 		WorkspaceManagerTriggers triggers,
@@ -122,7 +122,7 @@ public class WorkspaceTests
 		ILayoutEngine activeLayoutEngine = workspace.ActiveLayoutEngine;
 
 		// When
-		bool result = workspace.SetLayoutEngineFromName("Layout2");
+		bool result = workspace.TrySetLayoutEngineFromName("Layout2");
 
 		// Then
 		Assert.True(result);

--- a/src/Whim.Tests/Workspace/WorkspaceTests.cs
+++ b/src/Whim.Tests/Workspace/WorkspaceTests.cs
@@ -432,7 +432,7 @@ public class WorkspaceTests
 		ILayoutEngine givenEngine = workspace.ActiveLayoutEngine;
 
 		// When NextLayoutEngine is called
-		workspace.NextLayoutEngine();
+		workspace.CycleLayoutEngine(false);
 
 		// Then the active layout engine is set to the next one
 		Assert.True(Object.ReferenceEquals(layoutEngine2, workspace.ActiveLayoutEngine));
@@ -455,8 +455,8 @@ public class WorkspaceTests
 		ILayoutEngine givenEngine = workspace.ActiveLayoutEngine;
 
 		// When NextLayoutEngine is called
-		workspace.NextLayoutEngine();
-		workspace.NextLayoutEngine();
+		workspace.CycleLayoutEngine(false);
+		workspace.CycleLayoutEngine(false);
 
 		// Then the active layout engine is set to the first one
 		Assert.True(Object.ReferenceEquals(layoutEngine, workspace.ActiveLayoutEngine));
@@ -478,7 +478,7 @@ public class WorkspaceTests
 		ILayoutEngine givenEngine = workspace.ActiveLayoutEngine;
 
 		// When PreviousLayoutEngine is called
-		workspace.PreviousLayoutEngine();
+		workspace.CycleLayoutEngine(true);
 
 		// Then the active layout engine is set to the previous one
 		Assert.True(Object.ReferenceEquals(layoutEngine2, workspace.ActiveLayoutEngine));
@@ -500,8 +500,8 @@ public class WorkspaceTests
 		ILayoutEngine givenEngine = workspace.ActiveLayoutEngine;
 
 		// When PreviousLayoutEngine is called
-		workspace.PreviousLayoutEngine();
-		workspace.PreviousLayoutEngine();
+		workspace.CycleLayoutEngine(true);
+		workspace.CycleLayoutEngine(true);
 
 		// Then the active layout engine is set to the last one
 		Assert.True(Object.ReferenceEquals(layoutEngine, workspace.ActiveLayoutEngine));

--- a/src/Whim.Tests/Workspace/WorkspaceTests.cs
+++ b/src/Whim.Tests/Workspace/WorkspaceTests.cs
@@ -63,7 +63,7 @@ public class WorkspaceTests
 	}
 
 	[Theory, AutoSubstituteData<WorkspaceCustomization>]
-	internal void TrySetLayoutEngine_CannotFindEngine(
+	internal void SetLayoutEngineFromName_CannotFindEngine(
 		IContext ctx,
 		IInternalContext internalCtx,
 		WorkspaceManagerTriggers triggers,
@@ -75,7 +75,7 @@ public class WorkspaceTests
 		ILayoutEngine activeLayoutEngine = workspace.ActiveLayoutEngine;
 
 		// When
-		bool result = workspace.TrySetLayoutEngine("Layout2");
+		bool result = workspace.SetLayoutEngineFromName("Layout2");
 
 		// Then
 		Assert.False(result);
@@ -83,7 +83,7 @@ public class WorkspaceTests
 	}
 
 	[Theory, AutoSubstituteData<WorkspaceCustomization>]
-	internal void TrySetLayoutEngine_AlreadyActive(
+	internal void SetLayoutEngineFromName_AlreadyActive(
 		IContext ctx,
 		IInternalContext internalCtx,
 		WorkspaceManagerTriggers triggers,
@@ -98,7 +98,7 @@ public class WorkspaceTests
 		ILayoutEngine activeLayoutEngine = workspace.ActiveLayoutEngine;
 
 		// When
-		bool result = workspace.TrySetLayoutEngine("Layout");
+		bool result = workspace.SetLayoutEngineFromName("Layout");
 
 		// Then
 		Assert.True(result);
@@ -106,7 +106,7 @@ public class WorkspaceTests
 	}
 
 	[Theory, AutoSubstituteData<WorkspaceCustomization>]
-	internal void TrySetLayoutEngine_Success(
+	internal void SetLayoutEngineFromName_Success(
 		IContext ctx,
 		IInternalContext internalCtx,
 		WorkspaceManagerTriggers triggers,
@@ -122,7 +122,7 @@ public class WorkspaceTests
 		ILayoutEngine activeLayoutEngine = workspace.ActiveLayoutEngine;
 
 		// When
-		bool result = workspace.TrySetLayoutEngine("Layout2");
+		bool result = workspace.SetLayoutEngineFromName("Layout2");
 
 		// Then
 		Assert.True(result);

--- a/src/Whim/Workspace/IWorkspace.cs
+++ b/src/Whim/Workspace/IWorkspace.cs
@@ -46,7 +46,7 @@ public interface IWorkspace : IDisposable
 	/// </summary>
 	/// <param name="name">The name of the layout engine to make active.</param>
 	/// <returns></returns>
-	bool TrySetLayoutEngine(string name);
+	bool SetLayoutEngineFromName(string name);
 
 	/// <summary>
 	/// Trigger a layout.

--- a/src/Whim/Workspace/IWorkspace.cs
+++ b/src/Whim/Workspace/IWorkspace.cs
@@ -35,6 +35,11 @@ public interface IWorkspace : IDisposable
 	/// Rotate to the previous layout engine.
 	/// </summary>
 	void PreviousLayoutEngine();
+	
+	/// <summary>
+	/// Activates previously active layout engine.
+	/// </summary>
+	void LastActiveLayoutEngine();
 
 	/// <summary>
 	/// Tries to set the layout engine to one with the <c>name</c>.

--- a/src/Whim/Workspace/IWorkspace.cs
+++ b/src/Whim/Workspace/IWorkspace.cs
@@ -25,7 +25,7 @@ public interface IWorkspace : IDisposable
 	/// </summary>
 	/// <param name="nextIdx">The index of the layout engine to make active.</param>
 	void SetLayoutEngine(int nextIdx);
-	
+
 	/// <summary>
 	/// Rotate to the next layout engine.
 	/// </summary>
@@ -35,7 +35,7 @@ public interface IWorkspace : IDisposable
 	/// Rotate to the previous layout engine.
 	/// </summary>
 	void PreviousLayoutEngine();
-	
+
 	/// <summary>
 	/// Activates previously active layout engine.
 	/// </summary>

--- a/src/Whim/Workspace/IWorkspace.cs
+++ b/src/Whim/Workspace/IWorkspace.cs
@@ -27,13 +27,23 @@ public interface IWorkspace : IDisposable
 	bool TrySetLayoutEngineFromIndex(int nextIdx);
 
 	/// <summary>
+	/// Cycle to the next or previous layout engine.
+	/// </summary>
+	/// <param name="reverse">
+	/// When <see langword="true"/>, activate the previous layout, otherwise activate the next layout. Defaults to <see langword="false" />.
+	/// </param>
+	void CycleLayoutEngine(bool reverse = false);
+
+	/// <summary>
 	/// Rotate to the next layout engine.
 	/// </summary>
+	[Obsolete("Use CycleLayoutEngine instead, with `reverse: false`")]
 	void NextLayoutEngine();
 
 	/// <summary>
 	/// Rotate to the previous layout engine.
 	/// </summary>
+	[Obsolete("Use CycleLayoutEngine instead, with `reverse: true`")]
 	void PreviousLayoutEngine();
 
 	/// <summary>

--- a/src/Whim/Workspace/IWorkspace.cs
+++ b/src/Whim/Workspace/IWorkspace.cs
@@ -24,7 +24,7 @@ public interface IWorkspace : IDisposable
 	/// Rotate to the next layout engine.
 	/// </summary>
 	/// <param name="nextIdx">The index of the layout engine to make active.</param>
-	void TrySetLayoutEngineFromIndex(int nextIdx);
+	bool TrySetLayoutEngineFromIndex(int nextIdx);
 
 	/// <summary>
 	/// Rotate to the next layout engine.

--- a/src/Whim/Workspace/IWorkspace.cs
+++ b/src/Whim/Workspace/IWorkspace.cs
@@ -39,7 +39,7 @@ public interface IWorkspace : IDisposable
 	/// <summary>
 	/// Activates previously active layout engine.
 	/// </summary>
-	void LastActiveLayoutEngine();
+	void ActivatePreviouslyActiveLayoutEngine();
 
 	/// <summary>
 	/// Tries to set the layout engine to one with the <c>name</c>.

--- a/src/Whim/Workspace/IWorkspace.cs
+++ b/src/Whim/Workspace/IWorkspace.cs
@@ -24,7 +24,7 @@ public interface IWorkspace : IDisposable
 	/// Rotate to the next layout engine.
 	/// </summary>
 	/// <param name="nextIdx">The index of the layout engine to make active.</param>
-	void SetLayoutEngine(int nextIdx);
+	void TrySetLayoutEngineFromIndex(int nextIdx);
 
 	/// <summary>
 	/// Rotate to the next layout engine.
@@ -46,7 +46,7 @@ public interface IWorkspace : IDisposable
 	/// </summary>
 	/// <param name="name">The name of the layout engine to make active.</param>
 	/// <returns></returns>
-	bool SetLayoutEngineFromName(string name);
+	bool TrySetLayoutEngineFromName(string name);
 
 	/// <summary>
 	/// Trigger a layout.

--- a/src/Whim/Workspace/IWorkspace.cs
+++ b/src/Whim/Workspace/IWorkspace.cs
@@ -23,6 +23,12 @@ public interface IWorkspace : IDisposable
 	/// <summary>
 	/// Rotate to the next layout engine.
 	/// </summary>
+	/// <param name="nextIdx">The index of the layout engine to make active.</param>
+	void SetLayoutEngine(int nextIdx);
+	
+	/// <summary>
+	/// Rotate to the next layout engine.
+	/// </summary>
 	void NextLayoutEngine();
 
 	/// <summary>

--- a/src/Whim/Workspace/Workspace.cs
+++ b/src/Whim/Workspace/Workspace.cs
@@ -243,8 +243,12 @@ internal class Workspace : IWorkspace, IInternalWorkspace
 		return true;
 	}
 
-	private void CycleLayoutEngine(int delta)
+	public void CycleLayoutEngine(bool reverse = false)
 	{
+		Logger.Debug($"Cycling layout engine on workspace {Name}");
+
+		int delta = reverse ? -1 : 1;
+
 		int nextIdx;
 
 		lock (_workspaceLock)
@@ -255,17 +259,9 @@ internal class Workspace : IWorkspace, IInternalWorkspace
 		TrySetLayoutEngineFromIndex(nextIdx);
 	}
 
-	public void NextLayoutEngine()
-	{
-		Logger.Debug(Name);
-		CycleLayoutEngine(1);
-	}
+	public void NextLayoutEngine() => CycleLayoutEngine(false);
 
-	public void PreviousLayoutEngine()
-	{
-		Logger.Debug(Name);
-		CycleLayoutEngine(-1);
-	}
+	public void PreviousLayoutEngine() => CycleLayoutEngine(true);
 
 	public void ActivatePreviouslyActiveLayoutEngine()
 	{

--- a/src/Whim/Workspace/Workspace.cs
+++ b/src/Whim/Workspace/Workspace.cs
@@ -260,7 +260,7 @@ internal class Workspace : IWorkspace, IInternalWorkspace
 		SetLayoutEngine(_prevLayoutEngineIndex);
 	}
 
-	public bool TrySetLayoutEngine(string name)
+	public bool SetLayoutEngineFromName(string name)
 	{
 		Logger.Debug($"Trying to set layout engine {name} for workspace {Name}");
 

--- a/src/Whim/Workspace/Workspace.cs
+++ b/src/Whim/Workspace/Workspace.cs
@@ -55,6 +55,7 @@ internal class Workspace : IWorkspace, IInternalWorkspace
 	}
 
 	protected readonly ILayoutEngine[] _layoutEngines;
+	private int _prevLayoutEngineIndex;
 	private int _activeLayoutEngineIndex;
 	private bool _disposedValue;
 
@@ -212,6 +213,7 @@ internal class Workspace : IWorkspace, IInternalWorkspace
 		{
 			int prevIdx = _activeLayoutEngineIndex;
 			
+			_prevLayoutEngineIndex = prevIdx;
 			_activeLayoutEngineIndex = nextIdx;
 
 			prevLayoutEngine = _layoutEngines[prevIdx];
@@ -251,6 +253,11 @@ internal class Workspace : IWorkspace, IInternalWorkspace
 	{
 		Logger.Debug(Name);
 		CycleLayoutEngine(-1);
+	}
+
+	public void LastActiveLayoutEngine()
+	{
+		SetLayoutEngine(_prevLayoutEngineIndex);
 	}
 
 	public bool TrySetLayoutEngine(string name)

--- a/src/Whim/Workspace/Workspace.cs
+++ b/src/Whim/Workspace/Workspace.cs
@@ -267,7 +267,7 @@ internal class Workspace : IWorkspace, IInternalWorkspace
 		CycleLayoutEngine(-1);
 	}
 
-	public void LastActiveLayoutEngine()
+	public void ActivatePreviouslyActiveLayoutEngine()
 	{
 		TrySetLayoutEngineFromIndex(_prevLayoutEngineIndex);
 	}

--- a/src/Whim/Workspace/Workspace.cs
+++ b/src/Whim/Workspace/Workspace.cs
@@ -211,13 +211,11 @@ internal class Workspace : IWorkspace, IInternalWorkspace
 
 		lock (_workspaceLock)
 		{
-			int prevIdx = _activeLayoutEngineIndex;
-
-			_prevLayoutEngineIndex = prevIdx;
+			_prevLayoutEngineIndex = _activeLayoutEngineIndex;
 			_activeLayoutEngineIndex = nextIdx;
 
-			prevLayoutEngine = _layoutEngines[prevIdx];
-			nextLayoutEngine = _layoutEngines[nextIdx];
+			prevLayoutEngine = _layoutEngines[_prevLayoutEngineIndex];
+			nextLayoutEngine = _layoutEngines[_activeLayoutEngineIndex];
 		}
 
 		DoLayout();

--- a/src/Whim/Workspace/Workspace.cs
+++ b/src/Whim/Workspace/Workspace.cs
@@ -204,13 +204,26 @@ internal class Workspace : IWorkspace, IInternalWorkspace
 		}
 	}
 
-	public void TrySetLayoutEngineFromIndex(int nextIdx)
+	public bool TrySetLayoutEngineFromIndex(int nextIdx)
 	{
+		Logger.Debug($"Trying to set layout engine with index {nextIdx} for workspace");
+
 		ILayoutEngine prevLayoutEngine;
 		ILayoutEngine nextLayoutEngine;
 
 		lock (_workspaceLock)
 		{
+			if (nextIdx >= _layoutEngines.Length)
+			{
+				Logger.Error($"Index {nextIdx} exceeds number of layout engines for workspace");
+				return false;
+			}
+			if (nextIdx < 0)
+			{
+				Logger.Error($"Index {nextIdx} is negative");
+				return false;
+			}
+
 			_prevLayoutEngineIndex = _activeLayoutEngineIndex;
 			_activeLayoutEngineIndex = nextIdx;
 
@@ -227,6 +240,7 @@ internal class Workspace : IWorkspace, IInternalWorkspace
 				CurrentLayoutEngine = nextLayoutEngine
 			}
 		);
+		return true;
 	}
 
 	private void CycleLayoutEngine(int delta)

--- a/src/Whim/Workspace/Workspace.cs
+++ b/src/Whim/Workspace/Workspace.cs
@@ -263,10 +263,7 @@ internal class Workspace : IWorkspace, IInternalWorkspace
 
 	public void PreviousLayoutEngine() => CycleLayoutEngine(true);
 
-	public void ActivatePreviouslyActiveLayoutEngine()
-	{
-		TrySetLayoutEngineFromIndex(_prevLayoutEngineIndex);
-	}
+	public void ActivatePreviouslyActiveLayoutEngine() => TrySetLayoutEngineFromIndex(_prevLayoutEngineIndex);
 
 	public bool TrySetLayoutEngineFromName(string name)
 	{

--- a/src/Whim/Workspace/Workspace.cs
+++ b/src/Whim/Workspace/Workspace.cs
@@ -204,7 +204,7 @@ internal class Workspace : IWorkspace, IInternalWorkspace
 		}
 	}
 
-	public void SetLayoutEngine(int nextIdx)
+	public void TrySetLayoutEngineFromIndex(int nextIdx)
 	{
 		ILayoutEngine prevLayoutEngine;
 		ILayoutEngine nextLayoutEngine;
@@ -238,7 +238,7 @@ internal class Workspace : IWorkspace, IInternalWorkspace
 			nextIdx = (_activeLayoutEngineIndex + delta).Mod(_layoutEngines.Length);
 		}
 
-		SetLayoutEngine(nextIdx);
+		TrySetLayoutEngineFromIndex(nextIdx);
 	}
 
 	public void NextLayoutEngine()
@@ -255,10 +255,10 @@ internal class Workspace : IWorkspace, IInternalWorkspace
 
 	public void LastActiveLayoutEngine()
 	{
-		SetLayoutEngine(_prevLayoutEngineIndex);
+		TrySetLayoutEngineFromIndex(_prevLayoutEngineIndex);
 	}
 
-	public bool SetLayoutEngineFromName(string name)
+	public bool TrySetLayoutEngineFromName(string name)
 	{
 		Logger.Debug($"Trying to set layout engine {name} for workspace {Name}");
 
@@ -288,7 +288,7 @@ internal class Workspace : IWorkspace, IInternalWorkspace
 			}
 		}
 
-		SetLayoutEngine(nextIdx);
+		TrySetLayoutEngineFromIndex(nextIdx);
 		return true;
 	}
 

--- a/src/Whim/Workspace/Workspace.cs
+++ b/src/Whim/Workspace/Workspace.cs
@@ -208,11 +208,11 @@ internal class Workspace : IWorkspace, IInternalWorkspace
 	{
 		ILayoutEngine prevLayoutEngine;
 		ILayoutEngine nextLayoutEngine;
-		
+
 		lock (_workspaceLock)
 		{
 			int prevIdx = _activeLayoutEngineIndex;
-			
+
 			_prevLayoutEngineIndex = prevIdx;
 			_activeLayoutEngineIndex = nextIdx;
 
@@ -230,16 +230,16 @@ internal class Workspace : IWorkspace, IInternalWorkspace
 			}
 		);
 	}
-	
+
 	private void CycleLayoutEngine(int delta)
 	{
 		int nextIdx;
-		
+
 		lock (_workspaceLock)
 		{
 			nextIdx = (_activeLayoutEngineIndex + delta).Mod(_layoutEngines.Length);
 		}
-		
+
 		SetLayoutEngine(nextIdx);
 	}
 
@@ -288,7 +288,6 @@ internal class Workspace : IWorkspace, IInternalWorkspace
 				Logger.Debug($"Layout engine {name} is already active for workspace {Name}");
 				return true;
 			}
-
 		}
 
 		SetLayoutEngine(nextIdx);


### PR DESCRIPTION
- [x] refactor `Workspace` to use `SetLayoutEngine` for setting the active layout engine
- [x] keep track of `prevLayoutEngineIndex`
- [x] new method to activate previously active layout
- [x] rename `UpdateLayoutEngine` to `CycleLayoutEngine` -- this made more sense to me, but happy to revert if this isn't consensus
- [x] rename `TrySetLayoutEngine` to `SetLayoutEngineFromName` -- this made more sense to me, but happy to revert if this isn't consensus