### PR TITLE
Change focus indicator to polling

### DIFF
--- a/src/Whim.FocusIndicator/FocusIndicatorPlugin.cs
+++ b/src/Whim.FocusIndicator/FocusIndicatorPlugin.cs
@@ -62,28 +62,24 @@ public class FocusIndicatorPlugin : IFocusIndicatorPlugin
 		_focusIndicatorWindow.Activate();
 		_focusIndicatorWindow.Hide(_context);
 
-		// TODO: cancellation
 		Task.Factory.StartNew(
-			LongRunningTask,
+			ContinuousPolling,
 			_cancellationToken,
 			TaskCreationOptions.LongRunning,
 			TaskScheduler.Default
 		);
 	}
 
-	// TODO: Rename
-	private void LongRunningTask()
+	private void ContinuousPolling()
 	{
 		while (true)
 		{
-			NewMethod();
-
+			Poll();
 			Thread.Sleep(16);
 		}
 	}
 
-	// TODO: Rename
-	private void NewMethod()
+	private void Poll()
 	{
 		if (_isEnabled)
 		{
@@ -155,6 +151,12 @@ public class FocusIndicatorPlugin : IFocusIndicatorPlugin
 		}
 		else
 		{
+			// Reset the last focus start time so the fade timer starts over.
+			if (_focusIndicatorConfig.FadeEnabled)
+			{
+				_lastFocusStartTime = Environment.TickCount;
+			}
+
 			Show();
 		}
 	}
@@ -168,6 +170,12 @@ public class FocusIndicatorPlugin : IFocusIndicatorPlugin
 		_isEnabled = !_isEnabled;
 		if (_isEnabled)
 		{
+			// Reset the last focus start time so the fade timer starts over.
+			if (_focusIndicatorConfig.FadeEnabled)
+			{
+				_lastFocusStartTime = Environment.TickCount;
+			}
+
 			Show();
 		}
 		else

--- a/src/Whim.FocusIndicator/FocusIndicatorWindow.xaml
+++ b/src/Whim.FocusIndicator/FocusIndicatorWindow.xaml
@@ -5,5 +5,17 @@
 	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
 	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 	mc:Ignorable="d">
-	<Grid Background="{x:Bind Path=FocusIndicatorConfig.Color, Mode=OneWay}" />
+
+	<RelativePanel>
+		<Rectangle
+			RadiusX="12"
+			RadiusY="12"
+			RelativePanel.AlignBottomWithPanel="True"
+			RelativePanel.AlignLeftWithPanel="True"
+			RelativePanel.AlignRightWithPanel="True"
+			RelativePanel.AlignTopWithPanel="True"
+			Stroke="{x:Bind Path=FocusIndicatorConfig.Color, Mode=OneWay}"
+			StrokeThickness="{x:Bind Path=FocusIndicatorConfig.BorderSize, Mode=OneWay}"/>
+
+	</RelativePanel>
 </Window>

--- a/src/Whim.FocusIndicator/FocusIndicatorWindow.xaml
+++ b/src/Whim.FocusIndicator/FocusIndicatorWindow.xaml
@@ -7,9 +7,10 @@
 	mc:Ignorable="d">
 
 	<RelativePanel>
+		<!-- Windows 11 uses 8px radii -->
 		<Rectangle
-			RadiusX="12"
-			RadiusY="12"
+			RadiusX="8"
+			RadiusY="8"
 			RelativePanel.AlignBottomWithPanel="True"
 			RelativePanel.AlignLeftWithPanel="True"
 			RelativePanel.AlignRightWithPanel="True"

--- a/src/Whim.FocusIndicator/FocusIndicatorWindow.xaml
+++ b/src/Whim.FocusIndicator/FocusIndicatorWindow.xaml
@@ -7,7 +7,7 @@
 	mc:Ignorable="d">
 
 	<RelativePanel>
-		<!-- Windows 11 uses 8px radii -->
+		<!--  Windows 11 uses 8px radii  -->
 		<Rectangle
 			RadiusX="8"
 			RadiusY="8"
@@ -16,7 +16,7 @@
 			RelativePanel.AlignRightWithPanel="True"
 			RelativePanel.AlignTopWithPanel="True"
 			Stroke="{x:Bind Path=FocusIndicatorConfig.Color, Mode=OneWay}"
-			StrokeThickness="{x:Bind Path=FocusIndicatorConfig.BorderSize, Mode=OneWay}"/>
+			StrokeThickness="{x:Bind Path=FocusIndicatorConfig.BorderSize, Mode=OneWay}" />
 
 	</RelativePanel>
 </Window>

