### PR TITLE
Add logging to `Store` calls

### DIFF
--- a/src/Whim/Context/CoreSavedStateManager.cs
+++ b/src/Whim/Context/CoreSavedStateManager.cs
@@ -56,7 +56,11 @@ internal class CoreSavedStateManager : ICoreSavedStateManager
 			if (disposing)
 			{
 				// dispose managed state (managed objects)
-				SaveState();
+				try
+				{
+					SaveState();
+				}
+				catch (Exception) { }
 			}
 
 			_disposedValue = true;

--- a/src/Whim/Store/Store.cs
+++ b/src/Whim/Store/Store.cs
@@ -67,6 +67,8 @@ public class Store : IStore
 		{
 			return Task.Run(() =>
 			{
+				Logger.Debug($"Entering task, executing transform {transform}");
+
 				try
 				{
 					_lock.EnterWriteLock();
@@ -80,6 +82,7 @@ public class Store : IStore
 			}).Result;
 		}
 
+		Logger.Debug($"Executing transform {transform}");
 		return DispatchFn(transform);
 	}
 
@@ -93,6 +96,8 @@ public class Store : IStore
 		{
 			return Task.Run(() =>
 			{
+				Logger.Debug($"Entering task, executing picker {picker}");
+
 				try
 				{
 					_lock.EnterReadLock();
@@ -105,6 +110,7 @@ public class Store : IStore
 			}).Result;
 		}
 
+		Logger.Debug($"Executing picker {picker}");
 		return PickFn(picker);
 	}
 
@@ -117,6 +123,7 @@ public class Store : IStore
 		{
 			return Task.Run(() =>
 			{
+				Logger.Debug($"Entering task, executing picker {picker}");
 				try
 				{
 					_lock.EnterReadLock();
@@ -129,6 +136,7 @@ public class Store : IStore
 			}).Result;
 		}
 
+		Logger.Debug($"Executing picker {picker}");
 		return PurePickFn(picker);
 	}
 


### PR DESCRIPTION
Improve traceability of the sector data store by adding logs for each `Transform` and `Picker`.