### PR TITLE
Remove `DoLayout` calls from `Workspace`

### DIFF
--- a/src/Whim.Bar.Tests/ActiveLayout/NextLayoutEngineCommandTests.cs
+++ b/src/Whim.Bar.Tests/ActiveLayout/NextLayoutEngineCommandTests.cs
@@ -20,8 +20,23 @@ public class NextLayoutEngineCommandTests
 		command.Execute(null);
 
 		// Then
-		context.WorkspaceManager.Received(1).GetWorkspaceForMonitor(Arg.Any<IMonitor>());
-		context.WorkspaceManager.GetWorkspaceForMonitor(monitor)!.Received(1).CycleLayoutEngine(false);
+		context.Butler.Received(1).GetWorkspaceForMonitor(Arg.Any<IMonitor>());
+		context.Butler.GetWorkspaceForMonitor(monitor)!.Received(1).CycleLayoutEngine(false);
+	}
+
+	[Theory, AutoSubstituteData]
+	public void Execute_NoWorkspaceForMonitor(IContext context, IMonitor monitor)
+	{
+		// Given
+		ActiveLayoutWidgetViewModel viewModel = CreateSut(context, monitor);
+		NextLayoutEngineCommand command = new(context, viewModel);
+		context.Butler.GetWorkspaceForMonitor(monitor).Returns((IWorkspace?)null);
+
+		// When
+		command.Execute(null);
+
+		// Then
+		context.Butler.Received(1).GetWorkspaceForMonitor(Arg.Any<IMonitor>());
 	}
 
 	[Theory, AutoSubstituteData]

--- a/src/Whim.Bar/ActiveLayout/NextLayoutEngineCommand.cs
+++ b/src/Whim.Bar/ActiveLayout/NextLayoutEngineCommand.cs
@@ -31,6 +31,9 @@ internal class NextLayoutEngineCommand : System.Windows.Input.ICommand
 	public void Execute(object? parameter)
 	{
 		Logger.Debug("Switching to next layout engine");
-		_context.WorkspaceManager.GetWorkspaceForMonitor(_viewModel.Monitor)?.CycleLayoutEngine(false);
+		if (_context.Butler.GetWorkspaceForMonitor(_viewModel.Monitor) is IWorkspace workspace)
+		{
+			workspace.CycleLayoutEngine(false);
+		}
 	}
 }

--- a/src/Whim.CommandPalette.Tests/CommandPaletteCommandsTests.cs
+++ b/src/Whim.CommandPalette.Tests/CommandPaletteCommandsTests.cs
@@ -1,5 +1,6 @@
 using FluentAssertions;
 using NSubstitute;
+using NSubstitute.ReturnsExtensions;
 using Xunit;
 
 namespace Whim.CommandPalette.Tests;
@@ -361,6 +362,7 @@ public class CommandPaletteCommandsTests
 		Wrapper wrapper = new();
 
 		IWindow window = wrapper.Windows[0];
+		window.IsMinimized.Returns(true);
 		wrapper.Context.Butler.GetWorkspaceForWindow(window).Returns(wrapper.Workspace);
 
 		CommandPaletteCommands commands = new(wrapper.Context, wrapper.Plugin);
@@ -371,20 +373,20 @@ public class CommandPaletteCommandsTests
 
 		// Then
 		wrapper.Workspace.Received(1).MinimizeWindowEnd(window);
-		wrapper.Context.Butler.Received(1).Activate(Arg.Any<IWorkspace>());
+		wrapper.Context.Butler.DidNotReceive().Activate(Arg.Any<IWorkspace>());
 		wrapper.Workspace.Received(1).DoLayout();
 		window.Received(1).Focus();
 	}
 
 	[Fact]
-	public void FocusWindowCommandCreator_WindowIsNotMinimized()
+	public void FocusWindowCommandCreator_ActivateWorkspace()
 	{
 		// Given
 		Wrapper wrapper = new();
 
 		IWindow window = wrapper.Windows[0];
 		wrapper.Context.Butler.GetWorkspaceForWindow(window).Returns(wrapper.Workspace);
-		window.IsMinimized.Returns(false);
+		wrapper.Context.Butler.GetMonitorForWindow(window).ReturnsNull();
 
 		CommandPaletteCommands commands = new(wrapper.Context, wrapper.Plugin);
 
@@ -394,7 +396,7 @@ public class CommandPaletteCommandsTests
 
 		// Then
 		wrapper.Workspace.DidNotReceive().MinimizeWindowEnd(window);
-		wrapper.Context.Butler.Received(1).Activate(Arg.Any<IWorkspace>());
+		wrapper.Context.Butler.Received(1).Activate(wrapper.Workspace);
 		wrapper.Workspace.Received(1).DoLayout();
 		window.Received(1).Focus();
 	}

--- a/src/Whim.CommandPalette.Tests/CommandPaletteCommandsTests.cs
+++ b/src/Whim.CommandPalette.Tests/CommandPaletteCommandsTests.cs
@@ -306,6 +306,7 @@ public class CommandPaletteCommandsTests
 
 		// Then
 		wrapper.Workspace.Received(1).RemoveWindow(wrapper.Windows[0]);
+		wrapper.Workspace.Received(1).DoLayout();
 	}
 
 	[Fact]

--- a/src/Whim.CommandPalette/CommandPaletteCommands.cs
+++ b/src/Whim.CommandPalette/CommandPaletteCommands.cs
@@ -247,15 +247,24 @@ public class CommandPaletteCommands : PluginCommands
 			title: window.Title,
 			callback: () =>
 			{
-				IWorkspace? workspace = _context.WorkspaceManager.GetWorkspaceForWindow(window);
+				IWorkspace? workspace = _context.Butler.GetWorkspaceForWindow(window);
 				if (workspace == null)
 				{
 					return;
 				}
 
-				// A bit of a dirty hack to focus the window. If the window is minimised, it will
-				// now be shown. It will then be focused.
-				workspace.AddWindow(window);
+				if (window.IsMinimized)
+				{
+					workspace.MinimizeWindowEnd(window);
+				}
+
+				if (_context.Butler.GetMonitorForWindow(window) is null)
+				{
+					_context.Butler.Activate(workspace);
+				}
+
+				workspace.DoLayout();
+				window.Focus();
 			}
 		);
 }

--- a/src/Whim.CommandPalette/CommandPaletteCommands.cs
+++ b/src/Whim.CommandPalette/CommandPaletteCommands.cs
@@ -233,7 +233,12 @@ public class CommandPaletteCommands : PluginCommands
 		new Command(
 			identifier: $"{PluginName}.remove_window.{window.Title}",
 			title: window.Title,
-			callback: () => _context.WorkspaceManager.ActiveWorkspace.RemoveWindow(window)
+			callback: () =>
+			{
+				IWorkspace workspace = _context.WorkspaceManager.ActiveWorkspace;
+				workspace.RemoveWindow(window);
+				workspace.DoLayout();
+			}
 		);
 
 	/// <summary>

--- a/src/Whim.FloatingLayout.Tests/FloatingLayoutPluginTests.cs
+++ b/src/Whim.FloatingLayout.Tests/FloatingLayoutPluginTests.cs
@@ -128,7 +128,7 @@ public class FloatingLayoutPluginTests
 				WindowSize = WindowSize.Normal
 			};
 
-		context.WorkspaceManager.GetWorkspaceForWindow(window).Returns(activeWorkspace);
+		context.Butler.GetWorkspaceForWindow(window).Returns(activeWorkspace);
 		activeWorkspace.TryGetWindowState(window).Returns(windowState);
 		context.MonitorManager.GetMonitorAtPoint(rect).Returns(monitor);
 
