### PR TITLE
Fix Firefox handling with custom window event logic

### DIFF
--- a/docs/docs/getting-started/troubleshooting.md
+++ b/docs/docs/getting-started/troubleshooting.md
@@ -2,13 +2,9 @@
 
 ## Managing troublesome windows
 
-Some windows like to remember their size and position. This can be a problem for Whim, because it will try to manage the window's size and position, and the window will fight back.
+Some applications are difficult to manage. Whim will try to manage them as best as it can, but there are some limitations. For example, Firefox will try to remember its size and position, and will fight against Whim's attempts to manage it on first load.
 
-The <xref:Whim.IWindowManager> exposes an <xref:Whim.IFilterManager> called <xref:Whim.IWindowManager.LocationRestoringFilterManager>. `LocationRestoringFilterManager` listens to <xref:Whim.IWindowManager.WindowMoved> events for these windows and will force their parent <xref:Whim.IWorkspace> to do a layout two seconds after their first `WindowMoved` event, attempting to restore the window to its correct position.
-
-If this doesn't work, dragging a window's edge will force a layout, which should fix the window's position. This is an area which could use further improvement.
-
-Examples of troublesome windows include Firefox and JetBrains Gateway.
+To get around this, Whim has <xref:Whim.IWindowProcessor>s. These are used to tell Whim to ignore specific window messages (see [Event Constants](https://learn.microsoft.com/en-us/windows/win32/winauto/event-constants)). For example, the <xref:Whim.FirefoxWindowProcessor> ignores all events until the first [`EVENT_OBJECT_CLOAKED`](https://learn.microsoft.com/en-us/windows/win32/winauto/event-constants#:~:text=EVENT_OBJECT_CLOAKED) event is received.
 
 ## Window launch locations
 
@@ -18,7 +14,7 @@ To counteract this, the <xref:Whim.IRouterManager> has a <xref:Whim.IRouterManag
 
 ## Adding/removing monitors
 
-When adding and removing monitors, Windows will very helpfully move windows between monitors. However, this conflicts with Whim. To work around Windows' helpfulness, Whim (in the `WindowManager` and `ButlerEventHandlers` will) ignore [`WinEvents`](../architecture/events.md) for 3 seconds for tracked windows. After the 3 seconds have elapsed, Whim will layout all the active workspaces.
+When adding and removing monitors, Windows will very helpfully move windows between monitors. However, this conflicts with Whim. To work around Windows' helpfulness, Whim (in the `WindowManager` and `ButlerEventHandlers`) will ignore [`WinEvents`](../architecture/events.md) for 3 seconds for tracked windows. After the 3 seconds have elapsed, Whim will lay out all the active workspaces.
 
 ## Window overflows given area
 

--- a/docs/docs/plugins/focus-indicator.md
+++ b/docs/docs/plugins/focus-indicator.md
@@ -3,7 +3,7 @@
 The <xref:Whim.FocusIndicator.FocusIndicatorPlugin> adds a border around the current window which Whim has tracked as having focus. Various options can be configured using the <xref:Whim.FocusIndicator.FocusIndicatorConfig>.
 
 > [!WARNING]
-> The focus may remain on a window despite the focus shifting to an untracked window (e.g., the Start Menu). This depends on the config option <xref:Whim.IRouterManager.RouteToActiveWorkspace>.
+> The focus may remain on a window despite the focus shifting to an untracked window (e.g., the Start Menu). This depends on the config option <xref:Whim.IRouterManager.RouterOptions>.
 
 ![Focus indicator demo](../../images/focus-indicator-demo.gif)
 

--- a/docs/docs/toc.yml
+++ b/docs/docs/toc.yml
@@ -5,6 +5,7 @@ items:
   - href: getting-started/customize.md
   - href: getting-started/plugins.md
   - href: getting-started/inspiration.md
+  - href: getting-started/troubleshooting.md
 
   - name: Customize
   - href: customize/scripting.md

--- a/src/Whim.Tests/Store/WindowSector/Processors/FirefoxWindowProcessorTests.cs
+++ b/src/Whim.Tests/Store/WindowSector/Processors/FirefoxWindowProcessorTests.cs
@@ -4,8 +4,7 @@ namespace Whim.Tests;
 
 public class FirefoxWindowProcessorTests
 {
-	[Theory]
-	[AutoSubstituteData]
+	[Theory, AutoSubstituteData]
 	public void Create_Failure(IContext ctx, IWindow window)
 	{
 		// Given a window which is not a Firefox window
@@ -18,8 +17,7 @@ public class FirefoxWindowProcessorTests
 		Assert.Null(processor);
 	}
 
-	[Theory]
-	[AutoSubstituteData]
+	[Theory, AutoSubstituteData]
 	public void Create_Success(IContext ctx, IWindow window)
 	{
 		// Given a window which is a Firefox window
@@ -55,8 +53,7 @@ public class FirefoxWindowProcessorTests
 		Assert.Equal(WindowProcessorResult.Ignore, result);
 	}
 
-	[Theory]
-	[AutoSubstituteData]
+	[Theory, AutoSubstituteData]
 	public void ShouldBeIgnored_FirstCloaked(IContext ctx, IWindow window)
 	{
 		// Given the first `EVENT_OBJECT_CLOAKED` event
@@ -70,8 +67,7 @@ public class FirefoxWindowProcessorTests
 		Assert.Equal(WindowProcessorResult.Ignore, result);
 	}
 
-	[Theory]
-	[AutoSubstituteData]
+	[Theory, AutoSubstituteData]
 	public void ShouldNotBeIgnored_SecondCloaked(IContext ctx, IWindow window)
 	{
 		// Given the second `EVENT_OBJECT_CLOAKED` event
@@ -86,8 +82,7 @@ public class FirefoxWindowProcessorTests
 		Assert.Equal(WindowProcessorResult.Process, result);
 	}
 
-	[Theory]
-	[AutoSubstituteData]
+	[Theory, AutoSubstituteData]
 	public void ShouldBeRemoved(IContext ctx, IWindow window)
 	{
 		// Given an `EVENT_OBJECT_DESTROY` event
@@ -99,5 +94,19 @@ public class FirefoxWindowProcessorTests
 
 		// Then the processor should be removed
 		Assert.Equal(WindowProcessorResult.RemoveProcessor, result);
+	}
+
+	[Theory, AutoSubstituteData]
+	public void Window(IContext ctx, IWindow window)
+	{
+		// Given a window which is a Firefox window
+		window.ProcessFileName.Returns("firefox.exe");
+		IWindowProcessor processor = FirefoxWindowProcessor.Create(ctx, window)!;
+
+		// When `Window` is called
+		IWindow result = processor.Window;
+
+		// Then the result should be the window
+		Assert.Equal(window, result);
 	}
 }

--- a/src/Whim.Tests/Store/WindowSector/Processors/FirefoxWindowProcessorTests.cs
+++ b/src/Whim.Tests/Store/WindowSector/Processors/FirefoxWindowProcessorTests.cs
@@ -1,0 +1,103 @@
+using Windows.Win32;
+
+namespace Whim.Tests;
+
+public class FirefoxWindowProcessorTests
+{
+	[Theory]
+	[AutoSubstituteData]
+	public void Create_Failure(IContext ctx, IWindow window)
+	{
+		// Given a window which is not a Firefox window
+		window.ProcessFileName.Returns("chrome.exe");
+
+		// When `Create` is called
+		IWindowProcessor? processor = FirefoxWindowProcessor.Create(ctx, window);
+
+		// Then the processor should be null
+		Assert.Null(processor);
+	}
+
+	[Theory]
+	[AutoSubstituteData]
+	public void Create_Success(IContext ctx, IWindow window)
+	{
+		// Given a window which is a Firefox window
+		window.ProcessFileName.Returns("firefox.exe");
+
+		// When `Create` is called
+		IWindowProcessor? processor = FirefoxWindowProcessor.Create(ctx, window);
+
+		// Then the processor should not be null
+		Assert.NotNull(processor);
+	}
+
+	[Theory]
+	[InlineAutoSubstituteData(PInvoke.EVENT_OBJECT_SHOW)]
+	[InlineAutoSubstituteData(PInvoke.EVENT_SYSTEM_FOREGROUND)]
+	[InlineAutoSubstituteData(PInvoke.EVENT_OBJECT_UNCLOAKED)]
+	[InlineAutoSubstituteData(PInvoke.EVENT_OBJECT_HIDE)]
+	[InlineAutoSubstituteData(PInvoke.EVENT_SYSTEM_MOVESIZESTART)]
+	[InlineAutoSubstituteData(PInvoke.EVENT_SYSTEM_MOVESIZEEND)]
+	[InlineAutoSubstituteData(PInvoke.EVENT_OBJECT_LOCATIONCHANGE)]
+	[InlineAutoSubstituteData(PInvoke.EVENT_SYSTEM_MINIMIZESTART)]
+	[InlineAutoSubstituteData(PInvoke.EVENT_SYSTEM_MINIMIZEEND)]
+	public void ShouldBeIgnored_UntilCloaked(uint eventType, IContext ctx, IWindow window)
+	{
+		// Given an event which isn't `EVENT_OBJECT_CLOAKED` or `EVENT_OBJECT_DESTROY`
+		window.ProcessFileName.Returns("firefox.exe");
+		IWindowProcessor processor = FirefoxWindowProcessor.Create(ctx, window)!;
+
+		// When the event is passed to `ShouldBeIgnored`
+		WindowProcessorResult result = processor.ShouldBeIgnored(eventType, 0, 0, 0, 0);
+
+		// Then the event should be ignored
+		Assert.Equal(WindowProcessorResult.Ignore, result);
+	}
+
+	[Theory]
+	[AutoSubstituteData]
+	public void ShouldBeIgnored_FirstCloaked(IContext ctx, IWindow window)
+	{
+		// Given the first `EVENT_OBJECT_CLOAKED` event
+		window.ProcessFileName.Returns("firefox.exe");
+		IWindowProcessor processor = FirefoxWindowProcessor.Create(ctx, window)!;
+
+		// When the event is passed to `ShouldBeIgnored`
+		WindowProcessorResult result = processor.ShouldBeIgnored(PInvoke.EVENT_OBJECT_CLOAKED, 0, 0, 0, 0);
+
+		// Then the event should be ignored
+		Assert.Equal(WindowProcessorResult.Ignore, result);
+	}
+
+	[Theory]
+	[AutoSubstituteData]
+	public void ShouldNotBeIgnored_SecondCloaked(IContext ctx, IWindow window)
+	{
+		// Given the second `EVENT_OBJECT_CLOAKED` event
+		window.ProcessFileName.Returns("firefox.exe");
+		IWindowProcessor processor = FirefoxWindowProcessor.Create(ctx, window)!;
+		processor.ShouldBeIgnored(PInvoke.EVENT_OBJECT_CLOAKED, 0, 0, 0, 0);
+
+		// When the event is passed to `ShouldBeIgnored`
+		WindowProcessorResult result = processor.ShouldBeIgnored(PInvoke.EVENT_OBJECT_CLOAKED, 0, 0, 0, 0);
+
+		// Then the event should not be ignored
+		Assert.Equal(WindowProcessorResult.Process, result);
+	}
+
+	[Theory]
+	[AutoSubstituteData]
+	public void ShouldBeRemoved(IContext ctx, IWindow window)
+	{
+		// Given an `EVENT_OBJECT_DESTROY` event
+		window.ProcessFileName.Returns("firefox.exe");
+		IWindowProcessor processor = FirefoxWindowProcessor.Create(ctx, window)!;
+
+		// When the event is passed to `ShouldBeIgnored`
+		WindowProcessorResult result = processor.ShouldBeIgnored(PInvoke.EVENT_OBJECT_DESTROY, 0, 0, 0, 0);
+
+		// Then the processor should be removed
+		Assert.Equal(WindowProcessorResult.RemoveProcessor, result);
+	}
+}

--- a/src/Whim.Tests/Store/WindowSector/Processors/FirefoxWindowProcessorTests.cs
+++ b/src/Whim.Tests/Store/WindowSector/Processors/FirefoxWindowProcessorTests.cs
@@ -49,7 +49,7 @@ public class FirefoxWindowProcessorTests
 		IWindowProcessor processor = FirefoxWindowProcessor.Create(ctx, window)!;
 
 		// When the event is passed to `ShouldBeIgnored`
-		WindowProcessorResult result = processor.ShouldBeIgnored(eventType, 0, 0, 0, 0);
+		WindowProcessorResult result = processor.ProcessEvent(eventType, 0, 0, 0, 0);
 
 		// Then the event should be ignored
 		Assert.Equal(WindowProcessorResult.Ignore, result);
@@ -64,7 +64,7 @@ public class FirefoxWindowProcessorTests
 		IWindowProcessor processor = FirefoxWindowProcessor.Create(ctx, window)!;
 
 		// When the event is passed to `ShouldBeIgnored`
-		WindowProcessorResult result = processor.ShouldBeIgnored(PInvoke.EVENT_OBJECT_CLOAKED, 0, 0, 0, 0);
+		WindowProcessorResult result = processor.ProcessEvent(PInvoke.EVENT_OBJECT_CLOAKED, 0, 0, 0, 0);
 
 		// Then the event should be ignored
 		Assert.Equal(WindowProcessorResult.Ignore, result);
@@ -77,10 +77,10 @@ public class FirefoxWindowProcessorTests
 		// Given the second `EVENT_OBJECT_CLOAKED` event
 		window.ProcessFileName.Returns("firefox.exe");
 		IWindowProcessor processor = FirefoxWindowProcessor.Create(ctx, window)!;
-		processor.ShouldBeIgnored(PInvoke.EVENT_OBJECT_CLOAKED, 0, 0, 0, 0);
+		processor.ProcessEvent(PInvoke.EVENT_OBJECT_CLOAKED, 0, 0, 0, 0);
 
 		// When the event is passed to `ShouldBeIgnored`
-		WindowProcessorResult result = processor.ShouldBeIgnored(PInvoke.EVENT_OBJECT_CLOAKED, 0, 0, 0, 0);
+		WindowProcessorResult result = processor.ProcessEvent(PInvoke.EVENT_OBJECT_CLOAKED, 0, 0, 0, 0);
 
 		// Then the event should not be ignored
 		Assert.Equal(WindowProcessorResult.Process, result);
@@ -95,7 +95,7 @@ public class FirefoxWindowProcessorTests
 		IWindowProcessor processor = FirefoxWindowProcessor.Create(ctx, window)!;
 
 		// When the event is passed to `ShouldBeIgnored`
-		WindowProcessorResult result = processor.ShouldBeIgnored(PInvoke.EVENT_OBJECT_DESTROY, 0, 0, 0, 0);
+		WindowProcessorResult result = processor.ProcessEvent(PInvoke.EVENT_OBJECT_DESTROY, 0, 0, 0, 0);
 
 		// Then the processor should be removed
 		Assert.Equal(WindowProcessorResult.RemoveProcessor, result);

--- a/src/Whim.Tests/Store/WindowSector/Processors/WindowProcessorManagerTests.cs
+++ b/src/Whim.Tests/Store/WindowSector/Processors/WindowProcessorManagerTests.cs
@@ -1,0 +1,70 @@
+using Windows.Win32;
+
+namespace Whim.Tests;
+
+public class WindowProcessorManagerTests
+{
+	[Theory]
+	[AutoSubstituteData]
+	public void ShouldBeIgnored_CreateProcessor_Failure(IContext ctx, IWindow window)
+	{
+		// Given a window which is not a Firefox window
+		window.ProcessFileName.Returns("chrome.exe");
+		WindowProcessorManager sut = new(ctx);
+
+		// When ShouldBeIgnored is called
+		bool result = sut.ShouldBeIgnored(window, default, default, default, default, default, default);
+
+		// Then the result should be false
+		Assert.False(result);
+	}
+
+	[Theory]
+	[AutoSubstituteData]
+	public void ShouldBeIgnored_CreateProcessor_Success(IContext ctx, IWindow window)
+	{
+		// Given a window which is a Firefox window
+		window.ProcessFileName.Returns("firefox.exe");
+		WindowProcessorManager sut = new(ctx);
+
+		// When ShouldBeIgnored is called for the first time
+		bool result = sut.ShouldBeIgnored(window, default, default, default, default, default, default);
+
+		// Then the result should be true
+		Assert.True(result);
+	}
+
+	[Theory]
+	[AutoSubstituteData]
+	public void ShouldBeIgnored_ProcessorExists_Process(IContext ctx, IWindow window)
+	{
+		// Given a window which is a Firefox window
+		window.ProcessFileName.Returns("firefox.exe");
+		WindowProcessorManager sut = new(ctx);
+
+		// When ShouldBeIgnored is called for the second time
+		sut.ShouldBeIgnored(window, default, PInvoke.EVENT_OBJECT_CLOAKED, 0, 0, 0, 0);
+		bool result = sut.ShouldBeIgnored(window, default, 0, 0, 0, 0, 0);
+
+		// Then the processor should have been created by the second call, and the window should not be ignored
+		Assert.False(result);
+	}
+
+	[Theory]
+	[AutoSubstituteData]
+	public void ShouldBeIgnored_ProcessorExists_RemoveProcessor(IContext ctx, IWindow window)
+	{
+		// Given a window which is a Firefox window
+		window.ProcessFileName.Returns("firefox.exe");
+		WindowProcessorManager sut = new(ctx);
+
+		// When ShouldBeIgnored is called for the second time
+		sut.ShouldBeIgnored(window, default, PInvoke.EVENT_OBJECT_CLOAKED, 0, 0, 0, 0);
+		bool firstProcessorResult = sut.ShouldBeIgnored(window, default, PInvoke.EVENT_OBJECT_DESTROY, 0, 0, 0, 0);
+		bool secondProcessorResult = sut.ShouldBeIgnored(window, default, 0, 0, 0, 0, 0);
+
+		// Then the processor should have been removed by the second call, and the window should be ignored in the next call
+		Assert.False(firstProcessorResult);
+		Assert.True(secondProcessorResult);
+	}
+}

--- a/src/Whim.Tests/Store/WindowSector/Processors/WindowProcessorManagerTests.cs
+++ b/src/Whim.Tests/Store/WindowSector/Processors/WindowProcessorManagerTests.cs
@@ -4,8 +4,7 @@ namespace Whim.Tests;
 
 public class WindowProcessorManagerTests
 {
-	[Theory]
-	[AutoSubstituteData]
+	[Theory, AutoSubstituteData]
 	public void ShouldBeIgnored_CreateProcessor_Failure(IContext ctx, IWindow window)
 	{
 		// Given a window which is not a Firefox window
@@ -19,8 +18,7 @@ public class WindowProcessorManagerTests
 		Assert.False(result);
 	}
 
-	[Theory]
-	[AutoSubstituteData]
+	[Theory, AutoSubstituteData]
 	public void ShouldBeIgnored_CreateProcessor_Success(IContext ctx, IWindow window)
 	{
 		// Given a window which is a Firefox window
@@ -34,8 +32,7 @@ public class WindowProcessorManagerTests
 		Assert.True(result);
 	}
 
-	[Theory]
-	[AutoSubstituteData]
+	[Theory, AutoSubstituteData]
 	public void ShouldBeIgnored_ProcessorExists_Process(IContext ctx, IWindow window)
 	{
 		// Given a window which is a Firefox window
@@ -50,8 +47,7 @@ public class WindowProcessorManagerTests
 		Assert.False(result);
 	}
 
-	[Theory]
-	[AutoSubstituteData]
+	[Theory, AutoSubstituteData]
 	public void ShouldBeIgnored_ProcessorExists_RemoveProcessor(IContext ctx, IWindow window)
 	{
 		// Given a window which is a Firefox window

--- a/src/Whim.Tests/Store/WindowSector/Transforms/WindowMovedTransformTests.cs
+++ b/src/Whim.Tests/Store/WindowSector/Transforms/WindowMovedTransformTests.cs
@@ -56,46 +56,6 @@ public class WindowMovedTransformTests
 		// Given the window is not moving and the process file name is null
 		mutableRootSector.WindowSector.IsMovingWindow = false;
 		window.ProcessFileName.ReturnsNull();
-		ctx.WindowManager.LocationRestoringFilterManager.ShouldBeIgnored(window).Returns(true);
-
-		WindowMovedTransform sut = new(window);
-
-		// When we dispatch the transform
-		var result = AssertDoesNotRaise(ctx, mutableRootSector, sut);
-
-		// Then we get an empty result
-		Assert.True(result.IsSuccessful);
-		ctx.NativeManager.DidNotReceive().TryEnqueue(Arg.Any<DispatcherQueueHandler>());
-	}
-
-	[Theory, AutoSubstituteData<StoreCustomization>]
-	internal void IsNotMoving_IsHandledLocation(IContext ctx, MutableRootSector mutableRootSector, IWindow window)
-	{
-		// Given the window is not moving and the window is a handled restoring location window
-		mutableRootSector.WindowSector.IsMovingWindow = false;
-		mutableRootSector.WindowSector.HandledLocationRestoringWindows = ImmutableHashSet.Create(window.Handle);
-		ctx.WindowManager.LocationRestoringFilterManager.ShouldBeIgnored(window).Returns(true);
-
-		WindowMovedTransform sut = new(window);
-
-		// When we dispatch the transform
-		var result = AssertDoesNotRaise(ctx, mutableRootSector, sut);
-
-		// Then we get an empty result
-		Assert.True(result.IsSuccessful);
-		ctx.NativeManager.DidNotReceive().TryEnqueue(Arg.Any<DispatcherQueueHandler>());
-	}
-
-	[Theory, AutoSubstituteData<StoreCustomization>]
-	internal void IsNotMoving_IgnoredByLocationRestoringFilter(
-		IContext ctx,
-		MutableRootSector mutableRootSector,
-		IWindow window
-	)
-	{
-		// Given the window is not moving and the window is a handled restoring location window
-		mutableRootSector.WindowSector.IsMovingWindow = false;
-		ctx.WindowManager.LocationRestoringFilterManager.ShouldBeIgnored(window).Returns(false);
 
 		WindowMovedTransform sut = new(window);
 
@@ -117,9 +77,7 @@ public class WindowMovedTransformTests
 	{
 		// Given the window is not moving, we don't ignore the window moving event, but we can get the pos
 		mutableRootSector.WindowSector.IsMovingWindow = false;
-		mutableRootSector.WindowSector.WindowMovedDelay = 0;
 		mutableRootSector.WindowSector.IsLeftMouseButtonDown = true;
-		ctx.WindowManager.LocationRestoringFilterManager.ShouldBeIgnored(window).Returns(true);
 		Setup_GetCursorPos(internalCtx);
 
 		WindowMovedTransform sut = new(window);

--- a/src/Whim.Tests/Store/WindowSector/Transforms/WindowMovedTransformTests.cs
+++ b/src/Whim.Tests/Store/WindowSector/Transforms/WindowMovedTransformTests.cs
@@ -85,9 +85,8 @@ public class WindowMovedTransformTests
 		// When we dispatch the transform
 		(Result<Unit>? result, Assert.RaisedEvent<WindowMovedEventArgs> ev) = AssertRaises(ctx, mutableRootSector, sut);
 
-		// Then we get a resulting window, a NativeManager.TryEnqueue to restore a window's position, and a second TryEnqueue
-		// to dispatch the events.
-		ctx.NativeManager.Received(2).TryEnqueue(Arg.Any<DispatcherQueueHandler>());
+		// Then we get a resulting window and a second TryEnqueue to dispatch the events.
+		ctx.NativeManager.Received(1).TryEnqueue(Arg.Any<DispatcherQueueHandler>());
 		Assert.True(result!.Value.IsSuccessful);
 		Assert.Equal(new Point<int>(1, 2), ev.Arguments.CursorDraggedPoint);
 		Assert.Equal(window, ev.Arguments.Window);

--- a/src/Whim/Filter/DefaultFilteredWindows.cs
+++ b/src/Whim/Filter/DefaultFilteredWindows.cs
@@ -13,12 +13,4 @@ public static class DefaultFilteredWindows
 	{
 		DefaultFilteredWindowsKomorebi.LoadWindowsIgnoredByKomorebi(filterManager);
 	}
-
-	/// <summary>
-	/// Load the windows which try to set their own locations when the start up.
-	/// See <see cref="IWindowManager.LocationRestoringFilterManager"/>
-	/// </summary>
-	/// <param name="filterManager"></param>
-	public static void LoadLocationRestoringWindows(IFilterManager filterManager) =>
-		filterManager.AddProcessFileNameFilter("firefox.exe").AddProcessFileNameFilter("gateway64.exe");
 }

--- a/src/Whim/Native/HWND.cs
+++ b/src/Whim/Native/HWND.cs
@@ -16,7 +16,10 @@ namespace Windows.Win32
 
 			internal static HWND Null => default;
 
-			internal bool IsNull => Value == default;
+			/// <summary>
+			/// Whether the handle has a zero value.
+			/// </summary>
+			public bool IsNull => Value == default;
 
 			/// <inheritdoc />
 			public static implicit operator IntPtr(HWND value) => value.Value;

--- a/src/Whim/Store/Transform.cs
+++ b/src/Whim/Store/Transform.cs
@@ -3,7 +3,6 @@ namespace Whim;
 /// <summary>
 /// Operation describing how to update the state of the <see cref="Store"/>.
 /// The implementing record should be populated with the payload.
-/// <see cref="Execute"/> will specify how to update the store.
 /// </summary>
 /// <typeparam name="TResult"></typeparam>
 public abstract record Transform<TResult>

--- a/src/Whim/Store/WindowSector/IWindowSector.cs
+++ b/src/Whim/Store/WindowSector/IWindowSector.cs
@@ -11,12 +11,6 @@ public interface IWindowSector
 	ImmutableDictionary<HWND, IWindow> Windows { get; }
 
 	/// <summary>
-	/// The windows which had their first location change event handled - see <see cref="IWindowManager.LocationRestoringFilterManager"/>.
-	/// We maintain a set of the windows that have been handled so that we don't enter an infinite loop of location change events.
-	/// </summary>
-	ImmutableHashSet<HWND> HandledLocationRestoringWindows { get; }
-
-	/// <summary>
 	/// Whether a window is currently moving.
 	/// </summary>
 	bool IsMovingWindow { get; }
@@ -26,9 +20,4 @@ public interface IWindowSector
 	/// Used for window movement.
 	/// </summary>
 	bool IsLeftMouseButtonDown { get; }
-
-	/// <summary>
-	/// The delay to wait when trying to restore windows from <see cref="IWindowManager.LocationRestoringFilterManager"/>.
-	/// </summary>
-	int WindowMovedDelay { get; }
 }

--- a/src/Whim/Store/WindowSector/Processors/FirefoxWindowProcessor.cs
+++ b/src/Whim/Store/WindowSector/Processors/FirefoxWindowProcessor.cs
@@ -66,7 +66,6 @@ public class FirefoxWindowProcessor : IWindowProcessor
 		uint dwmsEventTime
 	)
 	{
-		Logger.Debug($"Firefox event: 0x{eventType:X4}");
 		if (eventType == PInvoke.EVENT_OBJECT_CLOAKED)
 		{
 			if (!_hasSeenFirstCloaked)
@@ -87,6 +86,5 @@ public class FirefoxWindowProcessor : IWindowProcessor
 		}
 
 		return WindowProcessorResult.Process;
-		// return WindowProcessorResult.Process;
 	}
 }

--- a/src/Whim/Store/WindowSector/Processors/FirefoxWindowProcessor.cs
+++ b/src/Whim/Store/WindowSector/Processors/FirefoxWindowProcessor.cs
@@ -7,7 +7,6 @@ namespace Whim;
 /// </summary>
 public class FirefoxWindowProcessor : IWindowProcessor
 {
-	private bool _hasSeenFirstShow;
 	private bool _hasSeenFirstCloaked;
 
 	/// <inheritdoc/>
@@ -51,7 +50,7 @@ public class FirefoxWindowProcessor : IWindowProcessor
 	/// </item>
 	/// </list>
 	///
-	/// To deal with these issues, we ignore the first <c>EVENT_OBJECT_SHOW</c> and <c>EVENT_OBJECT_CLOAKED</c> events.
+	/// To deal with these issues, we ignore all events until the first <see cref="PInvoke.EVENT_OBJECT_CLOAKED"/> event is received.
 	/// </remarks>
 	/// <param name="eventType"></param>
 	/// <param name="idObject"></param>
@@ -67,15 +66,7 @@ public class FirefoxWindowProcessor : IWindowProcessor
 		uint dwmsEventTime
 	)
 	{
-		if (eventType == PInvoke.EVENT_OBJECT_SHOW)
-		{
-			if (!_hasSeenFirstShow)
-			{
-				_hasSeenFirstShow = true;
-				return WindowProcessorResult.Ignore;
-			}
-		}
-
+		Logger.Debug($"Firefox event: 0x{eventType:X4}");
 		if (eventType == PInvoke.EVENT_OBJECT_CLOAKED)
 		{
 			if (!_hasSeenFirstCloaked)
@@ -90,6 +81,12 @@ public class FirefoxWindowProcessor : IWindowProcessor
 			return WindowProcessorResult.RemoveProcessor;
 		}
 
+		if (!_hasSeenFirstCloaked)
+		{
+			return WindowProcessorResult.Ignore;
+		}
+
 		return WindowProcessorResult.Process;
+		// return WindowProcessorResult.Process;
 	}
 }

