### PR TITLE
Add `NormalizeDeltaPoint` and rename other `ToUnitSquare` methods

### DIFF
--- a/src/Whim.FloatingLayout/FloatingLayoutEngine.cs
+++ b/src/Whim.FloatingLayout/FloatingLayoutEngine.cs
@@ -159,7 +159,7 @@ internal record FloatingLayoutEngine : BaseProxyLayoutEngine
 		}
 
 		IMonitor newMonitor = _context.MonitorManager.GetMonitorAtPoint(newActualRectangle);
-		IRectangle<double> newUnitSquareRectangle = newMonitor.WorkingArea.ToUnitSquare(newActualRectangle);
+		IRectangle<double> newUnitSquareRectangle = newMonitor.WorkingArea.NormalizeRectangle(newActualRectangle);
 		if (newUnitSquareRectangle.Equals(oldRectangle))
 		{
 			Logger.Debug($"Rectangle for window {window} has not changed");

--- a/src/Whim.FloatingLayout/FloatingLayoutPlugin.cs
+++ b/src/Whim.FloatingLayout/FloatingLayoutPlugin.cs
@@ -98,7 +98,7 @@ public class FloatingLayoutPlugin : IFloatingLayoutPlugin, IInternalFloatingLayo
 
 		// Convert the rectangle to a unit square rectangle.
 		IMonitor monitor = _context.MonitorManager.GetMonitorAtPoint(windowState.Rectangle);
-		IRectangle<double> unitSquareRect = monitor.WorkingArea.ToUnitSquare(windowState.Rectangle);
+		IRectangle<double> unitSquareRect = monitor.WorkingArea.NormalizeRectangle(windowState.Rectangle);
 
 		workspace.MoveWindowToPoint(window, unitSquareRect);
 	}

--- a/src/Whim.LayoutPreview/LayoutPreviewPlugin.cs
+++ b/src/Whim.LayoutPreview/LayoutPreviewPlugin.cs
@@ -74,7 +74,7 @@ public class LayoutPreviewPlugin : IPlugin, IDisposable
 			}
 
 			IMonitor monitor = _context.MonitorManager.GetMonitorAtPoint(cursorDraggedPoint);
-			IPoint<double> normalizedPoint = monitor.WorkingArea.ToUnitSquare(cursorDraggedPoint);
+			IPoint<double> normalizedPoint = monitor.WorkingArea.NormalizeAbsolutePoint(cursorDraggedPoint);
 
 			IWorkspace? workspace = _context.WorkspaceManager.GetWorkspaceForMonitor(monitor);
 			if (workspace == null)