@@ -162,7 +162,7 @@ public class FloatingLayoutPluginTests
 	{
 		// Given
 		FloatingLayoutPlugin plugin = CreateSut(context);
-		context.WorkspaceManager.GetWorkspaceForWindow(window).Returns((IWorkspace?)null);
+		context.Butler.GetWorkspaceForWindow(window).Returns((IWorkspace?)null);
 
 		// When
 		plugin.MarkWindowAsFloating(window);
@@ -181,7 +181,7 @@ public class FloatingLayoutPluginTests
 		// Given
 		FloatingLayoutPlugin plugin = CreateSut(context);
 
-		context.WorkspaceManager.GetWorkspaceForWindow(window).Returns((IWorkspace?)null);
+		context.Butler.GetWorkspaceForWindow(window).Returns((IWorkspace?)null);
 		activeWorkspace.LastFocusedWindow.Returns(window);
 
 		// When
@@ -195,7 +195,7 @@ public class FloatingLayoutPluginTests
 	public void MarkWindowAsFloating_NoWindowState(IContext context, IWindow window, IWorkspace activeWorkspace)
 	{
 		// Given
-		context.WorkspaceManager.GetWorkspaceForWindow(window).Returns(activeWorkspace);
+		context.Butler.GetWorkspaceForWindow(window).Returns(activeWorkspace);
 		activeWorkspace.TryGetWindowState(window).Returns((IWindowState?)null);
 
 		FloatingLayoutPlugin plugin = CreateSut(context);
@@ -211,7 +211,7 @@ public class FloatingLayoutPluginTests
 	public void MarkWindowAsFloating(IContext context, IWindow window, IWorkspace activeWorkspace)
 	{
 		// Given
-		context.WorkspaceManager.GetWorkspaceForWindow(window).Returns(activeWorkspace);
+		context.Butler.GetWorkspaceForWindow(window).Returns(activeWorkspace);
 		activeWorkspace
 			.TryGetWindowState(window)
 			.Returns(
@@ -232,6 +232,7 @@ public class FloatingLayoutPluginTests
 		Assert.Single(plugin.FloatingWindows);
 		Assert.Equal(window, plugin.FloatingWindows.Keys.First());
 		activeWorkspace.Received(1).MoveWindowToPoint(window, Arg.Any<IPoint<double>>());
+		activeWorkspace.Received(1).DoLayout();
 	}
 	#endregion
 
@@ -248,13 +249,14 @@ public class FloatingLayoutPluginTests
 		// Then
 		Assert.Empty(plugin.FloatingWindows);
 		activeWorkspace.DidNotReceive().MoveWindowToPoint(window, Arg.Any<IPoint<double>>());
+		activeWorkspace.DidNotReceive().DoLayout();
 	}
 
 	[Theory, AutoSubstituteData<FloatingLayoutPluginCustomization>]
 	public void MarkWindowAsDocked_WindowIsFloating(IContext context, IWindow window, IWorkspace activeWorkspace)
 	{
 		// Given
-		context.WorkspaceManager.GetWorkspaceForWindow(window).Returns(activeWorkspace);
+		context.Butler.GetWorkspaceForWindow(window).Returns(activeWorkspace);
 		activeWorkspace
 			.TryGetWindowState(window)
 			.Returns(
@@ -275,6 +277,7 @@ public class FloatingLayoutPluginTests
 		// Then
 		Assert.Empty(plugin.FloatingWindows);
 		activeWorkspace.Received(2).MoveWindowToPoint(window, Arg.Any<IPoint<double>>());
+		activeWorkspace.Received(2).DoLayout();
 	}
 	#endregion
 
@@ -296,7 +299,7 @@ public class FloatingLayoutPluginTests
 	public void ToggleWindowFloating_ToFloating(IContext context, IWindow window, IWorkspace activeWorkspace)
 	{
 		// Given
-		context.WorkspaceManager.GetWorkspaceForWindow(window).Returns(activeWorkspace);
+		context.Butler.GetWorkspaceForWindow(window).Returns(activeWorkspace);
 		activeWorkspace
 			.TryGetWindowState(window)
 			.Returns(
@@ -322,7 +325,7 @@ public class FloatingLayoutPluginTests
 	public void ToggleWindowFloating_ToDocked(IContext context, IWindow window, IWorkspace activeWorkspace)
 	{
 		// Given
-		context.WorkspaceManager.GetWorkspaceForWindow(window).Returns(activeWorkspace);
+		context.Butler.GetWorkspaceForWindow(window).Returns(activeWorkspace);
 		activeWorkspace
 			.TryGetWindowState(window)
 			.Returns(
@@ -402,7 +405,7 @@ public class FloatingLayoutPluginTests
 	{
 		// Given
 		ILayoutEngine layoutEngine = activeWorkspace.ActiveLayoutEngine;
-		context.WorkspaceManager.GetWorkspaceForWindow(window).Returns(activeWorkspace);
+		context.Butler.GetWorkspaceForWindow(window).Returns(activeWorkspace);
 		activeWorkspace
 			.TryGetWindowState(window)
 			.Returns(
@@ -447,7 +450,7 @@ public class FloatingLayoutPluginTests
 		ILayoutEngine layoutEngine = activeWorkspace.ActiveLayoutEngine;
 		layoutEngine2.Identity.Returns(new LayoutEngineIdentity());
 
-		context.WorkspaceManager.GetWorkspaceForWindow(window).Returns(activeWorkspace);
+		context.Butler.GetWorkspaceForWindow(window).Returns(activeWorkspace);
 		activeWorkspace
 			.TryGetWindowState(window)
 			.Returns(

--- a/src/Whim.FloatingLayout/FloatingLayoutPlugin.cs
+++ b/src/Whim.FloatingLayout/FloatingLayoutPlugin.cs
@@ -56,7 +56,7 @@ public class FloatingLayoutPlugin : IFloatingLayoutPlugin, IInternalFloatingLayo
 			return;
 		}
 
-		if (_context.WorkspaceManager.GetWorkspaceForWindow(window) is not IWorkspace workspace)
+		if (_context.Butler.GetWorkspaceForWindow(window) is not IWorkspace workspace)
 		{
 			Logger.Error($"Window {window} is not in a workspace");
 			return;
@@ -101,6 +101,7 @@ public class FloatingLayoutPlugin : IFloatingLayoutPlugin, IInternalFloatingLayo
 		IRectangle<double> unitSquareRect = monitor.WorkingArea.ToUnitSquare(windowState.Rectangle);
 
 		workspace.MoveWindowToPoint(window, unitSquareRect);
+		workspace.DoLayout();
 	}
 
 	/// <inheritdoc />

--- a/src/Whim.SliceLayout.Tests/SliceLayoutPluginTests.cs
+++ b/src/Whim.SliceLayout.Tests/SliceLayoutPluginTests.cs
@@ -113,8 +113,9 @@ public class SliceLayoutPluginTests
 		plugin.PromoteWindowInStack(window);
 
 		// Then nothing
-		ctx.WorkspaceManager.ActiveWorkspace.DidNotReceive()
-			.PerformCustomLayoutEngineAction(Arg.Any<LayoutEngineCustomAction>());
+		IWorkspace activeWorkspace = ctx.WorkspaceManager.ActiveWorkspace;
+		activeWorkspace.DidNotReceive().PerformCustomLayoutEngineAction(Arg.Any<LayoutEngineCustomAction>());
+		activeWorkspace.DidNotReceive().DoLayout();
 	}
 
 	[Theory, AutoSubstituteData]
@@ -136,6 +137,7 @@ public class SliceLayoutPluginTests
 					action.Name == plugin.PromoteWindowActionName && action.Window == window
 				)
 			);
+		workspace.Received(1).DoLayout();
 	}
 	#endregion
 
@@ -166,8 +168,9 @@ public class SliceLayoutPluginTests
 		plugin.DemoteWindowInStack(window);
 
 		// Then nothing
-		ctx.WorkspaceManager.ActiveWorkspace.DidNotReceive()
-			.PerformCustomLayoutEngineAction(Arg.Any<LayoutEngineCustomAction>());
+		IWorkspace activeWorkspace = ctx.WorkspaceManager.ActiveWorkspace;
+		activeWorkspace.DidNotReceive().PerformCustomLayoutEngineAction(Arg.Any<LayoutEngineCustomAction>());
+		activeWorkspace.DidNotReceive().DoLayout();
 	}
 
 	[Theory, AutoSubstituteData]
@@ -189,6 +192,7 @@ public class SliceLayoutPluginTests
 					action.Name == plugin.DemoteWindowActionName && action.Window == window
 				)
 			);
+		workspace.Received(1).DoLayout();
 	}
 	#endregion
 

--- a/src/Whim.SliceLayout/SliceLayoutPlugin.cs
+++ b/src/Whim.SliceLayout/SliceLayoutPlugin.cs
@@ -69,6 +69,7 @@ public class SliceLayoutPlugin : ISliceLayoutPlugin
 				Window = definedWindow
 			}
 		);
