### PR TITLE
Force double `SetWindowPos` for `BarWindow`

### DIFF
--- a/docs/docs/customize/styling.md
+++ b/docs/docs/customize/styling.md
@@ -64,7 +64,7 @@ The `bar:height` key is a special key that is used to communicate to Whim the de
 Notes:
 
 - The corresponding style must not contain any property other than `Height`.
-- This setting is overwritten if `Height` is explicitly set in <xref:Whim.Bar.BarConfig>.
+- This setting is overwritten if `Height` is explicitly set in <xref:Whim.Bar.BarConfig> - this may be required in some monitor configurations - tracked in [#887](https://github.com/dalyIsaac/Whim/issues/887)
 - The actual height of the bar may differ from the specified one due to overflowing elements.
 
 > [!NOTE]

--- a/src/Whim.Bar/BarPlugin.cs
+++ b/src/Whim.Bar/BarPlugin.cs
@@ -79,7 +79,7 @@ public class BarPlugin : IBarPlugin
 		foreach (BarWindow barWindow in _monitorBarMap.Values)
 		{
 			barWindow.UpdateRect();
-			deferPosHandle.DeferWindowPos(barWindow.WindowState);
+			deferPosHandle.DeferWindowPos(barWindow.WindowState, forceTwoPasses: true);
 			_context.NativeManager.SetWindowCorners(
 				barWindow.WindowState.Window.Handle,
 				DWM_WINDOW_CORNER_PREFERENCE.DWMWCP_DONOTROUND


### PR DESCRIPTION
It seems this is necessary for windows in monitors with 100% scaling. This will need further investigation in #887 for the difference in behavior between C# and what's fetched from the XAML.