### PR TITLE
Retain monitor focus when switching to an empty workspace

### DIFF
--- a/src/Whim.Tests/Butler/ButlerChoresTests.cs
+++ b/src/Whim.Tests/Butler/ButlerChoresTests.cs
@@ -39,7 +39,7 @@ public class ButlerChoresTests
 	{
 		// Given the monitor does not exist
 		ButlerChores sut = new(ctx, internalCtx, triggers);
-		ctx.WorkspaceManager.GetEnumerator().Returns(new List<IWorkspace> { workspace }.GetEnumerator());
+		ctx.WorkspaceManager.Contains(workspace).Returns(true);
 
 		// When Activate is called
 		sut.Activate(workspace, monitor);
@@ -60,7 +60,7 @@ public class ButlerChoresTests
 		// Given the workspace is already activated
 		ButlerChores sut = new(ctx, internalCtx, triggers);
 
-		ctx.WorkspaceManager.GetEnumerator().Returns(new List<IWorkspace> { workspace }.GetEnumerator());
+		ctx.WorkspaceManager.Contains(workspace).Returns(true);
 		ctx.MonitorManager.GetEnumerator().Returns(new List<IMonitor> { monitor }.GetEnumerator());
 		ctx.Butler.Pantry.GetMonitorForWorkspace(workspace).Returns(monitor);
 

--- a/src/Whim.Tests/Butler/ButlerChoresTests.cs
+++ b/src/Whim.Tests/Butler/ButlerChoresTests.cs
@@ -1,0 +1,30 @@
+using NSubstitute;
+using Whim.TestUtils;
+using Windows.Win32.Foundation;
+using Xunit;
+
+namespace Whim.Tests;
+
+public class ButlerChoresTests
+{
+	[Theory, AutoSubstituteData]
+	internal void FocusMonitorDesktop(
+		IContext ctx,
+		IInternalContext internalCtx,
+		ButlerTriggers triggers,
+		IMonitor monitor
+	)
+	{
+		// Given
+		ButlerChores chores = new(ctx, internalCtx, triggers);
+
+		// When
+		chores.FocusMonitorDesktop(monitor);
+
+		// Then
+		internalCtx.CoreNativeManager.Received(1).GetDesktopWindow();
+		internalCtx.CoreNativeManager.Received(1).SetForegroundWindow(Arg.Any<HWND>());
+		internalCtx.WindowManager.Received(1).OnWindowFocused(null);
+		internalCtx.MonitorManager.Received(1).ActivateEmptyMonitor(monitor);
+	}
+}

--- a/src/Whim.Tests/Butler/ButlerEventHandlersTests.cs
+++ b/src/Whim.Tests/Butler/ButlerEventHandlersTests.cs
@@ -36,7 +36,7 @@ internal class ButlerEventHandlersCustomization : ICustomization
 
 public class ButlerEventHandlersTests
 {
-	private const int DELAY_MS = 3500;
+	private const int DELAY_MS = 4000;
 
 	private static void AssertWindowAdded(IWindow window, IWorkspace currentWorkspace, RouteEventArgs actual)
 	{

--- a/src/Whim.Tests/Butler/ButlerEventHandlersTests.cs
+++ b/src/Whim.Tests/Butler/ButlerEventHandlersTests.cs
@@ -36,8 +36,6 @@ internal class ButlerEventHandlersCustomization : ICustomization
 
 public class ButlerEventHandlersTests
 {
-	private const int DELAY_MS = 4000;
-
 	private static void AssertWindowAdded(IWindow window, IWorkspace currentWorkspace, RouteEventArgs actual)
 	{
 		Assert.Equal(window, actual.Window);
@@ -552,7 +550,7 @@ public class ButlerEventHandlersTests
 
 	#region OnMonitorsChanged
 	[Theory, AutoSubstituteData<ButlerEventHandlersCustomization>]
-	internal async void OnMonitorsChanged_RemovedMonitor(
+	internal void OnMonitorsChanged_RemovedMonitor(
 		IContext ctx,
 		IInternalContext internalCtx,
 		ButlerTriggers triggers,
@@ -565,7 +563,7 @@ public class ButlerEventHandlersTests
 		IMonitor[] monitors = CreateMonitors(ctx, 3);
 		pantry.GetWorkspaceForMonitor(monitors[0]).Returns(workspace);
 
-		ButlerEventHandlers sut = new(ctx, internalCtx, triggers, pantry, chores);
+		ButlerEventHandlers sut = new(ctx, internalCtx, triggers, pantry, chores) { MonitorsChangedDelay = 0 };
 		NativeManagerUtils.SetupTryEnqueue(ctx);
 
 		// When a monitor is removed
@@ -577,7 +575,6 @@ public class ButlerEventHandlersTests
 				AddedMonitors = Array.Empty<IMonitor>()
 			}
 		);
-		await Task.Delay(DELAY_MS);
 
 		// Then the monitor is removed from the pantry
 		pantry.Received().RemoveMonitor(monitors[0]);
@@ -586,7 +583,7 @@ public class ButlerEventHandlersTests
 	}
 
 	[Theory, AutoSubstituteData<ButlerEventHandlersCustomization>]
-	internal async void OnMonitorsChanged_RemovedMonitor_NoWorkspaceForMonitor(
+	internal void OnMonitorsChanged_RemovedMonitor_NoWorkspaceForMonitor(
 		IContext ctx,
 		IInternalContext internalCtx,
 		ButlerTriggers triggers,
@@ -598,7 +595,7 @@ public class ButlerEventHandlersTests
 		IMonitor[] monitors = CreateMonitors(ctx, 3);
 		pantry.GetWorkspaceForMonitor(monitors[0]).ReturnsNull();
 
-		ButlerEventHandlers sut = new(ctx, internalCtx, triggers, pantry, chores);
+		ButlerEventHandlers sut = new(ctx, internalCtx, triggers, pantry, chores) { MonitorsChangedDelay = 0 };
 		NativeManagerUtils.SetupTryEnqueue(ctx);
 
 		// When a monitor is removed
@@ -610,7 +607,6 @@ public class ButlerEventHandlersTests
 				AddedMonitors = Array.Empty<IMonitor>()
 			}
 		);
-		await Task.Delay(DELAY_MS);
 
 		// Then nothing happens
 		pantry.Received().RemoveMonitor(monitors[0]);
@@ -636,7 +632,7 @@ public class ButlerEventHandlersTests
 	}
 
 	[Theory, AutoSubstituteData<ButlerEventHandlersCustomization>]
-	internal async void OnMonitorsChanged_AddedMonitor_UseSpareWorkspace(
+	internal void OnMonitorsChanged_AddedMonitor_UseSpareWorkspace(
 		IContext ctx,
 		IInternalContext internalCtx,
 		ButlerTriggers triggers,
@@ -652,7 +648,7 @@ public class ButlerEventHandlersTests
 
 		pantry.GetMonitorForWorkspace(workspaces[2]).ReturnsNull();
 
-		ButlerEventHandlers sut = new(ctx, internalCtx, triggers, pantry, chores);
+		ButlerEventHandlers sut = new(ctx, internalCtx, triggers, pantry, chores) { MonitorsChangedDelay = 0 };
 		NativeManagerUtils.SetupTryEnqueue(ctx);
 
 		// When a monitor is added
@@ -664,7 +660,6 @@ public class ButlerEventHandlersTests
 				AddedMonitors = new[] { newMonitor }
 			}
 		);
-		await Task.Delay(DELAY_MS);
 
 		// Then the monitor is added to the pantry
 		pantry.Received().SetMonitorWorkspace(newMonitor, workspaces[2]);
@@ -672,7 +667,7 @@ public class ButlerEventHandlersTests
 	}
 
 	[Theory, AutoSubstituteData<ButlerEventHandlersCustomization>]
-	internal async void OnMonitorsChanged_AddedMonitor_CreateWorkspace_Succeeds(
+	internal void OnMonitorsChanged_AddedMonitor_CreateWorkspace_Succeeds(
 		IContext ctx,
 		IInternalContext internalCtx,
 		ButlerTriggers triggers,
@@ -689,7 +684,7 @@ public class ButlerEventHandlersTests
 
 		ctx.WorkspaceManager.Add().Returns(newWorkspace);
 
-		ButlerEventHandlers sut = new(ctx, internalCtx, triggers, pantry, chores);
+		ButlerEventHandlers sut = new(ctx, internalCtx, triggers, pantry, chores) { MonitorsChangedDelay = 0 };
 		NativeManagerUtils.SetupTryEnqueue(ctx);
 
 		// When a monitor is added
@@ -701,7 +696,6 @@ public class ButlerEventHandlersTests
 				AddedMonitors = new[] { newMonitor }
 			}
 		);
-		await Task.Delay(DELAY_MS);
 
 		// Then the monitor is added to the pantry
 		pantry.Received().SetMonitorWorkspace(newMonitor, newWorkspace);
@@ -709,7 +703,7 @@ public class ButlerEventHandlersTests
 	}
 
 	[Theory, AutoSubstituteData<ButlerEventHandlersCustomization>]
-	internal async void OnMonitorsChanged_AddedMonitor_CreateWorkspace_Fails(
+	internal void OnMonitorsChanged_AddedMonitor_CreateWorkspace_Fails(
 		IContext ctx,
 		IInternalContext internalCtx,
 		ButlerTriggers triggers,
@@ -724,7 +718,7 @@ public class ButlerEventHandlersTests
 
 		ctx.WorkspaceManager.Add().ReturnsNull();
 
-		ButlerEventHandlers sut = new(ctx, internalCtx, triggers, pantry, chores);
+		ButlerEventHandlers sut = new(ctx, internalCtx, triggers, pantry, chores) { MonitorsChangedDelay = 0 };
 		NativeManagerUtils.SetupTryEnqueue(ctx);
 
 		// When a monitor is added
@@ -736,7 +730,6 @@ public class ButlerEventHandlersTests
 				AddedMonitors = new[] { monitors[1] }
 			}
 		);
-		await Task.Delay(DELAY_MS);
 
 		// Then the monitor is not added to the pantry
 		pantry.DidNotReceive().SetMonitorWorkspace(monitors[1], workspaces[0]);
@@ -744,7 +737,7 @@ public class ButlerEventHandlersTests
 	}
 
 	[Theory, AutoSubstituteData<ButlerEventHandlersCustomization>]
