### PR TITLE
Fix window focus during `MinimizeWindowEnd`

### DIFF
--- a/src/Whim.FocusIndicator/FocusIndicatorPlugin.cs
+++ b/src/Whim.FocusIndicator/FocusIndicatorPlugin.cs
@@ -56,7 +56,11 @@ public class FocusIndicatorPlugin : IFocusIndicatorPlugin
 		_context.WorkspaceManager.WorkspaceLayoutCompleted += WorkspaceManager_WorkspaceLayoutCompleted;
 	}
 
-	private void DispatcherTimer_Tick(object? sender, object e) => Hide();
+	private void DispatcherTimer_Tick(object? sender, object e)
+	{
+		Logger.Debug("Focus indicator timer ticked");
+		Hide();
+	}
 
 	private void WindowManager_WindowMoveStart(object? sender, WindowMovedEventArgs e) => Hide();
 

--- a/src/Whim.LayoutPreview.Tests/LayoutPreviewWindowTests.cs
+++ b/src/Whim.LayoutPreview.Tests/LayoutPreviewWindowTests.cs
@@ -182,6 +182,7 @@ public class LayoutPreviewWindowTests
 		// Given
 		ctx.NativeManager.DeferWindowPos().Returns(new DeferWindowPosHandle(ctx, internalCtx));
 		internalCtx.DeferWindowPosManager.CanDoLayout().Returns(true);
+		internalCtx.DeferWindowPosManager.ParallelOptions.Returns(new ParallelOptions { MaxDegreeOfParallelism = 1 });
 
 		// When
 		LayoutPreviewWindow.Activate(ctx, layoutWindow, movingWindow, monitor);

--- a/src/Whim.Tests/Native/DeferWindowPosHandleTests.cs
+++ b/src/Whim.Tests/Native/DeferWindowPosHandleTests.cs
@@ -85,10 +85,17 @@ public class DeferWindowPosHandleTests
 	}
 
 	[Theory, AutoSubstituteData<DeferWindowPosHandleCustomization>]
-	internal void Dispose_CannotDoLayout(IContext ctx, IInternalContext internalCtx, WindowPosState windowPosState)
+	internal void Dispose_CannotDoLayout(
+		IContext ctx,
+		IInternalContext internalCtx,
+		WindowPosState windowPosState,
+		WindowPosState windowPosState2
+	)
 	{
 		// Given DeferWindowPosManager.CanDoLayout() returns false
-		using DeferWindowPosHandle handle = new(ctx, internalCtx, new WindowPosState[] { windowPosState });
+		windowPosState2.WindowState.WindowSize = WindowSize.Minimized;
+		using DeferWindowPosHandle handle =
+			new(ctx, internalCtx, new WindowPosState[] { windowPosState, windowPosState2 });
 		internalCtx.DeferWindowPosManager.CanDoLayout().Returns(false);
 
 		// When disposing
@@ -96,7 +103,8 @@ public class DeferWindowPosHandleTests
 
 		// Then the layout is deferred
 		internalCtx.DeferWindowPosManager.DeferLayout(
-			Arg.Is<List<WindowPosState>>(x => x.Count == 1 && x[0] == windowPosState)
+			Arg.Is<List<WindowPosState>>(x => x.Count == 1 && x[0] == windowPosState),
+			Arg.Is<List<WindowPosState>>(x => x.Count == 1 && x[0] == windowPosState2)
 		);
 	}
 

--- a/src/Whim.Tests/Native/DeferWindowPosManagerTests.cs
+++ b/src/Whim.Tests/Native/DeferWindowPosManagerTests.cs
@@ -53,12 +53,14 @@ public class DeferWindowPosManagerTests
 		IContext ctx,
 		IInternalContext internalCtx,
 		WindowPosState windowPosState,
