### PR TITLE
Prevent crash when monitors change

### DIFF
--- a/src/Whim.TestUtils/MonitorTestUtils.cs
+++ b/src/Whim.TestUtils/MonitorTestUtils.cs
@@ -10,27 +10,51 @@ namespace Whim.TestUtils;
 
 internal static class MonitorTestUtils
 {
-	public static void SetupMultipleMonitors(IInternalContext internalCtx, (RECT Rect, HMONITOR HMonitor)[] monitors)
+	public static void SetupMultipleMonitors(
+		IInternalContext internalCtx,
+		(RECT Rect, HMONITOR HMonitor)[] monitors,
+		HMONITOR? primaryMonitor = null
+	)
 	{
-		// Get the primary rect.
-		RECT[] potentialPrimaryMonitors = monitors.Select(m => m.Rect).Where(r => r.left == 0 && r.top == 0).ToArray();
-		if (potentialPrimaryMonitors.Length != 1)
+		// Set up the primary monitor.
+		if (primaryMonitor is HMONITOR primaryMonitorHandle)
 		{
-			throw new Exception("No primary monitor found");
+			internalCtx
+				.CoreNativeManager.MonitorFromPoint(new Point(0, 0), MONITOR_FROM_FLAGS.MONITOR_DEFAULTTOPRIMARY)
+				.Returns(primaryMonitorHandle);
 		}
-		RECT primaryRect = potentialPrimaryMonitors[0];
+		else
+		{
+			// Get the primary rect.
+			RECT[] potentialPrimaryMonitors = monitors
+				.Select(m => m.Rect)
+				.Where(r => r.left == 0 && r.top == 0)
+				.ToArray();
+
+			if (potentialPrimaryMonitors.Length != 1)
+			{
+				throw new Exception("No primary monitor found");
+			}
+
+			RECT primaryRect = potentialPrimaryMonitors[0];
+
+			foreach ((RECT rect, HMONITOR hMonitor) in monitors)
+			{
+				if (primaryRect.Equals(rect))
+				{
+					internalCtx
+						.CoreNativeManager.MonitorFromPoint(
+							new Point(0, 0),
+							MONITOR_FROM_FLAGS.MONITOR_DEFAULTTOPRIMARY
+						)
+						.Returns(hMonitor);
+				}
+			}
+		}
 
 		// Set up monitor creation.
 		foreach ((RECT rect, HMONITOR hMonitor) in monitors)
 		{
-			// Set up the primary monitor, if it's the primary monitor.
-			if (primaryRect.Equals(rect))
-			{
-				internalCtx
-					.CoreNativeManager.MonitorFromPoint(new Point(0, 0), MONITOR_FROM_FLAGS.MONITOR_DEFAULTTOPRIMARY)
-					.Returns(hMonitor);
-			}
-
 			// Set up the fetching of metadata in a multiple monitor setup.
 			internalCtx
 				.CoreNativeManager.GetMonitorInfoEx(hMonitor)

--- a/src/Whim.Tests/Store/MonitorSector/Transforms/MonitorsChangedTransformTests.cs
+++ b/src/Whim.Tests/Store/MonitorSector/Transforms/MonitorsChangedTransformTests.cs
@@ -96,6 +96,23 @@ public class MonitorsChangedTransformTests
 		return new[] { workspace1, workspace2, workspace3 };
 	}
 
+	private static void AssertContainsTransform(IContext ctx, Guid workspaceId, int times = 1)
+	{
+		CustomAssert.Contains(
+			ctx.GetTransforms(),
+			t => (t as DeactivateWorkspaceTransform) == new DeactivateWorkspaceTransform(workspaceId),
+			times
+		);
+	}
+
+	private static void AssertDoesNotContainTransform(IContext ctx, Guid workspaceId)
+	{
+		Assert.DoesNotContain(
+			ctx.GetTransforms(),
+			t => (t as DeactivateWorkspaceTransform) == new DeactivateWorkspaceTransform(workspaceId)
+		);
+	}
+
 	[Theory, AutoSubstituteData<StoreCustomization>]
 	internal void WorkspaceSectorNotInitialized(
 		IContext ctx,
@@ -150,21 +167,9 @@ public class MonitorsChangedTransformTests
 		Assert.Equal(workspaces[2].Id, rootSector.MapSector.MonitorWorkspaceMap[RightMonitorSetup.Handle]);
 		Assert.DoesNotContain(LeftBottomMonitorSetup.Handle, rootSector.MapSector.MonitorWorkspaceMap.Keys);
 
-		Assert.Contains(
-			ctx.GetTransforms(),
-			t => (t as DeactivateWorkspaceTransform) == new DeactivateWorkspaceTransform(workspaces[0].Id)
-		);
-
-		CustomAssert.Contains(
-			ctx.GetTransforms(),
-			t => (t as DeactivateWorkspaceTransform) == new DeactivateWorkspaceTransform(workspaces[1].Id),
-			2
-		);
-
-		Assert.Contains(
-			ctx.GetTransforms(),
-			t => (t as DeactivateWorkspaceTransform) == new DeactivateWorkspaceTransform(workspaces[2].Id)
-		);
+		AssertContainsTransform(ctx, workspaces[0].Id);
+		AssertContainsTransform(ctx, workspaces[1].Id, 2);
+		AssertContainsTransform(ctx, workspaces[2].Id);
 	}
 
 	[Theory, AutoSubstituteData<StoreCustomization>]
@@ -198,20 +203,9 @@ public class MonitorsChangedTransformTests
 		Assert.Equal(workspaces[1].Id, rootSector.MapSector.MonitorWorkspaceMap[RightMonitorSetup.Handle]);
 		Assert.Equal(workspaces[2].Id, rootSector.MapSector.MonitorWorkspaceMap[LeftBottomMonitorSetup.Handle]);
 
-		Assert.Contains(
-			ctx.GetTransforms(),
-			t => (t as DeactivateWorkspaceTransform) == new DeactivateWorkspaceTransform(workspaces[0].Id)
-		);
-
-		Assert.Contains(
-			ctx.GetTransforms(),
-			t => (t as DeactivateWorkspaceTransform) == new DeactivateWorkspaceTransform(workspaces[1].Id)
-		);
-
-		Assert.DoesNotContain(
-			ctx.GetTransforms(),
-			t => (t as DeactivateWorkspaceTransform) == new DeactivateWorkspaceTransform(workspaces[2].Id)
-		);
+		AssertContainsTransform(ctx, workspaces[0].Id);
+		AssertContainsTransform(ctx, workspaces[1].Id);
+		AssertDoesNotContainTransform(ctx, workspaces[2].Id);
 	}
 
 	[Theory, AutoSubstituteData<StoreCustomization>]
@@ -292,19 +286,8 @@ public class MonitorsChangedTransformTests
 		Assert.Equal(workspaces[2].Id, rootSector.MapSector.MonitorWorkspaceMap[RightMonitorSetup.Handle]);
 		Assert.Equal(workspaces[1].Id, rootSector.MapSector.MonitorWorkspaceMap[LeftBottomMonitorSetup.Handle]);
 
-		Assert.DoesNotContain(
-			ctx.GetTransforms(),
-			t => (t as DeactivateWorkspaceTransform) == new DeactivateWorkspaceTransform(workspaces[0].Id)
-		);
-
-		Assert.DoesNotContain(
-			ctx.GetTransforms(),
-			t => (t as DeactivateWorkspaceTransform) == new DeactivateWorkspaceTransform(workspaces[1].Id)
-		);
-
-		Assert.DoesNotContain(
-			ctx.GetTransforms(),
-			t => (t as DeactivateWorkspaceTransform) == new DeactivateWorkspaceTransform(workspaces[2].Id)
-		);
+		AssertDoesNotContainTransform(ctx, workspaces[0].Id);
+		AssertDoesNotContainTransform(ctx, workspaces[1].Id);
+		AssertDoesNotContainTransform(ctx, workspaces[2].Id);
 	}
 }