+		workspace.DoLayout();
 	}
 
 	private (IWindow, IWorkspace)? GetWindowWithRankDelta(IWindow? window, bool promote)

--- a/src/Whim.Tests/Butler/ButlerEventHandlersTests.cs
+++ b/src/Whim.Tests/Butler/ButlerEventHandlersTests.cs
@@ -548,7 +548,8 @@ public class ButlerEventHandlersTests
 		);
 
 		// Then MinimizeWindowStart is called on the workspace
-		workspace.Received().MinimizeWindowStart(window);
+		workspace.Received(1).MinimizeWindowStart(window);
+		workspace.Received(1).DoLayout();
 	}
 	#endregion
 
@@ -600,7 +601,8 @@ public class ButlerEventHandlersTests
 		);
 
 		// Then MinimizeWindowEnd is called on the workspace
-		workspace.Received().MinimizeWindowEnd(window);
+		workspace.Received(1).MinimizeWindowEnd(window);
+		workspace.Received(1).DoLayout();
 	}
 	#endregion
 

--- a/src/Whim.Tests/Butler/ButlerEventHandlersTests.cs
+++ b/src/Whim.Tests/Butler/ButlerEventHandlersTests.cs
@@ -3,8 +3,6 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using AutoFixture;
-using FluentAssertions;
-using Microsoft.UI.Xaml.Input;
 using NSubstitute;
 using NSubstitute.ReturnsExtensions;
 using Whim.TestUtils;
@@ -44,6 +42,11 @@ public class ButlerEventHandlersTests
 		Assert.Equal(window, actual.Window);
 		Assert.Null(actual.PreviousWorkspace);
 		Assert.Equal(currentWorkspace, actual.CurrentWorkspace);
+
+		currentWorkspace.Received().AddWindow(window);
+		currentWorkspace.Received().DoLayout();
+
+		window.Received().Focus();
 	}
 
 	#region WindowAdded
@@ -75,10 +78,8 @@ public class ButlerEventHandlersTests
 		// Then the window is routed to the workspace
 		ctx.RouterManager.Received().RouteWindow(window);
 		pantry.Received().SetWindowWorkspace(window, routedWorkspace);
-		routedWorkspace.Received().AddWindow(window);
 
 		Assert.Single(triggersCalls.WindowRouted);
-
 		AssertWindowAdded(window, routedWorkspace, triggersCalls.WindowRouted[0]);
 	}
 
@@ -113,10 +114,8 @@ public class ButlerEventHandlersTests
 		ctx.RouterManager.Received().RouteWindow(window);
 		pantry.Received().SetWindowWorkspace(window, goodWorkspace);
 		badWorkspace.DidNotReceive().AddWindow(window);
-		goodWorkspace.Received().AddWindow(window);
 
 		Assert.Single(triggersCalls.WindowRouted);
-
 		AssertWindowAdded(window, goodWorkspace, triggersCalls.WindowRouted[0]);
 	}
 
@@ -149,10 +148,8 @@ public class ButlerEventHandlersTests
 
 		// Then the window is routed to the active workspace
 		pantry.Received().SetWindowWorkspace(window, activeWorkspace);
-		activeWorkspace.Received().AddWindow(window);
 
 		Assert.Single(triggersCalls.WindowRouted);
-
 		AssertWindowAdded(window, activeWorkspace, triggersCalls.WindowRouted[0]);
 	}
 
@@ -188,10 +185,8 @@ public class ButlerEventHandlersTests
 
 		// Then the window is routed to the last tracked active workspace
 		pantry.Received().SetWindowWorkspace(window, lastTrackedActiveWorkspace);
-		lastTrackedActiveWorkspace.Received().AddWindow(window);
 
 		Assert.Single(triggersCalls.WindowRouted);
-
 		AssertWindowAdded(window, lastTrackedActiveWorkspace, triggersCalls.WindowRouted[0]);
 	}
 
@@ -233,10 +228,8 @@ public class ButlerEventHandlersTests
 			.MonitorFromWindow(window.Handle, MONITOR_FROM_FLAGS.MONITOR_DEFAULTTONEAREST);
 		pantry.DidNotReceive().GetWorkspaceForMonitor(Arg.Any<IMonitor>());
 		pantry.Received().SetWindowWorkspace(window, workspace);
-		workspace.Received().AddWindow(window);
 
 		Assert.Single(triggersCalls.WindowRouted);
-
 		AssertWindowAdded(window, workspace, triggersCalls.WindowRouted[0]);
 	}
 
@@ -278,10 +271,8 @@ public class ButlerEventHandlersTests
 			.MonitorFromWindow(window.Handle, MONITOR_FROM_FLAGS.MONITOR_DEFAULTTONEAREST);
 		pantry.Received().GetWorkspaceForMonitor(monitor);
 		pantry.Received().SetWindowWorkspace(window, workspace);
-		workspace.Received().AddWindow(window);
 
 		Assert.Single(triggersCalls.WindowRouted);
-
 		AssertWindowAdded(window, workspace, triggersCalls.WindowRouted[0]);
 	}
 
@@ -317,7 +308,6 @@ public class ButlerEventHandlersTests
 		routedWorkspace.Received().MinimizeWindowStart(window);
 
 		Assert.Single(triggersCalls.WindowRouted);
-
 		AssertWindowAdded(window, routedWorkspace, triggersCalls.WindowRouted[0]);
 	}
 

--- a/src/Whim.Tests/Butler/ButlerEventHandlersTests.cs
+++ b/src/Whim.Tests/Butler/ButlerEventHandlersTests.cs
@@ -49,6 +49,18 @@ public class ButlerEventHandlersTests
 		window.Received().Focus();
 	}
 
+	private static void AssertWindowMinimized(IWindow window, IWorkspace currentWorkspace, RouteEventArgs actual)
+	{
+		Assert.Equal(window, actual.Window);
+		Assert.Null(actual.PreviousWorkspace);
+		Assert.Equal(currentWorkspace, actual.CurrentWorkspace);
+
+		currentWorkspace.Received().MinimizeWindowStart(window);
+		currentWorkspace.Received().DoLayout();
+
+		window.Received().Focus();
+	}
+
 	#region WindowAdded
 	[Theory, AutoSubstituteData<ButlerEventHandlersCustomization>]
 	internal void WindowAdded_RouteWindow(
@@ -308,9 +320,8 @@ public class ButlerEventHandlersTests
 		routedWorkspace.Received().MinimizeWindowStart(window);
 
 		Assert.Single(triggersCalls.WindowRouted);
-		AssertWindowAdded(window, routedWorkspace, triggersCalls.WindowRouted[0]);
+		AssertWindowMinimized(window, routedWorkspace, triggersCalls.WindowRouted[0]);
 	}
-
 	#endregion
 
 	#region WindowRemoved

--- a/src/Whim.Tests/Butler/ButlerEventHandlersTests.cs
+++ b/src/Whim.Tests/Butler/ButlerEventHandlersTests.cs
@@ -369,6 +369,7 @@ public class ButlerEventHandlersTests
 		// Then the window is removed from the workspace
 		pantry.Received().RemoveWindow(window);
 		workspace.Received().RemoveWindow(window);