--- a/src/Whim.Tests/Monitor/MonitorHelpersTests.cs
+++ b/src/Whim.Tests/Monitor/MonitorHelpersTests.cs
@@ -5,7 +5,83 @@ namespace Whim.Tests;
 
 public class MonitorHelpersTests
 {
-	public static IEnumerable<object[]> ToUnitSquare_Point_Data()
+	public static IEnumerable<object[]> NormalizeDeltaPoint_Data()
+	{
+		yield return new object[]
+		{
+			new Rectangle<int>() { Width = 1920, Height = 1080 },
+			new Point<int>() { X = 192, Y = 108 },
+			new Point<double>() { X = 0.1, Y = 0.1 }
+		};
+		yield return new object[]
+		{
+			new Rectangle<int>() { Width = 1920, Height = 1080 },
+			new Point<int>() { X = 960, Y = 270 },
+			new Point<double>() { X = 0.5, Y = 0.25 }
+		};
+		yield return new object[]
+		{
+			new Rectangle<int>()
+			{
+				X = 100,
+				Y = 100,
+				Width = 1920,
+				Height = 1080
+			},
+			new Point<int>() { X = 192, Y = 108 },
+			new Point<double>() { X = 0.1, Y = 0.1 }
+		};
+		yield return new object[]
+		{
+			new Rectangle<int>()
+			{
+				X = 100,
+				Y = 100,
+				Width = 1920,
+				Height = 1080
+			},
+			new Point<int>() { X = 960, Y = 270 },
+			new Point<double>() { X = 0.5, Y = 0.25 }
+		};
+		yield return new object[]
+		{
+			new Rectangle<int>()
+			{
+				X = -100,
+				Y = 100,
+				Width = 1920,
+				Height = 1080
+			},
+			new Point<int>() { X = 192, Y = 108 },
+			new Point<double>() { X = 0.1, Y = 0.1 }
+		};
+		yield return new object[]
+		{
+			new Rectangle<int>()
+			{
+				X = -100,
+				Y = 100,
+				Width = 1920,
+				Height = 1080
+			},
+			new Point<int>() { X = 960, Y = 270 },
+			new Point<double>() { X = 0.5, Y = 0.25 }
+		};
+	}
+
+	[Theory]
+	[MemberData(nameof(NormalizeDeltaPoint_Data))]
+	public void NormalizeDeltaPoint(IRectangle<int> monitor, IPoint<int> point, IPoint<double> expected)
+	{
+		// When
+		IPoint<double> actual = monitor.NormalizeDeltaPoint(point);
+
+		// Then
+		Assert.Equal(expected.X, actual.X);
+		Assert.Equal(expected.Y, actual.Y);
+	}
+
+	public static IEnumerable<object[]> NormalizeAbsolutePoint_Data()
 	{
 		yield return new object[]
 		{
@@ -70,18 +146,18 @@ public class MonitorHelpersTests
 	}
 
 	[Theory]
-	[MemberData(nameof(ToUnitSquare_Point_Data))]
-	public void ToUnitSquare_Point(IRectangle<int> monitor, IPoint<int> point, IPoint<double> expected)
+	[MemberData(nameof(NormalizeAbsolutePoint_Data))]
+	public void NormalizeAbsolutePoint(IRectangle<int> monitor, IPoint<int> point, IPoint<double> expected)
 	{
 		// When
-		IPoint<double> actual = monitor.ToUnitSquare(point);
+		IPoint<double> actual = monitor.NormalizeAbsolutePoint(point);
 
 		// Then
 		Assert.Equal(expected.X, actual.X);
 		Assert.Equal(expected.Y, actual.Y);
 	}
 
-	public static IEnumerable<object[]> ToUnitSquare_Point_Data_RespectSign()
+	public static IEnumerable<object[]> NormalizeAbsolutePoint_Data_RespectSign()
 	{
 		yield return new object[]
 		{
@@ -146,18 +222,22 @@ public class MonitorHelpersTests
 	}
 
 	[Theory]
-	[MemberData(nameof(ToUnitSquare_Point_Data_RespectSign))]
-	public void ToUnitSquare_PointRespectSignTheory(IRectangle<int> monitor, IPoint<int> point, IPoint<double> expected)
+	[MemberData(nameof(NormalizeAbsolutePoint_Data_RespectSign))]
+	public void NormalizeAbsolutePoint_RespectSignTheory(
+		IRectangle<int> monitor,
+		IPoint<int> point,
+		IPoint<double> expected
+	)
 	{
 		// When
-		IPoint<double> actual = monitor.ToUnitSquare(point, respectSign: true);
+		IPoint<double> actual = monitor.NormalizeAbsolutePoint(point, respectSign: true);
 
 		// Then
 		Assert.Equal(expected.X, actual.X);
 		Assert.Equal(expected.Y, actual.Y);
 	}
 
-	public static IEnumerable<object[]> ToUnitSquare_Rectangle_Data_Double()
+	public static IEnumerable<object[]> NormalizeRectangle_Double()
 	{
 		yield return new object[]
 		{
@@ -228,15 +308,11 @@ public class MonitorHelpersTests
 	}
 
 	[Theory]
-	[MemberData(nameof(ToUnitSquare_Rectangle_Data_Double))]
-	public void ToUnitSquare_Rectangle_Theory(
-		IRectangle<int> monitor,
-		IRectangle<int> rect,
-		IRectangle<double> expected
-	)
+	[MemberData(nameof(NormalizeRectangle_Double))]
+	public void NormalizeRectangle(IRectangle<int> monitor, IRectangle<int> rect, IRectangle<double> expected)
 	{
 		// When
-		IRectangle<double> actual = monitor.ToUnitSquare(rect);
+		IRectangle<double> actual = monitor.NormalizeRectangle(rect);
 
 		// Then
 		Assert.Equal(expected.X, actual.X);

--- a/src/Whim/Butler/ButlerChores.cs
+++ b/src/Whim/Butler/ButlerChores.cs
@@ -141,7 +141,7 @@ internal class ButlerChores : IButlerChores
 		Logger.Debug($"Moving window {window} to workspace {workspace}");
 
 		// Normalize `pixelsDeltas` into the unit square.
-		IPoint<double> normalized = monitor.WorkingArea.ToUnitSquare(pixelsDeltas, respectSign: true);
+		IPoint<double> normalized = monitor.WorkingArea.NormalizeDeltaPoint(pixelsDeltas);
 
 		Logger.Debug($"Normalized point: {normalized}");
 		workspace.MoveWindowEdgesInDirection(edges, normalized, window, deferLayout: false);
@@ -267,7 +267,7 @@ internal class ButlerChores : IButlerChores
 		}
 
 		// Normalize `point` into the unit square.
-		IPoint<double> normalized = targetMonitor.WorkingArea.ToUnitSquare(point);
+		IPoint<double> normalized = targetMonitor.WorkingArea.NormalizeAbsolutePoint(point);
 
 		Logger.Debug(
 			$"Moving window {window} to workspace {targetWorkspace} in monitor {targetMonitor} at normalized point {normalized}"

--- a/src/Whim/Context/CoreSavedStateManager.cs
+++ b/src/Whim/Context/CoreSavedStateManager.cs
@@ -85,7 +85,7 @@ internal class CoreSavedStateManager : ICoreSavedStateManager
 			foreach (IWindowState windowState in workspace.ActiveLayoutEngine.DoLayout(fakeMonitorRect, monitor))
 			{
 				Rectangle<double> scaled =
-					(Rectangle<double>)MonitorHelpers.ToUnitSquare(fakeMonitorRect, windowState.Rectangle);
+					(Rectangle<double>)MonitorHelpers.NormalizeRectangle(fakeMonitorRect, windowState.Rectangle);
 				savedWindows.Add(new SavedWindow(windowState.Window.Handle, scaled));
 			}
 

--- a/src/Whim/Monitor/IMonitor.cs
+++ b/src/Whim/Monitor/IMonitor.cs
@@ -44,15 +44,34 @@ public interface IMonitor
 public static class MonitorHelpers
 {
 	/// <summary>
-	/// Converts the <paramref name="point"/> from the system's coordinate system to the unit square.
+	/// Converts the <paramref name="point"/> from the system's coordinate system to the unit square,
+	/// where the unit square is the monitor's working area, ignoring the origin of the monitor.
+	/// This is good for converting deltas.
 	/// </summary>
 	/// <param name="monitor"></param>
-	/// <param name="point">The point to translate.</param>
+	/// <param name="point"></param>
+	/// <returns></returns>
+	public static IPoint<double> NormalizeDeltaPoint(this IRectangle<int> monitor, IPoint<int> point) =>
+		new Point<double>() { X = (double)point.X / monitor.Width, Y = (double)point.Y / monitor.Height };
+
+	/// <summary>
+	/// Converts the <paramref name="point"/> from the system's coordinate system to the unit square,
+	/// where the unit square is the monitor's working area, accounting for the origin of the monitor.
+	/// This is good for converting absolute positions.
+	/// </summary>
+	/// <param name="monitor"></param>
+	/// <param name="point">
+	/// The point to translate, in the system's coordinate system.
+	/// </param>
 	/// <param name="respectSign">
 	/// Whether to respect the sign. For example, values in [-infinity, 0] will become [-1, 0].
 	/// </param>
 	/// <returns>The converted point, where x and y are in the range [0, 1].</returns>
-	public static IPoint<double> ToUnitSquare(this IRectangle<int> monitor, IPoint<int> point, bool respectSign = false)
+	public static IPoint<double> NormalizeAbsolutePoint(
+		this IRectangle<int> monitor,
+		IPoint<int> point,
+		bool respectSign = false
+	)
 	{
 		Debug.Assert(monitor.Width != 0);
 		Debug.Assert(monitor.Height != 0);
@@ -75,7 +94,7 @@ public static class MonitorHelpers
 	/// <param name="monitor"></param>
 	/// <param name="rectangle">The point to translate.</param>
 	/// <returns>The converted point, where x and y are in the range [0, 1].</returns>
-	public static IRectangle<double> ToUnitSquare(this IRectangle<int> monitor, IRectangle<int> rectangle)
+	public static IRectangle<double> NormalizeRectangle(this IRectangle<int> monitor, IRectangle<int> rectangle)
 	{
 		Debug.Assert(monitor.Width != 0);
 		Debug.Assert(monitor.Height != 0);

--- a/src/Whim/Workspace/Workspace.cs
+++ b/src/Whim/Workspace/Workspace.cs
@@ -402,7 +402,7 @@ internal class Workspace : IWorkspace, IInternalWorkspace
 			DoLayout();
 		}
 
-		return true;
+		return changed;
 	}
 
 	public bool MoveWindowToPoint(IWindow window, IPoint<double> point, bool deferLayout = false)


### PR DESCRIPTION
Moving window edges on non-primary monitors was broken, as the given deltas were treated as absolute points, not deltas.

To resolve this, `NormalizeDeltaPoint` was added, and the other `ToUnitSquare` methods were renamed to be more descriptive.