--- a/src/Whim/Store/WindowSector/Processors/FirefoxWindowProcessor.cs
+++ b/src/Whim/Store/WindowSector/Processors/FirefoxWindowProcessor.cs
@@ -58,7 +58,7 @@ public class FirefoxWindowProcessor : IWindowProcessor
 	/// <param name="idEventThread"></param>
 	/// <param name="dwmsEventTime"></param>
 	/// <returns></returns>
-	public WindowProcessorResult ShouldBeIgnored(
+	public WindowProcessorResult ProcessEvent(
 		uint eventType,
 		int idObject,
 		int idChild,

--- a/src/Whim/Store/WindowSector/Processors/FirefoxWindowProcessor.cs
+++ b/src/Whim/Store/WindowSector/Processors/FirefoxWindowProcessor.cs
@@ -1,0 +1,95 @@
+using Windows.Win32;
+
+namespace Whim;
+
+/// <summary>
+/// Custom logic to handle events from Firefox.
+/// </summary>
+public class FirefoxWindowProcessor : IWindowProcessor
+{
+	private bool _hasSeenFirstShow;
+	private bool _hasSeenFirstCloaked;
+
+	/// <inheritdoc/>
+	public IWindow Window { get; }
+
+	private FirefoxWindowProcessor(IWindow window)
+	{
+		Window = window;
+	}
+
+	/// <summary>
+	/// Creates a new instance of the implementing class, if the given window matches the processor.
+	/// </summary>
+	public static IWindowProcessor? Create(IContext ctx, IWindow window) =>
+		window.ProcessFileName == "firefox.exe" ? new FirefoxWindowProcessor(window) : null;
+
+	/// <summary>
+	/// Indicates whether the event should be ignored by Whim.
+	/// </summary>
+	/// <remarks>
+	/// Firefox has some irregular behavior:
+	///
+	/// <list type="bullet">
+	///
+	/// <item>
+	/// <description>
+	/// Firefox will move a window after an interdeterminate timeout on startup <see href="https://searchfox.org/mozilla-central/source/browser/components/sessionstore/SessionStore.sys.mjs#5587">[Source]</see>
+	/// </description>
+	/// </item>
+	///
+	/// <item>
+	/// <description>
+	/// Firefox can perform actions 500ms after an event is received - e.g., after <c>WindowMoved</c> <see href="https://searchfox.org/mozilla-central/source/xpfe/appshell/AppWindow.cpp#2588">[Source]</see>
+	/// </description>
+	/// </item>
+	///
+	/// <item>
+	/// <description>
+	/// Firefox will cloak the window when showing for the first time <see href="https://searchfox.org/mozilla-central/source/widget/windows/nsWindow.cpp#1639">[Source]</see>
+	/// </description>
+	/// </item>
+	/// </list>
+	///
+	/// To deal with these issues, we ignore the first <c>EVENT_OBJECT_SHOW</c> and <c>EVENT_OBJECT_CLOAKED</c> events.
+	/// </remarks>
+	/// <param name="eventType"></param>
+	/// <param name="idObject"></param>
+	/// <param name="idChild"></param>
+	/// <param name="idEventThread"></param>
+	/// <param name="dwmsEventTime"></param>
+	/// <returns></returns>
+	public WindowProcessorResult ShouldBeIgnored(
+		uint eventType,
+		int idObject,
+		int idChild,
+		uint idEventThread,
+		uint dwmsEventTime
+	)
+	{
+		if (eventType == PInvoke.EVENT_OBJECT_SHOW)
+		{
+			if (!_hasSeenFirstShow)
+			{
+				_hasSeenFirstShow = true;
+				return WindowProcessorResult.Ignore;
+			}
+		}
+
+		if (eventType == PInvoke.EVENT_OBJECT_CLOAKED)
+		{
+			if (!_hasSeenFirstCloaked)
+			{
+				_hasSeenFirstCloaked = true;
+				return WindowProcessorResult.Ignore;
+			}
+		}
+
+		if (eventType == PInvoke.EVENT_OBJECT_DESTROY)
+		{
+			return WindowProcessorResult.RemoveProcessor;
+		}
+
+		return WindowProcessorResult.Process;
+	}
+}

--- a/src/Whim/Store/WindowSector/Processors/IWindowProcessor.cs
+++ b/src/Whim/Store/WindowSector/Processors/IWindowProcessor.cs
@@ -1,0 +1,35 @@
+namespace Whim;
+
+/// <summary>
+/// Represents a processor for events from Windows. This is for windows with non-standard behavior.
+/// For example, Firefox will try reset the window position on startup. The <see cref="FirefoxWindowProcessor"/>
+/// will ignore these events.
+/// </summary>
+public interface IWindowProcessor
+{
+	/// <summary>
+	/// The window that this processor is for.
+	/// </summary>
+	public IWindow Window { get; }
+
+	/// <summary>
+	/// Indicates whether the event should be ignored by Whim.
+	///
+	/// For more, see https://docs.microsoft.com/en-us/windows/win32/api/winuser/nc-winuser-wineventproc
+	/// </summary>
+	/// <param name="eventType"></param>
+	/// <param name="idObject"></param>
+	/// <param name="idChild"></param>
+	/// <param name="idEventThread"></param>
+	/// <param name="dwmsEventTime"></param>
+	/// <returns>
+	/// Whether the event should be ignored by Whim.
+	/// </returns>
+	public abstract WindowProcessorResult ShouldBeIgnored(
+		uint eventType,
+		int idObject,
+		int idChild,
+		uint idEventThread,
+		uint dwmsEventTime
+	);
+}

--- a/src/Whim/Store/WindowSector/Processors/IWindowProcessor.cs
+++ b/src/Whim/Store/WindowSector/Processors/IWindowProcessor.cs
@@ -13,9 +13,9 @@ public interface IWindowProcessor
 	public IWindow Window { get; }
 
 	/// <summary>
-	/// Indicates whether the event should be ignored by Whim.
+	/// Processes the given event.
 	///
-	/// For more, see https://docs.microsoft.com/en-us/windows/win32/api/winuser/nc-winuser-wineventproc
+	/// For more about the arguments, see https://docs.microsoft.com/en-us/windows/win32/api/winuser/nc-winuser-wineventproc
 	/// </summary>
 	/// <param name="eventType"></param>
 	/// <param name="idObject"></param>
@@ -25,7 +25,7 @@ public interface IWindowProcessor
 	/// <returns>
 	/// Whether the event should be ignored by Whim.
 	/// </returns>
-	public abstract WindowProcessorResult ShouldBeIgnored(
+	public abstract WindowProcessorResult ProcessEvent(
 		uint eventType,
 		int idObject,
 		int idChild,

--- a/src/Whim/Store/WindowSector/Processors/WindowProcessorManager.cs
+++ b/src/Whim/Store/WindowSector/Processors/WindowProcessorManager.cs
@@ -35,7 +35,7 @@ internal class WindowProcessorManager
 			}
 		}
 
-		WindowProcessorResult result = processor.ShouldBeIgnored(
+		WindowProcessorResult result = processor.ProcessEvent(
 			eventType,
 			idObject,
 			idChild,

--- a/src/Whim/Store/WindowSector/Processors/WindowProcessorManager.cs
+++ b/src/Whim/Store/WindowSector/Processors/WindowProcessorManager.cs
@@ -1,0 +1,74 @@
+using Windows.Win32.UI.Accessibility;
+
+namespace Whim;
+
+internal class WindowProcessorManager
+{
+	private readonly IContext _ctx;
+
+	private readonly List<Func<IContext, IWindow, IWindowProcessor?>> _processorCreators = new();
+
+	private readonly Dictionary<HWND, IWindowProcessor> _processors = new();
+
+	public WindowProcessorManager(IContext ctx)
+	{
+		_ctx = ctx;
+		_processorCreators.Add(FirefoxWindowProcessor.Create);
+	}
+
+	internal bool ShouldBeIgnored(
+		IWindow window,
+		HWINEVENTHOOK hWinEventHook,
+		uint eventType,
+		int idObject,
+		int idChild,
+		uint idEventThread,
+		uint dwmsEventTime
+	)
+	{
+		if (!_processors.TryGetValue(window.Handle, out IWindowProcessor? processor))
+		{
+			if ((processor = CreateProcessor(window)) == null)
+			{
+				// No processor was created for this window, so we don't have any special handling for it.
+				return false;
+			}
+		}
+
+		WindowProcessorResult result = processor.ShouldBeIgnored(
+			eventType,
+			idObject,
+			idChild,
+			idEventThread,
+			dwmsEventTime
+		);
+		switch (result)
+		{
+			case WindowProcessorResult.Process:
+				return false;
+			case WindowProcessorResult.Ignore:
+				return true;
+			case WindowProcessorResult.RemoveProcessor:
+				_processors.Remove(window.Handle);
+				return false;
+			default:
+				Logger.Error($"Unhandled WindowProcessorResult {result}");
+				return false;
+		}
+	}
+
+	private IWindowProcessor? CreateProcessor(IWindow window)
+	{
+		foreach (Func<IContext, IWindow, IWindowProcessor?> creator in _processorCreators)
+		{
+			IWindowProcessor? processor = creator(_ctx, window);
+			if (processor != null)
+			{
+				_processors.Add(window.Handle, processor);
+				return processor;
+			}
+		}
+
+		return null;
+	}
+}

--- a/src/Whim/Store/WindowSector/Processors/WindowProcessorResult.cs
+++ b/src/Whim/Store/WindowSector/Processors/WindowProcessorResult.cs
@@ -1,0 +1,22 @@
+namespace Whim;
+
+/// <summary>
+/// The result of processing a window event by a <see cref="IWindowProcessor"/>.
+/// </summary>
+public enum WindowProcessorResult
+{
+	/// <summary>
+	/// The event should be ignored.
+	/// </summary>
+	Ignore,
+
+	/// <summary>
+	/// The event should be processed.
+	/// </summary>
+	Process,
+
+	/// <summary>
+	/// The event should be processed and the processor should be removed.
+	/// </summary>
+	RemoveProcessor
+}

--- a/src/Whim/Store/WindowSector/Transforms/WindowMovedTransform.cs
+++ b/src/Whim/Store/WindowSector/Transforms/WindowMovedTransform.cs
@@ -12,29 +12,9 @@ internal record WindowMovedTransform(IWindow Window) : Transform
 	{
 		WindowSector windowSector = mutableRootSector.WindowSector;
 
-		if (!windowSector.IsMovingWindow)
+		if (!windowSector.IsMovingWindow && Window.ProcessFileName == null)
 		{
-			if (
-				Window.ProcessFileName == null
-				|| windowSector.HandledLocationRestoringWindows.Contains(Window.Handle)
-				|| !ctx.WindowManager.LocationRestoringFilterManager.ShouldBeIgnored(Window)
-			)
-			{
-				// Ignore the window moving event.
-				return Unit.Result;
-			}
-
-			// The window's application tried to restore its position.
-			// Wait, then restore the position.
-			ctx.NativeManager.TryEnqueue(async () =>
-			{
-				await Task.Delay(windowSector.WindowMovedDelay).ConfigureAwait(true);
-				if (ctx.Store.Pick(PickWorkspaceByWindow(Window.Handle)).TryGet(out IWorkspace workspace))
-				{
-					windowSector.HandledLocationRestoringWindows.Add(Window.Handle);
-					workspace.DoLayout();
-				}
-			});
+			return Unit.Result;
 		}
 
 		IPoint<int>? cursorPoint = null;

--- a/src/Whim/Store/WindowSector/Transforms/WindowRemovedTransform.cs
+++ b/src/Whim/Store/WindowSector/Transforms/WindowRemovedTransform.cs
@@ -32,9 +32,6 @@ internal record WindowRemovedTransform(IWindow Window) : Transform
 	private void UpdateWindowSector(WindowSector windowSector)
 	{
 		windowSector.Windows = windowSector.Windows.Remove(Window.Handle);
-		windowSector.HandledLocationRestoringWindows = windowSector.HandledLocationRestoringWindows.Remove(
-			Window.Handle
-		);
 		windowSector.QueueEvent(new WindowRemovedEventArgs() { Window = Window });
 	}
 

--- a/src/Whim/Store/WindowSector/WindowEventListener.cs
+++ b/src/Whim/Store/WindowSector/WindowEventListener.cs
@@ -20,11 +20,14 @@ internal class WindowEventListener : IDisposable
 	/// </summary>
 	private readonly WINEVENTPROC _hookDelegate;
 
+	private readonly WindowProcessorManager _processorManager;
+
 	public WindowEventListener(IContext ctx, IInternalContext internalCtx)
 	{
 		_ctx = ctx;
 		_internalCtx = internalCtx;
 		_hookDelegate = new WINEVENTPROC(WinEventProcWrapper);
+		_processorManager = new WindowProcessorManager(ctx);
 	}
 
 	public void Initialize()
@@ -130,6 +133,21 @@ internal class WindowEventListener : IDisposable
 			{
 				return;
 			}
+		}
+
+		if (
+			_processorManager.ShouldBeIgnored(
+				window,
+				_hWinEventHook,
+				eventType,
+				idObject,
+				idChild,
+				_idEventThread,
+				_dwmsEventTime
+			)
+		)
+		{
+			return;
 		}
 
 		Logger.Debug($"Windows event 0x{eventType:X4} for {window}");

--- a/src/Whim/Store/WindowSector/WindowEventListener.cs
+++ b/src/Whim/Store/WindowSector/WindowEventListener.cs
@@ -147,6 +147,7 @@ internal class WindowEventListener : IDisposable
 			)
 		)
 		{
+			Logger.Debug("Ignoring event for window due to processor");
 			return;
 		}
 

--- a/src/Whim/Store/WindowSector/WindowSector.cs
+++ b/src/Whim/Store/WindowSector/WindowSector.cs
@@ -10,13 +10,9 @@ internal class WindowSector : SectorBase, IWindowSector, IDisposable, IWindowSec
 
 	public ImmutableDictionary<HWND, IWindow> Windows { get; internal set; } = ImmutableDictionary<HWND, IWindow>.Empty;
 
-	public ImmutableHashSet<HWND> HandledLocationRestoringWindows { get; internal set; } = ImmutableHashSet<HWND>.Empty;
-
 	public bool IsMovingWindow { get; internal set; }
 
 	public bool IsLeftMouseButtonDown { get; internal set; }
-
-	public int WindowMovedDelay { get; internal set; } = 2000;
 
 	public event EventHandler<WindowAddedEventArgs>? WindowAdded;
 	public event EventHandler<WindowFocusedEventArgs>? WindowFocused;

--- a/src/Whim/Window/IWindowManager.cs
+++ b/src/Whim/Window/IWindowManager.cs
@@ -6,11 +6,6 @@ namespace Whim;
 public interface IWindowManager : IEnumerable<IWindow>, IDisposable
 {
 	/// <summary>
-	/// Filters for windows that will try restore window locations after their windows are created.
-	/// </summary>
-	IFilterManager LocationRestoringFilterManager { get; }
-
-	/// <summary>
 	/// Initialize the windows event hooks.
 	/// </summary>
 	/// <returns></returns>

--- a/src/Whim/Window/WindowManager.cs
+++ b/src/Whim/Window/WindowManager.cs
@@ -21,16 +21,10 @@ internal class WindowManager : IWindowManager, IInternalWindowManager
 	/// </summary>
 	private bool _disposedValue;
 
-	public IFilterManager LocationRestoringFilterManager { get; } = new FilterManager();
-
-	internal int WindowMovedDelay { get; init; } = 2000;
-
 	public WindowManager(IContext context, IInternalContext internalContext)
 	{
 		_context = context;
 		_internalContext = internalContext;
-
-		DefaultFilteredWindows.LoadLocationRestoringWindows(LocationRestoringFilterManager);
 	}
 
 	public void Initialize()


### PR DESCRIPTION
Previously, Whim would enqueue a `DoLayout` whenever a window moved. This was done to account for windows doing atypical things, like trying to restore their own position.

This worked prior to Whim becoming multi-threaded. Now that it is, this is no longer a viable approach. The `WindowMovedTransform` is triggered many times by Whim. Accordingly, the enqueueing of `DoLayout` similarly is done many times, sometimes overloading the main thread (related issues: #941, #944).

This PR allows custom logic for handling events for specific types of windows. `IWindowProcessor` s specify whether to ignore the current Windows event. A `FirefoxWindowProcessor` has been implemented to account for atypical behavior by Firefox during startup.
