### PR TITLE
Prefer using internal state when updating the focused monitor

### DIFF
--- a/src/Whim.Bar/BarWindow.xaml
+++ b/src/Whim.Bar/BarWindow.xaml
@@ -9,7 +9,6 @@
 	<RelativePanel Style="{StaticResource bar:root_panel}">
 		<StackPanel
 			x:Name="LeftPanel"
-			Grid.Column="0"
 			VerticalAlignment="Center"
 			Orientation="Horizontal"
 			RelativePanel.AlignVerticalCenterWithPanel="True"
@@ -17,19 +16,15 @@
 
 		<StackPanel
 			x:Name="CenterPanel"
-			Grid.Column="1"
 			HorizontalAlignment="Center"
 			VerticalAlignment="Center"
 			Orientation="Horizontal"
 			RelativePanel.AlignHorizontalCenterWithPanel="True"
 			RelativePanel.AlignVerticalCenterWithPanel="True"
-			RelativePanel.LeftOf="RightPanel"
-			RelativePanel.RightOf="LeftPanel"
 			Style="{StaticResource bar:center_panel}" />
 
 		<StackPanel
 			x:Name="RightPanel"
-			Grid.Column="2"
 			VerticalAlignment="Center"
 			FlowDirection="RightToLeft"
 			Orientation="Horizontal"

--- a/src/Whim.CommandPalette.Tests/CommandPaletteCommandsTests.cs
+++ b/src/Whim.CommandPalette.Tests/CommandPaletteCommandsTests.cs
@@ -357,7 +357,7 @@ public class CommandPaletteCommandsTests
 
 	[Theory]
 	[InlineAutoSubstituteData(false, 0, 1)]
