### PR TITLE
Restore windows when finding and focusing windows

### DIFF
--- a/docs/docs/plugins/command-palette.md
+++ b/docs/docs/plugins/command-palette.md
@@ -46,3 +46,4 @@ return DoConfig;
 | `whim.command_palette.move_window_to_workspace`           | Move window to workspace           | No default keybind                               |
 | `whim.command_palette.move_multiple_windows_to_workspace` | Move multiple windows to workspace | No default keybind                               |
 | `whim.command_palette.remove_window`                      | Select window to remove from Whim  | No default keybind                               |
+| `whim.command_palette.find_focus_window`                  | Find and focus window              | No default keybind                               |

--- a/src/Whim.CommandPalette.Tests/CommandPaletteCommandsTests.cs
+++ b/src/Whim.CommandPalette.Tests/CommandPaletteCommandsTests.cs
@@ -363,6 +363,7 @@ public class CommandPaletteCommandsTests
 		// Given the window is in a workspace.
 		Wrapper wrapper = new();
 		IWindow window = wrapper.Windows[0];
+		wrapper.Context.Butler.GetWorkspaceForWindow(window).Returns(wrapper.Workspace);
 		wrapper.Context.Butler.GetMonitorForWorkspace(wrapper.Workspace).Returns(Substitute.For<IMonitor>());
 
 		window.IsMinimized.Returns(isMinimized);
@@ -386,6 +387,7 @@ public class CommandPaletteCommandsTests
 		// Given the window is in a workspace.
 		Wrapper wrapper = new();
 		IWindow window = wrapper.Windows[0];
+		wrapper.Context.Butler.GetWorkspaceForWindow(window).Returns(wrapper.Workspace);
 		wrapper.Context.Butler.GetMonitorForWorkspace(wrapper.Workspace).Returns((IMonitor?)null);
 
 		window.IsMinimized.Returns(isMinimized);

--- a/src/Whim.CommandPalette.Tests/CommandPaletteCommandsTests.cs
+++ b/src/Whim.CommandPalette.Tests/CommandPaletteCommandsTests.cs
@@ -1,6 +1,7 @@
 using FluentAssertions;
 using NSubstitute;
 using NSubstitute.ReturnsExtensions;
+using Whim.TestUtils;
 using Xunit;
 
 namespace Whim.CommandPalette.Tests;
@@ -338,66 +339,65 @@ public class CommandPaletteCommandsTests
 	[Fact]
 	public void FocusWindowCommandCreator_CannotFindWorkspace()
 	{
-		// Given
+		// Given the window is not in a workspace.
 		Wrapper wrapper = new();
-
 		IWindow window = wrapper.Windows[0];
 		wrapper.Context.Butler.GetWorkspaceForWindow(window).Returns((IWorkspace?)null);
 
 		CommandPaletteCommands commands = new(wrapper.Context, wrapper.Plugin);
 
-		// When
+		// When the command is executed.
 		ICommand command = commands.FocusWindowCommandCreator(window);
 		command.TryExecute();
 
-		// Then
+		// Then the window is not focused.
 		wrapper.Workspace.DidNotReceive().DoLayout();
 		window.DidNotReceive().Focus();
 	}
 
-	[Fact]
-	public void FocusWindowCommandCreator_WindowIsMinimized()
+	[Theory]
+	[InlineAutoSubstituteData(false, 0, 1)]
+	[InlineAutoSubstituteData(true, 1, 0)]
+	public void FocusWindowCommandCreator_WorkspaceIsVisible(bool isMinimized, int restoredCount, int focusedCount)
 	{
-		// Given
+		// Given the window is in a workspace.
 		Wrapper wrapper = new();
-
 		IWindow window = wrapper.Windows[0];
-		window.IsMinimized.Returns(true);
-		wrapper.Context.Butler.GetWorkspaceForWindow(window).Returns(wrapper.Workspace);
+		wrapper.Context.Butler.GetMonitorForWorkspace(wrapper.Workspace).Returns(Substitute.For<IMonitor>());
+
+		window.IsMinimized.Returns(isMinimized);
 
 		CommandPaletteCommands commands = new(wrapper.Context, wrapper.Plugin);
 
-		// When
+		// When the command is executed.
 		ICommand command = commands.FocusWindowCommandCreator(window);
 		command.TryExecute();
 
-		// Then
-		wrapper.Workspace.Received(1).MinimizeWindowEnd(window);
-		wrapper.Context.Butler.DidNotReceive().Activate(Arg.Any<IWorkspace>());
-		wrapper.Workspace.Received(1).DoLayout();
-		window.Received(1).Focus();
+		// Then the window is focused.
+		window.Received(restoredCount).Restore();
+		window.Received(focusedCount).Focus();
 	}
 