-	internal async void OnMonitorsChanged_RemovedAndAddedMonitor(
+	internal void OnMonitorsChanged_RemovedAndAddedMonitor(
 		IContext ctx,
 		IInternalContext internalCtx,
 		ButlerTriggers triggers,
@@ -764,7 +757,7 @@ public class ButlerEventHandlersTests
 
 		pantry.GetMonitorForWorkspace(workspaces[0]).ReturnsNull();
 
-		ButlerEventHandlers sut = new(ctx, internalCtx, triggers, pantry, chores);
+		ButlerEventHandlers sut = new(ctx, internalCtx, triggers, pantry, chores) { MonitorsChangedDelay = 0 };
 		NativeManagerUtils.SetupTryEnqueue(ctx);
 
 		// When a monitor is removed and another is added
@@ -776,7 +769,6 @@ public class ButlerEventHandlersTests
 				AddedMonitors = new[] { newMonitor }
 			}
 		);
-		await Task.Delay(DELAY_MS);
 
 		// Then the monitor is removed from the pantry
 		pantry.Received().RemoveMonitor(monitors[0]);
@@ -808,7 +800,7 @@ public class ButlerEventHandlersTests
 		pantry.GetWorkspaceForMonitor(monitors[1]).Returns(workspaces[1]);
 		pantry.GetWorkspaceForMonitor(monitors[2]).Returns(workspaces[2]);
 