+		workspace.Received().DoLayout();
 		Assert.Single(triggersCalls.WindowRouted);
 	}
 	#endregion

--- a/src/Whim.Tests/Butler/ButlerTests.cs
+++ b/src/Whim.Tests/Butler/ButlerTests.cs
@@ -4,7 +4,7 @@ using NSubstitute;
 using Whim.TestUtils;
 using Xunit;
 
-namespace Whim;
+namespace Whim.Tests;
 
 [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope")]
 public class ButlerTests

--- a/src/Whim.Tests/Commands/CoreCommandsTests.cs
+++ b/src/Whim.Tests/Commands/CoreCommandsTests.cs
@@ -75,6 +75,7 @@ public class CoreCommandsTests
 
 		// Then
 		ctx.WorkspaceManager.ActiveWorkspace.Received(1).FocusWindowInDirection(direction, window);
+		ctx.WorkspaceManager.ActiveWorkspace.Received(1).DoLayout();
 	}
 
 	[Theory, AutoSubstituteData<CoreCommandsCustomization>]

--- a/src/Whim.Tests/Commands/CoreCommandsTests.cs
+++ b/src/Whim.Tests/Commands/CoreCommandsTests.cs
@@ -494,8 +494,9 @@ public class CoreCommandsTests
 		command.TryExecute();
 
 		// Then
-		ctx.WorkspaceManager.ActiveWorkspace.DidNotReceive()
-			.PerformCustomLayoutEngineAction(Arg.Any<LayoutEngineCustomAction>());
+		IWorkspace workspace = ctx.WorkspaceManager.ActiveWorkspace;
+		workspace.DidNotReceive().PerformCustomLayoutEngineAction(Arg.Any<LayoutEngineCustomAction>());
+		workspace.DidNotReceive().DoLayout();
 	}
 
 	[Theory, AutoSubstituteData<CoreCommandsCustomization>]
@@ -514,7 +515,8 @@ public class CoreCommandsTests
 		command.TryExecute();
 
 		// Then
-		ctx.WorkspaceManager.ActiveWorkspace.Received(1)
-			.PerformCustomLayoutEngineAction(Arg.Any<LayoutEngineCustomAction>());
+		IWorkspace workspace = ctx.WorkspaceManager.ActiveWorkspace;
+		workspace.Received(1).PerformCustomLayoutEngineAction(Arg.Any<LayoutEngineCustomAction>());
+		workspace.Received(1).DoLayout();
 	}
 }

--- a/src/Whim.Tests/Commands/CoreCommandsTests.cs
+++ b/src/Whim.Tests/Commands/CoreCommandsTests.cs
@@ -113,6 +113,7 @@ public class CoreCommandsTests
 
 		// Then
 		ctx.WorkspaceManager.ActiveWorkspace.Received(1).SwapWindowInDirection(direction, null);
+		ctx.WorkspaceManager.ActiveWorkspace.Received(1).DoLayout();
 	}
 
 	[InlineAutoSubstituteData<CoreCommandsCustomization>("whim.core.move_window_left_edge_left", Direction.Left, -1, 0)]

--- a/src/Whim.Tests/Workspace/WorkspaceManagerTests.cs
+++ b/src/Whim.Tests/Workspace/WorkspaceManagerTests.cs
@@ -1333,6 +1333,7 @@ public class WorkspaceManagerTests
 		// Then the window is not removed from the old workspace and not added to the new workspace
 		workspace.DidNotReceive().RemoveWindow(window);
 		workspace.DidNotReceive().MoveWindowToPoint(window, Arg.Any<Point<double>>());
+		workspace.DidNotReceive().DoLayout();
 	}
 
 	[Theory, AutoSubstituteData<WorkspaceManagerCustomization>]
@@ -1357,6 +1358,7 @@ public class WorkspaceManagerTests
 		// Then the window is not removed from the old workspace and not added to the new workspace
 		workspace.DidNotReceive().RemoveWindow(window);
 		workspace.DidNotReceive().MoveWindowToPoint(window, Arg.Any<Point<double>>());
+		workspace.DidNotReceive().DoLayout();
 	}
 
 	[Theory, AutoSubstituteData<WorkspaceManagerCustomization>]
@@ -1389,7 +1391,10 @@ public class WorkspaceManagerTests
 		// Then the window is removed from the old workspace and added to the new workspace
 		activeWorkspace.Received(1).RemoveWindow(window);
 		activeWorkspace.DidNotReceive().MoveWindowToPoint(window, Arg.Any<Point<double>>());
+		activeWorkspace.Received(1).DoLayout();
+
 		targetWorkspace.Received(1).MoveWindowToPoint(window, expectedPoint);
+		targetWorkspace.Received(1).DoLayout();
 
 		Assert.Equal(targetWorkspace, workspaceManager.GetWorkspaceForWindow(window));
 

--- a/src/Whim.Tests/Workspace/WorkspaceManagerTests.cs
+++ b/src/Whim.Tests/Workspace/WorkspaceManagerTests.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using AutoFixture;
+using FluentAssertions;
 using NSubstitute;
 using Whim.TestUtils;
 using Windows.Win32.Foundation;
@@ -1722,6 +1723,17 @@ public class WorkspaceManagerTests
 	#endregion
 
 	#region MoveWindowEdgesInDirection
+	private static void Workspaces_DidNotMoveWindowEdgesInDirection(IWorkspace[] workspaces)
+	{
+		for (int i = 0; i < workspaces.Length; i++)
+		{
+			workspaces[i]
+				.DidNotReceive()
+				.MoveWindowEdgesInDirection(Arg.Any<Direction>(), Arg.Any<IPoint<double>>(), Arg.Any<IWindow?>());
+			workspaces[i].DidNotReceive().DoLayout();
+		}
+	}
+
 	[Theory, AutoSubstituteData<WorkspaceManagerCustomization>]
 	internal void MoveWindowEdgesInDirection_NoWindow(IContext ctx, IInternalContext internalCtx)
 	{
@@ -1736,12 +1748,7 @@ public class WorkspaceManagerTests
 		workspaceManager.MoveWindowEdgesInDirection(Direction.Left, new Point<int>());
 
 		// Then nothing happens
-		workspaces[0]
-			.DidNotReceive()
-			.MoveWindowEdgesInDirection(Arg.Any<Direction>(), Arg.Any<IPoint<double>>(), Arg.Any<IWindow?>());
-		workspaces[1]
-			.DidNotReceive()
-			.MoveWindowEdgesInDirection(Arg.Any<Direction>(), Arg.Any<IPoint<double>>(), Arg.Any<IWindow?>());
+		Workspaces_DidNotMoveWindowEdgesInDirection(workspaces);
 	}
 
 	[Theory, AutoSubstituteData<WorkspaceManagerCustomization>]
@@ -1766,12 +1773,7 @@ public class WorkspaceManagerTests
 		workspaceManager.MoveWindowEdgesInDirection(Direction.Left, new Point<int>());
 
 		// Then nothing happens
-		workspaces[0]
-			.DidNotReceive()
-			.MoveWindowEdgesInDirection(Arg.Any<Direction>(), Arg.Any<IPoint<double>>(), Arg.Any<IWindow?>());
-		workspaces[1]
-			.DidNotReceive()
-			.MoveWindowEdgesInDirection(Arg.Any<Direction>(), Arg.Any<IPoint<double>>(), Arg.Any<IWindow?>());
+		Workspaces_DidNotMoveWindowEdgesInDirection(workspaces);
 	}
 
 	[Theory, AutoSubstituteData<WorkspaceManagerCustomization>]
@@ -1795,12 +1797,7 @@ public class WorkspaceManagerTests
 		workspaceManager.MoveWindowEdgesInDirection(Direction.Left, new Point<int>(), window);
 
 		// Then nothing happens
