### PR TITLE
Always hide layout preview when missing Windows events

### DIFF
--- a/src/Whim.FloatingLayout/FreeLayoutEngine.cs
+++ b/src/Whim.FloatingLayout/FreeLayoutEngine.cs
@@ -1,7 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
-using DotNext;
 
 namespace Whim.FloatingLayout;
 
@@ -134,11 +133,7 @@ public class FreeLayoutEngine : ILayoutEngine
 			return this;
 		}
 
-		if (!_context.Store.Pick(Pickers.PickMonitorAtPoint(newActualRectangle)).TryGet(out IMonitor newMonitor))
-		{
-			return this;
-		}
-
+		IMonitor newMonitor = _context.MonitorManager.GetMonitorAtPoint(newActualRectangle);
 		IRectangle<double> newUnitSquareRectangle = newMonitor.WorkingArea.NormalizeRectangle(newActualRectangle);
 		if (newUnitSquareRectangle.Equals(oldRectangle))
 		{

--- a/src/Whim.FloatingLayout/FreeLayoutEngine.cs
+++ b/src/Whim.FloatingLayout/FreeLayoutEngine.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
+using DotNext;
 
 namespace Whim.FloatingLayout;
 
@@ -133,7 +134,11 @@ public class FreeLayoutEngine : ILayoutEngine
 			return this;
 		}
 
-		IMonitor newMonitor = _context.MonitorManager.GetMonitorAtPoint(newActualRectangle);
+		if (!_context.Store.Pick(Pickers.PickMonitorAtPoint(newActualRectangle)).TryGet(out IMonitor newMonitor))
+		{
+			return this;
+		}
+
 		IRectangle<double> newUnitSquareRectangle = newMonitor.WorkingArea.NormalizeRectangle(newActualRectangle);
 		if (newUnitSquareRectangle.Equals(oldRectangle))
 		{

--- a/src/Whim.LayoutPreview.Tests/LayoutPreviewPluginTests.cs
+++ b/src/Whim.LayoutPreview.Tests/LayoutPreviewPluginTests.cs
@@ -115,7 +115,7 @@ public class LayoutPreviewPluginTests
 	}
 
 	[Theory, AutoSubstituteData<LayoutPreviewPluginCustomization>]
-	internal void WindowMoveStarted_NotDragged(IContext ctx)
+	internal void WindowMoveStarted_NotDragged(IContext ctx, MutableRootSector rootSector)
 	{
 		// Given
 		using LayoutPreviewPlugin plugin = new(ctx);
@@ -129,10 +129,8 @@ public class LayoutPreviewPluginTests
 
 		// When
 		plugin.PreInitialize();
-		ctx.Store.WindowEvents.WindowMoveStarted += Raise.Event<EventHandler<WindowMoveStartedEventArgs>>(
-			ctx.WindowManager,
-			e
-		);
+		rootSector.WindowSector.QueueEvent(e);
+		rootSector.DispatchEvents();
 
 		// Then
 		Assert.Null(plugin.DraggedWindow);
@@ -248,7 +246,7 @@ public class LayoutPreviewPluginTests
 	#endregion
 
 	[Theory, AutoSubstituteData<LayoutPreviewPluginCustomization>]
-	internal void WindowMoveEnded(IContext ctx)
+	internal void WindowMoveEnded(IContext ctx, MutableRootSector rootSector)
 	{
 		// Given
 		using LayoutPreviewPlugin plugin = new(ctx);
@@ -262,10 +260,8 @@ public class LayoutPreviewPluginTests
 
 		// When
 		plugin.PreInitialize();
-		ctx.Store.WindowEvents.WindowMoveEnded += Raise.Event<EventHandler<WindowMoveEndedEventArgs>>(
-			ctx.WindowManager,
-			e
-		);
+		rootSector.WindowSector.QueueEvent(e);
+		rootSector.DispatchEvents();
 
 		// Then
 		Assert.Null(plugin.DraggedWindow);

--- a/src/Whim.LayoutPreview.Tests/LayoutPreviewPluginTests.cs
+++ b/src/Whim.LayoutPreview.Tests/LayoutPreviewPluginTests.cs
@@ -19,6 +19,7 @@ public class LayoutPreviewPluginCustomization : StoreCustomization
 		fixture.Inject(workspace);
 
 		IMonitor monitor = StoreTestUtils.CreateMonitor((HMONITOR)1);
+		fixture.Inject(monitor);
 
 		StoreTestUtils.SetupMonitorAtPoint(
 			_ctx,
@@ -220,7 +221,8 @@ public class LayoutPreviewPluginTests
 		IContext ctx,
 		MutableRootSector rootSector,
 		IWindow window,
-		Workspace workspace
+		Workspace workspace,
+		IMonitor monitor
 	)
 	{
 		// Given
@@ -232,6 +234,7 @@ public class LayoutPreviewPluginTests
 			ActiveLayoutEngineIndex = 0
 		};
 		rootSector.WorkspaceSector.Workspaces = rootSector.WorkspaceSector.Workspaces.SetItem(workspace.Id, workspace);
+		ctx.MonitorManager.GetMonitorAtPoint(Arg.Any<IPoint<int>>()).Returns(monitor);
 
 		using LayoutPreviewPlugin plugin = new(ctx);
 		WindowMovedEventArgs e =

--- a/src/Whim.LayoutPreview.Tests/LayoutPreviewPluginTests.cs
+++ b/src/Whim.LayoutPreview.Tests/LayoutPreviewPluginTests.cs
@@ -231,6 +231,7 @@ public class LayoutPreviewPluginTests
 			),
 			ActiveLayoutEngineIndex = 0
 		};
