### PR TITLE
Undo LayoutEngineCustomAction breaking name change

### DIFF
--- a/src/Whim.Bar.Tests/BarLayoutEngineTests.cs
+++ b/src/Whim.Bar.Tests/BarLayoutEngineTests.cs
@@ -344,7 +344,7 @@ public class BarLayoutEngineTests
 	{
 		// Given
 		BarLayoutEngine engine = CreateSut(innerLayoutEngine);
-		LayoutEngineAction<string> action =
+		LayoutEngineCustomAction<string> action =
 			new()
 			{
 				Name = "Action",
@@ -366,7 +366,7 @@ public class BarLayoutEngineTests
 	{
 		// Given
 		BarLayoutEngine engine = CreateSut(innerLayoutEngine);
-		LayoutEngineAction<string> action =
+		LayoutEngineCustomAction<string> action =
 			new()
 			{
 				Name = "Action",

--- a/src/Whim.Bar/BarLayoutEngine.cs
+++ b/src/Whim.Bar/BarLayoutEngine.cs
@@ -81,6 +81,6 @@ public record BarLayoutEngine : BaseProxyLayoutEngine
 		UpdateInner(InnerLayoutEngine.MinimizeWindowEnd(window));
 
 	/// <inheritdoc />
-	public override ILayoutEngine PerformCustomAction<T>(LayoutEngineAction<T> action) =>
+	public override ILayoutEngine PerformCustomAction<T>(LayoutEngineCustomAction<T> action) =>
 		UpdateInner(InnerLayoutEngine.PerformCustomAction(action));
 }

--- a/src/Whim.FloatingLayout.Tests/FloatingLayoutEngineTests.cs
+++ b/src/Whim.FloatingLayout.Tests/FloatingLayoutEngineTests.cs
@@ -1113,7 +1113,7 @@ public class FloatingLayoutEngineTests
 	{
 		// Given
 		FloatingLayoutEngine engine = new(context, plugin, innerLayoutEngine);
-		LayoutEngineAction<string> action =
+		LayoutEngineCustomAction<string> action =
 			new()
 			{
 				Name = "Action",
@@ -1138,7 +1138,7 @@ public class FloatingLayoutEngineTests
 	{
 		// Given
 		FloatingLayoutEngine engine = new(context, plugin, innerLayoutEngine);
-		LayoutEngineAction<string> action =
+		LayoutEngineCustomAction<string> action =
 			new()
 			{
 				Name = "Action",
@@ -1166,7 +1166,7 @@ public class FloatingLayoutEngineTests
 	{
 		// Given
 		FloatingLayoutEngine engine = new(context, plugin, innerLayoutEngine);
-		LayoutEngineAction<string> action =
+		LayoutEngineCustomAction<string> action =
 			new()
 			{
 				Name = "Action",

--- a/src/Whim.FloatingLayout/FloatingLayoutEngine.cs
+++ b/src/Whim.FloatingLayout/FloatingLayoutEngine.cs
@@ -256,7 +256,7 @@ internal record FloatingLayoutEngine : BaseProxyLayoutEngine
 		UpdateInner(InnerLayoutEngine.MinimizeWindowEnd(window), window);
 
 	/// <inheritdoc />
-	public override ILayoutEngine PerformCustomAction<T>(LayoutEngineAction<T> action)
+	public override ILayoutEngine PerformCustomAction<T>(LayoutEngineCustomAction<T> action)
 	{
 		if (action.Window != null && IsWindowFloating(action.Window))
 		{

--- a/src/Whim.Gaps.Tests/GapsLayoutEngineTests.cs
+++ b/src/Whim.Gaps.Tests/GapsLayoutEngineTests.cs
@@ -720,7 +720,7 @@ public class GapsLayoutEngineTests
 		// Given
 		GapsConfig gapsConfig = new() { OuterGap = 10, InnerGap = 5 };
 
-		LayoutEngineAction<string> action =
+		LayoutEngineCustomAction<string> action =
 			new()
 			{
 				Name = "Action",
@@ -746,7 +746,7 @@ public class GapsLayoutEngineTests
 		// Given
 		GapsConfig gapsConfig = new() { OuterGap = 10, InnerGap = 5 };
 
-		LayoutEngineAction<string> action =
+		LayoutEngineCustomAction<string> action =
 			new()
 			{
 				Name = "Action",

--- a/src/Whim.Gaps/GapsLayoutEngine.cs
+++ b/src/Whim.Gaps/GapsLayoutEngine.cs
@@ -126,6 +126,6 @@ public record GapsLayoutEngine : BaseProxyLayoutEngine
 		UpdateInner(InnerLayoutEngine.MinimizeWindowEnd(window));
 
 	/// <inheritdoc />
-	public override ILayoutEngine PerformCustomAction<T>(LayoutEngineAction<T> action) =>
+	public override ILayoutEngine PerformCustomAction<T>(LayoutEngineCustomAction<T> action) =>
 		UpdateInner(InnerLayoutEngine.PerformCustomAction(action));
 }

--- a/src/Whim.SliceLayout.Tests/SliceLayoutEngine/PerformCustomActionTests.cs
+++ b/src/Whim.SliceLayout.Tests/SliceLayoutEngine/PerformCustomActionTests.cs
@@ -27,7 +27,7 @@ public class PerformCustomActionTests
 		IWindowState[] beforeStates = sut.DoLayout(primaryMonitorBounds, Substitute.For<IMonitor>()).ToArray();
 
 		sut = sut.PerformCustomAction(
-			new LayoutEngineAction<IWindow>()
+			new LayoutEngineCustomAction<IWindow>()
 			{
 				Name = "whim.slice_layout.window.promote",
 				Window = untrackedWindow,
@@ -74,7 +74,7 @@ public class PerformCustomActionTests
 		}
 
 		sut = sut.PerformCustomAction(
-			new LayoutEngineAction<IWindow>()
+			new LayoutEngineCustomAction<IWindow>()
 			{
 				Name = "whim.slice_layout.window.promote",
 				Window = windows[focusedWindowIdx],
@@ -99,7 +99,7 @@ public class PerformCustomActionTests
 		IWindowState[] beforeStates = sut.DoLayout(primaryMonitorBounds, Substitute.For<IMonitor>()).ToArray();
 
 		sut = sut.PerformCustomAction(
-			new LayoutEngineAction<IWindow>()
+			new LayoutEngineCustomAction<IWindow>()
 			{
 				Name = "whim.slice_layout.window.promote",
 				Window = window,
@@ -131,7 +131,7 @@ public class PerformCustomActionTests
 		IWindowState[] beforeStates = sut.DoLayout(primaryMonitorBounds, Substitute.For<IMonitor>()).ToArray();
 
 		sut = sut.PerformCustomAction(
-			new LayoutEngineAction<IWindow>()
+			new LayoutEngineCustomAction<IWindow>()
 			{
 				Name = "whim.slice_layout.window.demote",
 				Window = untrackedWindow,
@@ -173,7 +173,7 @@ public class PerformCustomActionTests
 		}
 
 		sut = sut.PerformCustomAction(
-			new LayoutEngineAction<IWindow>()
+			new LayoutEngineCustomAction<IWindow>()
 			{
 				Name = "whim.slice_layout.window.demote",
 				Window = windows[focusedWindowIdx],
@@ -198,7 +198,7 @@ public class PerformCustomActionTests
 		IWindowState[] beforeStates = sut.DoLayout(primaryMonitorBounds, Substitute.For<IMonitor>()).ToArray();
 
 		sut = sut.PerformCustomAction(
-			new LayoutEngineAction<IWindow>()
+			new LayoutEngineCustomAction<IWindow>()
 			{
 				Name = "whim.slice_layout.window.demote",
 				Window = window,
@@ -242,7 +242,7 @@ public class PerformCustomActionTests
 		}
 
 		ILayoutEngine resultSut = sut.PerformCustomAction(
-			new LayoutEngineAction<IWindow>()
+			new LayoutEngineCustomAction<IWindow>()
 			{
 				Name = promote ? plugin.PromoteFocusActionName : plugin.DemoteFocusActionName,
 				Window = windows[focusedWindowIdx],
@@ -273,7 +273,7 @@ public class PerformCustomActionTests
 		IWindowState[] beforeStates = sut.DoLayout(primaryMonitorBounds, Substitute.For<IMonitor>()).ToArray();
 
 		sut = sut.PerformCustomAction(
-			new LayoutEngineAction<IWindow>()
+			new LayoutEngineCustomAction<IWindow>()
 			{
 				Name = "whim.slice_layout.window.unknown",
 				Window = windows[0],

--- a/src/Whim.SliceLayout.Tests/SliceLayoutPluginTests.cs
+++ b/src/Whim.SliceLayout.Tests/SliceLayoutPluginTests.cs
@@ -114,7 +114,7 @@ public class SliceLayoutPluginTests
 
 		// Then nothing
 		IWorkspace activeWorkspace = ctx.WorkspaceManager.ActiveWorkspace;
-		activeWorkspace.DidNotReceive().PerformCustomLayoutEngineAction(Arg.Any<LayoutEngineAction>());
+		activeWorkspace.DidNotReceive().PerformCustomLayoutEngineAction(Arg.Any<LayoutEngineCustomAction>());
 		activeWorkspace.DidNotReceive().DoLayout();
 	}
 
@@ -133,7 +133,7 @@ public class SliceLayoutPluginTests
 		workspace
 			.Received(1)
 			.PerformCustomLayoutEngineAction(
-				Arg.Is<LayoutEngineAction>(action =>
+				Arg.Is<LayoutEngineCustomAction>(action =>
 					action.Name == plugin.PromoteWindowActionName && action.Window == window
 				)
 			);
@@ -168,7 +168,7 @@ public class SliceLayoutPluginTests
 
 		// Then nothing
 		IWorkspace activeWorkspace = ctx.WorkspaceManager.ActiveWorkspace;
-		activeWorkspace.DidNotReceive().PerformCustomLayoutEngineAction(Arg.Any<LayoutEngineAction>());
+		activeWorkspace.DidNotReceive().PerformCustomLayoutEngineAction(Arg.Any<LayoutEngineCustomAction>());
 		activeWorkspace.DidNotReceive().DoLayout();
 	}
 
@@ -187,7 +187,7 @@ public class SliceLayoutPluginTests
 		workspace
 			.Received(1)
 			.PerformCustomLayoutEngineAction(
-				Arg.Is<LayoutEngineAction>(action =>
+				Arg.Is<LayoutEngineCustomAction>(action =>
 					action.Name == plugin.DemoteWindowActionName && action.Window == window
 				)
 			);
@@ -239,7 +239,7 @@ public class SliceLayoutPluginTests
 
 		// Then nothing
 		ctx.WorkspaceManager.ActiveWorkspace.DidNotReceive()
-			.PerformCustomLayoutEngineAction(Arg.Any<LayoutEngineAction>());
+			.PerformCustomLayoutEngineAction(Arg.Any<LayoutEngineCustomAction>());
 	}
 
 	[Theory, AutoSubstituteData]
@@ -257,7 +257,7 @@ public class SliceLayoutPluginTests
 		workspace
 			.Received(1)
 			.PerformCustomLayoutEngineAction(
-				Arg.Is<LayoutEngineAction>(action =>
+				Arg.Is<LayoutEngineCustomAction>(action =>
 					action.Name == plugin.PromoteFocusActionName && action.Window == window
 				)
 			);
@@ -292,7 +292,7 @@ public class SliceLayoutPluginTests
 
 		// Then nothing
 		ctx.WorkspaceManager.ActiveWorkspace.DidNotReceive()
-			.PerformCustomLayoutEngineAction(Arg.Any<LayoutEngineAction>());
+			.PerformCustomLayoutEngineAction(Arg.Any<LayoutEngineCustomAction>());
 	}
 
 	[Theory, AutoSubstituteData]
@@ -310,7 +310,7 @@ public class SliceLayoutPluginTests
 		workspace
 			.Received(1)
 			.PerformCustomLayoutEngineAction(
-				Arg.Is<LayoutEngineAction>(action =>
+				Arg.Is<LayoutEngineCustomAction>(action =>
 					action.Name == plugin.DemoteFocusActionName && action.Window == window
 				)
 			);

--- a/src/Whim.SliceLayout/SliceLayoutEngine.cs
+++ b/src/Whim.SliceLayout/SliceLayoutEngine.cs
@@ -299,17 +299,18 @@ public partial record SliceLayoutEngine : ILayoutEngine
 	}
 
 	/// <inheritdoc />
-	public ILayoutEngine PerformCustomAction<T>(LayoutEngineAction<T> action) =>
+	public ILayoutEngine PerformCustomAction<T>(LayoutEngineCustomAction<T> action) =>
 		action switch
 		{
-			LayoutEngineAction<IWindow> promoteAction when promoteAction.Name == _plugin.PromoteWindowActionName
+			LayoutEngineCustomAction<IWindow> promoteAction when promoteAction.Name == _plugin.PromoteWindowActionName
 				=> PromoteWindowInStack(promoteAction.Payload, promote: true),
-			LayoutEngineAction<IWindow> demoteAction when demoteAction.Name == _plugin.DemoteWindowActionName
+			LayoutEngineCustomAction<IWindow> demoteAction when demoteAction.Name == _plugin.DemoteWindowActionName
 				=> PromoteWindowInStack(demoteAction.Payload, promote: false),
-			LayoutEngineAction<IWindow> promoteFocusAction
+			LayoutEngineCustomAction<IWindow> promoteFocusAction
 				when promoteFocusAction.Name == _plugin.PromoteFocusActionName
 				=> PromoteFocusInStack(promoteFocusAction.Payload, promote: true),
-			LayoutEngineAction<IWindow> demoteFocusAction when demoteFocusAction.Name == _plugin.DemoteFocusActionName
+			LayoutEngineCustomAction<IWindow> demoteFocusAction
+				when demoteFocusAction.Name == _plugin.DemoteFocusActionName
 				=> PromoteFocusInStack(demoteFocusAction.Payload, promote: false),
 			_ => this
 		};

--- a/src/Whim.SliceLayout/SliceLayoutPlugin.cs
+++ b/src/Whim.SliceLayout/SliceLayoutPlugin.cs
@@ -65,7 +65,7 @@ public class SliceLayoutPlugin : ISliceLayoutPlugin
 		}
 
 		workspace.PerformCustomLayoutEngineAction(
-			new LayoutEngineAction()
+			new LayoutEngineCustomAction()
 			{
 				Name = promote ? PromoteWindowActionName : DemoteWindowActionName,
 				Window = definedWindow
@@ -107,7 +107,7 @@ public class SliceLayoutPlugin : ISliceLayoutPlugin
 		}
 
 		workspace.PerformCustomLayoutEngineAction(
-			new LayoutEngineAction()
+			new LayoutEngineCustomAction()
 			{
 				Name = promote ? PromoteFocusActionName : DemoteFocusActionName,
 				Window = definedWindow

--- a/src/Whim.TestUtils/ImmutableTestLayoutEngine.cs
+++ b/src/Whim.TestUtils/ImmutableTestLayoutEngine.cs
@@ -33,7 +33,7 @@ public record ImmutableTestLayoutEngine : ILayoutEngine
 
 	public ILayoutEngine MoveWindowToPoint(IWindow window, IPoint<double> point) => this;
 
-	public ILayoutEngine PerformCustomAction<T>(LayoutEngineAction<T> action) => this;
+	public ILayoutEngine PerformCustomAction<T>(LayoutEngineCustomAction<T> action) => this;
 
 	public ILayoutEngine RemoveWindow(IWindow window) => this;
 

--- a/src/Whim.TestUtils/ProxyLayoutEngineBaseTests.cs
+++ b/src/Whim.TestUtils/ProxyLayoutEngineBaseTests.cs
@@ -186,7 +186,7 @@ public abstract class ProxyLayoutEngineBaseTests
 	{
 		// Given
 		ILayoutEngine layoutEngine = CreateLayoutEngine(inner).AddWindow(window1);
-		LayoutEngineAction<string> action =
+		LayoutEngineCustomAction<string> action =
 			new()
 			{
 				Name = "Action",

--- a/src/Whim.TestUtils/TestLayoutEngine.cs
+++ b/src/Whim.TestUtils/TestLayoutEngine.cs
@@ -49,7 +49,8 @@ public record TestLayoutEngine : ILayoutEngine
 		throw new NotImplementedException();
 
 	/// <inheritdoc/>
-	public ILayoutEngine PerformCustomAction<T>(LayoutEngineAction<T> action) => throw new NotImplementedException();
+	public ILayoutEngine PerformCustomAction<T>(LayoutEngineCustomAction<T> action) =>
+		throw new NotImplementedException();
 
 	/// <inheritdoc/>
 	public ILayoutEngine MinimizeWindowStart(IWindow window) => throw new NotImplementedException();

--- a/src/Whim.Tests/Commands/CoreCommandsTests.cs
+++ b/src/Whim.Tests/Commands/CoreCommandsTests.cs
@@ -480,7 +480,7 @@ public class CoreCommandsTests
 
 		// Then
 		IWorkspace workspace = ctx.WorkspaceManager.ActiveWorkspace;
-		workspace.DidNotReceive().PerformCustomLayoutEngineAction(Arg.Any<LayoutEngineAction>());
+		workspace.DidNotReceive().PerformCustomLayoutEngineAction(Arg.Any<LayoutEngineCustomAction>());
 		workspace.DidNotReceive().DoLayout();
 	}
 
@@ -501,6 +501,6 @@ public class CoreCommandsTests
 
 		// Then
 		IWorkspace workspace = ctx.WorkspaceManager.ActiveWorkspace;
-		workspace.Received(1).PerformCustomLayoutEngineAction(Arg.Any<LayoutEngineAction>());
+		workspace.Received(1).PerformCustomLayoutEngineAction(Arg.Any<LayoutEngineCustomAction>());
 	}
 }

--- a/src/Whim.Tests/Layout/ColumnLayoutEngineTests.cs
+++ b/src/Whim.Tests/Layout/ColumnLayoutEngineTests.cs
@@ -961,7 +961,7 @@ public class ColumnLayoutEngineTests
 	{
 		// Given
 		ILayoutEngine engine = new ColumnLayoutEngine(identity).AddWindow(window);
-		LayoutEngineAction<string> action =
+		LayoutEngineCustomAction<string> action =
 			new()
 			{
 				Name = "Action",

--- a/src/Whim.Tests/Layout/FocusLayoutEngineTests.cs
+++ b/src/Whim.Tests/Layout/FocusLayoutEngineTests.cs
@@ -297,7 +297,7 @@ public class FocusLayoutEngineTests
 
 		// When
 		ILayoutEngine result = sut.PerformCustomAction(
-			new LayoutEngineAction<IWindow?>()
+			new LayoutEngineCustomAction<IWindow?>()
 			{
 				Name = actionName,
 				Window = null,
@@ -339,7 +339,7 @@ public class FocusLayoutEngineTests
 
 		// When
 		ILayoutEngine result = sut.PerformCustomAction(
-			new LayoutEngineAction<IWindow?>()
+			new LayoutEngineCustomAction<IWindow?>()
 			{
 				Name = "Focus.unknown",
 				Window = null,

--- a/src/Whim.Tests/Store/WorkspaceSector/Transforms/LayoutEngineCustomActionTransformTests.cs
+++ b/src/Whim.Tests/Store/WorkspaceSector/Transforms/LayoutEngineCustomActionTransformTests.cs
@@ -3,26 +3,26 @@ using System.Diagnostics.CodeAnalysis;
 namespace Whim.TestUtils;
 
 [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope")]
-public class LayoutEngineActionTransformTests
+public class LayoutEngineCustomActionTransformTests
 {
 	private static readonly Guid WorkspaceId = Guid.NewGuid();
 
 	private static ILayoutEngine CreateLayoutEngineNotSupportingAction<T>()
 	{
 		ILayoutEngine engine = Substitute.For<ILayoutEngine>();
-		engine.PerformCustomAction(Arg.Any<LayoutEngineAction<T>>()).Returns(engine);
+		engine.PerformCustomAction(Arg.Any<LayoutEngineCustomAction<T>>()).Returns(engine);
 		return engine;
 	}
 
 	private static ILayoutEngine CreateLayoutEngineSupportingAction<T>()
 	{
 		ILayoutEngine engine = Substitute.For<ILayoutEngine>();
-		engine.PerformCustomAction(Arg.Any<LayoutEngineAction<T>>()).Returns(Substitute.For<ILayoutEngine>());
+		engine.PerformCustomAction(Arg.Any<LayoutEngineCustomAction<T>>()).Returns(Substitute.For<ILayoutEngine>());
 		return engine;
 	}
 
 	private static void NoChanges(
-		LayoutEngineActionWithPayloadTransform<IWindow?> sut,
+		LayoutEngineCustomActionWithPayloadTransform<IWindow?> sut,
 		IContext ctx,
 		MutableRootSector rootSector,
 		IWindow window
@@ -47,7 +47,7 @@ public class LayoutEngineActionTransformTests
 	}
 
 	private static void Changes(
-		LayoutEngineActionWithPayloadTransform<IWindow?> sut,
+		LayoutEngineCustomActionWithPayloadTransform<IWindow?> sut,
 		IContext ctx,
 		MutableRootSector root,
 		IWindow window
@@ -81,10 +81,10 @@ public class LayoutEngineActionTransformTests
 	[Theory, AutoSubstituteData<StoreCustomization>]
 	internal void PayloadAction_NoChanges(IContext ctx, MutableRootSector root, IWindow window)
 	{
-		LayoutEngineActionWithPayloadTransform<IWindow?> sut =
+		LayoutEngineCustomActionWithPayloadTransform<IWindow?> sut =
 			new(
 				WorkspaceId,
-				new LayoutEngineAction<IWindow?>
+				new LayoutEngineCustomAction<IWindow?>
 				{
 					Name = "Action",
 					Payload = window,
@@ -98,7 +98,8 @@ public class LayoutEngineActionTransformTests
 	[Theory, AutoSubstituteData<StoreCustomization>]
 	internal void NoPayload_NoChanges(IContext ctx, MutableRootSector root, IWindow window)
 	{
-		LayoutEngineActionTransform sut = new(WorkspaceId, new LayoutEngineAction { Name = "Action", Window = window });
+		LayoutEngineCustomActionTransform sut =
+			new(WorkspaceId, new LayoutEngineCustomAction { Name = "Action", Window = window });
 
 		NoChanges(sut, ctx, root, window);
 	}
@@ -106,10 +107,10 @@ public class LayoutEngineActionTransformTests
 	[Theory, AutoSubstituteData<StoreCustomization>]
 	internal void PayloadAction_Changes(IContext ctx, MutableRootSector root, IWindow window)
 	{
-		LayoutEngineActionWithPayloadTransform<IWindow?> sut =
+		LayoutEngineCustomActionWithPayloadTransform<IWindow?> sut =
 			new(
 				WorkspaceId,
-				new LayoutEngineAction<IWindow?>
+				new LayoutEngineCustomAction<IWindow?>
 				{
 					Name = "Action",
 					Payload = window,
@@ -123,7 +124,8 @@ public class LayoutEngineActionTransformTests
 	[Theory, AutoSubstituteData<StoreCustomization>]
 	internal void NoPayload_Changes(IContext ctx, MutableRootSector root, IWindow window)
 	{
-		LayoutEngineActionTransform sut = new(WorkspaceId, new LayoutEngineAction { Name = "Action", Window = window });
+		LayoutEngineCustomActionTransform sut =
+			new(WorkspaceId, new LayoutEngineCustomAction { Name = "Action", Window = window });
 
 		Changes(sut, ctx, root, window);
 	}

--- a/src/Whim.Tests/Workspace/LegacyWorkspaceTests.cs
+++ b/src/Whim.Tests/Workspace/LegacyWorkspaceTests.cs
@@ -390,9 +390,9 @@ public class LegacyWorkspaceTests
 	{
 		// Given
 		Workspace workspace = CreateWorkspace(ctx);
-		LayoutEngineAction action = new() { Name = "Test", Window = window };
+		LayoutEngineCustomAction action = new() { Name = "Test", Window = window };
 
-		ctx.Store.Dispatch(new LayoutEngineActionTransform(workspace.Id, action)).Returns(isChanged);
+		ctx.Store.Dispatch(new LayoutEngineCustomActionTransform(workspace.Id, action)).Returns(isChanged);
 
 		// When
 		bool result = workspace.PerformCustomLayoutEngineAction(action);
@@ -408,7 +408,7 @@ public class LegacyWorkspaceTests
 	{
 		// Given
 		Workspace workspace = CreateWorkspace(ctx);
-		LayoutEngineAction<IWindow> action =
+		LayoutEngineCustomAction<IWindow> action =
 			new()
 			{
 				Name = "Test",
@@ -416,7 +416,7 @@ public class LegacyWorkspaceTests
 				Payload = window
 			};
 
-		ctx.Store.Dispatch(new LayoutEngineActionWithPayloadTransform<IWindow>(workspace.Id, action))
+		ctx.Store.Dispatch(new LayoutEngineCustomActionWithPayloadTransform<IWindow>(workspace.Id, action))
 			.Returns(isChanged);
 
 		// When

--- a/src/Whim.TreeLayout.Tests/LayoutEngine/PerformCustomActionTests.cs
+++ b/src/Whim.TreeLayout.Tests/LayoutEngine/PerformCustomActionTests.cs
@@ -10,7 +10,7 @@ public class PerformCustomActionTests
 	{
 		// Given
 		LayoutEngineWrapper wrapper = new LayoutEngineWrapper().SetAsLastFocusedWindow(null);
-		LayoutEngineAction<string> action =
+		LayoutEngineCustomAction<string> action =
 			new()
 			{
 				Name = "Action",

--- a/src/Whim.TreeLayout/TreeLayoutEngine.cs
+++ b/src/Whim.TreeLayout/TreeLayoutEngine.cs
@@ -774,5 +774,5 @@ public record TreeLayoutEngine : ILayoutEngine
 	}
 
 	/// <inheritdoc />
-	public ILayoutEngine PerformCustomAction<T>(LayoutEngineAction<T> action) => this;
+	public ILayoutEngine PerformCustomAction<T>(LayoutEngineCustomAction<T> action) => this;
 }

--- a/src/Whim/Commands/CoreCommands.cs
+++ b/src/Whim/Commands/CoreCommands.cs
@@ -230,7 +230,11 @@ internal class CoreCommands : PluginCommands
 					}
 
 					workspace.PerformCustomLayoutEngineAction(
-						new LayoutEngineAction() { Name = $"{focusLayoutEngine.Name}.toggle_maximized", Window = null }
+						new LayoutEngineCustomAction()
+						{
+							Name = $"{focusLayoutEngine.Name}.toggle_maximized",
+							Window = null
+						}
 					);
 				},
 				condition: () =>

--- a/src/Whim/Layout/BaseProxyLayoutEngine.cs
+++ b/src/Whim/Layout/BaseProxyLayoutEngine.cs
@@ -75,7 +75,7 @@ public abstract record BaseProxyLayoutEngine : ILayoutEngine
 	public abstract IEnumerable<IWindowState> DoLayout(IRectangle<int> rectangle, IMonitor monitor);
 
 	/// <inheritdoc/>
-	public abstract ILayoutEngine PerformCustomAction<T>(LayoutEngineAction<T> action);
+	public abstract ILayoutEngine PerformCustomAction<T>(LayoutEngineCustomAction<T> action);
 
 	/// <inheritdoc/>
 	public abstract ILayoutEngine MinimizeWindowStart(IWindow window);

--- a/src/Whim/Layout/ColumnLayoutEngine.cs
+++ b/src/Whim/Layout/ColumnLayoutEngine.cs
@@ -315,5 +315,5 @@ public record ColumnLayoutEngine : ILayoutEngine
 	}
 
 	/// <inheritdoc/>
-	public ILayoutEngine PerformCustomAction<T>(LayoutEngineAction<T> action) => this;
+	public ILayoutEngine PerformCustomAction<T>(LayoutEngineCustomAction<T> action) => this;
 }

--- a/src/Whim/Layout/FocusLayoutEngine.cs
+++ b/src/Whim/Layout/FocusLayoutEngine.cs
@@ -285,7 +285,7 @@ public record FocusLayoutEngine : ILayoutEngine
 	}
 
 	/// <inheritdoc/>
-	public ILayoutEngine PerformCustomAction<T>(LayoutEngineAction<T> action)
+	public ILayoutEngine PerformCustomAction<T>(LayoutEngineCustomAction<T> action)
 	{
 		if (action.Name == $"{Name}.toggle_maximized")
 		{

--- a/src/Whim/Layout/ILayoutEngine.cs
+++ b/src/Whim/Layout/ILayoutEngine.cs
@@ -156,7 +156,7 @@ public interface ILayoutEngine
 	/// <returns>
 	/// A new layout engine if the action is handled, otherwise it returns the current layout engine.
 	/// </returns>
-	ILayoutEngine PerformCustomAction<T>(LayoutEngineAction<T> action);
+	ILayoutEngine PerformCustomAction<T>(LayoutEngineCustomAction<T> action);
 
 	/// <summary>
 	/// Checks to see if this <see cref="ILayoutEngine"/> or a child layout engine is type

--- a/src/Whim/Layout/LayoutEngineCustomAction.cs
+++ b/src/Whim/Layout/LayoutEngineCustomAction.cs
@@ -3,7 +3,7 @@ namespace Whim;
 /// <summary>
 /// The payload for a custom action for a layout engine to perform, via <see cref="ILayoutEngine.PerformCustomAction{T}"/>.
 /// </summary>
-public record LayoutEngineAction
+public record LayoutEngineCustomAction
 {
 	/// <summary>
 	/// The name of the action. This should be unique to the layout engine type.
@@ -25,7 +25,7 @@ public record LayoutEngineAction
 /// <typeparam name="T">
 /// The type of <see cref="Payload"/>.
 /// </typeparam>
-public record LayoutEngineAction<T> : LayoutEngineAction
+public record LayoutEngineCustomAction<T> : LayoutEngineCustomAction
 {
 	/// <summary>
 	/// The payload of the action, which the handler can use to perform the action.

--- a/src/Whim/Store/WorkspaceSector/Transforms/LayoutEngineCustomActionTransform.cs
+++ b/src/Whim/Store/WorkspaceSector/Transforms/LayoutEngineCustomActionTransform.cs
@@ -14,8 +14,10 @@ namespace Whim;
 /// <param name="PayloadAction">
 /// Metadata about the action to perform, and the payload to perform it with.
 /// </param>
-public record LayoutEngineActionWithPayloadTransform<T>(WorkspaceId WorkspaceId, LayoutEngineAction<T> PayloadAction)
-	: BaseWorkspaceTransform(WorkspaceId)
+public record LayoutEngineCustomActionWithPayloadTransform<T>(
+	WorkspaceId WorkspaceId,
+	LayoutEngineCustomAction<T> PayloadAction
+) : BaseWorkspaceTransform(WorkspaceId)
 {
 	private protected override Result<Workspace> WorkspaceOperation(
 		IContext ctx,
@@ -58,10 +60,10 @@ public record LayoutEngineActionWithPayloadTransform<T>(WorkspaceId WorkspaceId,
 /// <param name="Action">
 /// Metadata about the action to perform, and the payload to perform it with.
 /// </param>
-public record LayoutEngineActionTransform(WorkspaceId WorkspaceId, LayoutEngineAction Action)
-	: LayoutEngineActionWithPayloadTransform<IWindow?>(
+public record LayoutEngineCustomActionTransform(WorkspaceId WorkspaceId, LayoutEngineCustomAction Action)
+	: LayoutEngineCustomActionWithPayloadTransform<IWindow?>(
 		WorkspaceId,
-		new LayoutEngineAction<IWindow?>()
+		new LayoutEngineCustomAction<IWindow?>()
 		{
 			Name = Action.Name,
 			Payload = Action.Window,

--- a/src/Whim/Workspace/IWorkspace.cs
+++ b/src/Whim/Workspace/IWorkspace.cs
@@ -283,7 +283,7 @@ public interface IWorkspace : IDisposable
 	/// <returns>
 	/// Whether the <see cref="ActiveLayoutEngine"/> changed.
 	/// </returns>
-	bool PerformCustomLayoutEngineAction(LayoutEngineAction action);
+	bool PerformCustomLayoutEngineAction(LayoutEngineCustomAction action);
 
 	/// <summary>
 	/// Performs a custom action in a layout engine.
@@ -301,6 +301,6 @@ public interface IWorkspace : IDisposable
 	/// <returns>
 	/// Whether the <see cref="ActiveLayoutEngine"/> changed.
 	/// </returns>
-	bool PerformCustomLayoutEngineAction<T>(LayoutEngineAction<T> action);
+	bool PerformCustomLayoutEngineAction<T>(LayoutEngineCustomAction<T> action);
 	#endregion
 }

--- a/src/Whim/Workspace/LegacyWorkspace.cs
+++ b/src/Whim/Workspace/LegacyWorkspace.cs
@@ -142,13 +142,15 @@ public partial record Workspace : IInternalWorkspace
 	public bool ContainsWindow(IWindow window) => LatestWorkspace.WindowPositions.ContainsKey(window.Handle);
 
 	/// <inheritdoc/>
-	public bool PerformCustomLayoutEngineAction(LayoutEngineAction action) =>
-		_context.Store.Dispatch(new LayoutEngineActionTransform(Id, action)).TryGet(out bool isChanged) && isChanged;
+	public bool PerformCustomLayoutEngineAction(LayoutEngineCustomAction action) =>
+		_context.Store.Dispatch(new LayoutEngineCustomActionTransform(Id, action)).TryGet(out bool isChanged)
+		&& isChanged;
 
 	/// <inheritdoc/>
-	public bool PerformCustomLayoutEngineAction<T>(LayoutEngineAction<T> action) =>
-		_context.Store.Dispatch(new LayoutEngineActionWithPayloadTransform<T>(Id, action)).TryGet(out bool isChanged)
-		&& isChanged;
+	public bool PerformCustomLayoutEngineAction<T>(LayoutEngineCustomAction<T> action) =>
+		_context
+			.Store.Dispatch(new LayoutEngineCustomActionWithPayloadTransform<T>(Id, action))
+			.TryGet(out bool isChanged) && isChanged;
 
 	/// <inheritdoc/>
 	public void Dispose()


### PR DESCRIPTION
In #909 I went a bit overzealous with a simplification which I wouldn't think would hit anyone. `LayoutEngineAction` has been renamed back to `LayoutEngineCustomAction`.
