### PR TITLE
Fix floating windows not working on monitors with `X < 0` or `Y < 0`

### DIFF
--- a/src/Whim.Tests/Monitor/MonitorHelpersTests.cs
+++ b/src/Whim.Tests/Monitor/MonitorHelpersTests.cs
@@ -1,26 +1,21 @@
-using NSubstitute.Core;
-using Windows.Web.Syndication;
-
 namespace Whim.Tests;
 
 public class MonitorHelpersTests
 {
-	public static TheoryData<Rectangle<int>, Point<int>, Point<double>> NormalizeDeltaPoint_Data
-	{
-		get
+	public static TheoryData<Rectangle<int>, Point<int>, Point<double>> NormalizeDeltaPoint_Data =>
+		new()
 		{
-			TheoryData<Rectangle<int>, Point<int>, Point<double>> data = new();
-			data.Add(
+			{
 				new Rectangle<int>() { Width = 1920, Height = 1080 },
 				new Point<int>() { X = 192, Y = 108 },
 				new Point<double>() { X = 0.1, Y = 0.1 }
-			);
-			data.Add(
+			},
+			{
 				new Rectangle<int>() { Width = 1920, Height = 1080 },
 				new Point<int>() { X = 960, Y = 270 },
 				new Point<double>() { X = 0.5, Y = 0.25 }
-			);
-			data.Add(
+			},
+			{
 				new Rectangle<int>()
 				{
 					X = 100,
@@ -30,8 +25,8 @@ public class MonitorHelpersTests
 				},
 				new Point<int>() { X = 192, Y = 108 },
 				new Point<double>() { X = 0.1, Y = 0.1 }
-			);
-			data.Add(
+			},
+			{
 				new Rectangle<int>()
 				{
 					X = 100,
@@ -41,8 +36,8 @@ public class MonitorHelpersTests
 				},
 				new Point<int>() { X = 960, Y = 270 },
 				new Point<double>() { X = 0.5, Y = 0.25 }
-			);
-			data.Add(
+			},
+			{
 				new Rectangle<int>()
 				{
 					X = -100,
@@ -52,8 +47,8 @@ public class MonitorHelpersTests
 				},
 				new Point<int>() { X = 192, Y = 108 },
 				new Point<double>() { X = 0.1, Y = 0.1 }
-			);
-			data.Add(
+			},
+			{
 				new Rectangle<int>()
 				{
 					X = -100,
@@ -63,10 +58,8 @@ public class MonitorHelpersTests
 				},
 				new Point<int>() { X = 960, Y = 270 },
 				new Point<double>() { X = 0.5, Y = 0.25 }
-			);
-			return data;
-		}
-	}
+			}
+		};
 
 	[Theory]
 	[MemberData(nameof(NormalizeDeltaPoint_Data))]
@@ -80,22 +73,20 @@ public class MonitorHelpersTests
 		Assert.Equal(expected.Y, actual.Y);
 	}
 
-	public static TheoryData<Rectangle<int>, Point<int>, Point<double>> NormalizeAbsolutePoint_Data
-	{
-		get
+	public static TheoryData<Rectangle<int>, Point<int>, Point<double>> NormalizeAbsolutePoint_Data =>
+		new()
 		{
-			TheoryData<Rectangle<int>, Point<int>, Point<double>> data = new();
-			data.Add(
+			{
 				new Rectangle<int>() { Width = 1920, Height = 1080 },
 				new Point<int>() { X = 192, Y = 108 },
 				new Point<double>() { X = 0.1, Y = 0.1 }
-			);
-			data.Add(
+			},
+			{
 				new Rectangle<int>() { Width = 1920, Height = 1080 },
 				new Point<int>() { X = 960, Y = 270 },
 				new Point<double>() { X = 0.5, Y = 0.25 }
-			);
-			data.Add(
+			},
+			{
 				new Rectangle<int>()
 				{
 					X = 100,
@@ -105,8 +96,8 @@ public class MonitorHelpersTests
 				},
 				new Point<int>() { X = 192 + 100, Y = 108 + 100 },
 				new Point<double>() { X = 0.1, Y = 0.1 }
-			);
-			data.Add(
+			},
+			{
 				new Rectangle<int>()
 				{
 					X = 100,
@@ -116,8 +107,8 @@ public class MonitorHelpersTests
 				},
 				new Point<int>() { X = 960 + 100, Y = 270 + 100 },
 				new Point<double>() { X = 0.5, Y = 0.25 }
-			);
-			data.Add(
+			},
+			{
 				new Rectangle<int>()
 				{
 					X = -100,
@@ -127,8 +118,8 @@ public class MonitorHelpersTests
 				},
 				new Point<int>() { X = 192 - 100, Y = 108 + 100 },
 				new Point<double>() { X = 0.1, Y = 0.1 }
-			);
-			data.Add(
+			},
+			{
 				new Rectangle<int>()
 				{
 					X = -100,
@@ -138,10 +129,8 @@ public class MonitorHelpersTests
 				},
 				new Point<int>() { X = 960 - 100, Y = 270 + 100 },
 				new Point<double>() { X = 0.5, Y = 0.25 }
-			);
-			return data;
-		}
-	}
+			},
+		};
 
 	[Theory]
 	[MemberData(nameof(NormalizeAbsolutePoint_Data))]
@@ -155,22 +144,20 @@ public class MonitorHelpersTests
 		Assert.Equal(expected.Y, actual.Y);
 	}
 
