### PR TITLE
Retain monitor focus when switching between workspaces

### DIFF
--- a/src/Whim.Tests/Store/WindowSector/Transforms/WindowFocusedTransformTests.cs
+++ b/src/Whim.Tests/Store/WindowSector/Transforms/WindowFocusedTransformTests.cs
@@ -79,6 +79,11 @@ public class WindowFocusedTransformTests
 
 		internalCtx.CoreNativeManager.GetForegroundWindow().Returns((HWND)0);
 
+		// Mock out the next call to make sure it doesn't matter
+		internalCtx
+			.CoreNativeManager.MonitorFromWindow(Arg.Any<HWND>(), MONITOR_FROM_FLAGS.MONITOR_DEFAULTTONEAREST)
+			.Returns(HMONITOR_1);
+
 		WindowFocusedTransform sut = new(null);
 
 		// When we dispatch the transform

--- a/src/Whim/Store/WindowSector/Transforms/WindowFocusedTransform.cs
+++ b/src/Whim/Store/WindowSector/Transforms/WindowFocusedTransform.cs
@@ -42,6 +42,7 @@ internal record WindowFocusedTransform(IWindow? Window) : Transform()
 		if (hwnd.IsNull)
 		{
 			Logger.Debug($"Hwnd is desktop window, ignoring");
+			return;
 		}
 
 		HMONITOR monitorHandle = internalCtx.CoreNativeManager.MonitorFromWindow(
@@ -68,7 +69,6 @@ internal record WindowFocusedTransform(IWindow? Window) : Transform()
 		}
 	}
 
-	///
 	private static void UpdateMapSector(IContext ctx, IWindow? window)
 	{
 		foreach (IWorkspace workspace in ctx.WorkspaceManager)


### PR DESCRIPTION
Previously, switching between workspaces with no windows or no non-minimized windows would result in focus being gained by a workspace/monitor with windows.

There was a missing `return`, which has been added back in.