-		workspaces[0]
-			.DidNotReceive()
-			.MoveWindowEdgesInDirection(Arg.Any<Direction>(), Arg.Any<IPoint<double>>(), Arg.Any<IWindow?>());
-		workspaces[1]
-			.DidNotReceive()
-			.MoveWindowEdgesInDirection(Arg.Any<Direction>(), Arg.Any<IPoint<double>>(), Arg.Any<IWindow?>());
+		Workspaces_DidNotMoveWindowEdgesInDirection(workspaces);
 	}
 
 	[Theory, AutoSubstituteData<WorkspaceManagerCustomization>]
@@ -1827,9 +1824,11 @@ public class WorkspaceManagerTests
 
 		// Then the window edges are moved
 		workspaces[0].Received(1).MoveWindowEdgesInDirection(Direction.Left, Arg.Any<IPoint<double>>(), window);
+		workspaces[0].Received(1).DoLayout();
 		workspaces[1]
 			.DidNotReceive()
 			.MoveWindowEdgesInDirection(Arg.Any<Direction>(), Arg.Any<IPoint<double>>(), Arg.Any<IWindow?>());
+		workspaces[1].DidNotReceive().DoLayout();
 	}
 	#endregion
 }

--- a/src/Whim.Tests/Workspace/WorkspaceManagerTests.cs
+++ b/src/Whim.Tests/Workspace/WorkspaceManagerTests.cs
@@ -4,7 +4,6 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using AutoFixture;
-using FluentAssertions;
 using NSubstitute;
 using Whim.TestUtils;
 using Windows.Win32.Foundation;

--- a/src/Whim.Tests/Workspace/WorkspaceManagerTests.cs
+++ b/src/Whim.Tests/Workspace/WorkspaceManagerTests.cs
@@ -1131,6 +1131,9 @@ public class WorkspaceManagerTests
 		// Then the window is removed from the first workspace and added to the second
 		workspaces[0].Received(1).RemoveWindow(window);
 		workspaces[1].Received(1).AddWindow(window);
+		workspaces[0].Received(1).DoLayout();
+		workspaces[1].Received(1).DoLayout();
+		window.Received(1).Focus();
 		window.DidNotReceive().Hide();
 	}
 	#endregion

--- a/src/Whim.Tests/Workspace/WorkspaceManagerTests.cs
+++ b/src/Whim.Tests/Workspace/WorkspaceManagerTests.cs
@@ -822,6 +822,7 @@ public class WorkspaceManagerTests
 		{
 			workspace.DidNotReceive().RemoveWindow(Arg.Any<IWindow>());
 			workspace.DidNotReceive().AddWindow(Arg.Any<IWindow>());
+			workspace.DidNotReceive().DoLayout();
 		}
 	}
 
@@ -844,6 +845,7 @@ public class WorkspaceManagerTests
 		{
 			workspace.DidNotReceive().RemoveWindow(Arg.Any<IWindow>());
 			workspace.DidNotReceive().AddWindow(Arg.Any<IWindow>());
+			workspace.DidNotReceive().DoLayout();
 		}
 	}
 
@@ -871,6 +873,8 @@ public class WorkspaceManagerTests
 
 		// Then the workspace does not receive any calls
 		workspaces[0].DidNotReceive().RemoveWindow(Arg.Any<IWindow>());
+		workspaces[0].DidNotReceive().AddWindow(Arg.Any<IWindow>());
+		workspaces[0].DidNotReceive().DoLayout();
 	}
 
 	[Theory]
@@ -912,6 +916,9 @@ public class WorkspaceManagerTests
 		// Then the window is removed from the first workspace and added to the activated workspace
 		workspaces[firstActivatedIdx].Received(1).RemoveWindow(window);
 		activatedWorkspace.Received(1).AddWindow(window);
+		activatedWorkspace.Received(1).DoLayout();
+		window.Received(1).Focus();
+
 		Assert.Equal(workspaces[activatedWorkspaceIdx], workspaceManager.GetWorkspaceForWindow(window));
 	}
 	#endregion

--- a/src/Whim.Tests/Workspace/WorkspaceManagerTests.cs
+++ b/src/Whim.Tests/Workspace/WorkspaceManagerTests.cs
@@ -1510,7 +1510,7 @@ public class WorkspaceManagerTests
 		Assert.Raises<ActiveLayoutEngineChangedEventArgs>(
 			h => workspaceManager.ActiveLayoutEngineChanged += h,
 			h => workspaceManager.ActiveLayoutEngineChanged -= h,
-			workspaceManager.ActiveWorkspace.NextLayoutEngine
+			() => workspaceManager.ActiveWorkspace.CycleLayoutEngine(false)
 		);
 	}
 

--- a/src/Whim.Tests/Workspace/WorkspaceManagerTests.cs
+++ b/src/Whim.Tests/Workspace/WorkspaceManagerTests.cs
@@ -910,6 +910,7 @@ public class WorkspaceManagerTests
 		WindowAdded(ctx, window);
 
 		ClearWorkspaceReceivedCalls(workspaces);
+		window.ClearReceivedCalls();
 
 		// When MoveWindowToAdjacentWorkspace is called
 		workspaceManager.MoveWindowToAdjacentWorkspace(window, reverse, skipActive);
@@ -1386,6 +1387,8 @@ public class WorkspaceManagerTests
 		Point<int> givenPoint = new() { X = 2460, Y = 720 };
 		Point<double> expectedPoint = new() { X = 0.5, Y = 0.5 };
 
+		window.ClearReceivedCalls();
+
 		// When a window is moved to a point
 		workspaceManager.MoveWindowToPoint(window, givenPoint);
 
@@ -1429,6 +1432,7 @@ public class WorkspaceManagerTests
 
 		Point<int> givenPoint = new() { X = 960, Y = 540 };
 		Point<double> expectedPoint = new() { X = 0.5, Y = 0.5 };
+		window.ClearReceivedCalls();
 
 		// When a window is moved to a point
 		workspaceManager.MoveWindowToPoint(window, givenPoint);
@@ -1743,6 +1747,7 @@ public class WorkspaceManagerTests
 		workspaceManager.Initialize();
 
 		workspaces[0].LastFocusedWindow.Returns((IWindow?)null);
+		ClearWorkspaceReceivedCalls(workspaces);
 
 		// When moving the window edges in a direction
 		workspaceManager.MoveWindowEdgesInDirection(Direction.Left, new Point<int>());
@@ -1768,6 +1773,7 @@ public class WorkspaceManagerTests
 
 		workspaceManager.Initialize();
 		ctx.MonitorManager.ActiveMonitor.Returns(monitors[1]);
+		ClearWorkspaceReceivedCalls(workspaces);
 
 		// When moving the window edges in a direction
 		workspaceManager.MoveWindowEdgesInDirection(Direction.Left, new Point<int>());
@@ -1792,6 +1798,7 @@ public class WorkspaceManagerTests
 		WorkspaceManagerTestWrapper workspaceManager = CreateSut(ctx, internalCtx, workspaces);
 		workspaceManager.Initialize();
 		WindowAdded(ctx, window);
+		ClearWorkspaceReceivedCalls(workspaces);
 
 		// When moving the window edges in a direction
 		workspaceManager.MoveWindowEdgesInDirection(Direction.Left, new Point<int>(), window);
@@ -1818,6 +1825,7 @@ public class WorkspaceManagerTests
 
 		workspaceManager.Initialize();
 		WindowAdded(ctx, window);
+		ClearWorkspaceReceivedCalls(workspaces);
 
 		// When moving the window edges in a direction
 		workspaceManager.MoveWindowEdgesInDirection(Direction.Left, new Point<int>());

--- a/src/Whim.Tests/Workspace/WorkspaceTests.cs
+++ b/src/Whim.Tests/Workspace/WorkspaceTests.cs
@@ -724,14 +724,18 @@ public class WorkspaceTests
 		WorkspaceManagerTriggers triggers,
 		ILayoutEngine layoutEngine,
 		IWindow window,