-		ButlerEventHandlers sut = new(ctx, internalCtx, triggers, pantry, chores);
+		ButlerEventHandlers sut = new(ctx, internalCtx, triggers, pantry, chores) { MonitorsChangedDelay = 500 };
 		NativeManagerUtils.SetupTryEnqueue(ctx);
 
 		// When there are two events in quick succession
@@ -822,7 +814,7 @@ public class ButlerEventHandlersTests
 		sut.OnMonitorsChanged(e);
 		sut.OnMonitorsChanged(e);
 		Assert.True(sut.AreMonitorsChanging);
-		await Task.Delay(DELAY_MS);
+		await Task.Delay(2000);
 
 		// Then LayoutAllActiveWorkspaces is called just once
 		workspaces[0].Received().Deactivate();

--- a/src/Whim.Tests/Window/WindowManagerTests.cs
+++ b/src/Whim.Tests/Window/WindowManagerTests.cs
@@ -793,7 +793,7 @@ public class WindowManagerTests
 		HWND hwnd = new(1);
 		CaptureWinEventProc capture = CaptureWinEventProc.Create(internalCtx);
 		AllowWindowCreation(ctx, internalCtx, hwnd);
-		WindowManager windowManager = new(ctx, internalCtx) { MonitorChangedDelay = 0 };
+		WindowManager windowManager = new(ctx, internalCtx) { WindowMovedDelay = 0 };
 		windowManager.Initialize();
 		return (capture, windowManager, hwnd);
 	}

