### PR TITLE
Reduce logging noise

### DIFF
--- a/src/Whim/Store/MonitorSector/MonitorEventListener.cs
+++ b/src/Whim/Store/MonitorSector/MonitorEventListener.cs
@@ -16,6 +16,7 @@ internal class MonitorEventListener : IDisposable
 
 	public void Initialize()
 	{
+		Logger.Information("Initializing MonitorEventListener");
 		_internalCtx.WindowMessageMonitor.DisplayChanged += WindowMessageMonitor_MonitorsChanged;
 		_internalCtx.WindowMessageMonitor.WorkAreaChanged += WindowMessageMonitor_MonitorsChanged;
 		_internalCtx.WindowMessageMonitor.DpiChanged += WindowMessageMonitor_MonitorsChanged;

--- a/src/Whim/Store/MonitorSector/MonitorSector.cs
+++ b/src/Whim/Store/MonitorSector/MonitorSector.cs
@@ -23,6 +23,7 @@ internal class MonitorSector : SectorBase, IDisposable, IMonitorSector, IMonitor
 
 	public override void Initialize()
 	{
+		Logger.Information("Initializing MonitorSector");
 		_ctx.Store.Dispatch(new MonitorsChangedTransform());
 		_listener.Initialize();
 	}

--- a/src/Whim/Store/RootSector/MutableRootSector.cs
+++ b/src/Whim/Store/RootSector/MutableRootSector.cs
@@ -26,6 +26,7 @@ internal class MutableRootSector : SectorBase, IDisposable
 
 	public override void Initialize()
 	{
+		Logger.Information("Initializing MutableRootSector");
 		MonitorSector.Initialize();
 		WindowSector.Initialize();
 		WorkspaceSector.Initialize();

--- a/src/Whim/Store/Store.cs
+++ b/src/Whim/Store/Store.cs
@@ -67,7 +67,16 @@ public class Store : IStore
 		{
 			return Task.Run(() =>
 			{
-				Logger.Debug($"Entering task, executing transform {transform}");
+				// A very ugly way of minimizing the noise from getting notified of the many window added events.
+				switch (transform)
+				{
+					case WindowAddedTransform:
+						Logger.Verbose($"Entering task, executing transform {transform}");
+						break;
+					default:
+						Logger.Debug($"Entering task, executing transform {transform}");
+						break;
+				}
 
 				try
 				{
@@ -83,6 +92,7 @@ public class Store : IStore
 
 					if (hasQueuedEvents)
 					{
+						Logger.Debug("Enqueuing dispatch events");
 						_ctx.NativeManager.TryEnqueue(_root.DispatchEvents);
 					}
 				}

--- a/src/Whim/Store/WindowSector/Transforms/WindowAddedTransform.cs
+++ b/src/Whim/Store/WindowSector/Transforms/WindowAddedTransform.cs
@@ -14,6 +14,7 @@ internal record WindowAddedTransform(HWND Handle, RouterOptions? CustomRouterOpt
 			return windowResult;
 		}
 
+		Logger.Debug($"Adding window {window}");
 		UpdateWindowSector(mutableRootSector, window);
 		UpdateMapSector(ctx, internalCtx, mutableRootSector, window);
 
@@ -25,24 +26,30 @@ internal record WindowAddedTransform(HWND Handle, RouterOptions? CustomRouterOpt
 		// Filter the handle.
 		if (internalCtx.CoreNativeManager.IsSplashScreen(Handle))
 		{
-			return Result.FromException<IWindow>(new WhimException($"Window {Handle} is a splash screen, ignoring"));
+			return Result.FromException<IWindow>(
+				new WhimException($"Window {Handle} is a splash screen, ignoring", LogLevel.Verbose)
+			);
 		}
 
 		if (internalCtx.CoreNativeManager.IsCloakedWindow(Handle))
 		{
-			return Result.FromException<IWindow>(new WhimException($"Window {Handle} is cloaked, ignoring"));
+			return Result.FromException<IWindow>(
+				new WhimException($"Window {Handle} is cloaked, ignoring", LogLevel.Verbose)
+			);
 		}
 
 		if (!internalCtx.CoreNativeManager.IsStandardWindow(Handle))
 		{
 			return Result.FromException<IWindow>(
-				new WhimException($"Window {Handle} is not a standard window, ignoring")
+				new WhimException($"Window {Handle} is not a standard window, ignoring", LogLevel.Verbose)
 			);
 		}
 
 		if (!internalCtx.CoreNativeManager.HasNoVisibleOwner(Handle))
 		{
-			return Result.FromException<IWindow>(new WhimException($"Window {Handle} has a visible owner, ignoring"));
+			return Result.FromException<IWindow>(
+				new WhimException($"Window {Handle} has a visible owner, ignoring", LogLevel.Verbose)
+			);
 		}
 
 		Result<IWindow> windowResult = Window.CreateWindow(ctx, internalCtx, Handle);

--- a/src/Whim/Store/WindowSector/WindowEventListener.cs
+++ b/src/Whim/Store/WindowSector/WindowEventListener.cs
@@ -29,7 +29,7 @@ internal class WindowEventListener : IDisposable
 
 	public void Initialize()
 	{
-		Logger.Debug("Initializing window manager...");
+		Logger.Information("Initializing WindowEventListener");
 
 		// Each of the following hooks add just one or two event constants from https://docs.microsoft.com/en-us/windows/win32/winauto/event-constants
 		_addedHooks[0] = _internalCtx.CoreNativeManager.SetWinEventHook(

--- a/src/Whim/Store/WindowSector/WindowSector.cs
+++ b/src/Whim/Store/WindowSector/WindowSector.cs
@@ -34,6 +34,7 @@ internal class WindowSector : SectorBase, IWindowSector, IDisposable, IWindowSec
 
 	public override void Initialize()
 	{
+		Logger.Information("Initializing WindowSector");
 		_listener.Initialize();
 	}
 

--- a/src/Whim/Store/WorkspaceSector/Transforms/InitializeWorkspacesTransform.cs
+++ b/src/Whim/Store/WorkspaceSector/Transforms/InitializeWorkspacesTransform.cs
@@ -62,7 +62,7 @@ internal record InitializeWorkspacesTransform : Transform
 
 			if (workspace == null)
 			{
-				Logger.Debug($"Could not find workspace {savedWorkspace.Name}");
+				Logger.Information($"Could not find workspace {savedWorkspace.Name}");
 				continue;
 			}
 
@@ -72,7 +72,7 @@ internal record InitializeWorkspacesTransform : Transform
 				processedWindows.Add(hwnd);
 				if (!ctx.WindowManager.CreateWindow(hwnd).TryGet(out IWindow window))
 				{
-					Logger.Debug($"Could not find window with handle {savedWindow.Handle}");
+					Logger.Information($"Could not find window with handle {savedWindow.Handle}");
 					continue;
 				}
 

--- a/src/Whim/Store/WorkspaceSector/WorkspaceSector.cs
+++ b/src/Whim/Store/WorkspaceSector/WorkspaceSector.cs
@@ -51,6 +51,7 @@ internal class WorkspaceSector : SectorBase, IWorkspaceSector, IWorkspaceSectorE
 
 	public override void Initialize()
 	{
+		Logger.Information("Initializing WorkspaceSector");
 		_ctx.Store.Dispatch(new InitializeWorkspacesTransform());
 	}
 

--- a/src/Whim/Utils/WhimException.cs
+++ b/src/Whim/Utils/WhimException.cs
@@ -12,13 +12,48 @@ public class WhimException : Exception
 	public WhimException(string message)
 		: base(message)
 	{
-		Logger.Error(message);
+		Logger.Debug(message);
 	}
 
 	/// <inheritdoc/>
 	public WhimException(string message, Exception innerException)
 		: base(message, innerException)
 	{
-		Logger.Error(message);
+		Logger.Debug(message);
+	}
+
+	/// <summary>
+	/// Log the given <paramref name="message"/> with the given <paramref name="logLevel"/>.
+	/// </summary>
+	/// <param name="message">
+	/// The message to log.
+	/// </param>
+	/// <param name="logLevel">
+	/// The log level to log the message at.
+	/// </param>
+	public WhimException(string message, LogLevel logLevel)
+	{
+		switch (logLevel)
+		{
+			case LogLevel.Verbose:
+				Logger.Verbose(message);
+				break;
+			case LogLevel.Debug:
+				Logger.Debug(message);
+				break;
+			case LogLevel.Information:
+				Logger.Information(message);
+				break;
+			case LogLevel.Warning:
+				Logger.Warning(message);
+				break;
+			case LogLevel.Error:
+			default:
+				Logger.Error(message);
+				break;
+			case LogLevel.Fatal:
+				Logger.Fatal(message);
+				break;
+		}
 	}
 }


### PR DESCRIPTION
- Changed `WhimException` to log `Debug` by default.
- Changed the logging of `WindowAddedTransform` to `Verbose`.
- Added some logging for `Initialize`, set to `Information`.

The muting of `WindowAddedTransform` and the configurable logging level for `WhimException` were achieved in ugly ways. In #673, these should be improved.