--- a/src/Whim.FocusIndicator/FocusIndicatorWindow.xaml.cs
+++ b/src/Whim.FocusIndicator/FocusIndicatorWindow.xaml.cs
@@ -32,7 +32,7 @@ internal sealed partial class FocusIndicatorWindow : Microsoft.UI.Xaml.Window, S
 	/// <param name="windowRectangle">The rectangle of the window to activate behind.</param>
 	public void Activate(HWND handle, IRectangle<int> windowRectangle)
 	{
-		Logger.Debug("Activating focus indicator window");
+		Logger.Verbose("Activating focus indicator window");
 		int borderSize = FocusIndicatorConfig.BorderSize;
 
 		IRectangle<int> borderRect = new Rectangle<int>()

--- a/src/Whim.FocusIndicator/FocusIndicatorWindow.xaml.cs
+++ b/src/Whim.FocusIndicator/FocusIndicatorWindow.xaml.cs
@@ -1,4 +1,5 @@
-﻿using Windows.Win32.UI.WindowsAndMessaging;
+﻿using Windows.Win32.Foundation;
+using Windows.Win32.UI.WindowsAndMessaging;
 
 namespace Whim.FocusIndicator;
 
@@ -27,19 +28,19 @@ internal sealed partial class FocusIndicatorWindow : Microsoft.UI.Xaml.Window, S
 	/// <summary>
 	/// Activates the window behind the given window.
 	/// </summary>
-	/// <param name="targetWindowState">The window to show the indicator for.</param>
-	public void Activate(IWindowState targetWindowState)
+	/// <param name="handle">The handle of the window to activate behind.</param>
+	/// <param name="windowRectangle">The rectangle of the window to activate behind.</param>
+	public void Activate(HWND handle, IRectangle<int> windowRectangle)
 	{
 		Logger.Debug("Activating focus indicator window");
-		IRectangle<int> focusedWindowRect = targetWindowState.Rectangle;
 		int borderSize = FocusIndicatorConfig.BorderSize;
 
 		IRectangle<int> borderRect = new Rectangle<int>()
 		{
-			X = focusedWindowRect.X - borderSize,
-			Y = focusedWindowRect.Y - borderSize,
-			Height = focusedWindowRect.Height + (borderSize * 2),
-			Width = focusedWindowRect.Width + (borderSize * 2)
+			X = windowRectangle.X - borderSize,
+			Y = windowRectangle.Y - borderSize,
+			Height = windowRectangle.Height + (borderSize * 2),
+			Width = windowRectangle.Width + (borderSize * 2)
 		};
 
 		// Prevent the window from being activated.
@@ -53,7 +54,7 @@ internal sealed partial class FocusIndicatorWindow : Microsoft.UI.Xaml.Window, S
 				_window.Handle,
 				WindowSize.Normal,
 				borderRect,
-				targetWindowState.Window.Handle,
+				handle,
 				SET_WINDOW_POS_FLAGS.SWP_NOREDRAW | SET_WINDOW_POS_FLAGS.SWP_NOACTIVATE
 			)
 		);

--- a/src/Whim/Native/DeferWindowPosHandle.cs
+++ b/src/Whim/Native/DeferWindowPosHandle.cs
@@ -44,7 +44,7 @@ public sealed class DeferWindowPosHandle : IDisposable
 	/// <param name="internalContext"></param>
 	internal DeferWindowPosHandle(IContext context, IInternalContext internalContext)
 	{
-		Logger.Debug("Creating new WindowDeferPosHandle");
+		Logger.Verbose("Creating new WindowDeferPosHandle");
 		_context = context;
 		_internalContext = internalContext;
 	}
@@ -85,7 +85,9 @@ public sealed class DeferWindowPosHandle : IDisposable
 	/// </param>
 	public void DeferWindowPos(DeferWindowPosState posState, bool forceTwoPasses = false)
 	{
-		Logger.Debug($"Adding window {posState.Handle} after {posState.HandleInsertAfter} with flags {posState.Flags}");
+		Logger.Verbose(
+			$"Adding window {posState.Handle} after {posState.HandleInsertAfter} with flags {posState.Flags}"
+		);
 
 		if (forceTwoPasses)
 		{
@@ -109,11 +111,11 @@ public sealed class DeferWindowPosHandle : IDisposable
 	/// <inheritdoc />
 	public void Dispose()
 	{
-		Logger.Debug("Disposing WindowDeferPosHandle");
+		Logger.Verbose("Disposing WindowDeferPosHandle");
 
 		if (_windowStates.Count == 0 && _minimizedWindowStates.Count == 0)
 		{
-			Logger.Debug("No windows to set position for");
+			Logger.Verbose("No windows to set position for");
 			return;
 		}
 
@@ -129,7 +131,7 @@ public sealed class DeferWindowPosHandle : IDisposable
 			}
 		}
 
-		Logger.Debug($"Setting window position {numPasses} times for {_windowStates.Count} windows");
+		Logger.Verbose($"Setting window position {numPasses} times for {_windowStates.Count} windows");
 
 		// Set the window positions for non-minimized windows first, then minimized windows.
 		// This was done to prevent the minimized windows being hidden, and Windows focusing the previous window.
@@ -165,7 +167,7 @@ public sealed class DeferWindowPosHandle : IDisposable
 			}
 		}
 
-		Logger.Debug("Finished setting window position");
+		Logger.Verbose("Finished setting window position");
 	}
 
 	private void SetWindowPos(DeferWindowPosState source)