-	[InlineAutoSubstituteData(true, 1, 0)]
+	[InlineAutoSubstituteData(true, 1, 1)]
 	public void FocusWindowCommandCreator_WorkspaceIsVisible(bool isMinimized, int restoredCount, int focusedCount)
 	{
 		// Given the window is in a workspace.
@@ -381,7 +381,7 @@ public class CommandPaletteCommandsTests
 
 	[Theory]
 	[InlineAutoSubstituteData(false, 0, 1)]
-	[InlineAutoSubstituteData(true, 1, 0)]
+	[InlineAutoSubstituteData(true, 1, 1)]
 	public void FocusWindowCommandCreator_WorkspaceIsNotVisible(bool isMinimized, int restoredCount, int focusedCount)
 	{
 		// Given the window is in a workspace.

--- a/src/Whim.CommandPalette/CommandPaletteCommands.cs
+++ b/src/Whim.CommandPalette/CommandPaletteCommands.cs
@@ -274,13 +274,10 @@ public class CommandPaletteCommands : PluginCommands
 	/// <param name="window"></param>
 	private static void FocusWindow(IWindow window)
 	{
+		window.Focus();
 		if (window.IsMinimized)
 		{
 			window.Restore();
-		}
-		else
-		{
-			window.Focus();
 		}
 	}
 }

--- a/src/Whim.Tests/Monitor/MonitorManagerTests.cs
+++ b/src/Whim.Tests/Monitor/MonitorManagerTests.cs
@@ -10,6 +10,7 @@ using FluentAssertions;
 using Microsoft.UI.Dispatching;
 using NSubstitute;
 using NSubstitute.ClearExtensions;
+using NSubstitute.ReturnsExtensions;
 using Whim.TestUtils;
 using Windows.Win32.Foundation;
 using Windows.Win32.Graphics.Gdi;
@@ -172,85 +173,114 @@ public class MonitorManagerTests
 
 	#region OnWindowFocused
 	[Theory, AutoSubstituteData<MonitorManagerCustomization>]
-	internal void WindowFocused_NullWindow(IContext ctx, IInternalContext internalCtx)
+	internal void OnWindowFocused_DefinedWindow_MonitorDefined_Success(
+		IContext ctx,
+		IInternalContext internalCtx,
+		IWindow window,
+		IMonitor monitor
+	)
 	{
-		// Given
-		internalCtx
-			.CoreNativeManager.MonitorFromWindow(Arg.Any<HWND>(), Arg.Any<MONITOR_FROM_FLAGS>())
-			.Returns((HMONITOR)1);
-
+		// Given the window is defined, and GetMonitorForWindow returns a monitor
 		MonitorManager monitorManager = new(ctx, internalCtx);
-		IMonitor monitorBefore = monitorManager.ActiveMonitor;
+		IMonitor originalMonitor = monitorManager.ActiveMonitor;
+		ctx.Butler.GetMonitorForWindow(window).Returns(monitor);
 
 		// When
-		monitorManager.OnWindowFocused(Substitute.For<IWindow>());
+		monitorManager.OnWindowFocused(window);
 
-		// Then
-		internalCtx.CoreNativeManager.DidNotReceive().GetForegroundWindow();
-		internalCtx.CoreNativeManager.DidNotReceive().MonitorFromWindow(Arg.Any<HWND>(), Arg.Any<MONITOR_FROM_FLAGS>());
-		Assert.Equal(monitorBefore, monitorManager.ActiveMonitor);
+		// Then the active monitors are both updated
+		Assert.NotEqual(originalMonitor, monitorManager.ActiveMonitor);
+		Assert.Equal(monitor, monitorManager.ActiveMonitor);
+		Assert.Equal(monitor, monitorManager.LastWhimActiveMonitor);
 	}
 
 	[Theory, AutoSubstituteData<MonitorManagerCustomization>]
-	internal void WindowFocused_NullMonitor(IContext ctx, IInternalContext internalCtx, IWindow window)
+	internal void OnWindowFocused_DefinedWindow_MonitorNotDefined(
+		IContext ctx,
+		IInternalContext internalCtx,
+		IWindow window
+	)
 	{
-		// Given
+		// Given the window is defined, and GetMonitorForWindow does not return a monitor
+		MonitorManager monitorManager = new(ctx, internalCtx);
+		IMonitor originalMonitor = monitorManager.ActiveMonitor;
+
+		ctx.Butler.GetMonitorForWindow(window).ReturnsNull();
 		window.Handle.Returns((HWND)1);
 		internalCtx
-			.CoreNativeManager.MonitorFromWindow(Arg.Any<HWND>(), Arg.Any<MONITOR_FROM_FLAGS>())
-			.Returns((HMONITOR)1);
-
-		MonitorManager monitorManager = new(ctx, internalCtx);
-		IMonitor monitorBefore = monitorManager.ActiveMonitor;
-
-		// When
-		monitorManager.OnWindowFocused(Substitute.For<IWindow>());
-
-		// Then
-		internalCtx.CoreNativeManager.DidNotReceive().GetForegroundWindow();
-		internalCtx.CoreNativeManager.DidNotReceive().MonitorFromWindow(Arg.Any<HWND>(), Arg.Any<MONITOR_FROM_FLAGS>());
-		Assert.Equal(monitorBefore, monitorManager.ActiveMonitor);
-	}
-
-	[Theory, AutoSubstituteData<MonitorManagerCustomization>]
-	internal void WindowFocused_Success(IContext ctx, IInternalContext internalCtx, IWindow window)
-	{
-		// Given
-		MonitorManager monitorManager = new(ctx, internalCtx);
-		IMonitor monitorBefore = monitorManager.ActiveMonitor;
-
-		window.Handle.Returns((HWND)1);
-		internalCtx
-			.CoreNativeManager.MonitorFromWindow(Arg.Any<HWND>(), Arg.Any<MONITOR_FROM_FLAGS>())
+			.CoreNativeManager.MonitorFromWindow(window.Handle, MONITOR_FROM_FLAGS.MONITOR_DEFAULTTONEAREST)
 			.Returns((HMONITOR)1);
 
 		// When
 		monitorManager.OnWindowFocused(window);
 
-		// Then
-		internalCtx.CoreNativeManager.DidNotReceive().GetForegroundWindow();
-		internalCtx.CoreNativeManager.Received(1).MonitorFromWindow(Arg.Any<HWND>(), Arg.Any<MONITOR_FROM_FLAGS>());
-		Assert.NotEqual(monitorBefore, monitorManager.ActiveMonitor);
+		// Then the active monitor is updated, but not the LastWhimActiveMonitor
+		Assert.NotEqual(originalMonitor, monitorManager.ActiveMonitor);
+		Assert.Equal((HMONITOR)1, ((Monitor)monitorManager.ActiveMonitor)._hmonitor);
+		Assert.Equal(originalMonitor, monitorManager.LastWhimActiveMonitor);
 	}
 
 	[Theory, AutoSubstituteData<MonitorManagerCustomization>]
-	internal void WindowFocused_GetForegroundWindow(IContext ctx, IInternalContext internalCtx)
+	internal void OnWindowFocused_NullWindow_InvalidHandle(IContext ctx, IInternalContext internalCtx)
 	{
-		// Given
-		internalCtx.CoreNativeManager.GetForegroundWindow().Returns((HWND)1);
-		internalCtx
-			.CoreNativeManager.MonitorFromWindow(Arg.Any<HWND>(), Arg.Any<MONITOR_FROM_FLAGS>())
-			.Returns((HMONITOR)1);
-
+		// Given the window is null, and Windows returns an invalid handle
 		MonitorManager monitorManager = new(ctx, internalCtx);
+		IMonitor originalMonitor = monitorManager.ActiveMonitor;
+		internalCtx.CoreNativeManager.GetForegroundWindow().Returns((HWND)0);
 
 		// When
 		monitorManager.OnWindowFocused(null);
 
-		// Then
-		internalCtx.CoreNativeManager.Received(1).GetForegroundWindow();
-		internalCtx.CoreNativeManager.Received(1).MonitorFromWindow(Arg.Any<HWND>(), Arg.Any<MONITOR_FROM_FLAGS>());
+		// Then neither active monitors are updated
+		Assert.Equal(originalMonitor, monitorManager.ActiveMonitor);
+		Assert.Equal(originalMonitor, monitorManager.LastWhimActiveMonitor);
 	}
+
+	[Theory, AutoSubstituteData<MonitorManagerCustomization>]
+	internal void OnWindowFocused_NullWindow_CannotFindHMonitor(IContext ctx, IInternalContext internalCtx)
+	{
+		// Given the window is null, we get a valid HWND, but we can't find the monitor
+		MonitorManager monitorManager = new(ctx, internalCtx);
+		IMonitor originalMonitor = monitorManager.ActiveMonitor;
+
+		HWND hwnd = (HWND)100;
+		HMONITOR hmonitor = (HMONITOR)100;
+		internalCtx.CoreNativeManager.GetForegroundWindow().Returns(hwnd);
+		internalCtx
+			.CoreNativeManager.MonitorFromWindow(hwnd, MONITOR_FROM_FLAGS.MONITOR_DEFAULTTONEAREST)
+			.Returns(hmonitor);
+
+		// When
+		monitorManager.OnWindowFocused(null);
+
+		// Then neither active monitors are updated
+		Assert.Equal(originalMonitor, monitorManager.ActiveMonitor);
+		Assert.Equal(originalMonitor, monitorManager.LastWhimActiveMonitor);
+	}
+
+	[Theory, AutoSubstituteData<MonitorManagerCustomization>]
+	internal void OnWindowFocused_NullWindow_Success(IContext ctx, IInternalContext internalCtx)
+	{
+		// Given the window is null, we get a valid HWND, but we can't find the monitor
+		MonitorManager monitorManager = new(ctx, internalCtx);
+		IMonitor originalMonitor = monitorManager.ActiveMonitor;
+
+		HWND hwnd = (HWND)100;
+		HMONITOR hmonitor = (HMONITOR)1;
+		internalCtx.CoreNativeManager.GetForegroundWindow().Returns(hwnd);
+		internalCtx
+			.CoreNativeManager.MonitorFromWindow(hwnd, MONITOR_FROM_FLAGS.MONITOR_DEFAULTTONEAREST)
+			.Returns(hmonitor);
+
+		// When
+		monitorManager.OnWindowFocused(null);
+
+		// Then the active monitor is updated, but not the LastWhimActiveMonitor
+		Assert.NotEqual(originalMonitor, monitorManager.ActiveMonitor);
+		Assert.Equal((HMONITOR)1, ((Monitor)monitorManager.ActiveMonitor)._hmonitor);
+		Assert.Equal(originalMonitor, monitorManager.LastWhimActiveMonitor);
+	}
+
 	#endregion
 
 	private static WindowMessageMonitorEventArgs WindowMessageMonitorEventArgs =>

--- a/src/Whim.Tests/Monitor/MonitorManagerTests.cs
+++ b/src/Whim.Tests/Monitor/MonitorManagerTests.cs
@@ -216,8 +216,9 @@ public class MonitorManagerTests
 
 		// Then the active monitor is updated, but not the LastWhimActiveMonitor
 		Assert.NotEqual(originalMonitor, monitorManager.ActiveMonitor);
+		Assert.NotEqual(originalMonitor, monitorManager.LastWhimActiveMonitor);
 		Assert.Equal((HMONITOR)1, ((Monitor)monitorManager.ActiveMonitor)._hmonitor);
-		Assert.Equal(originalMonitor, monitorManager.LastWhimActiveMonitor);
+		Assert.Equal((HMONITOR)1, ((Monitor)monitorManager.LastWhimActiveMonitor)._hmonitor);
 	}
 
 	[Theory, AutoSubstituteData<MonitorManagerCustomization>]