-	[Fact]
-	public void FocusWindowCommandCreator_ActivateWorkspace()
+	[Theory]
+	[InlineAutoSubstituteData(false, 0, 1)]
+	[InlineAutoSubstituteData(true, 1, 0)]
+	public void FocusWindowCommandCreator_WorkspaceIsNotVisible(bool isMinimized, int restoredCount, int focusedCount)
 	{
-		// Given
+		// Given the window is in a workspace.
 		Wrapper wrapper = new();
-
 		IWindow window = wrapper.Windows[0];
-		wrapper.Context.Butler.GetWorkspaceForWindow(window).Returns(wrapper.Workspace);
-		wrapper.Context.Butler.GetMonitorForWindow(window).ReturnsNull();
+		wrapper.Context.Butler.GetMonitorForWorkspace(wrapper.Workspace).Returns((IMonitor?)null);
+
+		window.IsMinimized.Returns(isMinimized);
 
 		CommandPaletteCommands commands = new(wrapper.Context, wrapper.Plugin);
 
-		// When
+		// When the command is executed.
 		ICommand command = commands.FocusWindowCommandCreator(window);
 		command.TryExecute();
 
-		// Then
-		wrapper.Workspace.DidNotReceive().MinimizeWindowEnd(window);
-		wrapper.Context.Butler.Received(1).Activate(wrapper.Workspace);
-		wrapper.Workspace.Received(1).DoLayout();
-		window.Received(1).Focus();
+		// Then the window is focused.
+		window.Received(restoredCount).Restore();
+		window.Received(focusedCount).Focus();
 	}
 }

--- a/src/Whim.CommandPalette/CommandPaletteCommands.cs
+++ b/src/Whim.CommandPalette/CommandPaletteCommands.cs
@@ -258,18 +258,39 @@ public class CommandPaletteCommands : PluginCommands
 					return;
 				}
 
-				if (window.IsMinimized)
+				if (_context.WorkspaceManager.ActiveWorkspace.Equals(window))
 				{
-					workspace.MinimizeWindowEnd(window);
+					// The workspace is currently active.
+					if (window.IsMinimized)
+					{
+						workspace.MinimizeWindowEnd(window);
+					}
+					else
+					{
+						window.Focus();
+					}
+					return;
 				}
 
-				if (_context.Butler.GetMonitorForWindow(window) is null)
+				if (_context.Butler.GetMonitorForWorkspace(workspace) is IMonitor monitor)
 				{
+					// The workspace is not active, but is visible.
+					_context.Butler.Activate(workspace, monitor);
+				}
+				else
+				{
+					// The workspace is not active, and is not visible.
 					_context.Butler.Activate(workspace);
 				}
 
-				workspace.DoLayout();
-				window.Focus();
+				if (window.IsMinimized)
+				{
+					window.ShowNormal();
+				}
+				else
+				{
+					window.Focus();
+				}
 			}
 		);
 }

--- a/src/Whim.CommandPalette/CommandPaletteCommands.cs
+++ b/src/Whim.CommandPalette/CommandPaletteCommands.cs
@@ -96,8 +96,8 @@ public class CommandPaletteCommands : PluginCommands
 						new MenuVariantConfig()
 						{
 							Hint = "Select window",
-							Commands = _context.WorkspaceManager.ActiveWorkspace.Windows.Select(w =>
-								RemoveWindowCommandCreator(w)
+							Commands = _context.WorkspaceManager.ActiveWorkspace.Windows.Select(
+								w => RemoveWindowCommandCreator(w)
 							),
 							ConfirmButtonText = "Remove"
 						}
@@ -160,13 +160,16 @@ public class CommandPaletteCommands : PluginCommands
 			.OrderBy(w => w.Title);
 
 		return windows
-			.Select(w => new SelectOption()
-			{
-				Id = $"{PluginName}.move_multiple_windows_to_workspace.{w.Title}",
-				Title = w.Title,
-				IsEnabled = true,
-				IsSelected = false
-			})
+			.Select(
+				w =>
+					new SelectOption()
+					{
+						Id = $"{PluginName}.move_multiple_windows_to_workspace.{w.Title}",
+						Title = w.Title,
+						IsEnabled = true,
+						IsSelected = false
+					}
+			)
 			.ToArray();
 	}
 