+		rootSector.WorkspaceSector.Workspaces = rootSector.WorkspaceSector.Workspaces.SetItem(workspace.Id, workspace);
 
 		using LayoutPreviewPlugin plugin = new(ctx);
 		WindowMovedEventArgs e =
@@ -247,8 +248,7 @@ public class LayoutPreviewPluginTests
 		rootSector.DispatchEvents();
 
 		// Then
-		Assert.Single(workspace.ActiveLayoutEngine.ReceivedCalls());
-		Assert.Equal(window, plugin.DraggedWindow);
+		Assert.Null(plugin.DraggedWindow);
 	}
 
 	[Theory, AutoSubstituteData<LayoutPreviewPluginCustomization>]

--- a/src/Whim.LayoutPreview.Tests/LayoutPreviewPluginTests.cs
+++ b/src/Whim.LayoutPreview.Tests/LayoutPreviewPluginTests.cs
@@ -18,7 +18,13 @@ public class LayoutPreviewPluginCustomization : StoreCustomization
 
 		IMonitor monitor = StoreTestUtils.CreateMonitor((HMONITOR)1);
 
-		StoreTestUtils.SetupMonitorAtPoint(_internalCtx, new Point<int>(0, 0), monitor);
+		StoreTestUtils.SetupMonitorAtPoint(
+			_ctx,
+			_internalCtx,
+			_store._root.MutableRootSector,
+			new Point<int>(0, 0),
+			monitor
+		);
 		StoreTestUtils.PopulateMonitorWorkspaceMap(_ctx, _store._root.MutableRootSector, monitor, workspace);
 	}
 }

--- a/src/Whim.LayoutPreview/LayoutPreviewPlugin.cs
+++ b/src/Whim.LayoutPreview/LayoutPreviewPlugin.cs
@@ -69,6 +69,8 @@ public class LayoutPreviewPlugin : IPlugin, IDisposable
 		// Only run if the window is being dragged. If the window is being resized, we don't want to do anything.
 		if (e.CursorDraggedPoint is not IPoint<int> cursorDraggedPoint || e.MovedEdges is not null)
 		{
+			_layoutPreviewWindow?.Hide(_context);
+			DraggedWindow = null;
 			return;
 		}
 
@@ -78,6 +80,8 @@ public class LayoutPreviewPlugin : IPlugin, IDisposable
 		IWorkspace? workspace = _context.Butler.Pantry.GetWorkspaceForMonitor(monitor);
 		if (workspace == null)
 		{
+			_layoutPreviewWindow?.Hide(_context);
+			DraggedWindow = null;
 			return;
 		}
 