-		IWindow window2
+		IWindow window2,
+		IWindow window3
 	)
 	{
 		// Given multiple windows are in the workspace
 		Workspace workspace = new(ctx, internalCtx, triggers, "Workspace", new ILayoutEngine[] { layoutEngine });
 		workspace.AddWindow(window);
 		workspace.AddWindow(window2);
+		workspace.AddWindow(window3);
 		workspace.WindowFocused(window);
+
+		window2.IsMinimized.Returns(true);
 
 		ILayoutEngine givenEngine = workspace.ActiveLayoutEngine;
 		ctx.Butler.ClearReceivedCalls();
@@ -743,7 +747,7 @@ public class WorkspaceTests
 		// Then the window is removed from the layout engine, and LastFocusedWindow is set to the next window
 		Assert.True(result);
 		givenEngine.Received(1).RemoveWindow(window);
-		Assert.Equal(window2, workspace.LastFocusedWindow);
+		Assert.Equal(window3, workspace.LastFocusedWindow);
 		Assert.NotSame(givenEngine, workspace.ActiveLayoutEngine);
 	}
 	#endregion

--- a/src/Whim.Tests/Workspace/WorkspaceTests.cs
+++ b/src/Whim.Tests/Workspace/WorkspaceTests.cs
@@ -427,27 +427,9 @@ public class WorkspaceTests
 	}
 	#endregion
 
-	[Theory, AutoSubstituteData<WorkspaceCustomization>]
-	internal void FocusFirstWindow(
-		IContext ctx,
-		IInternalContext internalCtx,
-		WorkspaceManagerTriggers triggers,
-		ILayoutEngine layoutEngine
-	)
-	{
-		// Given
-		Workspace workspace = new(ctx, internalCtx, triggers, "Workspace", new ILayoutEngine[] { layoutEngine });
 
-		// When FocusFirstWindow is called
-		workspace.FocusFirstWindow();
-
-		// Then the LayoutEngine's GetFirstWindow method is called
-		layoutEngine.Received(1).GetFirstWindow();
-	}
 
 	#region FocusLastFocusedWindow
-
-
 	[Theory, AutoSubstituteData<WorkspaceCustomization>]
 	internal void FocusLastFocusedWindow_LastFocusedWindow(
 		IContext ctx,

--- a/src/Whim.TreeLayout.Tests/LayoutEngine/RemoveTests.cs
+++ b/src/Whim.TreeLayout.Tests/LayoutEngine/RemoveTests.cs
@@ -180,4 +180,25 @@ public class RemoveTests
 		Assert.True(result.ContainsWindow(window2));
 		Assert.Equal(2, result.Count);
 	}
+
+	[Theory, AutoSubstituteData]
+	public void Remove_WindowWasVisible(IWindow windowWasVisible, IWindow minimizedWindow1, IWindow minimizedWindow2)
+	{
+		// Given only one window is visible, and the others are minimized
+		LayoutEngineWrapper wrapper = new();
+		ILayoutEngine engine = new TreeLayoutEngine(wrapper.Context, wrapper.Plugin, wrapper.Identity)
+			.MinimizeWindowStart(minimizedWindow1)
+			.MinimizeWindowStart(minimizedWindow2)
+			.AddWindow(windowWasVisible);
+
+		// When the visible window is removed
+		ILayoutEngine result = engine.RemoveWindow(windowWasVisible);
+
+		// Then it is no longer tracked
+		Assert.NotSame(engine, result);
+		Assert.False(result.ContainsWindow(windowWasVisible));
+		Assert.True(result.ContainsWindow(minimizedWindow1));
+		Assert.True(result.ContainsWindow(minimizedWindow2));
+		Assert.Equal(2, result.Count);
+	}
 }

--- a/src/Whim.TreeLayout/TreeLayoutEngine.cs
+++ b/src/Whim.TreeLayout/TreeLayoutEngine.cs
@@ -556,23 +556,23 @@ public record TreeLayoutEngine : ILayoutEngine
 	{
 		Logger.Debug($"Removing window {window} from layout engine {Name}");
 
-		if (_root is null)
-		{
-			Logger.Error($"Root is null, cannot remove window {window} from layout engine {Name}");
-			return this;
-		}
-
 		ImmutableHashSet<IWindow> minimizedWindows = _minimizedWindows.Remove(window);
 		if (minimizedWindows != _minimizedWindows)
 		{
 			return new TreeLayoutEngine(this, _root, _windows, minimizedWindows);
 		}
 
+		if (_root is null)
+		{
+			Logger.Error($"Root is null, cannot remove window {window} from layout engine {Name}");
+			return this;
+		}
+
 		if (_root is WindowNode windowNode)
 		{
 			if (windowNode.Window.Equals(window))
 			{
-				return new TreeLayoutEngine(_context, _plugin, Identity);
+				return new TreeLayoutEngine(this, null, _windows.Remove(window), _minimizedWindows);
 			}
 			else
 			{
@@ -739,15 +739,15 @@ public record TreeLayoutEngine : ILayoutEngine
 		Logger.Debug($"Minimizing window {window} in layout engine {Name}");
 
 		TreeLayoutEngine newEngine = this;
-		if (newEngine._windows.ContainsKey(window))
-		{
-			newEngine = (TreeLayoutEngine)newEngine.RemoveWindow(window);
-		}
-
 		ImmutableHashSet<IWindow> minimizedWindows = newEngine._minimizedWindows;
 		if (minimizedWindows.Contains(window))
 		{
 			return this;
+		}
+
+		if (newEngine._windows.ContainsKey(window))
+		{
+			newEngine = (TreeLayoutEngine)newEngine.RemoveWindow(window);
 		}
 
 		return new TreeLayoutEngine(

--- a/src/Whim/Butler/ButlerChores.cs
+++ b/src/Whim/Butler/ButlerChores.cs
@@ -1,3 +1,5 @@
+using System.Linq;
+
 namespace Whim;
 
 internal class ButlerChores : IButlerChores
@@ -100,7 +102,9 @@ internal class ButlerChores : IButlerChores
 		Logger.Debug("Layout all active workspaces");
 
 		// For each workspace which is active in a monitor, do a layout.
-		foreach (IWorkspace workspace in _context.Butler.Pantry.GetAllActiveWorkspaces())
+		// Convert to an array to prevent enumeration modification during execution.
+		IWorkspace[] workspaces = _context.Butler.Pantry.GetAllActiveWorkspaces().ToArray();
+		foreach (IWorkspace workspace in workspaces)
 		{
 			workspace.DoLayout();
 		}

--- a/src/Whim/Butler/ButlerChores.cs
+++ b/src/Whim/Butler/ButlerChores.cs
@@ -141,6 +141,7 @@ internal class ButlerChores : IButlerChores
 
 		Logger.Debug($"Normalized point: {normalized}");
 		workspace.MoveWindowEdgesInDirection(edges, normalized, window);
+		workspace.DoLayout();
 		return true;
 	}
 

--- a/src/Whim/Butler/ButlerChores.cs
+++ b/src/Whim/Butler/ButlerChores.cs
@@ -312,6 +312,11 @@ internal class ButlerChores : IButlerChores
 
 		currentWorkspace.RemoveWindow(window);
 		workspace.AddWindow(window);
+
+		currentWorkspace.DoLayout();
+		workspace.DoLayout();
+
+		window.Focus();
 	}
 
 	public void MergeWorkspaceWindows(IWorkspace source, IWorkspace target)

--- a/src/Whim/Butler/ButlerChores.cs
+++ b/src/Whim/Butler/ButlerChores.cs
@@ -264,12 +264,6 @@ internal class ButlerChores : IButlerChores
 			return;
 		}
 
-		bool isSameWorkspace = targetWorkspace.Equals(oldWorkspace);
-		if (!isSameWorkspace)
-		{
-			_context.Butler.Pantry.SetWindowWorkspace(window, targetWorkspace);
-		}
-
 		// Normalize `point` into the unit square.
 		IPoint<double> normalized = targetMonitor.WorkingArea.ToUnitSquare(point);
 
@@ -278,11 +272,15 @@ internal class ButlerChores : IButlerChores
 		);
 
 		// If the window is being moved to a different workspace, remove it from the current workspace.
