### PR TITLE
Reduce calls to the main thread

### DIFF
--- a/src/Whim.Tests/Store/Root/MutableSectorTests.cs
+++ b/src/Whim.Tests/Store/Root/MutableSectorTests.cs
@@ -26,4 +26,68 @@ public class MutableRootSectorTests
 		Assert.Single(rootSector.WorkspaceSector.Workspaces);
 		Assert.Single(rootSector.WorkspaceSector.WorkspaceOrder);
 	}
+
+	[Theory, AutoSubstituteData<StoreCustomization>]
+	internal void HasQueuedEvents_False(MutableRootSector rootSector)
+	{
+		// Given no queued events
+
+		// When we check if there are queued events
+		bool result = rootSector.HasQueuedEvents;
+
+		// Then we get false
+		Assert.False(result);
+	}
+
+	[Theory, AutoSubstituteData<StoreCustomization>]
+	internal void HasQueuedEvents_MonitorSector(MutableRootSector rootSector)
+	{
+		// Given queued events in the monitor sector
+		rootSector.MonitorSector.QueueEvent(new EventArgs());
+
+		// When we check if there are queued events
+		bool result = rootSector.HasQueuedEvents;
+
+		// Then we get true
+		Assert.True(result);
+	}
+
+	[Theory, AutoSubstituteData<StoreCustomization>]
+	internal void HasQueuedEvents_WindowSector(MutableRootSector rootSector)
+	{
+		// Given queued events in the window sector
+		rootSector.WindowSector.QueueEvent(new EventArgs());
+
+		// When we check if there are queued events
+		bool result = rootSector.HasQueuedEvents;
+
+		// Then we get true
+		Assert.True(result);
+	}
+
+	[Theory, AutoSubstituteData<StoreCustomization>]
+	internal void HasQueuedEvents_WorkspaceSector(MutableRootSector rootSector)
+	{
+		// Given queued events in the workspace sector
+		rootSector.WorkspaceSector.QueueEvent(new EventArgs());
+
+		// When we check if there are queued events
+		bool result = rootSector.HasQueuedEvents;
+
+		// Then we get true
+		Assert.True(result);
+	}
+
+	[Theory, AutoSubstituteData<StoreCustomization>]
+	internal void HasQueuedEvents_MapSector(MutableRootSector rootSector)
+	{
+		// Given queued events in the map sector
+		rootSector.MapSector.QueueEvent(new EventArgs());
+
+		// When we check if there are queued events
+		bool result = rootSector.HasQueuedEvents;
+
+		// Then we get true
+		Assert.True(result);
+	}
 }

--- a/src/Whim.Tests/Store/Root/StoreTests.cs
+++ b/src/Whim.Tests/Store/Root/StoreTests.cs
@@ -1,0 +1,85 @@
+namespace Whim.Tests;
+
+public class StoreTests
+{
+	private record EmptyTransform : Transform
+	{
+		internal override Result<Unit> Execute(
+			IContext ctx,
+			IInternalContext internalCtx,
+			MutableRootSector rootSector
+		) => Unit.Result;
+	}
+
+	private record PopulatedTransform : Transform
+	{
+		internal override Result<Unit> Execute(IContext ctx, IInternalContext internalCtx, MutableRootSector rootSector)
+		{
+			rootSector.WorkspaceSector.QueueEvent(
+				new WorkspaceAddedEventArgs() { Workspace = Substitute.For<IWorkspace>() }
+			);
+			return Unit.Result;
+		}
+	}
+
+	// TODO: Add tests for Pure pickers
+
+	// TODO: Add tests for pickers
+
+	[Theory, AutoSubstituteData<StoreCustomization>]
+	internal void Dispatch_IsStaThread_NoQueuedEvents(IContext ctx)
+	{
+		// Given no queued events
+
+		// When we dispatch
+		// Then no events are raised
+		CustomAssert.DoesNotRaise<WorkspaceAddedEventArgs>(
+			h => ctx.Store.WorkspaceEvents.WorkspaceAdded += h,
+			h => ctx.Store.WorkspaceEvents.WorkspaceAdded -= h,
+			() => ctx.Store.Dispatch(new EmptyTransform())
+		);
+	}
+
+	[Theory, AutoSubstituteData<StoreCustomization>]
+	internal void Dispatch_IsStaThread_QueuedEvents(IContext ctx)
+	{
+		// Given the transform queues an event
+		// When we dispatch
+		// Then the event is raised
+		Assert.Raises<WorkspaceAddedEventArgs>(
+			h => ctx.Store.WorkspaceEvents.WorkspaceAdded += h,
+			h => ctx.Store.WorkspaceEvents.WorkspaceAdded -= h,
+			() => ctx.Store.Dispatch(new PopulatedTransform())
+		);
+	}
+
+	[Theory, AutoSubstituteData<StoreCustomization>]
+	internal void Dispatch_IsNotStaThread_NoQueuedEvents(IContext ctx, IInternalContext internalCtx)
+	{
+		// Given no queued events
+		internalCtx.CoreNativeManager.IsStaThread().Returns(false);
+
+		// When we dispatch
+		// Then no events are raised
+		CustomAssert.DoesNotRaise<WorkspaceAddedEventArgs>(
+			h => ctx.Store.WorkspaceEvents.WorkspaceAdded += h,
+			h => ctx.Store.WorkspaceEvents.WorkspaceAdded -= h,
+			() => ctx.Store.Dispatch(new EmptyTransform())
+		);
+	}
+
+	[Theory, AutoSubstituteData<StoreCustomization>]
+	internal void Dispatch_IsNotStaThread_QueuedEvents(IContext ctx, IInternalContext internalCtx)
+	{
+		// Given the transform queues an event
+		internalCtx.CoreNativeManager.IsStaThread().Returns(false);
+
+		// When we dispatch
+		// Then the event is raised
+		CustomAssert.DoesNotRaise<WorkspaceAddedEventArgs>(
+			h => ctx.Store.WorkspaceEvents.WorkspaceAdded += h,
+			h => ctx.Store.WorkspaceEvents.WorkspaceAdded -= h,
+			() => ctx.Store.Dispatch(new PopulatedTransform())
+		);
+	}
+}