--- a/src/Whim/Native/NativeManager.cs
+++ b/src/Whim/Native/NativeManager.cs
@@ -77,7 +77,7 @@ internal partial class NativeManager : INativeManager
 
 	public bool ShowWindowNoActivate(HWND hwnd)
 	{
-		Logger.Debug($"Showing window HWND {hwnd} no activate");
+		Logger.Verbose($"Showing window HWND {hwnd} no activate");
 		return (bool)PInvoke.ShowWindow(hwnd, SHOW_WINDOW_CMD.SW_SHOWNOACTIVATE);
 	}
 

--- a/src/Whim/Store/Store.cs
+++ b/src/Whim/Store/Store.cs
@@ -106,7 +106,7 @@ public class Store : IStore
 		{
 			return Task.Run(() =>
 			{
-				Logger.Debug($"Entering task, executing picker {picker}");
+				Logger.Verbose($"Entering task, executing picker {picker}");
 
 				try
 				{
@@ -120,7 +120,7 @@ public class Store : IStore
 			}).Result;
 		}
 
-		Logger.Debug($"Executing picker {picker}");
+		Logger.Verbose($"Executing picker {picker}");
 		return PickFn(picker);
 	}
 
@@ -133,7 +133,7 @@ public class Store : IStore
 		{
 			return Task.Run(() =>
 			{
-				Logger.Debug($"Entering task, executing picker {picker}");
+				Logger.Verbose($"Entering task, executing picker {picker}");
 				try
 				{
 					_lock.EnterReadLock();
@@ -146,7 +146,7 @@ public class Store : IStore
 			}).Result;
 		}
 
-		Logger.Debug($"Executing picker {picker}");
+		Logger.Verbose($"Executing picker {picker}");
 		return PurePickFn(picker);
 	}
 

--- a/src/Whim/Store/WorkspaceSector/WorkspacePickers.cs
+++ b/src/Whim/Store/WorkspaceSector/WorkspacePickers.cs
@@ -80,6 +80,11 @@ public static partial class Pickers
 		Func<IWorkspace, Result<TResult>> operation
 	)
 	{
+		if (workspaceId == default)
+		{
+			workspaceId = PickActiveWorkspaceId()(rootSector);
+		}
+
 		if (!rootSector.WorkspaceSector.Workspaces.TryGetValue(workspaceId, out Workspace? workspace))
 		{
 			return Result.FromException<TResult>(StoreExceptions.WorkspaceNotFound(workspaceId));
@@ -145,8 +150,8 @@ public static partial class Pickers
 	/// <summary>
 	/// Get the last focused window in the provided workspace.
 	/// </summary>
-	/// <param name="workspaceId">The workspace to get the last focused window for.</param>
-	public static PurePicker<Result<IWindow>> PickLastFocusedWindow(WorkspaceId workspaceId) =>
+	/// <param name="workspaceId">The workspace to get the last focused window for. Defaults to the active workspace</param>
+	public static PurePicker<Result<IWindow>> PickLastFocusedWindow(WorkspaceId workspaceId = default) =>
 		(IRootSector rootSector) =>
 			BaseWorkspacePicker(
 				workspaceId,
@@ -159,6 +164,27 @@ public static partial class Pickers
 					}
 
 					return PickWindowByHandle(workspace.LastFocusedWindowHandle)(rootSector);
+				}
+			);
+
+	/// <summary>
+	/// Get the last focused window handle in the provided workspace.
+	/// </summary>
+	/// <param name="workspaceId">The workspace to get the last focused window handle for. Defaults to the active workspace</param>
+	/// <returns></returns>
+	public static PurePicker<Result<HWND>> PickLastFocusedWindowHandle(WorkspaceId workspaceId = default) =>
+		(IRootSector rootSector) =>
+			BaseWorkspacePicker(
+				workspaceId,
+				rootSector,
+				workspace =>
+				{
+					if (workspace.LastFocusedWindowHandle.IsNull)
+					{
+						return Result.FromException<HWND>(new WhimException("No last focused window in workspace"));
+					}
+
+					return Result.FromValue(workspace.LastFocusedWindowHandle);
 				}
 			);
 


### PR DESCRIPTION
Previously, the focus indicator plugin would show and hide based on events from Whim's core. However, this had the downside that the focus indicator could suffer from flickering. This was a result of the multi-threading work for #859, as all events were being processed (as opposed to relying on the STA always providing the latest event).

The focus indicator has now switched to a polling model running on a long-running task (i.e., a different thread). There is a hardcoded sleep for 16ms between each poll (roughly corresponding to 60fps). Polling avoids the continual handling of each event Windows emits and instead relies on the **current state of Whim**. This should resolve #944.

The polling has the downside of significantly increasing the logs which are generated. Some of the more common logs have been moved to `Verbose` to ameliorate this.

The polling has the additional benefit of having the indicator follow the window as it moves around the screen. This was not feasible with the event-based model. The focus indicator also now uses the _actual_ window size, rather than the size which Whim stores. This is good for naughty windows (like Logi Options+) which prevent Whim from resizing them.

This PR also changes the focus indicator to only apply the indicator color to the border of the indicator window, resolving #669. This does not use an actual border for each window - it still uses the prior approach of using a Whim-managed window. From the brief research I did, it did not seem that Windows really supports custom borders without potentially messing with the window itself. This does not resolve #908.