-		if (!isSameWorkspace)
+		if (!targetWorkspace.Equals(oldWorkspace))
 		{
+			_context.Butler.Pantry.SetWindowWorkspace(window, targetWorkspace);
 			oldWorkspace.RemoveWindow(window);
+			oldWorkspace.DoLayout();
 		}
+
 		targetWorkspace.MoveWindowToPoint(window, normalized);
+		targetWorkspace.DoLayout();
 
 		// Trigger layouts.
 		window.Focus();

--- a/src/Whim/Butler/ButlerChores.cs
+++ b/src/Whim/Butler/ButlerChores.cs
@@ -175,6 +175,11 @@ internal class ButlerChores : IButlerChores
 
 		currentWorkspace.RemoveWindow(window);
 		nextWorkspace.AddWindow(window);
+
+		currentWorkspace.DoLayout();
+		nextWorkspace.DoLayout();
+
+		window.Focus();
 	}
 
 	public void MoveWindowToMonitor(IMonitor monitor, IWindow? window = null)

--- a/src/Whim/Butler/ButlerEventHandlers.cs
+++ b/src/Whim/Butler/ButlerEventHandlers.cs
@@ -96,6 +96,7 @@ internal class ButlerEventHandlers : IDisposable
 		}
 
 		_triggers.WindowRouted(RouteEventArgs.WindowAdded(window, workspace));
+
 		workspace.DoLayout();
 		window.Focus();
 		Logger.Debug($"Window {window} added to workspace {workspace.Name}");
@@ -116,6 +117,8 @@ internal class ButlerEventHandlers : IDisposable
 
 		workspace.RemoveWindow(window);
 		_triggers.WindowRouted(RouteEventArgs.WindowRemoved(window, workspace));
+
+		workspace.DoLayout();
 	}
 
 	private void WindowManager_WindowFocused(object? sender, WindowFocusedEventArgs args)

--- a/src/Whim/Butler/ButlerEventHandlers.cs
+++ b/src/Whim/Butler/ButlerEventHandlers.cs
@@ -96,6 +96,8 @@ internal class ButlerEventHandlers : IDisposable
 		}
 
 		_triggers.WindowRouted(RouteEventArgs.WindowAdded(window, workspace));
+		workspace.DoLayout();
+		window.Focus();
 		Logger.Debug($"Window {window} added to workspace {workspace.Name}");
 	}
 

--- a/src/Whim/Butler/ButlerEventHandlers.cs
+++ b/src/Whim/Butler/ButlerEventHandlers.cs
@@ -162,6 +162,7 @@ internal class ButlerEventHandlers : IDisposable
 		}
 
 		workspace.MinimizeWindowStart(window);
+		workspace.DoLayout();
 	}
 
 	private void WindowManager_WindowMinimizeEnd(object? sender, WindowEventArgs args)
@@ -176,6 +177,7 @@ internal class ButlerEventHandlers : IDisposable
 		}
 
 		workspace.MinimizeWindowEnd(window);
+		workspace.DoLayout();
 	}
 
 	private void MonitorManager_MonitorsChanged(object? sender, MonitorsChangedEventArgs e)

--- a/src/Whim/Commands/CoreCommands.cs
+++ b/src/Whim/Commands/CoreCommands.cs
@@ -284,6 +284,7 @@ internal class CoreCommands : PluginCommands
 			}
 
 			workspace.FocusWindowInDirection(direction, workspace.LastFocusedWindow);
+			workspace.DoLayout();
 		};
 
 	/// <summary>

--- a/src/Whim/Commands/CoreCommands.cs
+++ b/src/Whim/Commands/CoreCommands.cs
@@ -237,6 +237,7 @@ internal class CoreCommands : PluginCommands
 							Window = null
 						}
 					);
+					workspace.DoLayout();
 				},
 				condition: () =>
 				{

--- a/src/Whim/Commands/CoreCommands.cs
+++ b/src/Whim/Commands/CoreCommands.cs
@@ -293,7 +293,9 @@ internal class CoreCommands : PluginCommands
 	internal Action SwapWindowInDirection(Direction direction) =>
 		() =>
 		{
-			_context.WorkspaceManager.ActiveWorkspace.SwapWindowInDirection(direction);
+			IWorkspace workspace = _context.WorkspaceManager.ActiveWorkspace;
+			workspace.SwapWindowInDirection(direction);
+			workspace.DoLayout();
 		};
 
 	internal Action FocusMonitorInDirection(bool getNext) =>

--- a/src/Whim/Native/DeferWindowPosHandle.cs
+++ b/src/Whim/Native/DeferWindowPosHandle.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Windows.Win32.Foundation;
 using Windows.Win32.UI.WindowsAndMessaging;
@@ -144,7 +143,7 @@ public sealed class DeferWindowPosHandle : IDisposable
 			}
 		}
 
-		Logger.Debug($"Setting window position {numPasses} times");
+		Logger.Debug($"Setting window position {numPasses} times for {_windowStates.Count} windows");
 
 		// Set the window positions for non-minimized windows first, then minimized windows.
 		// This was done to prevent the minimized windows being hidden, and Windows focusing the previous window.

--- a/src/Whim/Workspace/IWorkspace.cs
+++ b/src/Whim/Workspace/IWorkspace.cs
@@ -84,7 +84,8 @@ public interface IWorkspace : IDisposable
 	/// Adds the window to the workspace.
 	/// </summary>
 	/// <param name="window"></param>
-	void AddWindow(IWindow window);
+	/// <returns>Whether the <paramref name="window"/> was added.</returns>
+	bool AddWindow(IWindow window);
 
 	/// <summary>
 	/// Removes the window from the workspace.
@@ -135,7 +136,10 @@ public interface IWorkspace : IDisposable
 	/// <param name="window">
 	/// The origin window
 	/// </param>
-	void FocusWindowInDirection(Direction direction, IWindow? window = null);
+	/// <returns>
+	/// Whether the <see cref="ActiveLayoutEngine"/> changed.
+	/// </returns>
+	bool FocusWindowInDirection(Direction direction, IWindow? window = null);
 
 	/// <summary>
 	/// Swaps the <paramref name="window"/> in the <paramref name="direction"/>.
@@ -144,7 +148,10 @@ public interface IWorkspace : IDisposable
 	/// <param name="window">
 	/// The window to swap. If null, the currently focused window is swapped.
 	/// </param>
-	void SwapWindowInDirection(Direction direction, IWindow? window = null);
+	/// <returns>
+	/// Whether the <see cref="ActiveLayoutEngine"/> changed.
+	/// </returns>
+	bool SwapWindowInDirection(Direction direction, IWindow? window = null);
 
 	/// <summary>
 	/// Change the <paramref name="window"/>'s <paramref name="edges"/> direction by
@@ -161,7 +168,10 @@ public interface IWorkspace : IDisposable
 	/// The window to change the edge of. If null, the currently focused window is
 	/// used.
 	/// </param>
-	void MoveWindowEdgesInDirection(Direction edges, IPoint<double> deltas, IWindow? window = null);
+	/// <returns>
+	/// Whether the <see cref="ActiveLayoutEngine"/> changed.
+	/// </returns>
+	bool MoveWindowEdgesInDirection(Direction edges, IPoint<double> deltas, IWindow? window = null);
 
 	/// <summary>
 	/// Moves or adds the given <paramref name="window"/> to the given <paramref name="point"/>.
@@ -180,7 +190,6 @@ public interface IWorkspace : IDisposable
 	/// Will minimize a window in the <see cref="ActiveLayoutEngine"/>.
 	/// </summary>
 	/// <param name="window"></param>
-	/// <returns></returns>
 	void MinimizeWindowStart(IWindow window);
 
 	/// <summary>
