### PR TITLE
Add window garbage collection back in

### DIFF
--- a/src/Whim.TestUtils/StoreCustomization.cs
+++ b/src/Whim.TestUtils/StoreCustomization.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using AutoFixture;
 using DotNext;
 using NSubstitute;
+using Windows.Win32.Foundation;
 
 namespace Whim.TestUtils;
 
@@ -43,6 +44,9 @@ public class StoreCustomization : ICustomization
 		// All further calls will run in the same thread.
 		internalCtx.CoreNativeManager.IsStaThread().Returns(_ => true, _ => false);
 		DeferWindowPosHandle.ParallelOptions = new() { MaxDegreeOfParallelism = 1 };
+
+		// Assume that all windows are windows.
+		internalCtx.CoreNativeManager.IsWindow(Arg.Any<HWND>()).Returns(true);
 
 		NativeManagerUtils.SetupTryEnqueue(ctx);
 	}

--- a/src/Whim.Tests/Store/WorkspaceSector/WorkspaceSectorTests.cs
+++ b/src/Whim.Tests/Store/WorkspaceSector/WorkspaceSectorTests.cs
@@ -6,6 +6,9 @@ namespace Whim.Tests;
 [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope")]
 public class WorkspaceSectorTests
 {
+	// TODO: DispatchEvents
+	// TODO: GarbageCollect
+
 	[Theory, AutoSubstituteData<StoreCustomization>]
 	internal void DoLayout_NoMonitorFoundForWorkspace(IContext ctx, MutableRootSector root)
 	{
@@ -14,7 +17,7 @@ public class WorkspaceSectorTests
 
 		// When
 		root.WorkspaceSector.WorkspacesToLayout = root.WorkspaceSector.WorkspacesToLayout.Add(workspace.Id);
-		root.WorkspaceSector.DispatchEvents();
+		root.WorkspaceSector.DoLayout();
 
 		// Then
 		ctx.NativeManager.DidNotReceive().TryEnqueue(Arg.Any<DispatcherQueueHandler>());
@@ -57,7 +60,7 @@ public class WorkspaceSectorTests
 
 		// When
 		root.WorkspaceSector.WorkspacesToLayout = root.WorkspaceSector.WorkspacesToLayout.Add(workspace.Id);
-		CustomAssert.Layout(root, root.WorkspaceSector.DispatchEvents, new[] { workspace.Id });
+		CustomAssert.Layout(root, root.WorkspaceSector.DoLayout, new[] { workspace.Id });
 
 		// Then
 		ctx.NativeManager.Received(2).TryEnqueue(Arg.Any<DispatcherQueueHandler>());

--- a/src/Whim/Store/RootSector/MutableRootSector.cs
+++ b/src/Whim/Store/RootSector/MutableRootSector.cs
@@ -34,6 +34,8 @@ internal class MutableRootSector : SectorBase, IDisposable
 		MapSector.DispatchEvents();
 	}
 
+	public void DoLayout() => WorkspaceSector.DoLayout();
+
 	protected virtual void Dispose(bool disposing)
 	{
 		if (!_disposedValue)

--- a/src/Whim/Store/RootSector/RootSector.cs
+++ b/src/Whim/Store/RootSector/RootSector.cs
@@ -34,6 +34,8 @@ public class RootSector : IRootSector, IDisposable
 
 	internal void DispatchEvents() => MutableRootSector.DispatchEvents();
 
+	internal void DoLayout() => MutableRootSector.DoLayout();
+
 	/// <inheritdoc/>
 	protected virtual void Dispose(bool disposing)
 	{

--- a/src/Whim/Store/Store.cs
+++ b/src/Whim/Store/Store.cs
@@ -77,6 +77,7 @@ public class Store : IStore
 				finally
 				{
 					_lock.ExitWriteLock();
+					_root.DoLayout();
 					_ctx.NativeManager.TryEnqueue(_root.DispatchEvents);
 				}
 			}).Result;


### PR DESCRIPTION
Whim can sometimes miss windows being closed (often due to waking from sleep). 

This PR removes invalid windows during each layout batch call.