### PR TITLE
Optimize event dispatching

### DIFF
--- a/src/Whim/Store/Store.cs
+++ b/src/Whim/Store/Store.cs
@@ -85,16 +85,9 @@ public class Store : IStore
 				}
 				finally
 				{
-					bool hasQueuedEvents = _root.MutableRootSector.HasQueuedEvents;
-
-					_lock.ExitWriteLock();
 					_root.DoLayout();
-
-					if (hasQueuedEvents)
-					{
-						Logger.Debug("Enqueuing dispatch events");
-						_ctx.NativeManager.TryEnqueue(_root.DispatchEvents);
-					}
+					_root.DispatchEvents();
+					_lock.ExitWriteLock();
 				}
 			}).Result;
 		}


### PR DESCRIPTION
This PR reduces the amount of event dispatches being enqueued onto the STA thread. Previously, it was possible to have the STA thread execute >80 callbacks queued and for them all to execute within 300ms.

This is related to #941.

