### PR TITLE
Fix bar alignment

### DIFF
--- a/src/Whim.Bar/BarWindow.xaml
+++ b/src/Whim.Bar/BarWindow.xaml
@@ -9,7 +9,6 @@
 	<RelativePanel Style="{StaticResource bar:root_panel}">
 		<StackPanel
 			x:Name="LeftPanel"
-			Grid.Column="0"
 			VerticalAlignment="Center"
 			Orientation="Horizontal"
 			RelativePanel.AlignVerticalCenterWithPanel="True"
@@ -17,19 +16,15 @@
 
 		<StackPanel
 			x:Name="CenterPanel"
-			Grid.Column="1"
 			HorizontalAlignment="Center"
 			VerticalAlignment="Center"
 			Orientation="Horizontal"
 			RelativePanel.AlignHorizontalCenterWithPanel="True"
 			RelativePanel.AlignVerticalCenterWithPanel="True"
-			RelativePanel.LeftOf="RightPanel"
-			RelativePanel.RightOf="LeftPanel"
 			Style="{StaticResource bar:center_panel}" />
 
 		<StackPanel
 			x:Name="RightPanel"
-			Grid.Column="2"
 			VerticalAlignment="Center"
 			FlowDirection="RightToLeft"
 			Orientation="Horizontal"


### PR DESCRIPTION
Small fix and clean up of the bar plugin:

1. Remove unused `Grid.Column` attached properties 
2. Fix alignment of center panel

## Current issue

The `CenterPanel` is centered within the space _unoccupied_ by the other two panels. If the `LeftPanel` and `RightPanel` have different widths, this results in the `CenterPanel` being off-centered. 

Moreover, if the width of one of the other panels changes, the `CenterPanel` will move around. This occurs for example if the `RightPanel` contains the `FocusedWindowWidget`.

## Diagnosis

The issue is caused because:

> The panel-center alignment properties ([AlignVerticalCenterWith](https://learn.microsoft.com/en-us/uwp/api/windows.ui.xaml.controls.relativepanel.alignverticalcenterwith), [AlignHorizontalCenterWithPanel](https://learn.microsoft.com/en-us/uwp/api/windows.ui.xaml.controls.relativepanel.alignhorizontalcenterwithpanel), ...) are typically used independently of other constraints and are applied if there is no conflict.

In other words, `AlignHorizontalCenterWithPanel` is ignored due the presence of the sibling positional relations. (The reason it still looks roughly centered, is that `HorizontalAlignment="Center"` causes it to center _within its available space_).

## Proposed fix

Eliminating the sibling positional relations from the `CenterPanel` does the trick. The three panels are still ordered correctly based on their absolute positions. (The left panel defaults to `AlignLeftWithPanel` -- we could make that explicit)

## Alternatives considered
 
Moving the `LeftOf` and `RightOf` relations from the `CenterPanel` to the left and right panels (and eliminating the absolute placement of the right panel) works in fixing the alignment of the center panel. 

However, in this case the left and right panel won't fill the remaining space, and will instead be placed adjacent to the center panel (the `HorizontalAlignment` options below doesn't help with taking more space). I didn't see an option to fix this, but if we can stretch the available space for the outer panels to the entire bar this would be an alternative.

```xaml
	<RelativePanel Style="{StaticResource bar:root_panel}">
		<StackPanel
			x:Name="LeftPanel"
			HorizontalAlignment="Left"
			VerticalAlignment="Center"
			Orientation="Horizontal"
			RelativePanel.LeftOf="CenterPanel"
			RelativePanel.AlignVerticalCenterWithPanel="True"
			Style="{StaticResource bar:left_panel}" />

		<StackPanel
			x:Name="CenterPanel"
			HorizontalAlignment="Center"
			VerticalAlignment="Center"
			Orientation="Horizontal"
			RelativePanel.AlignHorizontalCenterWithPanel="True"
			RelativePanel.AlignVerticalCenterWithPanel="True"
			Style="{StaticResource bar:center_panel}" />

		<StackPanel
			x:Name="RightPanel"
			HorizontalAlignment="Right"
			VerticalAlignment="Center"
			FlowDirection="RightToLeft"
			Orientation="Horizontal"
			RelativePanel.RightOf="CenterPanel"
			RelativePanel.AlignVerticalCenterWithPanel="True"
			Style="{StaticResource bar:right_panel}" />
	</RelativePanel>
```