### PR TITLE
Prefer `SetItem` over `Add` for  `ImmutableDictionary`

### DIFF
--- a/src/Whim.Tests/Store/WorkspaceSector/WorkspacePickersTests.cs
+++ b/src/Whim.Tests/Store/WorkspaceSector/WorkspacePickersTests.cs
@@ -261,7 +261,7 @@ public class WorkspacePickersTests
 
 		workspace = workspace with
 		{
-			WindowPositions = workspace.WindowPositions.Add(
+			WindowPositions = workspace.WindowPositions.SetItem(
 				window.Handle,
 				new WindowPosition(WindowSize.Minimized, new Rectangle<int>())
 			)

--- a/src/Whim/Store/WorkspaceSector/Transforms/MinimizeWindowEndTransform.cs
+++ b/src/Whim/Store/WorkspaceSector/Transforms/MinimizeWindowEndTransform.cs
@@ -34,7 +34,7 @@ internal record MinimizeWindowEndTransform(WorkspaceId WorkspaceId, HWND WindowH
 			? workspace
 			: workspace with
 			{
-				WindowPositions = workspace.WindowPositions.Add(window.Handle, new WindowPosition()),
+				WindowPositions = workspace.WindowPositions.SetItem(window.Handle, new WindowPosition()),
 
 				// Restore in just the active layout engine. MinimizeWindowEnd is not called as part of
 				// Whim starting up.

--- a/src/Whim/Store/WorkspaceSector/Transforms/MinimizeWindowStartTransform.cs
+++ b/src/Whim/Store/WorkspaceSector/Transforms/MinimizeWindowStartTransform.cs
@@ -41,7 +41,7 @@ internal record MinimizeWindowStartTransform(Guid WorkspaceId, HWND WindowHandle
 
 		workspace = workspace with
 		{
-			WindowPositions = workspace.WindowPositions.Add(window.Handle, new WindowPosition())
+			WindowPositions = workspace.WindowPositions.SetItem(window.Handle, new WindowPosition())
 		};
 
 		for (int idx = 0; idx < workspace.LayoutEngines.Count; idx++)


### PR DESCRIPTION
This handles the odd case where an item already exists in the dictionary - it's just safer this way.