@@ -205,7 +214,10 @@ public interface IWorkspace : IDisposable
 	/// <param name="action">
 	/// Metadata about the action to perform, and the payload to perform it with.
 	/// </param>
-	void PerformCustomLayoutEngineAction(LayoutEngineCustomAction action);
+	/// <returns>
+	/// Whether the <see cref="ActiveLayoutEngine"/> changed.
+	/// </returns>
+	bool PerformCustomLayoutEngineAction(LayoutEngineCustomAction action);
 
 	/// <summary>
 	/// Performs a custom action in a layout engine.
@@ -220,6 +232,9 @@ public interface IWorkspace : IDisposable
 	/// <param name="action">
 	/// Metadata about the action to perform, and the payload to perform it with.
 	/// </param>
-	void PerformCustomLayoutEngineAction<T>(LayoutEngineCustomAction<T> action);
+	/// <returns>
+	/// Whether the <see cref="ActiveLayoutEngine"/> changed.
+	/// </returns>
+	bool PerformCustomLayoutEngineAction<T>(LayoutEngineCustomAction<T> action);
 	#endregion
 }

--- a/src/Whim/Workspace/IWorkspace.cs
+++ b/src/Whim/Workspace/IWorkspace.cs
@@ -36,18 +36,6 @@ public interface IWorkspace : IDisposable
 	void CycleLayoutEngine(bool reverse = false);
 
 	/// <summary>
-	/// Rotate to the next layout engine.
-	/// </summary>
-	[Obsolete("Use CycleLayoutEngine instead, with `reverse: false`")]
-	void NextLayoutEngine();
-
-	/// <summary>
-	/// Rotate to the previous layout engine.
-	/// </summary>
-	[Obsolete("Use CycleLayoutEngine instead, with `reverse: true`")]
-	void PreviousLayoutEngine();
-
-	/// <summary>
 	/// Activates previously active layout engine.
 	/// </summary>
 	void ActivatePreviouslyActiveLayoutEngine();
@@ -115,12 +103,6 @@ public interface IWorkspace : IDisposable
 	/// <c>null</c> is returned.
 	/// </returns>
 	IWindowState? TryGetWindowState(IWindow window);
-
-	/// <summary>
-	/// Focuses on the first window in the workspace.
-	/// </summary>
-	[Obsolete("Use FocusLastFocusedWindow instead.")]
-	void FocusFirstWindow();
 
 	/// <summary>
 	/// Focuses on the last window in the workspace. If <see cref="LastFocusedWindow"/> is null,

--- a/src/Whim/Workspace/Workspace.cs
+++ b/src/Whim/Workspace/Workspace.cs
@@ -133,7 +133,7 @@ internal class Workspace : IWorkspace, IInternalWorkspace
 			Logger.Debug($"No windows in workspace {Name} to focus, focusing desktop");
 
 			// Get the bounds of the monitor for this workspace.
-			IMonitor? monitor = _context.WorkspaceManager.GetMonitorForWorkspace(this);
+			IMonitor? monitor = _context.Butler.GetMonitorForWorkspace(this);
 			if (monitor == null)
 			{
 				Logger.Debug($"No active monitors found for workspace {Name}.");
@@ -247,7 +247,6 @@ internal class Workspace : IWorkspace, IInternalWorkspace
 		if (_windows.Contains(window))
 		{
 			Logger.Error($"Window {window} already exists in workspace {Name}");
-			window.Focus();
 			return false;
 		}
 
@@ -449,7 +448,7 @@ internal class Workspace : IWorkspace, IInternalWorkspace
 		}
 
 		// Get the monitor for this workspace
-		IMonitor? monitor = _context.WorkspaceManager.GetMonitorForWorkspace(this);
+		IMonitor? monitor = _context.Butler.GetMonitorForWorkspace(this);
 		if (monitor == null)
 		{
 			Logger.Debug($"No active monitors found for workspace {Name}.");
@@ -574,7 +573,7 @@ internal class Workspace : IWorkspace, IInternalWorkspace
 				Logger.Debug($"Disposing workspace {Name}");
 
 				// dispose managed state (managed objects)
-				bool isWorkspaceActive = _context.WorkspaceManager.GetMonitorForWorkspace(this) != null;
+				bool isWorkspaceActive = _context.Butler.GetMonitorForWorkspace(this) != null;
 
 				// If the workspace isn't active on the monitor, show all the windows in as minimized.
 				if (!isWorkspaceActive)

--- a/src/Whim/Workspace/Workspace.cs
+++ b/src/Whim/Workspace/Workspace.cs
@@ -463,6 +463,7 @@ internal class Workspace : IWorkspace, IInternalWorkspace
 		{
 			windowStates.Add(new(loc, (HWND)1, null));
 			windowRects.Add(loc.Window.Handle, loc);
+			Logger.Debug($"Window {loc.Window} has rectangle {loc.Rectangle}");
 		}
 
 		using DeferWindowPosHandle handle = _context.NativeManager.DeferWindowPos(windowStates);

--- a/src/Whim/Workspace/Workspace.cs
+++ b/src/Whim/Workspace/Workspace.cs
@@ -263,8 +263,11 @@ internal class Workspace : IWorkspace, IInternalWorkspace
 					continue;
 				}
 
-				LastFocusedWindow = nextWindow;
-				break;
+				if (!nextWindow.IsMinimized)
+				{
+					LastFocusedWindow = nextWindow;
+					break;
+				}
 			}
 
 			// If there are no other windows, set the last focused window to null.

--- a/src/Whim/Workspace/Workspace.cs
+++ b/src/Whim/Workspace/Workspace.cs
@@ -390,7 +390,10 @@ internal class Workspace : IWorkspace, IInternalWorkspace
 		if (_windows.Contains(window))
 		{
 			// The window is already in the workspace, so move it in just the active layout engine
-			_layoutEngines[_activeLayoutEngineIndex] = ActiveLayoutEngine.MoveWindowToPoint(window, point);
+			_layoutEngines[_activeLayoutEngineIndex] = _layoutEngines[_activeLayoutEngineIndex].MoveWindowToPoint(
+				window,
+				point
+			);
 		}
 		else
 		{

--- a/src/Whim/Workspace/Workspace.cs
+++ b/src/Whim/Workspace/Workspace.cs
@@ -115,12 +115,6 @@ internal class Workspace : IWorkspace, IInternalWorkspace
 		_layoutEngines[_activeLayoutEngineIndex] = _layoutEngines[_activeLayoutEngineIndex].MinimizeWindowEnd(window);
 	}
 
-	public void FocusFirstWindow()
-	{
-		Logger.Debug($"Focusing first window in workspace {Name}");
-		ActiveLayoutEngine.GetFirstWindow()?.Focus();
-	}
-
 	public void FocusLastFocusedWindow()
 	{
 		Logger.Debug($"Focusing last focused window in workspace {Name}");
@@ -202,10 +196,6 @@ internal class Workspace : IWorkspace, IInternalWorkspace
 
 		TrySetLayoutEngineFromIndex(nextIdx);
 	}
-
-	public void NextLayoutEngine() => CycleLayoutEngine(false);
-
-	public void PreviousLayoutEngine() => CycleLayoutEngine(true);
 
 	public void ActivatePreviouslyActiveLayoutEngine() => TrySetLayoutEngineFromIndex(_prevLayoutEngineIndex);
 


### PR DESCRIPTION
The two major changes in this PR are:

- `Workspace`s are now simply a container for `ILayoutEngine`s and `IWindow`s
- `Workspace` continues to expose `DoLayout`, but **does not call `DoLayout` itself**
- Calling `Workspace` methods **requires** `DoLayout` calls in order to see changes

This makes it simpler to update `Workspace`s while preventing unnecessary layout calls.

> [!WARNING]
>
> - Custom functionality may require additional `DoLayout` calls.
> - Existing Whim-provided functionality may be broken by this change - please report any issues.