@@ -87,6 +91,9 @@ public class LayoutPreviewPlugin : IPlugin, IDisposable
 		{
 			// To be renamed when FreeLayoutEngine will be renamed
 			Logger.Debug("Skip LayoutPreview as LeafLayoutEngine is a FreeLayoutEngine");
+
+			_layoutPreviewWindow?.Hide(_context);
+			DraggedWindow = null;
 			return;
 		}
 

--- a/src/Whim.LayoutPreview/LayoutPreviewPlugin.cs
+++ b/src/Whim.LayoutPreview/LayoutPreviewPlugin.cs
@@ -76,8 +76,7 @@ public class LayoutPreviewPlugin : IPlugin, IDisposable
 			|| !_context.Store.Pick(Pickers.PickWorkspaceByMonitor(monitor.Handle)).TryGet(out IWorkspace workspace)
 		)
 		{
-			_layoutPreviewWindow?.Hide(_context);
-			DraggedWindow = null;
+			Hide();
 			return;
 		}
 
@@ -90,8 +89,7 @@ public class LayoutPreviewPlugin : IPlugin, IDisposable
 			// To be renamed when FreeLayoutEngine will be renamed
 			Logger.Debug("Skip LayoutPreview as LeafLayoutEngine is a FreeLayoutEngine");
 
-			_layoutPreviewWindow?.Hide(_context);
-			DraggedWindow = null;
+			Hide();
 			return;
 		}
 
@@ -117,18 +115,15 @@ public class LayoutPreviewPlugin : IPlugin, IDisposable
 	{
 		if (DraggedWindow == e.Window)
 		{
-			_layoutPreviewWindow?.Hide(_context);
-			DraggedWindow = null;
+			Hide();
 		}
 	}
 
-	private void WindowManager_WindowFocused(object? sender, WindowFocusedEventArgs e)
-	{
-		_layoutPreviewWindow?.Hide(_context);
-		DraggedWindow = null;
-	}
+	private void WindowManager_WindowFocused(object? sender, WindowFocusedEventArgs e) => Hide();
 
-	private void WindowManager_WindowMoveEnd(object? sender, WindowEventArgs e)
+	private void WindowManager_WindowMoveEnd(object? sender, WindowEventArgs e) => Hide();
+
+	private void Hide()
 	{
 		_layoutPreviewWindow?.Hide(_context);
 		DraggedWindow = null;

--- a/src/Whim.LayoutPreview/LayoutPreviewPlugin.cs
+++ b/src/Whim.LayoutPreview/LayoutPreviewPlugin.cs
@@ -36,11 +36,11 @@ public class LayoutPreviewPlugin : IPlugin, IDisposable
 	/// <inheritdoc	/>
 	public void PreInitialize()
 	{
-		_context.Store.WindowEvents.WindowMoveStarted += WindowManager_WindowMoveStart;
+		_context.Store.WindowEvents.WindowMoveStarted += WindowEvents_WindowMoveStart;
 		_context.Store.WindowEvents.WindowMoved += WindowMoved;
-		_context.Store.WindowEvents.WindowMoveEnded += WindowManager_WindowMoveEnd;
-		_context.Store.WindowEvents.WindowRemoved += WindowManager_WindowRemoved;
-		_context.Store.WindowEvents.WindowFocused += WindowManager_WindowFocused;
+		_context.Store.WindowEvents.WindowMoveEnded += WindowEvents_WindowMoveEnd;
+		_context.Store.WindowEvents.WindowRemoved += WindowEvents_WindowRemoved;
+		_context.Store.WindowEvents.WindowFocused += WindowEvents_WindowFocused;
 		_context.FilterManager.AddTitleMatchFilter(LayoutPreviewWindow.WindowTitle);
 	}
 
@@ -53,13 +53,14 @@ public class LayoutPreviewPlugin : IPlugin, IDisposable
 	/// <inheritdoc />
 	public JsonElement? SaveState() => null;
 
-	private void WindowManager_WindowMoveStart(object? sender, WindowMoveStartedEventArgs e)
+	private void WindowEvents_WindowMoveStart(object? sender, WindowMoveStartedEventArgs e)
 	{
 		if (e.CursorDraggedPoint == null)
 		{
 			return;
 		}
 
+		// We don't hit this code path in tests to avoid UI code not working in tests.
 		_layoutPreviewWindow ??= new(_context);
 		WindowMoved(this, e);
 	}
@@ -111,7 +112,7 @@ public class LayoutPreviewPlugin : IPlugin, IDisposable
 		);
 	}
 