--- a/src/Whim.Tests/Workspace/WorkspaceManagerTests.cs
+++ b/src/Whim.Tests/Workspace/WorkspaceManagerTests.cs
@@ -530,6 +530,26 @@ public class WorkspaceManagerTests
 	}
 
 	[Theory, AutoSubstituteData<WorkspaceManagerCustomization>]
+	internal void Activate_WorkspaceAlreadyActivated(
+		IContext ctx,
+		IInternalContext internalCtx,
+		IWorkspace workspace,
+		IMonitor monitor
+	)
+	{
+		// Given the workspace is already assigned to the monitor
+		WorkspaceManagerTestWrapper workspaceManager = CreateSut(ctx, internalCtx);
+		ctx.Butler.Pantry.SetMonitorWorkspace(monitor, workspace);
+
+		// When we activate the workspace, then nothing happens
+		CustomAssert.DoesNotRaise<MonitorWorkspaceChangedEventArgs>(
+			h => ctx.Butler.MonitorWorkspaceChanged += h,
+			h => ctx.Butler.MonitorWorkspaceChanged -= h,
+			() => workspaceManager.Activate(workspace)
+		);
+	}
+
+	[Theory, AutoSubstituteData<WorkspaceManagerCustomization>]
 	internal void Activate_WithPreviousWorkspace(
 		IContext ctx,
 		IInternalContext internalCtx,

--- a/src/Whim.Tests/Workspace/WorkspaceTests.cs
+++ b/src/Whim.Tests/Workspace/WorkspaceTests.cs
@@ -367,8 +367,6 @@ public class WorkspaceTests
 	}
 	#endregion
 
-
-
 	#region FocusLastFocusedWindow
 	[Theory, AutoSubstituteData<WorkspaceCustomization>]
 	internal void FocusLastFocusedWindow_LastFocusedWindow(
@@ -389,9 +387,35 @@ public class WorkspaceTests
 		workspace.WindowFocused(window);
 		workspace.FocusLastFocusedWindow();
 
-		// Then the LayoutEngine's GetFirstWindow method is called
-		layoutEngine.DidNotReceive().GetFirstWindow();
+		// Then the window is focused
 		window.Received(1).Focus();
+	}
+
+	[Theory, AutoSubstituteData<WorkspaceCustomization>]
+	internal void FocusLastFocusedWindow_MinimizedLastFocusedWindow(
+		IContext ctx,
+		IInternalContext internalCtx,
+		WorkspaceManagerTriggers triggers,
+		ILayoutEngine layoutEngine,
+		IWindow window,
+		IMonitor monitor
+	)
+	{
+		// Given the window is in the workspace
+		Workspace workspace = new(ctx, internalCtx, triggers, "Workspace", new ILayoutEngine[] { layoutEngine });
+		ctx.Butler.GetMonitorForWorkspace(workspace).Returns(monitor);
+
+		workspace.AddWindow(window);
+		window.IsMinimized.Returns(true);
+
+		window.ClearReceivedCalls();
+
+		// When FocusLastFocusedWindow is called
+		workspace.WindowFocused(window);
+		workspace.FocusLastFocusedWindow();
+
+		// Then the monitor is focused
+		internalCtx.MonitorManager.Received(1).ActivateEmptyMonitor(monitor);
 	}
 
 	[Theory, AutoSubstituteData<WorkspaceCustomization>]