@@ -280,7 +281,6 @@ public class MonitorManagerTests
 		Assert.Equal((HMONITOR)1, ((Monitor)monitorManager.ActiveMonitor)._hmonitor);
 		Assert.Equal(originalMonitor, monitorManager.LastWhimActiveMonitor);
 	}
-
 	#endregion
 
 	private static WindowMessageMonitorEventArgs WindowMessageMonitorEventArgs =>

--- a/src/Whim/Monitor/MonitorManager.cs
+++ b/src/Whim/Monitor/MonitorManager.cs
@@ -74,7 +74,19 @@ internal class MonitorManager : IInternalMonitorManager, IMonitorManager
 
 	public void OnWindowFocused(IWindow? window)
 	{
-		HWND hwnd = window?.Handle ?? _internalContext.CoreNativeManager.GetForegroundWindow();
+		if (window is not null)
+		{
+			Logger.Debug($"Focusing window {window}");
+			if (_context.Butler.GetMonitorForWindow(window) is IMonitor monitor)
+			{
+				Logger.Debug($"Setting active monitor to {monitor}");
+				ActiveMonitor = monitor;
+				LastWhimActiveMonitor = monitor;
+				return;
+			}
+		}
+
+		HWND hwnd = _internalContext.CoreNativeManager.GetForegroundWindow();
 		Logger.Debug($"Focusing hwnd {hwnd}");
 
 		if (hwnd.IsNull)
@@ -93,13 +105,7 @@ internal class MonitorManager : IInternalMonitorManager, IMonitorManager
 			if (monitor._hmonitor.Equals(hMONITOR))
 			{
 				Logger.Debug($"Setting active monitor to {monitor}");
-
 				ActiveMonitor = monitor;
-
-				if (window is not null)
-				{
-					LastWhimActiveMonitor = monitor;
-				}
 				break;
 			}
 		}