-	private void WindowManager_WindowRemoved(object? sender, WindowEventArgs e)
+	private void WindowEvents_WindowRemoved(object? sender, WindowEventArgs e)
 	{
 		if (DraggedWindow == e.Window)
 		{
@@ -119,9 +120,9 @@ public class LayoutPreviewPlugin : IPlugin, IDisposable
 		}
 	}
 
-	private void WindowManager_WindowFocused(object? sender, WindowFocusedEventArgs e) => Hide();
+	private void WindowEvents_WindowFocused(object? sender, WindowFocusedEventArgs e) => Hide();
 
-	private void WindowManager_WindowMoveEnd(object? sender, WindowEventArgs e) => Hide();
+	private void WindowEvents_WindowMoveEnd(object? sender, WindowEventArgs e) => Hide();
 
 	private void Hide()
 	{

--- a/src/Whim.LayoutPreview/LayoutPreviewPlugin.cs
+++ b/src/Whim.LayoutPreview/LayoutPreviewPlugin.cs
@@ -36,11 +36,11 @@ public class LayoutPreviewPlugin : IPlugin, IDisposable
 	/// <inheritdoc	/>
 	public void PreInitialize()
 	{
-		_context.WindowManager.WindowMoveStart += WindowManager_WindowMoveStart;
-		_context.WindowManager.WindowMoved += WindowMoved;
-		_context.WindowManager.WindowMoveEnd += WindowManager_WindowMoveEnd;
-		_context.WindowManager.WindowRemoved += WindowManager_WindowRemoved;
-		_context.WindowManager.WindowFocused += WindowManager_WindowFocused;
+		_context.Store.WindowEvents.WindowMoveStarted += WindowManager_WindowMoveStart;
+		_context.Store.WindowEvents.WindowMoved += WindowMoved;
+		_context.Store.WindowEvents.WindowMoveEnded += WindowManager_WindowMoveEnd;
+		_context.Store.WindowEvents.WindowRemoved += WindowManager_WindowRemoved;
+		_context.Store.WindowEvents.WindowFocused += WindowManager_WindowFocused;
 		_context.FilterManager.AddTitleMatchFilter(LayoutPreviewWindow.WindowTitle);
 	}
 

--- a/src/Whim.LayoutPreview/LayoutPreviewWindow.xaml
+++ b/src/Whim.LayoutPreview/LayoutPreviewWindow.xaml
@@ -7,6 +7,6 @@
 	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 	mc:Ignorable="d">
 
-	<Canvas x:Name="LayoutPreviewCanvas" />
+	<Canvas x:Name="LayoutPreviewCanvas" PointerPressed="LayoutPreviewCanvas_PointerPressed"/>
 
 </Window>

--- a/src/Whim.LayoutPreview/LayoutPreviewWindow.xaml
+++ b/src/Whim.LayoutPreview/LayoutPreviewWindow.xaml
@@ -7,6 +7,6 @@
 	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 	mc:Ignorable="d">
 
-	<Canvas x:Name="LayoutPreviewCanvas" PointerPressed="LayoutPreviewCanvas_PointerPressed"/>
+	<Canvas x:Name="LayoutPreviewCanvas" PointerPressed="LayoutPreviewCanvas_PointerPressed" />
 
 </Window>

--- a/src/Whim.LayoutPreview/LayoutPreviewWindow.xaml.cs
+++ b/src/Whim.LayoutPreview/LayoutPreviewWindow.xaml.cs
@@ -143,11 +143,8 @@ internal sealed partial class LayoutPreviewWindow : Window, IDisposable
 		);
 	}
 