--- a/src/Whim.Tests/Workspace/WorkspaceTests.cs
+++ b/src/Whim.Tests/Workspace/WorkspaceTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using AutoFixture;
 using NSubstitute;
 using Whim.TestUtils;
@@ -415,7 +416,7 @@ public class WorkspaceTests
 		workspace.FocusLastFocusedWindow();
 
 		// Then the monitor is focused
-		internalCtx.MonitorManager.Received(1).ActivateEmptyMonitor(monitor);
+		ctx.Butler.Received(1).FocusMonitorDesktop(monitor);
 	}
 
 	[Theory, AutoSubstituteData<WorkspaceCustomization>]
@@ -434,7 +435,7 @@ public class WorkspaceTests
 		workspace.FocusLastFocusedWindow();
 
 		// Then
-		internalCtx.MonitorManager.DidNotReceive().ActivateEmptyMonitor(Arg.Any<IMonitor>());
+		ctx.Butler.DidNotReceive().FocusMonitorDesktop(Arg.Any<IMonitor>());
 	}
 
 	[Theory, AutoSubstituteData<WorkspaceCustomization>]
@@ -454,7 +455,7 @@ public class WorkspaceTests
 		workspace.FocusLastFocusedWindow();
 
 		// Then
-		internalCtx.MonitorManager.Received(1).ActivateEmptyMonitor(monitor);
+		ctx.Butler.Received(1).FocusMonitorDesktop(monitor);
 	}
 	#endregion
 

--- a/src/Whim.Tests/Workspace/WorkspaceTests.cs
+++ b/src/Whim.Tests/Workspace/WorkspaceTests.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Threading;
 using AutoFixture;
 using NSubstitute;
 using Whim.TestUtils;

--- a/src/Whim/Butler/Butler.cs
+++ b/src/Whim/Butler/Butler.cs
@@ -41,7 +41,7 @@ internal partial class Butler : IButler
 		};
 
 		_pantry = new ButlerPantry(_context);
-		_chores = new ButlerChores(_context, _triggers);
+		_chores = new ButlerChores(_context, _internalContext, _triggers);
 		EventHandlers = new ButlerEventHandlers(_context, _internalContext, _triggers, _pantry, _chores);
 	}
 
@@ -125,6 +125,8 @@ internal partial class Butler : IButler
 		_chores.ActivateAdjacent(monitor, reverse, skipActive);
 
 	public void LayoutAllActiveWorkspaces() => _chores.LayoutAllActiveWorkspaces();
+
+	public void FocusMonitorDesktop(IMonitor monitor) => _chores.FocusMonitorDesktop(monitor);
 
 	public void MergeWorkspaceWindows(IWorkspace workspaceToDelete, IWorkspace workspaceMergeTarget) =>
 		_chores.MergeWorkspaceWindows(workspaceToDelete, workspaceMergeTarget);

--- a/src/Whim/Butler/ButlerChores.cs
+++ b/src/Whim/Butler/ButlerChores.cs
@@ -22,7 +22,7 @@ internal class ButlerChores : IButlerChores
 
 		if (!_context.WorkspaceManager.Contains(workspace))
 		{
-			Logger.Error($"Workspace {workspace} is not tracked in Whim.");
+			Logger.Error($"Workspace {workspace} is not tracked");
 			return;
 		}
 
@@ -32,7 +32,7 @@ internal class ButlerChores : IButlerChores
 		}
 		else if (!_context.MonitorManager.Contains(monitor))
 		{
-			Logger.Error($"Workspace {monitor} is not tracked in Whim");
+			Logger.Error($"Workspace {monitor} is not tracked");
 			return;
 		}
 

--- a/src/Whim/Butler/ButlerChores.cs
+++ b/src/Whim/Butler/ButlerChores.cs
@@ -26,6 +26,12 @@ internal class ButlerChores : IButlerChores
 			return;
 		}
 