--- a/src/Whim.Tests/Store/WorkspaceSector/Transforms/LayoutEngineCustomActionTransformTests.cs
+++ b/src/Whim.Tests/Store/WorkspaceSector/Transforms/LayoutEngineCustomActionTransformTests.cs
@@ -1,6 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 
-namespace Whim.TestUtils;
+namespace Whim.Tests;
 
 [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope")]
 public class LayoutEngineCustomActionTransformTests

--- a/src/Whim/Store/MonitorSector/Transforms/MonitorsChangedTransform.cs
+++ b/src/Whim/Store/MonitorSector/Transforms/MonitorsChangedTransform.cs
@@ -18,7 +18,6 @@ internal record MonitorsChangedTransform : Transform
 
 		// Get the new monitors.
 		ImmutableArray<IMonitor> previousMonitors = sector.Monitors;
-
 		UpdateMonitorSector(ctx, internalCtx, mutableRootSector);
 
 		List<IMonitor> unchangedMonitors = new();

--- a/src/Whim/Store/MonitorSector/Transforms/MonitorsChangedTransform.cs
+++ b/src/Whim/Store/MonitorSector/Transforms/MonitorsChangedTransform.cs
@@ -19,7 +19,7 @@ internal record MonitorsChangedTransform : Transform
 		// Get the new monitors.
 		ImmutableArray<IMonitor> previousMonitors = sector.Monitors;
 
-		sector.Monitors = MonitorUtils.GetCurrentMonitors(internalCtx);
+		UpdateMonitorSector(ctx, internalCtx, mutableRootSector);
 
 		List<IMonitor> unchangedMonitors = new();
 		List<IMonitor> removedMonitors = new();
@@ -76,6 +76,24 @@ internal record MonitorsChangedTransform : Transform
 		sector.QueueEvent(args);
 
 		return Unit.Result;
+	}
+
+	private static void UpdateMonitorSector(IContext ctx, IInternalContext internalCtx, MutableRootSector rootSector)
+	{
+		MonitorSector sector = rootSector.MonitorSector;
+
+		sector.Monitors = MonitorUtils.GetCurrentMonitors(internalCtx);
+
+		foreach (IMonitor m in sector.Monitors)
+		{
+			if (m.IsPrimary)
+			{
+				sector.PrimaryMonitorHandle = m.Handle;
+				sector.ActiveMonitorHandle = m.Handle;
+				sector.LastWhimActiveMonitorHandle = m.Handle;
+				break;
+			}
+		}
 	}
 
 	private static void UpdateMapSector(


### PR DESCRIPTION
Replace the stored `PrimaryMonitorHandle`, `ActiveMonitorHandle`, and LastWhimActiveMonitorHandle` when the monitors are changed. `HMONITOR`s can change as monitors change.