+		WindowPosState minimizedWindowPosState,
 		IWorkspace workspace
 	)
 	{
 		// Given a window is provided, and a workspace is found for it
+		minimizedWindowPosState.WindowState.WindowSize = WindowSize.Minimized;
 		DeferWindowPosManager manager = CreateSut(ctx, internalCtx);
-		manager.DeferLayout(new() { windowPosState });
+		manager.DeferLayout(new() { windowPosState }, new() { minimizedWindowPosState });
 
 		ctx.WorkspaceManager.GetWorkspaceForWindow(windowPosState.WindowState.Window).Returns(workspace);
 
@@ -76,15 +78,17 @@ public class DeferWindowPosManagerTests
 		IInternalContext internalCtx,
 		WindowPosState windowPosState1,
 		WindowPosState windowPosState2,
+		WindowPosState minimizedWindowPosState,
 		IWorkspace workspace
 	)
 	{
 		// Given two windows are provided for the same workspace
 		DeferWindowPosManager manager = CreateSut(ctx, internalCtx);
-		manager.DeferLayout(new() { windowPosState1, windowPosState2 });
+		manager.DeferLayout(new() { windowPosState1, windowPosState2 }, new() { minimizedWindowPosState });
 
 		ctx.WorkspaceManager.GetWorkspaceForWindow(windowPosState1.WindowState.Window).Returns(workspace);
 		ctx.WorkspaceManager.GetWorkspaceForWindow(windowPosState2.WindowState.Window).Returns(workspace);
+		ctx.WorkspaceManager.GetWorkspaceForWindow(minimizedWindowPosState.WindowState.Window).Returns(workspace);
 
 		// When RecoverLayout is called
 		manager.RecoverLayout();
@@ -104,7 +108,7 @@ public class DeferWindowPosManagerTests
 		// Given a window is provided, no workspace is found for the window, and the window is
 		// ignored by the FilterManager
 		DeferWindowPosManager manager = CreateSut(ctx, internalCtx);
-		manager.DeferLayout(new() { windowPosState });
+		manager.DeferLayout(new() { windowPosState }, new());
 
 		ctx.WorkspaceManager.GetWorkspaceForWindow(windowPosState.WindowState.Window).Returns((IWorkspace?)null);
 		ctx.FilterManager.ShouldBeIgnored(windowPosState.WindowState.Window).Returns(true);
@@ -126,7 +130,7 @@ public class DeferWindowPosManagerTests
 		// Given a window is provided, no workspace is found for the window, and the window is
 		// not ignored by the FilterManager
 		DeferWindowPosManager manager = CreateSut(ctx, internalCtx);
-		manager.DeferLayout(new() { windowPosState });
+		manager.DeferLayout(new() { windowPosState }, new());
 
 		ctx.WorkspaceManager.GetWorkspaceForWindow(windowPosState.WindowState.Window).Returns((IWorkspace?)null);
 		ctx.FilterManager.ShouldBeIgnored(windowPosState.WindowState.Window).Returns(false);

--- a/src/Whim.Tests/Workspace/WorkspaceTests.cs
+++ b/src/Whim.Tests/Workspace/WorkspaceTests.cs
@@ -1237,6 +1237,8 @@ public class WorkspaceTests
 
 		ILayoutEngine givenEngine = workspace.ActiveLayoutEngine;
 
+		window.ClearReceivedCalls();
+
 		// When MinimizeWindowEnd is called
 		workspace.MinimizeWindowEnd(window);
 

--- a/src/Whim.Tests/Workspace/WorkspaceTests.cs
+++ b/src/Whim.Tests/Workspace/WorkspaceTests.cs
@@ -1244,6 +1244,7 @@ public class WorkspaceTests
 		givenEngine.Received(1).MinimizeWindowEnd(window);
 		layoutEngine2.DidNotReceive().MinimizeWindowEnd(window);
 		Assert.NotSame(givenEngine, workspace.ActiveLayoutEngine);
+		window.Received(1).Focus();
 	}
 
 	#region PerformCustomLayoutEngineAction

--- a/src/Whim/Native/DeferWindowPosHandle.cs
+++ b/src/Whim/Native/DeferWindowPosHandle.cs
@@ -142,6 +142,12 @@ public sealed class DeferWindowPosHandle : IDisposable
 		// This was done to prevent the minimized windows being hidden, and Windows focusing the previous window.
 		// When windows are restored, then we make sure to focus them - see the window.Focus()` in
 		// `Workspace.MinimizeWindowEnd`.
+		// This is delicate code - to test:
+		// 1. Set monitor 2 to FocusLayoutEngine
+		// 2. Focus a tracked window in monitor 1
+		// 3. Change focus to a tracked window in monitor 2
+		// 4. Focus next window
+		// If monitor 1 receives the focus indicator, then this code is broken.
 		WindowPosState[] allStates = new WindowPosState[_windowStates.Count + _minimizedWindowStates.Count];
 		_windowStates.CopyTo(allStates);
 		_minimizedWindowStates.CopyTo(allStates, _windowStates.Count);