+		if (!_context.MonitorManager.Contains(monitor))
+		{
+			Logger.Error($"Workspace {monitor} is not tracked in Whim");
+			return;
+		}
+
 		monitor ??= _context.MonitorManager.ActiveMonitor;
 
 		// Get the old workspace for the event.

--- a/src/Whim/Butler/ButlerChores.cs
+++ b/src/Whim/Butler/ButlerChores.cs
@@ -26,13 +26,15 @@ internal class ButlerChores : IButlerChores
 			return;
 		}
 
-		if (!_context.MonitorManager.Contains(monitor))
+		if (monitor is null)
+		{
+			monitor = _context.MonitorManager.ActiveMonitor;
+		}
+		else if (!_context.MonitorManager.Contains(monitor))
 		{
 			Logger.Error($"Workspace {monitor} is not tracked in Whim");
 			return;
 		}
-
-		monitor ??= _context.MonitorManager.ActiveMonitor;
 
 		// Get the old workspace for the event.
 		IWorkspace? oldWorkspace = _context.Butler.Pantry.GetWorkspaceForMonitor(monitor);

--- a/src/Whim/Butler/ButlerChores.cs
+++ b/src/Whim/Butler/ButlerChores.cs
@@ -31,6 +31,12 @@ internal class ButlerChores : IButlerChores
 		// Find the monitor which just lost `workspace`.
 		IMonitor? loserMonitor = _context.Butler.Pantry.GetMonitorForWorkspace(workspace);
 
+		if (monitor.Equals(loserMonitor))
+		{
+			Logger.Debug("Workspace is already activated");
+			return;
+		}
+
 		// Update the active monitor. Having this line before the old workspace is deactivated
 		// is important, as WindowManager.OnWindowHidden() checks to see if a window is in a
 		// visible workspace when it receives the EVENT_OBJECT_HIDE event.

--- a/src/Whim/Butler/ButlerEventHandlers.cs
+++ b/src/Whim/Butler/ButlerEventHandlers.cs
@@ -14,6 +14,8 @@ internal class ButlerEventHandlers : IButlerEventHandlers
 	private int _monitorsChangingTasks;
 	public bool AreMonitorsChanging => _monitorsChangingTasks > 0;
 