--- a/src/Whim/Monitor/MonitorManager.cs
+++ b/src/Whim/Monitor/MonitorManager.cs
@@ -74,6 +74,7 @@ internal class MonitorManager : IInternalMonitorManager, IMonitorManager
 
 	public void OnWindowFocused(IWindow? window)
 	{
+		// If we know the window, use what the butler knows instead of Windows.
 		if (window is not null)
 		{
 			Logger.Debug($"Focusing window {window}");
@@ -86,7 +87,7 @@ internal class MonitorManager : IInternalMonitorManager, IMonitorManager
 			}
 		}
 
-		HWND hwnd = _internalContext.CoreNativeManager.GetForegroundWindow();
+		HWND hwnd = window?.Handle ?? _internalContext.CoreNativeManager.GetForegroundWindow();
 		Logger.Debug($"Focusing hwnd {hwnd}");
 
 		if (hwnd.IsNull)

--- a/src/Whim/Monitor/MonitorManager.cs
+++ b/src/Whim/Monitor/MonitorManager.cs
@@ -74,7 +74,7 @@ internal class MonitorManager : IInternalMonitorManager, IMonitorManager
 
 	public void OnWindowFocused(IWindow? window)
 	{
-		// If we know the window, use what the butler knows instead of Windows.
+		// If we know the window, use what the Butler knows instead of Windows.
 		if (window is not null)
 		{
 			Logger.Debug($"Focusing window {window}");
@@ -107,6 +107,11 @@ internal class MonitorManager : IInternalMonitorManager, IMonitorManager
 			{
 				Logger.Debug($"Setting active monitor to {monitor}");
 				ActiveMonitor = monitor;
+
+				if (window is not null)
+				{
+					LastWhimActiveMonitor = monitor;
+				}
 				break;
 			}
 		}


### PR DESCRIPTION
Previously, Whim would consult Windows to get the monitor for a window, even if Whim already stored this state. We now attempt to retrieve the monitor from Whim's internal state, as Windows can sometimes return the incorrect result.

When focusing minimized windows, we focus them before restoring, to avoid concurrency issues with single-threaded apartments.