@@ -261,14 +264,7 @@ public class CommandPaletteCommands : PluginCommands
 				if (_context.WorkspaceManager.ActiveWorkspace.Equals(window))
 				{
 					// The workspace is currently active.
-					if (window.IsMinimized)
-					{
-						workspace.MinimizeWindowEnd(window);
-					}
-					else
-					{
-						window.Focus();
-					}
+					FocusWindow(window);
 					return;
 				}
 
@@ -283,14 +279,23 @@ public class CommandPaletteCommands : PluginCommands
 					_context.Butler.Activate(workspace);
 				}
 
-				if (window.IsMinimized)
-				{
-					window.ShowNormal();
-				}
-				else
-				{
-					window.Focus();
-				}
+				FocusWindow(window);
 			}
 		);
+
+	/// <summary>
+	/// Focuses the given <paramref name="window"/>. If the window is minimized, it will be restored.
+	/// </summary>
+	/// <param name="window"></param>
+	private static void FocusWindow(IWindow window)
+	{
+		if (window.IsMinimized)
+		{
+			window.Restore();
+		}
+		else
+		{
+			window.Focus();
+		}
+	}
 }

--- a/src/Whim.CommandPalette/CommandPaletteCommands.cs
+++ b/src/Whim.CommandPalette/CommandPaletteCommands.cs
@@ -261,7 +261,7 @@ public class CommandPaletteCommands : PluginCommands
 					return;
 				}
 
-				if (_context.WorkspaceManager.ActiveWorkspace.Equals(window))
+				if (_context.WorkspaceManager.ActiveWorkspace.Equals(workspace))
 				{
 					// The workspace is currently active.
 					FocusWindow(window);

--- a/src/Whim.CommandPalette/CommandPaletteCommands.cs
+++ b/src/Whim.CommandPalette/CommandPaletteCommands.cs
@@ -96,8 +96,8 @@ public class CommandPaletteCommands : PluginCommands
 						new MenuVariantConfig()
 						{
 							Hint = "Select window",
-							Commands = _context.WorkspaceManager.ActiveWorkspace.Windows.Select(
-								w => RemoveWindowCommandCreator(w)
+							Commands = _context.WorkspaceManager.ActiveWorkspace.Windows.Select(w =>
+								RemoveWindowCommandCreator(w)
 							),
 							ConfirmButtonText = "Remove"
 						}
@@ -160,16 +160,13 @@ public class CommandPaletteCommands : PluginCommands
 			.OrderBy(w => w.Title);
 
 		return windows
-			.Select(
-				w =>
-					new SelectOption()
-					{
-						Id = $"{PluginName}.move_multiple_windows_to_workspace.{w.Title}",
-						Title = w.Title,
-						IsEnabled = true,
-						IsSelected = false
-					}
-			)
+			.Select(w => new SelectOption()
+			{
+				Id = $"{PluginName}.move_multiple_windows_to_workspace.{w.Title}",
+				Title = w.Title,
+				IsEnabled = true,
+				IsSelected = false
+			})
 			.ToArray();
 	}
 
@@ -261,19 +258,7 @@ public class CommandPaletteCommands : PluginCommands
 					return;
 				}
 
-				if (_context.WorkspaceManager.ActiveWorkspace.Equals(workspace))
-				{
-					// The workspace is currently active.
-					FocusWindow(window);
-					return;
-				}
-
-				if (_context.Butler.GetMonitorForWorkspace(workspace) is IMonitor monitor)
-				{
-					// The workspace is not active, but is visible.
-					_context.Butler.Activate(workspace, monitor);
-				}
-				else
+				if (_context.Butler.GetMonitorForWorkspace(workspace) is null)
 				{
 					// The workspace is not active, and is not visible.
 					_context.Butler.Activate(workspace);

--- a/src/Whim.Tests/Window/WindowTests.cs
+++ b/src/Whim.Tests/Window/WindowTests.cs
@@ -333,6 +333,21 @@ public class WindowTests
 	}
 
 	[Theory, AutoSubstituteData<WindowCustomization>]