+	public int MonitorsChangedDelay { init; get; } = 3 * 1000;
+
 	public ButlerEventHandlers(
 		IContext context,
 		IInternalContext internalContext,
@@ -231,7 +233,7 @@ internal class ButlerEventHandlers : IButlerEventHandlers
 		// windows around after a monitor change.
 		_context.NativeManager.TryEnqueue(async () =>
 		{
-			await Task.Delay(3 * 1000).ConfigureAwait(true);
+			await Task.Delay(MonitorsChangedDelay).ConfigureAwait(true);
 
 			_monitorsChangingTasks--;
 			if (_monitorsChangingTasks > 0)

--- a/src/Whim/Butler/IButlerChores.cs
+++ b/src/Whim/Butler/IButlerChores.cs
@@ -36,6 +36,12 @@ public interface IButlerChores
 	void LayoutAllActiveWorkspaces();
 
 	/// <summary>
+	/// Focus the Windows desktop's window.
+	/// </summary>
+	/// <param name="monitor"></param>
+	void FocusMonitorDesktop(IMonitor monitor);
+
+	/// <summary>
 	/// Moves the given <paramref name="window"/> by the given <paramref name="pixelsDeltas"/>.
 	/// </summary>
 	/// <param name="edges">The edges to change.</param>

--- a/src/Whim/Butler/IButlerEventHandlers.cs
+++ b/src/Whim/Butler/IButlerEventHandlers.cs
@@ -2,6 +2,7 @@ namespace Whim;
 
 internal interface IButlerEventHandlers
 {
+	int MonitorsChangedDelay { get; }
 	bool AreMonitorsChanging { get; }
 	void OnWindowAdded(WindowEventArgs args);
 	void OnWindowRemoved(WindowEventArgs args);

--- a/src/Whim/Window/WindowManager.cs
+++ b/src/Whim/Window/WindowManager.cs
@@ -47,7 +47,7 @@ internal class WindowManager : IWindowManager, IInternalWindowManager
 
 	public IFilterManager LocationRestoringFilterManager { get; } = new FilterManager();
 
-	internal int MonitorChangedDelay { get; init; } = 2000;
+	internal int WindowMovedDelay { get; init; } = 2000;
 
 	/// <summary>
 	/// The windows which had their first location change event handled - see <see cref="IWindowManager.LocationRestoringFilterManager"/>.
@@ -570,7 +570,7 @@ internal class WindowManager : IWindowManager, IInternalWindowManager
 				// Wait, then restore the position.
 				_context.NativeManager.TryEnqueue(async () =>
 				{
-					await Task.Delay(MonitorChangedDelay).ConfigureAwait(true);
+					await Task.Delay(WindowMovedDelay).ConfigureAwait(true);
 					if (_context.Butler.GetWorkspaceForWindow(window) is IWorkspace workspace)
 					{
 						_handledLocationRestoringWindows.Add(window);

--- a/src/Whim/Window/WindowManager.cs
+++ b/src/Whim/Window/WindowManager.cs
@@ -47,6 +47,8 @@ internal class WindowManager : IWindowManager, IInternalWindowManager
 
 	public IFilterManager LocationRestoringFilterManager { get; } = new FilterManager();
 
+	internal int MonitorChangedDelay { get; init; } = 2000;
+
 	/// <summary>
 	/// The windows which had their first location change event handled - see <see cref="IWindowManager.LocationRestoringFilterManager"/>.
 	/// We maintain a set of the windows that have been handled so that we don't enter an infinite loop of location change events.
@@ -568,7 +570,7 @@ internal class WindowManager : IWindowManager, IInternalWindowManager
 				// Wait, then restore the position.
 				_context.NativeManager.TryEnqueue(async () =>
 				{
-					await Task.Delay(2000).ConfigureAwait(true);
+					await Task.Delay(MonitorChangedDelay).ConfigureAwait(true);
 					if (_context.Butler.GetWorkspaceForWindow(window) is IWorkspace workspace)
 					{
 						_handledLocationRestoringWindows.Add(window);

--- a/src/Whim/Workspace/IWorkspace.cs
+++ b/src/Whim/Workspace/IWorkspace.cs
@@ -119,9 +119,8 @@ public interface IWorkspace : IDisposable
 	IWindowState? TryGetWindowState(IWindow window);
 
 	/// <summary>
-	/// Focuses on the last window in the workspace. If <see cref="LastFocusedWindow"/> is null,
-	/// then we try focus the first window. If there are no windows, then we focus the Windows
-	/// desktop window.
+	/// If <see cref="LastFocusedWindow"/> is not <see langword="null"/> or not minimized, then we focus the
+	/// last window in the workspace.
 	/// </summary>
 	void FocusLastFocusedWindow();
 

--- a/src/Whim/Workspace/Workspace.cs
+++ b/src/Whim/Workspace/Workspace.cs
@@ -134,12 +134,7 @@ internal class Workspace : IWorkspace, IInternalWorkspace
 				return;
 			}
 
-			// Focus the desktop.
-			HWND desktop = _internalContext.CoreNativeManager.GetDesktopWindow();
-			_internalContext.CoreNativeManager.SetForegroundWindow(desktop);
-			_internalContext.WindowManager.OnWindowFocused(null);
-
-			_internalContext.MonitorManager.ActivateEmptyMonitor(monitor);
+			_context.Butler.FocusMonitorDesktop(monitor);
 		}
 	}
 

--- a/src/Whim/Workspace/Workspace.cs
+++ b/src/Whim/Workspace/Workspace.cs
@@ -118,7 +118,7 @@ internal class Workspace : IWorkspace, IInternalWorkspace
 	public void FocusLastFocusedWindow()
 	{
 		Logger.Debug($"Focusing last focused window in workspace {Name}");
-		if (LastFocusedWindow != null)
+		if (LastFocusedWindow != null && !LastFocusedWindow.IsMinimized)
 		{
 			LastFocusedWindow.Focus();
 		}


### PR DESCRIPTION
- `FocusLastFocusedWindow` will no longer attempt to focus a window if the window is minimized.
- When deactivating a workspace, the desktop's window will be focused to prevent Windows from activating any other remaining windows, until Whim can activate replacement desktop.
