### PR TITLE
Switch to a timer-based approach for Firefox handling

### DIFF
--- a/src/Whim.Tests/Store/WindowSector/Processors/FirefoxWindowProcessorTests.cs
+++ b/src/Whim.Tests/Store/WindowSector/Processors/FirefoxWindowProcessorTests.cs
@@ -65,7 +65,7 @@ public class FirefoxWindowProcessorTests
 		WindowProcessorResult result = processor.ProcessEvent(eventType, 0, 0, 0, 0);
 
 		// Then the event should be ignored
-		Assert.Equal(WindowProcessorResult.Ignore, result);
+		Assert.Equal(WindowProcessorResult.IgnoreAndLayout, result);
 	}
 
 	[Theory, AutoSubstituteData]
@@ -108,7 +108,7 @@ public class FirefoxWindowProcessorTests
 		WindowProcessorResult result = processor.ProcessEvent(PInvoke.EVENT_OBJECT_DESTROY, 0, 0, 0, 0);
 
 		// Then the processor should be removed
-		Assert.Equal(WindowProcessorResult.RemoveProcessor, result);
+		Assert.Equal(WindowProcessorResult.ProcessAndRemove, result);
 	}
 
 	[Theory, AutoSubstituteData]

--- a/src/Whim.Tests/Store/WindowSector/Processors/WindowProcessorManagerTests.cs
+++ b/src/Whim.Tests/Store/WindowSector/Processors/WindowProcessorManagerTests.cs
@@ -63,4 +63,19 @@ public class WindowProcessorManagerTests
 		Assert.False(firstProcessorResult);
 		Assert.True(secondProcessorResult);
 	}
+
+	[Theory, AutoSubstituteData]
+	public void ShouldBeIgnored_LayoutAllActiveWorkspacesTransform(IContext ctx, IWindow window)
+	{
+		// Given a window which is a Firefox window
+		window.ProcessFileName.Returns("firefox.exe");
+		WindowProcessorManager sut = new(ctx);
+
+		// When ShouldBeIgnored is called with a ProcessAndRemove result
+		bool result = sut.ShouldBeIgnored(window, default, PInvoke.EVENT_OBJECT_LOCATIONCHANGE, 0, 0, 0, 0);
+
+		// Then the result should be true, and a LayoutAllActiveWorkspacesTransform should be dispatched
+		Assert.True(result);
+		ctx.Store.Received().Dispatch(Arg.Any<LayoutAllActiveWorkspacesTransform>());
+	}
 }

--- a/src/Whim/Store/WindowSector/Processors/WindowProcessorManager.cs
+++ b/src/Whim/Store/WindowSector/Processors/WindowProcessorManager.cs
@@ -44,11 +44,14 @@ internal class WindowProcessorManager
 		);
 		switch (result)
 		{
-			case WindowProcessorResult.Process:
-				return false;
 			case WindowProcessorResult.Ignore:
 				return true;
-			case WindowProcessorResult.RemoveProcessor:
+			case WindowProcessorResult.IgnoreAndLayout:
+				_ctx.Store.Dispatch(new LayoutAllActiveWorkspacesTransform());
+				return true;
+			case WindowProcessorResult.Process:
+				return false;
+			case WindowProcessorResult.ProcessAndRemove:
 				_processors.Remove(window.Handle);
 				return false;
 			default:

--- a/src/Whim/Store/WindowSector/Processors/WindowProcessorResult.cs
+++ b/src/Whim/Store/WindowSector/Processors/WindowProcessorResult.cs
@@ -11,6 +11,11 @@ public enum WindowProcessorResult
 	Ignore,
 
 	/// <summary>
+	/// The event should be ignored, and the active workspaces should be laid out.
+	/// </summary>
+	IgnoreAndLayout,
+
+	/// <summary>
 	/// The event should be processed.
 	/// </summary>
 	Process,
@@ -18,5 +23,5 @@ public enum WindowProcessorResult
 	/// <summary>
 	/// The event should be processed and the processor should be removed.
 	/// </summary>
-	RemoveProcessor
+	ProcessAndRemove
 }


### PR DESCRIPTION
After switching the logger to a less verbose option, it turns out that the `FirefoxWindowProcessor` wouldn't work reliably. I think two things were occurring here:

1. No `EVENT_OBJECT_CLOAKED` event was being sent sometimes, causing Whim to ignore events to the Firefox window. 
2. The Firefox window wouldn't respect Whim's `SetWindowPos` calls due to Firefox's window startup logic. 

The following changes have been made, respectively:

1. The `FirefoxWindowProcessor` now listens to all events after a timeout of 5 seconds. This is unpleasant, but seems necessary to handle the case when `EVENT_OBJECT_CLOAKED` was not emitted.
2. Ignored events can now trigger layouts. This necessitated a change to the `WindowProcessorManager`.