--- a/src/Whim.Tests/Store/WindowSector/Transforms/WindowMovedTransformTests.cs
+++ b/src/Whim.Tests/Store/WindowSector/Transforms/WindowMovedTransformTests.cs
@@ -65,7 +65,7 @@ public class WindowMovedTransformTests
 
 		// Then we get an empty result
 		Assert.True(result.IsSuccessful);
-		ctx.NativeManager.Received(1).TryEnqueue(Arg.Any<DispatcherQueueHandler>());
+		ctx.NativeManager.DidNotReceive().TryEnqueue(Arg.Any<DispatcherQueueHandler>());
 	}
 
 	[Theory, AutoSubstituteData<StoreCustomization>]
@@ -83,7 +83,7 @@ public class WindowMovedTransformTests
 
 		// Then we get an empty result
 		Assert.True(result.IsSuccessful);
-		ctx.NativeManager.Received(1).TryEnqueue(Arg.Any<DispatcherQueueHandler>());
+		ctx.NativeManager.DidNotReceive().TryEnqueue(Arg.Any<DispatcherQueueHandler>());
 	}
 
 	[Theory, AutoSubstituteData<StoreCustomization>]
@@ -104,7 +104,7 @@ public class WindowMovedTransformTests
 
 		// Then we get an empty result
 		Assert.True(result.IsSuccessful);
-		ctx.NativeManager.Received(1).TryEnqueue(Arg.Any<DispatcherQueueHandler>());
+		ctx.NativeManager.DidNotReceive().TryEnqueue(Arg.Any<DispatcherQueueHandler>());
 	}
 
 	[Theory, AutoSubstituteData<StoreCustomization>]

--- a/src/Whim/Store/RootSector/MutableRootSector.cs
+++ b/src/Whim/Store/RootSector/MutableRootSector.cs
@@ -9,6 +9,13 @@ internal class MutableRootSector : SectorBase, IDisposable
 	public WorkspaceSector WorkspaceSector { get; }
 	public MapSector MapSector { get; }
 
+	/// <inheritdoc/>
+	public override bool HasQueuedEvents =>
+		MonitorSector.HasQueuedEvents
+		|| WindowSector.HasQueuedEvents
+		|| WorkspaceSector.HasQueuedEvents
+		|| MapSector.HasQueuedEvents;
+
 	public MutableRootSector(IContext ctx, IInternalContext internalCtx)
 	{
 		MonitorSector = new MonitorSector(ctx, internalCtx);

--- a/src/Whim/Store/SectorBase.cs
+++ b/src/Whim/Store/SectorBase.cs
@@ -8,7 +8,7 @@ internal abstract class SectorBase
 	/// <summary>
 	/// Queue of events to dispatch.
 	/// </summary>
-	protected readonly List<EventArgs> _events = [];
+	protected readonly List<EventArgs> _events = new();
 
 	/// <summary>
 	/// Whether there are events queued.

--- a/src/Whim/Store/SectorBase.cs
+++ b/src/Whim/Store/SectorBase.cs
@@ -8,7 +8,12 @@ internal abstract class SectorBase
 	/// <summary>
 	/// Queue of events to dispatch.
 	/// </summary>
-	protected readonly List<EventArgs> _events = new();
+	protected readonly List<EventArgs> _events = [];
+
+	/// <summary>
+	/// Whether there are events queued.
+	/// </summary>
+	public virtual bool HasQueuedEvents => _events.Count > 0;
 
 	/// <summary>
 	/// Initialize the event listeners.

--- a/src/Whim/Store/Store.cs
+++ b/src/Whim/Store/Store.cs
@@ -76,9 +76,15 @@ public class Store : IStore
 				}
 				finally
 				{
+					bool hasQueuedEvents = _root.MutableRootSector.HasQueuedEvents;
+
 					_lock.ExitWriteLock();
 					_root.DoLayout();
-					_ctx.NativeManager.TryEnqueue(_root.DispatchEvents);
+
+					if (hasQueuedEvents)
+					{
+						_ctx.NativeManager.TryEnqueue(_root.DispatchEvents);
+					}
 				}
 			}).Result;
 		}


### PR DESCRIPTION
Whim would previously enqueue at the end of every transform, even if there weren't any queued events. I suspect that this may be the case of #941 (without any evidence at this stage). Regardless of whether it is, I think it's a worthy check to put in place.
