### PR TITLE
Update komorebi application rules license

### DIFF
--- a/THIRD-PARTY-NOTICES.TXT
+++ b/THIRD-PARTY-NOTICES.TXT
@@ -1105,7 +1105,7 @@ https://github.com/LGUG2Z/komorebi-application-specific-configuration/
 
 MIT License
 
-Copyright (c) 2023 Jade Iqbal
+Copyright (c) 2024 Jade Iqbal
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/app_rules/generate_app_rules.py
+++ b/app_rules/generate_app_rules.py
@@ -16,7 +16,7 @@ HEADER = """\
  *
  * MIT License
  *
- * Copyright (c) 2021 Jade Iqbal
+ * Copyright (c) 2024 Jade Iqbal
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
- [x] This code is up-to-date with the `main` branch.
- [x] I have updated relevant (if any) areas in the docs.

A tiny update to `THIRD-PARTY-NOTICES`, reflecting the newly added [MIT license](https://github.com/LGUG2Z/komorebi-application-specific-configuration/blob/master/LICENSE) to the komorebi-application-specific-configuration collection.

In the past, we had included the license of the main komorebi repo instead (which used to be MIT as well). So this ends up just being a change in date.