-	public static TheoryData<Rectangle<int>, Point<int>, Point<double>> NormalizeAbsolutePoint_Data_RespectSign
-	{
-		get
+	public static TheoryData<Rectangle<int>, Point<int>, Point<double>> NormalizeAbsolutePoint_Data_RespectSign =>
+		new()
 		{
-			TheoryData<Rectangle<int>, Point<int>, Point<double>> data = new();
-			data.Add(
+			{
 				new Rectangle<int>() { Width = 1920, Height = 1080 },
 				new Point<int>() { X = -192, Y = 108 },
 				new Point<double>() { X = -0.1, Y = 0.1 }
-			);
-			data.Add(
+			},
+			{
 				new Rectangle<int>() { Width = 1920, Height = 1080 },
 				new Point<int>() { X = 960, Y = -270 },
 				new Point<double>() { X = 0.5, Y = -0.25 }
-			);
-			data.Add(
+			},
+			{
 				new Rectangle<int>()
 				{
 					X = 100,
@@ -180,8 +167,8 @@ public class MonitorHelpersTests
 				},
 				new Point<int>() { X = -192 + 100, Y = -108 + 100 },
 				new Point<double>() { X = -0.1, Y = -0.1 }
-			);
-			data.Add(
+			},
+			{
 				new Rectangle<int>()
 				{
 					X = 100,
@@ -191,8 +178,8 @@ public class MonitorHelpersTests
 				},
 				new Point<int>() { X = -960 + 100, Y = 270 + 100 },
 				new Point<double>() { X = -0.5, Y = 0.25 }
-			);
-			data.Add(
+			},
+			{
 				new Rectangle<int>()
 				{
 					X = -100,
@@ -202,8 +189,8 @@ public class MonitorHelpersTests
 				},
 				new Point<int>() { X = 192 - 100, Y = -108 + 100 },
 				new Point<double>() { X = 0.1, Y = -0.1 }
-			);
-			data.Add(
+			},
+			{
 				new Rectangle<int>()
 				{
 					X = -100,
@@ -213,10 +200,8 @@ public class MonitorHelpersTests
 				},
 				new Point<int>() { X = -960 - 100, Y = -270 + 100 },
 				new Point<double>() { X = -0.5, Y = -0.25 }
-			);
-			return data;
-		}
-	}
+			},
+		};
 
 	[Theory]
 	[MemberData(nameof(NormalizeAbsolutePoint_Data_RespectSign))]
@@ -314,12 +299,10 @@ public class MonitorHelpersTests
 		Assert.Equal(expected.Y, actual.Y);
 	}
 
-	public static TheoryData<Rectangle<int>, Rectangle<double>, Rectangle<int>> ToMonitor_Data
-	{
-		get
+	public static TheoryData<Rectangle<int>, Rectangle<double>, Rectangle<int>> ToMonitor_Data =>
+		new()
 		{
-			TheoryData<Rectangle<int>, Rectangle<double>, Rectangle<int>> data = new();
-			data.Add(
+			{
 				new Rectangle<int>() { Width = 1920, Height = 1080 },
 				new Rectangle<double>()
 				{
@@ -335,8 +318,8 @@ public class MonitorHelpersTests
 					Width = 192,
 					Height = 108
 				}
-			);
-			data.Add(
+			},
+			{
 				new Rectangle<int>()
 				{
 					X = 100,
@@ -358,10 +341,8 @@ public class MonitorHelpersTests
 					Width = 192,
 					Height = 108
 				}
-			);
-			return data;
-		}
-	}
+			},
+		};
 
 	[Theory]
 	[MemberData(nameof(ToMonitor_Data))]

--- a/src/Whim.Tests/Monitor/MonitorHelpersTests.cs
+++ b/src/Whim.Tests/Monitor/MonitorHelpersTests.cs
@@ -342,6 +342,29 @@ public class MonitorHelpersTests
 					Height = 108
 				}
 			},
+			{
+				new Rectangle<int>()
+				{
+					X = -1920,
+					Y = -1080,
+					Width = 1920,
+					Height = 1080
+				},
+				new Rectangle<double>()
+				{
+					X = 0.1,
+					Y = 0.1,
+					Width = 0.1,
+					Height = 0.1
+				},
+				new Rectangle<int>()
+				{
+					X = -1920 + 192,
+					Y = -1080 + 108,
+					Width = 192,
+					Height = 108
+				}
+			}
 		};
 
 	[Theory]

--- a/src/Whim/Monitor/IMonitor.cs
+++ b/src/Whim/Monitor/IMonitor.cs
@@ -130,8 +130,8 @@ public static class MonitorHelpers
 	{
 		return new Rectangle<int>()
 		{
-			X = Math.Abs(Convert.ToInt32(monitor.X + (rectangle.X * monitor.Width))),
-			Y = Math.Abs(Convert.ToInt32(monitor.Y + (rectangle.Y * monitor.Height))),
+			X = Convert.ToInt32(monitor.X + (rectangle.X * monitor.Width)),
+			Y = Convert.ToInt32(monitor.Y + (rectangle.Y * monitor.Height)),
 			Width = Math.Abs(Convert.ToInt32(rectangle.Width * monitor.Width)),
 			Height = Math.Abs(Convert.ToInt32(rectangle.Height * monitor.Height))
 		};


### PR DESCRIPTION
Previously, moving a floating window to a monitor with `X < 0` or `Y < 0` would result in the window moving to the primary monitor (the monitor with `X = 0` and `Y = 0`).

This has been fixed by removing `Math.Abs` for `X` and `Y`.