-	private void LayoutPreviewCanvas_PointerPressed(object sender, PointerRoutedEventArgs e)
-	{
-		// Hide the window when the user clicks on it.
-		this.Hide(_context);
-	}
+	// Hide the window when the user clicks on it.
+	private void LayoutPreviewCanvas_PointerPressed(object sender, PointerRoutedEventArgs e) => this.Hide(_context);
 
 	private void Dispose(bool disposing)
 	{

--- a/src/Whim.LayoutPreview/LayoutPreviewWindow.xaml.cs
+++ b/src/Whim.LayoutPreview/LayoutPreviewWindow.xaml.cs
@@ -1,6 +1,7 @@
 using System;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Input;
 using Windows.Win32.UI.WindowsAndMessaging;
 
 namespace Whim.LayoutPreview;
@@ -140,6 +141,12 @@ internal sealed partial class LayoutPreviewWindow : Window, IDisposable
 				flags: SET_WINDOW_POS_FLAGS.SWP_NOACTIVATE | SET_WINDOW_POS_FLAGS.SWP_SHOWWINDOW
 			)
 		);
+	}
+
+	private void LayoutPreviewCanvas_PointerPressed(object sender, PointerRoutedEventArgs e)
+	{
+		// Hide the window when the user clicks on it.
+		this.Hide(_context);
 	}
 
 	private void Dispose(bool disposing)

--- a/src/Whim.TestUtils/StoreTestUtils.cs
+++ b/src/Whim.TestUtils/StoreTestUtils.cs
@@ -161,8 +161,22 @@ internal static class StoreTestUtils
 		return workspace;
 	}
 
-	public static void SetupMonitorAtPoint(IContext ctx, IPoint<int> point, IMonitor monitor)
+	internal static void SetupMonitorAtPoint(IInternalContext internalCtx, IPoint<int> point, IMonitor monitor)
 	{
-		ctx.MonitorManager.GetMonitorAtPoint(point).Returns(monitor);
+		internalCtx
+			.CoreNativeManager.MonitorFromPoint(
+				Arg.Any<System.Drawing.Point>(),
+				MONITOR_FROM_FLAGS.MONITOR_DEFAULTTONEAREST
+			)
+			.Returns(callInfo =>
+			{
+				System.Drawing.Point calledPoint = callInfo.Arg<System.Drawing.Point>();
+				if (calledPoint.X == point.X && calledPoint.Y == point.Y)
+				{
+					return monitor.Handle;
+				}
+
+				return default;
+			});
 	}
 }

--- a/src/Whim.TestUtils/StoreTestUtils.cs
+++ b/src/Whim.TestUtils/StoreTestUtils.cs
@@ -161,7 +161,13 @@ internal static class StoreTestUtils
 		return workspace;
 	}
 
-	internal static void SetupMonitorAtPoint(IInternalContext internalCtx, IPoint<int> point, IMonitor monitor)
+	internal static void SetupMonitorAtPoint(
+		IContext ctx,
+		IInternalContext internalCtx,
+		MutableRootSector rootSector,
+		IPoint<int> point,
+		IMonitor monitor
+	)
 	{
 		internalCtx
 			.CoreNativeManager.MonitorFromPoint(
@@ -178,5 +184,7 @@ internal static class StoreTestUtils
 
 				return default;
 			});
+
+		AddMonitorsToManager(ctx, rootSector, monitor);
 	}
 }

--- a/src/Whim.TestUtils/Whim.TestUtils.csproj
+++ b/src/Whim.TestUtils/Whim.TestUtils.csproj
@@ -40,5 +40,6 @@
   </ItemGroup>
   <ItemGroup>
     <InternalsVisibleTo Include="Whim.Tests" />
+    <InternalsVisibleTo Include="Whim.LayoutPreview.Tests" />
   </ItemGroup>
 </Project>

