### PR TITLE
Fix `MonitorSector` initialization race condition

### DIFF
--- a/src/Whim.Tests/Store/MonitorSector/Transforms/MonitorsChangedTransformTests.cs
+++ b/src/Whim.Tests/Store/MonitorSector/Transforms/MonitorsChangedTransformTests.cs
@@ -91,6 +91,22 @@ public class MonitorsChangedTransformTests
 	}
 
 	[Theory, AutoSubstituteData<StoreCustomization>]
+	internal void MonitorsAdded_Initialization(IContext ctx, IInternalContext internalCtx)
+	{
+		// Given we have no monitors
+
+		// When we add monitors
+		MonitorTestUtils.SetupMultipleMonitors(internalCtx, new[] { RightMonitorSetup, LeftTopMonitorSetup });
+		var raisedEvent = DispatchTransformEvent(ctx);
+
+		// Then the resulting event will have a monitor added, and the other monitors in the sector will be set.
+		Assert.Equal(2, raisedEvent.Arguments.AddedMonitors.Count());
+
+		Assert.Equal((HMONITOR)2, ctx.Store.Pick(Pickers.PickLastWhimActiveMonitor()).Handle);
+		Assert.Equal((HMONITOR)2, ctx.Store.Pick(Pickers.PickActiveMonitor()).Handle);
+	}
+
+	[Theory, AutoSubstituteData<StoreCustomization>]
 	internal void MonitorsUnchanged(IContext ctx, IInternalContext internalCtx)
 	{
 		// Given there are no changes in the monitors.

--- a/src/Whim/Store/MonitorSector/Transforms/MonitorsChangedTransform.cs
+++ b/src/Whim/Store/MonitorSector/Transforms/MonitorsChangedTransform.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using DotNext;
+using Windows.Win32.Graphics.Gdi;
 
 namespace Whim;
 
@@ -66,6 +67,13 @@ internal record MonitorsChangedTransform : Transform
 		if (addedMonitors.Count != 0 || removedMonitors.Count != 0)
 		{
 			internalCtx.ButlerEventHandlers.OnMonitorsChanged(args);
+		}
+
+		// Make sure the other monitor handles are set if they're unset.
+		if (sector.ActiveMonitorHandle == (HMONITOR)0)
+		{
+			sector.ActiveMonitorHandle = sector.PrimaryMonitorHandle;
+			sector.LastWhimActiveMonitorHandle = sector.PrimaryMonitorHandle;
 		}
 
 		sector.QueueEvent(args);


### PR DESCRIPTION
Previously, the `ActiveMonitor` and `LastWhimActiveMonitor` were not set in the initial `MonitorsChangedTransform` dispatched by `MonitorSector.Initialize`.