+	internal void Restore(IContext ctx, IInternalContext internalCtx)
+	{
+		// Given
+		ctx.NativeManager.RestoreWindow(Arg.Any<HWND>());
+
+		IWindow window = Window.CreateWindow(ctx, internalCtx, new HWND(123))!;
+
+		// When
+		window.Restore();
+
+		// Then
+		ctx.NativeManager.Received(1).RestoreWindow(Arg.Any<HWND>());
+	}
+
+	[Theory, AutoSubstituteData<WindowCustomization>]
 	internal void CreateWindow_Null(IContext ctx, IInternalContext internalCtx)
 	{
 		// Given

--- a/src/Whim/Butler/ButlerChores.cs
+++ b/src/Whim/Butler/ButlerChores.cs
@@ -15,7 +15,7 @@ internal class ButlerChores : IButlerChores
 
 	public void Activate(IWorkspace workspace, IMonitor? monitor = null)
 	{
-		Logger.Debug($"Activating workspace {workspace}");
+		Logger.Debug($"Activating workspace {workspace} in monitor {monitor}");
 
 		if (!_context.WorkspaceManager.Contains(workspace))
 		{

--- a/src/Whim/Native/INativeManager.cs
+++ b/src/Whim/Native/INativeManager.cs
@@ -55,6 +55,14 @@ public interface INativeManager
 	bool ShowWindowNoActivate(HWND hwnd);
 
 	/// <summary>
+	/// Activates and displays the window. If the window is minimized, maximized, or arranged,
+	/// the system restores it to its original size and position
+	/// </summary>
+	/// <param name="hwnd"></param>
+	/// <returns></returns>
+	bool RestoreWindow(HWND hwnd);
+
+	/// <summary>
 	/// Safe wrapper around <see cref="PInvoke.GetClassName"/>.
 	/// </summary>
 	/// <param name="hwnd"></param>

--- a/src/Whim/Native/NativeManager.cs
+++ b/src/Whim/Native/NativeManager.cs
@@ -84,6 +84,12 @@ internal partial class NativeManager : INativeManager
 		return (bool)PInvoke.ShowWindow(hwnd, SHOW_WINDOW_CMD.SW_SHOWNOACTIVATE);
 	}
 
+	public bool RestoreWindow(HWND hwnd)
+	{
+		Logger.Debug($"Restoring window HWND {hwnd}");
+		return (bool)PInvoke.ShowWindow(hwnd, SHOW_WINDOW_CMD.SW_RESTORE);
+	}
+
 	public string GetClassName(HWND hwnd)
 	{
 		unsafe

--- a/src/Whim/Window/IWindow.cs
+++ b/src/Whim/Window/IWindow.cs
@@ -104,6 +104,12 @@ public interface IWindow
 	void ShowMinimized();
 
 	/// <summary>
+	/// Activates and displays the window. If the window is minimized, maximized, or arranged,
+	/// the system restores it to its original size and position
+	/// </summary>
+	void Restore();
+
+	/// <summary>
 	/// Brings the window to the top.
 	/// </summary>
 	void BringToTop();

--- a/src/Whim/Window/Window.cs
+++ b/src/Whim/Window/Window.cs
@@ -105,6 +105,12 @@ internal class Window : IWindow
 		_context.NativeManager.ShowWindowNoActivate(Handle);
 	}
 
+	public void Restore()
+	{
+		Logger.Debug(ToString());
+		_context.NativeManager.RestoreWindow(Handle);
+	}
+
 	/// <summary>
 	/// Constructor for the <see cref="IWindow"/> implementation.
 	/// </summary>


### PR DESCRIPTION
Previously, the command `whim.command_palette.find_focus_window` would not do anything for windows which were minimized. 
This has been fixed and tested in the following scenarios:

- Window is in active workspace
- Window is minimized in active workspace
- Window is in visible but inactive workspace
- Window is minimized in an inactive workspace
- Window is "visible" in hidden workspace
- Window is minimized in hidden workspace