--- a/src/Whim/Native/DeferWindowPosHandle.cs
+++ b/src/Whim/Native/DeferWindowPosHandle.cs
@@ -86,7 +86,7 @@ public sealed class DeferWindowPosHandle : IDisposable
 		SET_WINDOW_POS_FLAGS? flags = null
 	)
 	{
-		Logger.Debug($"Adding window {windowState} after {hwndInsertAfter} with flags {flags}");
+		Logger.Debug($"Adding window {windowState.Window} after {hwndInsertAfter} with flags {flags}");
 		// We use HWND_BOTTOM, as modifying the Z-order of a window
 		// may cause EVENT_SYSTEM_FOREGROUND to be set, which in turn
 		// causes the relevant window to be focused, when the user hasn't

--- a/src/Whim/Native/DeferWindowPosHandle.cs
+++ b/src/Whim/Native/DeferWindowPosHandle.cs
@@ -65,9 +65,10 @@ public sealed class DeferWindowPosHandle : IDisposable
 	)
 		: this(context, internalContext)
 	{
+		// Add each window state to the appropriate list.
 		foreach (WindowPosState windowState in windowStates)
 		{
-			Add(windowState);
+			AddToCorrectList(windowState);
 		}
 	}
 
@@ -92,10 +93,17 @@ public sealed class DeferWindowPosHandle : IDisposable
 		// causes the relevant window to be focused, when the user hasn't
 		// actually changed the focus.
 		HWND targetHwndInsertAfter = hwndInsertAfter ?? (HWND)1; // HWND_BOTTOM
-		Add(new(windowState, targetHwndInsertAfter, flags));
+		AddToCorrectList(new(windowState, targetHwndInsertAfter, flags));
 	}
 
-	private void Add(WindowPosState windowPosState)
+	/// <summary>
+	/// Adds the given <paramref name="windowPosState"/> to the appropriate list.
+	/// </summary>
+	/// <param name="windowPosState">
+	/// Minimized windows are added to <see cref="_minimizedWindowStates"/>, otherwise they are added to
+	/// <see cref="_windowStates"/>.
+	/// </param>
+	private void AddToCorrectList(WindowPosState windowPosState)
 	{
 		if (windowPosState.WindowState.WindowSize == WindowSize.Minimized)
 		{

--- a/src/Whim/Native/DeferWindowPosManager.cs
+++ b/src/Whim/Native/DeferWindowPosManager.cs
@@ -19,10 +19,14 @@ internal class DeferWindowPosManager : IDeferWindowPosManager
 		_internalContext = internalContext;
 	}
 
-	public void DeferLayout(List<WindowPosState> windowStates)
+	public void DeferLayout(List<WindowPosState> windowStates, List<WindowPosState> minimizedWindowStates)
 	{
 		Logger.Debug("Deferring layout");
 		foreach (WindowPosState windowState in windowStates)
+		{
+			_deferredWindowStates[windowState.WindowState.Window] = windowState;
+		}
+		foreach (WindowPosState windowState in minimizedWindowStates)
 		{
 			_deferredWindowStates[windowState.WindowState.Window] = windowState;
 		}

--- a/src/Whim/Native/IDeferWindowPosManager.cs
+++ b/src/Whim/Native/IDeferWindowPosManager.cs
@@ -48,7 +48,8 @@ internal interface IDeferWindowPosManager
 	/// Defers layout of the given windows until <see cref="RecoverLayout"/> is called.
 	/// </summary>
 	/// <param name="windowStates"></param>
-	void DeferLayout(List<WindowPosState> windowStates);
+	/// <param name="minimizedWindowStates"></param>
+	void DeferLayout(List<WindowPosState> windowStates, List<WindowPosState> minimizedWindowStates);
 
 	/// <summary>
 	/// Returns whether or not layout can be performed, based on whether Whim has been reentered.

--- a/src/Whim/Window/WindowManager.cs
+++ b/src/Whim/Window/WindowManager.cs
@@ -261,7 +261,9 @@ internal class WindowManager : IWindowManager, IInternalWindowManager
 			)
 			{
 				// Even if the window was ignored, we need to fire OnWindowFocused.
-				Logger.Debug($"Window {hwnd} was ignored, but still notifying listeners of focus");
+				Logger.Debug(
+					$"Window {hwnd} with event 0x{eventType:X4} was ignored, but still notifying listeners of focus"
+				);
 				OnWindowFocused(window);
 
 				_internalContext.DeferWindowPosManager.RecoverLayout();

--- a/src/Whim/Workspace/Workspace.cs
+++ b/src/Whim/Workspace/Workspace.cs
@@ -168,6 +168,7 @@ internal class Workspace : IWorkspace, IInternalWorkspace
 		}
 
 		DoLayout();
+		window.Focus();
 	}
 
 	public void FocusFirstWindow()


### PR DESCRIPTION
The two main changes in this PR are:

- focus the window which is being unminimized in `Workspace.MinimizeWindowEnd`
- minimized windows have their window position set last (given the API calls in `Parallel.ForEach` behave in an ordered manner, which I know isn't really a guarantee)

The focus behavior is particularly brittle - a more thorough explanation can be found in `DeferWindowPosHandle.Dispose`.
