### PR TITLE
Build in basic commands to cycle layouts

### DIFF
--- a/src/Whim.Tests/Commands/CoreCommandsTests.cs
+++ b/src/Whim.Tests/Commands/CoreCommandsTests.cs
@@ -276,6 +276,45 @@ public class CoreCommandsTests
 	}
 	#endregion
 
+	#region Cycle layouts
+	[Theory, AutoSubstituteData<CoreCommandsCustomization>]
+	public void CycleLayoutEngine_Next(IContext ctx)
+	{
+		// Given
+		CoreCommands commands = new(ctx);
+		PluginCommandsTestUtils testUtils = new(commands);
+
+		IWorkspace activeWorkspace = ctx.WorkspaceManager.ActiveWorkspace;
+
+		ICommand command = testUtils.GetCommand("whim.core.cycle_layout_engine.next");
+
+		// When
+		command.TryExecute();
+
+		// Then
+		activeWorkspace.Received(1).CycleLayoutEngine();
+	}
+
+	[Theory, AutoSubstituteData<CoreCommandsCustomization>]
+	public void CycleLayoutEngine_Previous(IContext ctx)
+	{
+		// Given
+		CoreCommands commands = new(ctx);
+		PluginCommandsTestUtils testUtils = new(commands);
+
+		IWorkspace activeWorkspace = ctx.WorkspaceManager.ActiveWorkspace;
+
+		ICommand command = testUtils.GetCommand("whim.core.cycle_layout_engine.previous");
+
+		// When
+		command.TryExecute();
+
+		// Then
+		activeWorkspace.Received(1).CycleLayoutEngine(reverse: true);
+	}
+	#endregion
+
+
 	[InlineAutoSubstituteData<CoreCommandsCustomization>("whim.core.focus_previous_monitor")]
 	[InlineAutoSubstituteData<CoreCommandsCustomization>("whim.core.focus_next_monitor")]
 	[Theory]

--- a/src/Whim/Commands/CoreCommands.cs
+++ b/src/Whim/Commands/CoreCommands.cs
@@ -195,6 +195,16 @@ internal class CoreCommands : PluginCommands
 				}
 			)
 			.Add(
+				identifier: "cycle_layout_engine.next",
+				title: "Cycle to the next layout engine",
+				callback: () => _context.WorkspaceManager.ActiveWorkspace.CycleLayoutEngine()
+			)
+			.Add(
+				identifier: "cycle_layout_engine.previous",
+				title: "Cycle to the previous layout engine",
+				callback: () => _context.WorkspaceManager.ActiveWorkspace.CycleLayoutEngine(reverse: true)
+			)
+			.Add(
 				identifier: "focus_previous_monitor",
 				title: "Focus the previous monitor",
 				callback: FocusMonitorInDirection(getNext: false)

--- a/src/Whim/Filter/DefaultFilteredWindowsKomorebi.g.cs
+++ b/src/Whim/Filter/DefaultFilteredWindowsKomorebi.g.cs
@@ -211,6 +211,9 @@ internal static class DefaultFilteredWindowsKomorebi
 		// Task Manager
 		filterManager.Add((window) => window.WindowClass.StartsWith("TaskManagerWindow") || window.WindowClass.EndsWith("TaskManagerWindow"));
 
+		// Total Commander
+		filterManager.AddWindowClassFilter("TDLG2FILEACTIONMIN");  // Target standard copy window
+
 		// TouchCursor
 		filterManager.AddProcessFileNameFilter("tcconfig.exe");
 


### PR DESCRIPTION
This PR adds in basic command to activate the next/previous layout engines.
While this is possible to do manually, I thought I'd add it as #796 will require another call to be made for this to work.