### PR TITLE
Add minimized windows to the appropriate workspace

### DIFF
--- a/src/Whim.Tests/Monitor/MonitorManagerTests.cs
+++ b/src/Whim.Tests/Monitor/MonitorManagerTests.cs
@@ -793,4 +793,33 @@ public class MonitorManagerTests
 		Assert.Equal(monitorManager.ActiveMonitor, monitor);
 	}
 	#endregion
+
+	#region GetMonitorByHandle
+	[Theory, AutoSubstituteData<MonitorManagerCustomization>]
+	internal void GetMonitorByHandle_ReturnsNull(IContext ctx, IInternalContext internalCtx)
+	{
+		// Given
+		MonitorManager monitorManager = new(ctx, internalCtx);
+
+		// When
+		IMonitor? monitor = monitorManager.GetMonitorByHandle((HMONITOR)5);
+
+		// Then
+		Assert.Null(monitor);
+	}
+
+	[Theory, AutoSubstituteData<MonitorManagerCustomization>]
+	internal void GetMonitorByHandle_ReturnsMonitor(IContext ctx, IInternalContext internalCtx)
+	{
+		// Given
+		MonitorManager monitorManager = new(ctx, internalCtx);
+		IMonitor monitor = monitorManager.ElementAt(1);
+
+		// When
+		IMonitor? result = monitorManager.GetMonitorByHandle((HMONITOR)1);
+
+		// Then
+		Assert.Equal(monitor, result);
+	}
+	#endregion
 }

--- a/src/Whim/Butler/ButlerEventHandlers.cs
+++ b/src/Whim/Butler/ButlerEventHandlers.cs
@@ -1,4 +1,5 @@
 using System;
+using Windows.Win32.Graphics.Gdi;
 
 namespace Whim;
 
@@ -66,11 +67,15 @@ internal class ButlerEventHandlers : IDisposable
 			workspace = null;
 		}
 
-		// If no workspace has been selected, route the window to the monitor it's on.
+		// If the workspace is still null, try to find a workspace for the window's monitor.
 		if (workspace == null)
 		{
-			IMonitor? monitor = _context.MonitorManager.GetMonitorAtPoint(window.Rectangle.Center);
-			if (monitor is not null)
+			HMONITOR hmonitor = _internalContext.CoreNativeManager.MonitorFromWindow(
+				window.Handle,
+				MONITOR_FROM_FLAGS.MONITOR_DEFAULTTONEAREST
+			);
+
+			if (_internalContext.MonitorManager.GetMonitorByHandle(hmonitor) is IMonitor monitor)
 			{
 				workspace = _pantry.GetWorkspaceForMonitor(monitor);
 			}

--- a/src/Whim/Monitor/IInternalMonitorManager.cs
+++ b/src/Whim/Monitor/IInternalMonitorManager.cs
@@ -1,3 +1,5 @@
+using Windows.Win32.Graphics.Gdi;
+
 namespace Whim;
 
 internal interface IInternalMonitorManager
@@ -6,6 +8,13 @@ internal interface IInternalMonitorManager
 	/// The last <see cref="IMonitor"/> which received an event sent by Windows which Whim did not ignore.
 	/// </summary>
 	IMonitor LastWhimActiveMonitor { get; set; }
+
+	/// <summary>
+	/// Try to get the <see cref="IMonitor"/> for the given <paramref name="hmonitor"/>.
+	/// </summary>
+	/// <param name="hmonitor"></param>
+	/// <returns></returns>
+	IMonitor? GetMonitorByHandle(HMONITOR hmonitor);
 
 	/// <summary>
 	/// Called when the window has been focused.

--- a/src/Whim/Monitor/MonitorManager.cs
+++ b/src/Whim/Monitor/MonitorManager.cs
@@ -302,6 +302,8 @@ internal class MonitorManager : IInternalMonitorManager, IMonitorManager
 		return _monitors[(index + 1).Mod(_monitors.Length)];
 	}
 
+	public IMonitor? GetMonitorByHandle(HMONITOR hmonitor) => _monitors.FirstOrDefault(m => m._hmonitor == hmonitor);
+
 	protected virtual void Dispose(bool disposing)
 	{
 		if (!_disposedValue)


### PR DESCRIPTION
Previously, when starting Whim, minimized windows would get added to the currently active workspace/monitor.

The expected behavior was that minimized windows would be added to the workspace/monitor which contains them.

This has been rectified (though #784 remains incomplete).