### PR TITLE
Add `FreeLayoutEngine`

### DIFF
--- a/docs/docs/customize/layout-engines.md
+++ b/docs/docs/customize/layout-engines.md
@@ -103,6 +103,6 @@ context.PluginManager.AddPlugin(treeLayoutPlugin);
 
 ### `FreeLayoutEngine`
 
-<xref:Whim.Layout.FreeEngineLayout> is a layout that allows users to have only free-floating windows.
+<xref:Whim.FreeLayoutEngine> is a layout that has all windows being free-floating. To have specific windows float within a different layout, see the [Floating Layout Plugin](../plugins/floating-layout.md).
 
 ![FreeLayoutEngine demo](../../images/free-layout-demo.gif)

--- a/docs/docs/customize/layout-engines.md
+++ b/docs/docs/customize/layout-engines.md
@@ -100,3 +100,9 @@ context.PluginManager.AddPlugin(treeLayoutPlugin);
 ```
 
 ![TreeLayoutEngine demo](../../images/tree-layout-demo.gif)
+
+### `FreeLayoutEngine`
+
+<xref:Whim.Layout.FreeEngineLayout> is a layout that allows users to have only free-floating windows.
+
+![FreeLayoutEngine demo](../../images/free-layout-demo.gif)

--- a/src/Whim.FloatingLayout.Tests/FreeLayoutEngineTests.cs
+++ b/src/Whim.FloatingLayout.Tests/FreeLayoutEngineTests.cs
@@ -32,7 +32,7 @@ public class FreeLayoutEngineTests
 	public void Name(IContext context)
 	{
 		// Given
-		FreeLayoutEngine engine = new(context, identity);
+		ILayoutEngine engine = new FreeLayoutEngine(context, identity);
 
 		// When
 		string name = engine.Name;
@@ -41,62 +41,67 @@ public class FreeLayoutEngineTests
 		Assert.Equal("Free", name);
 	}
 
+	#region AddWindow
 	[Theory, AutoSubstituteData<FreeLayoutEngineCustomization>]
 	public void AddWindow(IContext context, IWindow window)
 	{
 		// Given
-		FreeLayoutEngine engine = new(context, identity);
+		ILayoutEngine engine = new FreeLayoutEngine(context, identity);
 
 		// When
 		ILayoutEngine newLayoutEngine = engine.AddWindow(window);
 
 		// Then
-		Assert.NotSame(engine, newLayoutEngine);
+		Assert.Equal(0, engine.Count);
 		Assert.Equal(1, newLayoutEngine.Count);
 	}
 
 	[Theory, AutoSubstituteData<FreeLayoutEngineCustomization>]
-	public void AddWindow_WindowAlreadyPresent(IWindow window)
+	public void AddWindow_WindowAlreadyPresent(IContext context, IWindow window)
 	{
 		// Given
-		ILayoutEngine engine = new ColumnLayoutEngine(identity).AddWindow(window);
+		ILayoutEngine engine = new FreeLayoutEngine(context, identity).AddWindow(window);
 
 		// When
 		ILayoutEngine newLayoutEngine = engine.AddWindow(window);
 
 		// Then
-		Assert.Same(engine, newLayoutEngine);
+		Assert.Equal(1, engine.Count);
 		Assert.Equal(1, newLayoutEngine.Count);
 	}
+	#endregion
 
+	#region RemoveWindow
 	[Theory, AutoSubstituteData<FreeLayoutEngineCustomization>]
-	public void Remove(IWindow window)
+	public void Remove(IContext context, IWindow window)
 	{
 		// Given
-		ILayoutEngine engine = new ColumnLayoutEngine(identity).AddWindow(window);
+		ILayoutEngine engine = new FreeLayoutEngine(context, identity).AddWindow(window);
 
 		// When
 		ILayoutEngine newLayoutEngine = engine.RemoveWindow(window);
 
 		// Then
-		Assert.NotSame(engine, newLayoutEngine);
+		Assert.Equal(1, engine.Count);
 		Assert.Equal(0, newLayoutEngine.Count);
 	}
 
 	[Theory, AutoSubstituteData<FreeLayoutEngineCustomization>]
-	public void Remove_NoChanges(IWindow window)
+	public void Remove_NoChanges(IContext context, IWindow window)
 	{
 		// Given
-		ILayoutEngine engine = new ColumnLayoutEngine(identity).AddWindow(window);
+		ILayoutEngine engine = new FreeLayoutEngine(context, identity).AddWindow(window);
 
 		// When
 		ILayoutEngine newLayoutEngine = engine.RemoveWindow(Substitute.For<IWindow>());
 
 		// Then
-		Assert.Same(engine, newLayoutEngine);
+		Assert.Equal(1, engine.Count);
 		Assert.Equal(1, newLayoutEngine.Count);
 	}
+	#endregion RemoveWindow
 
+	#region Contains
 	[Theory, AutoSubstituteData<FreeLayoutEngineCustomization>]
 	public void Contains(IContext context, IWindow window)
 	{
@@ -122,13 +127,14 @@ public class FreeLayoutEngineTests
 		// Then
 		Assert.False(contains);
 	}
+	#endregion
 
 	#region DoLayout
-	[Fact]
-	public void DoLayout_Empty()
+	[Theory, AutoSubstituteData<FreeLayoutEngineCustomization>]
+	public void DoLayout_Empty(IContext context)
 	{
 		// Given
-		ILayoutEngine engine = new ColumnLayoutEngine(identity);
+		ILayoutEngine engine = new FreeLayoutEngine(context, identity);
 
 		// When
 		IWindowState[] windowStates = engine
@@ -169,6 +175,7 @@ public class FreeLayoutEngineTests
 	}
 	#endregion
 
+	#region GetFirstWindow
 	[Theory, AutoSubstituteData]
 	public void GetFirstWindow_Null(IContext context)
 	{
@@ -193,5 +200,108 @@ public class FreeLayoutEngineTests
 
 		// Then
 		Assert.Same(window, result);
+	}
+	#endregion
+
+	#region WindowRelated
+	[Theory, AutoSubstituteData<FreeLayoutEngineCustomization>]
+	public void MoveWindowToPoint(IContext context, IWindow window)
+	{
+		// Given
+		ILayoutEngine engine = new FreeLayoutEngine(context, identity).AddWindow(window);
+		IRectangle<double> rect = new Rectangle<double>();
+
+		// When
+		ILayoutEngine newEngine = engine.MoveWindowToPoint(window, rect);
+
+		// Then
+		Assert.Equal(engine, newEngine);
+	}
+
+	[Theory, AutoSubstituteData<FreeLayoutEngineCustomization>]
+	public void MoveWindowEdgesInDirection(IContext context, IWindow window)
+	{
+		// Given
+		ILayoutEngine engine = new FreeLayoutEngine(context, identity).AddWindow(window);
+		IRectangle<double> rect = new Rectangle<double>();
+
+		// When
+		ILayoutEngine newEngine = engine.MoveWindowToPoint(window, rect);
+
+		// Then
+		Assert.Equal(engine, newEngine);
+	}
+
+	[Theory, AutoSubstituteData<FreeLayoutEngineCustomization>]
+	public void MinimizeWindowStart(IContext context, IWindow window)
+	{
+		// Given
+		ILayoutEngine engine = new FreeLayoutEngine(context, identity).AddWindow(window);
+
+		// When
+		ILayoutEngine newEngine = engine.MinimizeWindowStart(window);
+
+		// Then
+		Assert.Equal(engine, newEngine);
+	}
+
+	[Theory, AutoSubstituteData<FreeLayoutEngineCustomization>]
+	public void MinimizeWindowEnd(IContext context, IWindow window)
+	{
+		// Given
+		ILayoutEngine engine = new FreeLayoutEngine(context, identity).AddWindow(window);
+
+		// When
+		ILayoutEngine newEngine = engine.MinimizeWindowEnd(window);
+
+		// Then
+		Assert.Equal(engine, newEngine);
+	}
+
+	[Theory, AutoSubstituteData<FreeLayoutEngineCustomization>]
+	public void FocusWindowInDirection(IContext context, IWindow window)
+	{
+		// Given
+		ILayoutEngine engine = new FreeLayoutEngine(context, identity).AddWindow(window);
+
+		// When
+		ILayoutEngine newEngine = engine.FocusWindowInDirection(Direction.Up, window);
+
+		// Then
+		Assert.Equal(engine, newEngine);
+	}
+
+	[Theory, AutoSubstituteData<FreeLayoutEngineCustomization>]
+	public void SwapWindowInDirection(IContext context, IWindow window)
+	{
+		// Given
+		ILayoutEngine engine = new FreeLayoutEngine(context, identity).AddWindow(window);
+
+		// When
+		ILayoutEngine newEngine = engine.SwapWindowInDirection(Direction.Up, window);
+
+		// Then
+		Assert.Equal(engine, newEngine);
+	}
+	#endregion
+
+	[Theory, AutoSubstituteData<FreeLayoutEngineCustomization>]
+	public void PerformCustomAction(IContext context, IWindow window)
+	{
+		// Given
+		ILayoutEngine engine = new FreeLayoutEngine(context, identity).AddWindow(window);
+		LayoutEngineCustomAction<string> action =
+			new()
+			{
+				Name = "Action",
+				Payload = "payload",
+				Window = null
+			};
+
+		// When
+		ILayoutEngine newEngine = engine.PerformCustomAction(action);
+
+		// Then
+		Assert.Equal(engine, newEngine);
 	}
 }

--- a/src/Whim.FloatingLayout.Tests/FreeLayoutEngineTests.cs
+++ b/src/Whim.FloatingLayout.Tests/FreeLayoutEngineTests.cs
@@ -1,7 +1,10 @@
-﻿using System.Linq;
-using AutoFixture;
+﻿using AutoFixture;
+using NSubstitute;
+using Whim.TestUtils;
+using Windows.Win32.Foundation;
+using Xunit;
 
-namespace Whim.Tests;
+namespace Whim.FloatingLayout.Tests;
 
 public class FreeLayoutEngineCustomization : ICustomization
 {

--- a/src/Whim.FloatingLayout/FreeLayoutEngine.cs
+++ b/src/Whim.FloatingLayout/FreeLayoutEngine.cs
@@ -1,9 +1,12 @@
-﻿using System.Linq;
+﻿using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
 
-namespace Whim;
+namespace Whim.FloatingLayout;
 
 /// <summary>
 /// Layout engine that lays out all windows as free-floating.
+/// This layout will be soon renamed FloatingLayoutEngine.
 /// </summary>
 public class FreeLayoutEngine : ILayoutEngine
 {

--- a/src/Whim.Gaps.Tests/GapsLayoutEngineTests.cs
+++ b/src/Whim.Gaps.Tests/GapsLayoutEngineTests.cs
@@ -1,5 +1,6 @@
 using FluentAssertions;
 using NSubstitute;
+using Whim.FloatingLayout;
 using Whim.TestUtils;
 using Xunit;
 
@@ -410,6 +411,37 @@ public class GapsLayoutEngineTests
 
 		// Then
 		windowStates.Should().Equal(expectedWindowStates);
+	}
+
+	[Theory, AutoSubstituteData]
+	public void DoLayout_WithFreeLayoutEngine(GapsConfig gapsConfig, IWindow window)
+	{
+		// Input
+		Rectangle<int> rect = new(0, 0, -300, -300);
+		IWindowState[] inputWindowStates =
+		{
+			new WindowState()
+			{
+				Window = window,
+				Rectangle = rect,
+				WindowSize = WindowSize.Normal
+			}
+		};
+
+		// Given
+		ILayoutEngine innerLayoutEngine = Substitute.For<ILayoutEngine>();
+		innerLayoutEngine
+			.GetLayoutEngine<FreeLayoutEngine>()
+			.Returns(new FreeLayoutEngine(Substitute.For<IContext>(), _identity));
+		innerLayoutEngine.DoLayout(rect, Arg.Any<IMonitor>()).Returns(inputWindowStates);
+
+		GapsLayoutEngine gapsLayoutEngine = new(gapsConfig, innerLayoutEngine);
+
+		// When
+		IWindowState[] outputWindowStates = gapsLayoutEngine.DoLayout(rect, Substitute.For<IMonitor>()).ToArray();
+
+		// Then
+		outputWindowStates.Should().Equal(inputWindowStates);
 	}
 
 	[Theory, AutoSubstituteData]

--- a/src/Whim.Gaps/GapsLayoutEngine.cs
+++ b/src/Whim.Gaps/GapsLayoutEngine.cs
@@ -30,6 +30,8 @@ public record GapsLayoutEngine : BaseProxyLayoutEngine
 	private GapsLayoutEngine UpdateInner(ILayoutEngine newInnerLayoutEngine) =>
 		InnerLayoutEngine == newInnerLayoutEngine ? this : new GapsLayoutEngine(this, newInnerLayoutEngine);
 
+	private bool isFreeLayoutEngine() => InnerLayoutEngine.GetLayoutEngine<FreeLayoutEngine>() is not null;
+
 	/// <inheritdoc />
 	public override int Count => InnerLayoutEngine.Count;
 
@@ -42,6 +44,16 @@ public record GapsLayoutEngine : BaseProxyLayoutEngine
 	/// <inheritdoc />
 	public override IEnumerable<IWindowState> DoLayout(IRectangle<int> rectangle, IMonitor monitor)
 	{
+		if (isFreeLayoutEngine())
+		{
+			foreach (IWindowState windowState in InnerLayoutEngine.DoLayout(rectangle, monitor))
+			{
+				yield return windowState;
+			}
+
+			yield break;
+		}
+
 		double scaleFactor = monitor.ScaleFactor;
 		double scale = scaleFactor / 100.0;
 

--- a/src/Whim.Gaps/GapsLayoutEngine.cs
+++ b/src/Whim.Gaps/GapsLayoutEngine.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using Whim.FloatingLayout;
 
 namespace Whim.Gaps;
 

--- a/src/Whim.Gaps/GapsLayoutEngine.cs
+++ b/src/Whim.Gaps/GapsLayoutEngine.cs
@@ -31,8 +31,6 @@ public record GapsLayoutEngine : BaseProxyLayoutEngine
 	private GapsLayoutEngine UpdateInner(ILayoutEngine newInnerLayoutEngine) =>
 		InnerLayoutEngine == newInnerLayoutEngine ? this : new GapsLayoutEngine(this, newInnerLayoutEngine);
 
-	private bool isFreeLayoutEngine() => InnerLayoutEngine.GetLayoutEngine<FreeLayoutEngine>() is not null;
-
 	/// <inheritdoc />
 	public override int Count => InnerLayoutEngine.Count;
 
@@ -45,7 +43,7 @@ public record GapsLayoutEngine : BaseProxyLayoutEngine
 	/// <inheritdoc />
 	public override IEnumerable<IWindowState> DoLayout(IRectangle<int> rectangle, IMonitor monitor)
 	{
-		if (isFreeLayoutEngine())
+		if (InnerLayoutEngine.GetLayoutEngine<FreeLayoutEngine>() is not null)
 		{
 			foreach (IWindowState windowState in InnerLayoutEngine.DoLayout(rectangle, monitor))
 			{

--- a/src/Whim.Gaps/Whim.Gaps.csproj
+++ b/src/Whim.Gaps/Whim.Gaps.csproj
@@ -26,5 +26,6 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Whim\Whim.csproj" />
+    <ProjectReference Include="..\Whim.FloatingLayout\Whim.FloatingLayout.csproj" />
   </ItemGroup>
 </Project>

--- a/src/Whim.LayoutPreview/LayoutPreviewPlugin.cs
+++ b/src/Whim.LayoutPreview/LayoutPreviewPlugin.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using System.Text.Json;
+using Whim.FloatingLayout;
 
 namespace Whim.LayoutPreview;
 
@@ -86,6 +87,12 @@ public class LayoutPreviewPlugin : IPlugin, IDisposable
 
 			DraggedWindow = e.Window;
 			ILayoutEngine layoutEngine = workspace.ActiveLayoutEngine.MoveWindowToPoint(e.Window, normalizedPoint);
+			if (layoutEngine.GetLayoutEngine<FreeLayoutEngine>() is not null)
+			{
+				// To be renamed when FreeLayoutEngine will be renamed
+				Logger.Debug("Skip LayoutPreview as LeafLayoutEngine is a FreeLayoutEngine");
+				return;
+			}
 
 			Rectangle<int> rect = new() { Height = monitor.WorkingArea.Height, Width = monitor.WorkingArea.Width };
 

--- a/src/Whim.LayoutPreview/Whim.LayoutPreview.csproj
+++ b/src/Whim.LayoutPreview/Whim.LayoutPreview.csproj
@@ -42,6 +42,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Whim\Whim.csproj" />
+    <ProjectReference Include="..\Whim.FloatingLayout\Whim.FloatingLayout.csproj" />
   </ItemGroup>
   <ItemGroup>
     <Page Update="LayoutPreviewWindowItem.xaml">

--- a/src/Whim.Tests/Layout/FreeLayoutEngineTests.cs
+++ b/src/Whim.Tests/Layout/FreeLayoutEngineTests.cs
@@ -1,0 +1,194 @@
+﻿using System.Linq;
+using AutoFixture;
+
+namespace Whim.Tests;
+
+public class FreeLayoutEngineCustomization : ICustomization
+{
+	public void Customize(IFixture fixture)
+	{
+		IContext context = fixture.Freeze<IContext>();
+		IMonitor monitor = fixture.Freeze<IMonitor>();
+
+		context.MonitorManager.GetMonitorAtPoint(Arg.Any<IRectangle<int>>()).Returns(monitor);
+		monitor.WorkingArea.Returns(new Rectangle<int>() { Width = 1000, Height = 1000 });
+		context
+			.NativeManager.DwmGetWindowRectangle(Arg.Any<HWND>())
+			.Returns(new Rectangle<int>() { Width = 100, Height = 100 });
+
+		fixture.Inject(context);
+		fixture.Inject(monitor);
+	}
+}
+
+public class FreeLayoutEngineTests
+{
+	private static readonly LayoutEngineIdentity identity = new();
+
+	[Theory, AutoSubstituteData]
+	public void Name(IContext context)
+	{
+		// Given
+		FreeLayoutEngine engine = new(context, identity);
+
+		// When
+		string name = engine.Name;
+
+		// Then
+		Assert.Equal("Free", name);
+	}
+
+	[Theory, AutoSubstituteData<FreeLayoutEngineCustomization>]
+	public void AddWindow(IContext context, IWindow window)
+	{
+		// Given
+		FreeLayoutEngine engine = new(context, identity);
+
+		// When
+		ILayoutEngine newLayoutEngine = engine.AddWindow(window);
+
+		// Then
+		Assert.NotSame(engine, newLayoutEngine);
+		Assert.Equal(1, newLayoutEngine.Count);
+	}
+
+	[Theory, AutoSubstituteData<FreeLayoutEngineCustomization>]
+	public void AddWindow_WindowAlreadyPresent(IWindow window)
+	{
+		// Given
+		ILayoutEngine engine = new ColumnLayoutEngine(identity).AddWindow(window);
+
+		// When
+		ILayoutEngine newLayoutEngine = engine.AddWindow(window);
+
+		// Then
+		Assert.Same(engine, newLayoutEngine);
+		Assert.Equal(1, newLayoutEngine.Count);
+	}
+
+	[Theory, AutoSubstituteData<FreeLayoutEngineCustomization>]
+	public void Remove(IWindow window)
+	{
+		// Given
+		ILayoutEngine engine = new ColumnLayoutEngine(identity).AddWindow(window);
+
+		// When
+		ILayoutEngine newLayoutEngine = engine.RemoveWindow(window);
+
+		// Then
+		Assert.NotSame(engine, newLayoutEngine);
+		Assert.Equal(0, newLayoutEngine.Count);
+	}
+
+	[Theory, AutoSubstituteData<FreeLayoutEngineCustomization>]
+	public void Remove_NoChanges(IWindow window)
+	{
+		// Given
+		ILayoutEngine engine = new ColumnLayoutEngine(identity).AddWindow(window);
+
+		// When
+		ILayoutEngine newLayoutEngine = engine.RemoveWindow(Substitute.For<IWindow>());
+
+		// Then
+		Assert.Same(engine, newLayoutEngine);
+		Assert.Equal(1, newLayoutEngine.Count);
+	}
+
+	[Theory, AutoSubstituteData<FreeLayoutEngineCustomization>]
+	public void Contains(IContext context, IWindow window)
+	{
+		// Given
+		ILayoutEngine engine = new FreeLayoutEngine(context, identity).AddWindow(window);
+
+		// When
+		bool contains = engine.ContainsWindow(window);
+
+		// Then
+		Assert.True(contains);
+	}
+
+	[Theory, AutoSubstituteData<FreeLayoutEngineCustomization>]
+	public void Contains_False(IContext context, IWindow window)
+	{
+		// Given
+		ILayoutEngine engine = new FreeLayoutEngine(context, identity).AddWindow(window);
+
+		// When
+		bool contains = engine.ContainsWindow(Substitute.For<IWindow>());
+
+		// Then
+		Assert.False(contains);
+	}
+
+	#region DoLayout
+	[Fact]
+	public void DoLayout_Empty()
+	{
+		// Given
+		ILayoutEngine engine = new ColumnLayoutEngine(identity);
+
+		// When
+		IWindowState[] windowStates = engine
+			.DoLayout(new Rectangle<int>() { Width = 1920, Height = 1080 }, Substitute.For<IMonitor>())
+			.ToArray();
+
+		// Then
+		Assert.Empty(windowStates);
+	}
+
+	[Theory, AutoSubstituteData<FreeLayoutEngineCustomization>]
+	public void DoLayout_KeepWindowSize(
+		IContext context,
+		IWindow windowNormal,
+		IWindow windowMinimized,
+		IWindow windowMaximized
+	)
+	{
+		// Given
+		windowMinimized.IsMinimized.Returns(true);
+		windowMaximized.IsMaximized.Returns(true);
+		ILayoutEngine engine = new FreeLayoutEngine(context, identity)
+			.AddWindow(windowNormal)
+			.AddWindow(windowMinimized)
+			.AddWindow(windowMaximized);
+
+		// When
+		WindowSize[] windowSizes = engine
+			.DoLayout(new Rectangle<int>() { Width = 1920, Height = 1080 }, Substitute.For<IMonitor>())
+			.Select(window => window.WindowSize)
+			.ToArray();
+
+		// Then
+		Assert.Equal(3, windowSizes.Length);
+		Assert.Contains(WindowSize.Normal, windowSizes);
+		Assert.Contains(WindowSize.Minimized, windowSizes);
+		Assert.Contains(WindowSize.Maximized, windowSizes);
+	}
+	#endregion
+
+	[Theory, AutoSubstituteData]
+	public void GetFirstWindow_Null(IContext context)
+	{
+		// Given
+		ILayoutEngine engine = new FreeLayoutEngine(context, identity);
+
+		// When
+		IWindow? result = engine.GetFirstWindow();
+
+		// Then
+		Assert.Null(result);
+	}
+
+	[Theory, AutoSubstituteData<FreeLayoutEngineCustomization>]
+	public void GetFirstWindow_SingleWindow(IContext context, IWindow window)
+	{
+		// Given
+		ILayoutEngine engine = new FreeLayoutEngine(context, identity).AddWindow(window);
+
+		// When
+		IWindow? result = engine.GetFirstWindow();
+
+		// Then
+		Assert.Same(window, result);
+	}
+}

--- a/src/Whim/Layout/FreeLayoutEngine.cs
+++ b/src/Whim/Layout/FreeLayoutEngine.cs
@@ -1,6 +1,5 @@
 ﻿using System.Linq;
-using DotNext.Collections.Generic;
-
+	
 namespace Whim;
 
 /// <summary>
@@ -17,6 +16,7 @@ public class FreeLayoutEngine : ILayoutEngine
 	/// <inheritdoc/>
 	public int Count => _dict.Count;
 
+	/// <inheritdoc/>
 	public LayoutEngineIdentity Identity { get; }
 
 	/// <summary>

--- a/src/Whim/Layout/FreeLayoutEngine.cs
+++ b/src/Whim/Layout/FreeLayoutEngine.cs
@@ -1,0 +1,145 @@
+﻿using System.Linq;
+using DotNext.Collections.Generic;
+
+namespace Whim;
+
+/// <summary>
+/// Layout engine that lays out all windows as free-floating.
+/// </summary>
+public class FreeLayoutEngine : ILayoutEngine
+{
+	private readonly IContext _context;
+	private readonly ImmutableDictionary<IWindow, IRectangle<double>> _dict;
+
+	/// <inheritdoc/>
+	public string Name { get; init; } = "Free";
+
+	/// <inheritdoc/>
+	public int Count => _dict.Count;
+
+	public LayoutEngineIdentity Identity { get; }
+
+	/// <summary>
+	/// Creates a new instance of the <see cref="FreeLayoutEngine"/> class.
+	/// </summary>
+	/// <param name="context">The identity of the layout engine.</param>
+	/// <param name="identity">The context of the layout engine.</param>
+	public FreeLayoutEngine(IContext context, LayoutEngineIdentity identity)
+	{
+		Identity = identity;
+		_context = context;
+		_dict = ImmutableDictionary<IWindow, IRectangle<double>>.Empty;
+	}
+
+	private FreeLayoutEngine(FreeLayoutEngine layoutEngine, ImmutableDictionary<IWindow, IRectangle<double>> dict)
+	{
+		Name = layoutEngine.Name;
+		Identity = layoutEngine.Identity;
+		_context = layoutEngine._context;
+		_dict = dict;
+	}
+
+	/// <inheritdoc/>
+	public ILayoutEngine AddWindow(IWindow window)
+	{
+		Logger.Debug($"Adding window {window} to layout engine {Name}");
+
+		if (_dict.ContainsKey(window))
+		{
+			Logger.Debug($"Window {window} already exists in layout engine {Name}");
+			return this;
+		}
+
+		return UpdateWindowRectangle(window);
+	}
+
+	/// <inheritdoc/>
+	public ILayoutEngine RemoveWindow(IWindow window)
+	{
+		Logger.Debug($"Removing window {window} from layout engine {Name}");
+
+		ImmutableDictionary<IWindow, IRectangle<double>> newDict = _dict.Remove(window);
+
+		return new FreeLayoutEngine(this, newDict);
+	}
+
+	/// <inheritdoc/>
+	public bool ContainsWindow(IWindow window)
+	{
+		Logger.Debug($"Checking if layout engine {Name} contains window {window}");
+		return _dict.ContainsKey(window);
+	}
+
+	/// <inheritdoc/>
+	public IWindow? GetFirstWindow() => _dict.Keys.FirstOrDefault();
+
+	/// <inheritdoc/>
+	public IEnumerable<IWindowState> DoLayout(IRectangle<int> rectangle, IMonitor monitor)
+	{
+		Logger.Debug($"Doing layout for engine {Name}");
+
+		foreach ((IWindow window, IRectangle<double> loc) in _dict)
+		{
+			yield return new WindowState()
+			{
+				Window = window,
+				Rectangle = monitor.WorkingArea.ToMonitor(loc),
+				WindowSize = window.IsMaximized
+					? WindowSize.Maximized
+					: window.IsMinimized
+						? WindowSize.Minimized
+						: WindowSize.Normal
+			};
+		}
+	}
+
+	/// <inheritdoc/>
+	public ILayoutEngine PerformCustomAction<T>(LayoutEngineCustomAction<T> action) => this;
+
+	/// <inheritdoc/>
+	public ILayoutEngine MoveWindowToPoint(IWindow window, IPoint<double> point) => UpdateWindowRectangle(window);
+
+	/// <inheritdoc/>
+	public ILayoutEngine MoveWindowEdgesInDirection(Direction edges, IPoint<double> deltas, IWindow window) =>
+		UpdateWindowRectangle(window);
+
+	/// <inheritdoc/>
+	public ILayoutEngine MinimizeWindowStart(IWindow window) => this;
+
+	/// <inheritdoc/>
+	public ILayoutEngine MinimizeWindowEnd(IWindow window) => this;
+
+	/// <inheritdoc/>
+	public ILayoutEngine FocusWindowInDirection(Direction direction, IWindow window) => this;
+
+	/// <inheritdoc/>
+	public ILayoutEngine SwapWindowInDirection(Direction direction, IWindow window) => this;
+
+	private FreeLayoutEngine UpdateWindowRectangle(IWindow window)
+	{
+		// Try get the old rectangle.
+		IRectangle<double>? oldRectangle = _dict.TryGetValue(window, out IRectangle<double>? rectangle)
+			? rectangle
+			: null;
+
+		// Since the window is floating, we update the rectangle, and return.
+		IRectangle<int>? newActualRectangle = _context.NativeManager.DwmGetWindowRectangle(window.Handle);
+		if (newActualRectangle == null)
+		{
+			Logger.Error($"Could not obtain rectangle for floating window {window}");
+			return this;
+		}
+
+		IMonitor newMonitor = _context.MonitorManager.GetMonitorAtPoint(newActualRectangle);
+		IRectangle<double> newUnitSquareRectangle = newMonitor.WorkingArea.NormalizeRectangle(newActualRectangle);
+		if (newUnitSquareRectangle.Equals(oldRectangle))
+		{
+			Logger.Debug($"Rectangle for window {window} has not changed");
+			return this;
+		}
+
+		ImmutableDictionary<IWindow, IRectangle<double>> newDict = _dict.SetItem(window, newUnitSquareRectangle);
+
+		return new FreeLayoutEngine(this, newDict);
+	}
+}

--- a/src/Whim/Layout/FreeLayoutEngine.cs
+++ b/src/Whim/Layout/FreeLayoutEngine.cs
@@ -1,5 +1,5 @@
 ﻿using System.Linq;
-	
+
 namespace Whim;
 
 /// <summary>

--- a/src/Whim/Template/whim.config.csx
+++ b/src/Whim/Template/whim.config.csx
@@ -113,7 +113,8 @@ void DoConfig(IContext context)
 			(id) => SliceLayouts.CreatePrimaryStackLayout(context, sliceLayoutPlugin, id),
 			(id) => SliceLayouts.CreateSecondaryPrimaryLayout(context, sliceLayoutPlugin, id),
 			(id) => new FocusLayoutEngine(id),
-			(id) => new TreeLayoutEngine(context, treeLayoutPlugin, id)
+			(id) => new TreeLayoutEngine(context, treeLayoutPlugin, id),
+			(id) => new FreeLayoutEngine(context, id)
 		};
 }
 


### PR DESCRIPTION
Adds a free-floating layout engine, similar to Windows.
Concretely, all windows are floating.

There is not correspond feature request yet to be associated with.

I tried to add tests, but I am not sure there are enough.
If you want some more, let me know, and I will try to add them.

I have some questions and comments, I will write them directly in the pull request.

- [x] This code is up-to-date with the `main` branch.
- [x] I have updated relevant (if any) areas in the docs.
- [x] Add the gif for the FreeLayoutEngine's documentation



