### PR TITLE
Always focus windows in `FocusLayout`

### DIFF
--- a/src/Whim.Tests/Layout/FocusLayoutEngineTests.cs
+++ b/src/Whim.Tests/Layout/FocusLayoutEngineTests.cs
@@ -207,6 +207,7 @@ public class FocusLayoutEngineTests
 
 		// Then
 		Assert.Same(sut, result);
+		window.DidNotReceive().Focus();
 	}
 
 	[Theory]
@@ -231,6 +232,7 @@ public class FocusLayoutEngineTests
 		Assert.NotSame(sut, result);
 		Assert.Equal(sut.Count, result.Count);
 		Assert.Equal(WindowSize.Normal, windowStates[expectedIndex].WindowSize);
+		windowStates[expectedIndex].Window.Received().Focus();
 	}
 
 	[Theory, AutoSubstituteData]

--- a/src/Whim/Layout/FocusLayoutEngine.cs
+++ b/src/Whim/Layout/FocusLayoutEngine.cs
@@ -206,6 +206,7 @@ public record FocusLayoutEngine : ILayoutEngine
 		};
 		newIndex = newIndex.Mod(_list.Count);
 
+		_list[newIndex].Focus();
 		return new FocusLayoutEngine(this, _list, newIndex, _maximized, false);
 	}
 


### PR DESCRIPTION
This may be related to #765, but is necessary regardless.