### PR TITLE
Don't apply custom Firefox processing on startup

### DIFF
--- a/src/Whim.Tests/Store/MapSector/Transforms/InitializeWorkspacesTransformTests.cs
+++ b/src/Whim.Tests/Store/MapSector/Transforms/InitializeWorkspacesTransformTests.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using FluentAssertions;
 
 namespace Whim.Tests;
 
@@ -254,5 +255,11 @@ public class InitializeWorkspacesTransformTests
 		Assert.Equal(browserWorkspace.Id, rootSector.MapSector.MonitorWorkspaceMap[BrowserMonitor]);
 		Assert.Equal(codeWorkspace.Id, rootSector.MapSector.MonitorWorkspaceMap[CodeMonitor]);
 		Assert.Equal(autoWorkspace.Id, rootSector.MapSector.MonitorWorkspaceMap[AutoMonitor]);
+
+		// - the startup windows are set
+		Assert.Equal(5, rootSector.WindowSector.StartupWindows.Count);
+		rootSector
+			.WindowSector.StartupWindows.Should()
+			.BeEquivalentTo(new[] { BrowserHandle, DiscordHandle, SpotifyHandle, BrokenHandle, VscodeHandle });
 	}
 }

--- a/src/Whim.Tests/Store/WindowSector/WindowPickersTests.cs
+++ b/src/Whim.Tests/Store/WindowSector/WindowPickersTests.cs
@@ -1,0 +1,101 @@
+using System.Linq;
+
+namespace Whim.Tests;
+
+public class WindowPickersTests
+{
+	[Theory, AutoSubstituteData]
+	public void PickAllWindows(IRootSector rootSector, IWindow window1, IWindow window2, IWindow window3)
+	{
+		// Given there are three windows
+		rootSector.WindowSector.Windows.Returns(
+			new Dictionary<HWND, IWindow>
+			{
+				[(HWND)1] = window1,
+				[(HWND)2] = window2,
+				[(HWND)3] = window3,
+			}.ToImmutableDictionary()
+		);
+
+		// When we get the windows
+		var result = Pickers.PickAllWindows()(rootSector);
+
+		// Then we get the windows
+		Assert.Equal(3, result.Count());
+	}
+
+	[Theory, AutoSubstituteData]
+	public void PickWindowByHandle_Failure(IRootSector rootSector, IWindow window1, IWindow window2, IWindow window3)
+	{
+		// Given there are three windows
+		rootSector.WindowSector.Windows.Returns(
+			new Dictionary<HWND, IWindow>
+			{
+				[(HWND)1] = window1,
+				[(HWND)2] = window2,
+				[(HWND)3] = window3,
+			}.ToImmutableDictionary()
+		);
+
+		HWND handle = (HWND)4;
+
+		// When we get the window
+		var result = Pickers.PickWindowByHandle(handle)(rootSector);
+
+		// Then we get an exception
+		Assert.False(result.IsSuccessful);
+	}
+
+	[Theory, AutoSubstituteData]
+	public void PickWindowByHandle_Success(IRootSector rootSector, IWindow window1, IWindow window2, IWindow window3)
+	{
+		// Given there are three windows
+		rootSector.WindowSector.Windows.Returns(
+			new Dictionary<HWND, IWindow>
+			{
+				[(HWND)1] = window1,
+				[(HWND)2] = window2,
+				[(HWND)3] = window3,
+			}.ToImmutableDictionary()
+		);
+
+		// When we get the window
+		var result = Pickers.PickWindowByHandle((HWND)1)(rootSector);
+
+		// Then we get the window
+		Assert.True(result.IsSuccessful);
+		Assert.Same(window1, result.Value);
+	}
+
+	[Theory, AutoSubstituteData]
+	public void PickIsStartupWindow_Failure(IRootSector rootSector)
+	{
+		// Given there are three startup windows
+		rootSector.WindowSector.StartupWindows.Returns(
+			new HashSet<HWND> { (HWND)1, (HWND)2, (HWND)3, }.ToImmutableHashSet()
+		);
+
+		HWND handle = (HWND)4;
+
+		// When we get whether the window is a startup window
+		var result = Pickers.PickIsStartupWindow(handle)(rootSector);
+
+		// Then we get false
+		Assert.False(result);
+	}
+
+	[Theory, AutoSubstituteData]
+	public void PickIsStartupWindow_Success(IRootSector rootSector)
+	{
+		// Given there are three startup windows
+		rootSector.WindowSector.StartupWindows.Returns(
+			new HashSet<HWND> { (HWND)1, (HWND)2, (HWND)3, }.ToImmutableHashSet()
+		);
+
+		// When we get whether the window is a startup window
+		var result = Pickers.PickIsStartupWindow((HWND)1)(rootSector);
+
+		// Then we get true
+		Assert.True(result);
+	}
+}

--- a/src/Whim/Store/WindowSector/IWindowSector.cs
+++ b/src/Whim/Store/WindowSector/IWindowSector.cs
@@ -11,6 +11,11 @@ public interface IWindowSector
 	ImmutableDictionary<HWND, IWindow> Windows { get; }
 
 	/// <summary>
+	/// The windows which were open when Whim started.
+	/// </summary>
+	ImmutableHashSet<HWND> StartupWindows { get; }
+
+	/// <summary>
 	/// Whether a window is currently moving.
 	/// </summary>
 	bool IsMovingWindow { get; }