--- a/src/Whim.Tests/Store/MapSector/Transforms/MoveWindowToPointTransformTests.cs
+++ b/src/Whim.Tests/Store/MapSector/Transforms/MoveWindowToPointTransformTests.cs
@@ -4,6 +4,21 @@ namespace Whim.Tests;
 public class MoveWindowToPointTransformTests
 {
 	[Theory, AutoSubstituteData<StoreCustomization>]
+	internal void NoMonitorAtPoint(IContext ctx)
+	{
+		// Given there is monitor at the given point
+		Point<int> point = new(10, 10);
+
+		MoveWindowToPointTransform sut = new((HWND)10, point);
+
+		// When we execute the transform
+		var result = ctx.Store.Dispatch(sut);
+
+		// Then we fail
+		Assert.False(result.IsSuccessful);
+	}
+
+	[Theory, AutoSubstituteData<StoreCustomization>]
 	internal void NoWorkspaceForMonitor(IContext ctx, IInternalContext internalCtx, MutableRootSector rootSector)
 	{
 		// Given there is no workspace for the monitor at the given point

--- a/src/Whim.Tests/Store/MapSector/Transforms/MoveWindowToPointTransformTests.cs
+++ b/src/Whim.Tests/Store/MapSector/Transforms/MoveWindowToPointTransformTests.cs
@@ -4,12 +4,12 @@ namespace Whim.Tests;
 public class MoveWindowToPointTransformTests
 {
 	[Theory, AutoSubstituteData<StoreCustomization>]
-	internal void NoWorkspaceForMonitor(IContext ctx)
+	internal void NoWorkspaceForMonitor(IContext ctx, IInternalContext internalCtx)
 	{
 		// Given there is no workspace for the monitor at the given point
 		IMonitor monitor = CreateMonitor((HMONITOR)10);
 		Point<int> point = new(10, 10);
-		SetupMonitorAtPoint(ctx, point, monitor);
+		SetupMonitorAtPoint(internalCtx, point, monitor);
 
 		MoveWindowToPointTransform sut = new((HWND)10, point);
 
@@ -21,7 +21,7 @@ public class MoveWindowToPointTransformTests
 	}
 
 	[Theory, AutoSubstituteData<StoreCustomization>]
-	internal void NoWorkspaceForWindow(IContext ctx, MutableRootSector rootSector)
+	internal void NoWorkspaceForWindow(IContext ctx, IInternalContext internalCtx, MutableRootSector rootSector)
 	{
 		// Given there is no workspace for the window
 		IWindow window = CreateWindow((HWND)10);
@@ -30,7 +30,7 @@ public class MoveWindowToPointTransformTests
 		Point<int> point = new(10, 10);
 
 		AddWindowToSector(rootSector, window);
-		SetupMonitorAtPoint(ctx, point, monitor);
+		SetupMonitorAtPoint(internalCtx, point, monitor);
 		PopulateMonitorWorkspaceMap(ctx, rootSector, monitor, workspace);
 
 		MoveWindowToPointTransform sut = new(window.Handle, point);
@@ -43,7 +43,11 @@ public class MoveWindowToPointTransformTests
 	}
 
 	[Theory, AutoSubstituteData<StoreCustomization>]
-	internal void MoveWindowToPointOnSameMonitor(IContext ctx, MutableRootSector rootSector)
+	internal void MoveWindowToPointOnSameMonitor(
+		IContext ctx,
+		IInternalContext internalCtx,
+		MutableRootSector rootSector
+	)
 	{
 		// Given there is a workspace for the window
 		IWindow window = CreateWindow((HWND)10);
@@ -52,7 +56,7 @@ public class MoveWindowToPointTransformTests
 		Point<int> point = new(10, 10);
 
 		AddWindowToSector(rootSector, window);
-		SetupMonitorAtPoint(ctx, point, monitor);
+		SetupMonitorAtPoint(internalCtx, point, monitor);
 		PopulateThreeWayMap(ctx, rootSector, monitor, workspace, window);
 
 		MoveWindowToPointTransform sut = new(window.Handle, point);
@@ -77,7 +81,11 @@ public class MoveWindowToPointTransformTests
 	}
 
 	[Theory, AutoSubstituteData<StoreCustomization>]
-	internal void MoveWindowToPointOnDifferentMonitor(IContext ctx, MutableRootSector rootSector)
+	internal void MoveWindowToPointOnDifferentMonitor(
+		IContext ctx,
+		IInternalContext internalCtx,
+		MutableRootSector rootSector
+	)
 	{
 		// Given there is a workspace for the window
 		IWindow window = CreateWindow((HWND)10);
@@ -90,7 +98,7 @@ public class MoveWindowToPointTransformTests
 		Point<int> point = new(10, 10);
 
 		AddWindowToSector(rootSector, window);
-		SetupMonitorAtPoint(ctx, point, targetMonitor);
+		SetupMonitorAtPoint(internalCtx, point, targetMonitor);
 		PopulateThreeWayMap(ctx, rootSector, sourceMonitor, sourceWorkspace, window);
 		PopulateMonitorWorkspaceMap(ctx, rootSector, targetMonitor, targetWorkspace);
 

--- a/src/Whim.Tests/Store/MapSector/Transforms/MoveWindowToPointTransformTests.cs
+++ b/src/Whim.Tests/Store/MapSector/Transforms/MoveWindowToPointTransformTests.cs
@@ -4,12 +4,12 @@ namespace Whim.Tests;
 public class MoveWindowToPointTransformTests
 {
 	[Theory, AutoSubstituteData<StoreCustomization>]
-	internal void NoWorkspaceForMonitor(IContext ctx, IInternalContext internalCtx)
+	internal void NoWorkspaceForMonitor(IContext ctx, IInternalContext internalCtx, MutableRootSector rootSector)
 	{
 		// Given there is no workspace for the monitor at the given point
 		IMonitor monitor = CreateMonitor((HMONITOR)10);
 		Point<int> point = new(10, 10);
-		SetupMonitorAtPoint(internalCtx, point, monitor);
+		SetupMonitorAtPoint(ctx, internalCtx, rootSector, point, monitor);
 
 		MoveWindowToPointTransform sut = new((HWND)10, point);
 
@@ -30,7 +30,7 @@ public class MoveWindowToPointTransformTests
 		Point<int> point = new(10, 10);
 
 		AddWindowToSector(rootSector, window);
-		SetupMonitorAtPoint(internalCtx, point, monitor);
+		SetupMonitorAtPoint(ctx, internalCtx, rootSector, point, monitor);
 		PopulateMonitorWorkspaceMap(ctx, rootSector, monitor, workspace);
 
 		MoveWindowToPointTransform sut = new(window.Handle, point);
@@ -56,7 +56,7 @@ public class MoveWindowToPointTransformTests
 		Point<int> point = new(10, 10);
 
 		AddWindowToSector(rootSector, window);
-		SetupMonitorAtPoint(internalCtx, point, monitor);
+		SetupMonitorAtPoint(ctx, internalCtx, rootSector, point, monitor);
 		PopulateThreeWayMap(ctx, rootSector, monitor, workspace, window);
 
 		MoveWindowToPointTransform sut = new(window.Handle, point);
@@ -98,7 +98,7 @@ public class MoveWindowToPointTransformTests
 		Point<int> point = new(10, 10);
 
 		AddWindowToSector(rootSector, window);
-		SetupMonitorAtPoint(internalCtx, point, targetMonitor);
+		SetupMonitorAtPoint(ctx, internalCtx, rootSector, point, targetMonitor);
 		PopulateThreeWayMap(ctx, rootSector, sourceMonitor, sourceWorkspace, window);
 		PopulateMonitorWorkspaceMap(ctx, rootSector, targetMonitor, targetWorkspace);
 

--- a/src/Whim/Store/MapSector/Transforms/MoveWindowToPointTransform.cs
+++ b/src/Whim/Store/MapSector/Transforms/MoveWindowToPointTransform.cs
@@ -15,7 +15,10 @@ public record MoveWindowToPointTransform(HWND WindowHandle, IPoint<int> Point) :
 	internal override Result<Unit> Execute(IContext ctx, IInternalContext internalCtx, MutableRootSector rootSector)
 	{
 		// Get the monitor.
-		IMonitor targetMonitor = ctx.MonitorManager.GetMonitorAtPoint(Point);
+		if (!ctx.Store.Pick(PickMonitorAtPoint(Point)).TryGet(out IMonitor targetMonitor))
+		{
+			return Result.FromException<Unit>(StoreExceptions.NoMonitorFoundAtPoint(Point));
+		}
 
 		// Get the target workspace.
 		Result<IWorkspace> targetWorkspaceResult = ctx.Store.Pick(PickWorkspaceByMonitor(targetMonitor.Handle));


### PR DESCRIPTION
Previously, the layout preview would sometimes fail to hide in certain scenarios (see below). This has been resolved by:

- Always hiding the preview whenever a window gains focus
- Hiding the preview whenever the preview is clicked

Additionally, `*Manager` references have been replaced by `*Store` references.

<details>
<summary>Bug description</summary>
1. Double click to maximize window
2. Click and drag maximized window to a position
3. Double click to maximize window again
4. Double click to restore window position

Expected behavior: Layout preview hides

Actual behavior: Layout preview is still visible
</details>