--- a/src/Whim/Store/WindowSector/Processors/FirefoxWindowProcessor.cs
+++ b/src/Whim/Store/WindowSector/Processors/FirefoxWindowProcessor.cs
@@ -7,13 +7,15 @@ namespace Whim;
 /// </summary>
 public class FirefoxWindowProcessor : IWindowProcessor
 {
+	private readonly IContext _ctx;
 	private bool _hasSeenFirstCloaked;
 
 	/// <inheritdoc/>
 	public IWindow Window { get; }
 
-	private FirefoxWindowProcessor(IWindow window)
+	private FirefoxWindowProcessor(IContext ctx, IWindow window)
 	{
+		_ctx = ctx;
 		Window = window;
 	}
 
@@ -21,7 +23,7 @@ public class FirefoxWindowProcessor : IWindowProcessor
 	/// Creates a new instance of the implementing class, if the given window matches the processor.
 	/// </summary>
 	public static IWindowProcessor? Create(IContext ctx, IWindow window) =>
-		window.ProcessFileName == "firefox.exe" ? new FirefoxWindowProcessor(window) : null;
+		window.ProcessFileName == "firefox.exe" ? new FirefoxWindowProcessor(ctx, window) : null;
 
 	/// <summary>
 	/// Indicates whether the event should be ignored by Whim.
@@ -51,6 +53,7 @@ public class FirefoxWindowProcessor : IWindowProcessor
 	/// </list>
 	///
 	/// To deal with these issues, we ignore all events until the first <see cref="PInvoke.EVENT_OBJECT_CLOAKED"/> event is received.
+	/// If Firefox is already visible
 	/// </remarks>
 	/// <param name="eventType"></param>
 	/// <param name="idObject"></param>
@@ -66,6 +69,16 @@ public class FirefoxWindowProcessor : IWindowProcessor
 		uint dwmsEventTime
 	)
 	{
+		if (eventType == PInvoke.EVENT_OBJECT_DESTROY)
+		{
+			return WindowProcessorResult.RemoveProcessor;
+		}
+
+		if (_ctx.Store.Pick(PickIsStartupWindow(Window.Handle)))
+		{
+			return WindowProcessorResult.Process;
+		}
+
 		if (eventType == PInvoke.EVENT_OBJECT_CLOAKED)
 		{
 			if (!_hasSeenFirstCloaked)
@@ -73,11 +86,6 @@ public class FirefoxWindowProcessor : IWindowProcessor
 				_hasSeenFirstCloaked = true;
 				return WindowProcessorResult.Ignore;
 			}
-		}
-
-		if (eventType == PInvoke.EVENT_OBJECT_DESTROY)
-		{
-			return WindowProcessorResult.RemoveProcessor;
 		}
 
 		if (!_hasSeenFirstCloaked)

--- a/src/Whim/Store/WindowSector/Processors/FirefoxWindowProcessor.cs
+++ b/src/Whim/Store/WindowSector/Processors/FirefoxWindowProcessor.cs
@@ -53,7 +53,7 @@ public class FirefoxWindowProcessor : IWindowProcessor
 	/// </list>
 	///
 	/// To deal with these issues, we ignore all events until the first <see cref="PInvoke.EVENT_OBJECT_CLOAKED"/> event is received.
-	/// If Firefox is already visible
+	/// If Firefox is already visible, we process all events.
 	/// </remarks>
 	/// <param name="eventType"></param>
 	/// <param name="idObject"></param>

--- a/src/Whim/Store/WindowSector/WindowPickers.cs
+++ b/src/Whim/Store/WindowSector/WindowPickers.cs
@@ -19,4 +19,12 @@ public static partial class Pickers
 			rootSector.WindowSector.Windows.TryGetValue(handle, out IWindow? w)
 				? Result.FromValue(w)
 				: Result.FromException<IWindow>(StoreExceptions.WindowNotFound(handle));
+
+	/// <summary>
+	/// Returns whether a window was open when Whim started.
+	/// </summary>
+	/// <param name="handle"></param>
+	/// <returns></returns>
+	public static PurePicker<bool> PickIsStartupWindow(HWND handle) =>
+		(rootSector) => rootSector.WindowSector.StartupWindows.Contains(handle);
 }

--- a/src/Whim/Store/WindowSector/WindowSector.cs
+++ b/src/Whim/Store/WindowSector/WindowSector.cs
@@ -10,6 +10,8 @@ internal class WindowSector : SectorBase, IWindowSector, IDisposable, IWindowSec
 
 	public ImmutableDictionary<HWND, IWindow> Windows { get; internal set; } = ImmutableDictionary<HWND, IWindow>.Empty;
 
+	public ImmutableHashSet<HWND> StartupWindows { get; internal set; } = ImmutableHashSet<HWND>.Empty;
+
 	public bool IsMovingWindow { get; internal set; }
 
 	public bool IsLeftMouseButtonDown { get; internal set; }

--- a/src/Whim/Store/WorkspaceSector/Transforms/InitializeWorkspacesTransform.cs
+++ b/src/Whim/Store/WorkspaceSector/Transforms/InitializeWorkspacesTransform.cs
@@ -49,6 +49,8 @@ internal record InitializeWorkspacesTransform : Transform
 		WindowSector windowSector = rootSector.WindowSector;
 		MapSector mapSector = rootSector.MapSector;
 
+		windowSector.StartupWindows = internalCtx.CoreNativeManager.GetAllWindows().ToImmutableHashSet();
+
 		// Add the saved windows at their saved locations inside their saved workspaces.
 		// Other windows are routed to the monitor they're on.
 		List<HWND> processedWindows = new();


### PR DESCRIPTION
#957 introduced custom logic to handle Firefox starting while Whim was running. However, this logic is unnecessary if Firefox is started prior to Whim. 

This PR introduces `IWindowSector.StartupWindow` to store the windows which were open when Whim started. If the Firefox window is in this set, then the custom logic is not needed and all events are processed as normal.
