### PR TITLE
Bump Whim version to 0.7.0

### DIFF
--- a/src/Whim.Bar.Tests/Whim.Bar.Tests.csproj
+++ b/src/Whim.Bar.Tests/Whim.Bar.Tests.csproj
@@ -22,7 +22,7 @@
     <Nullable>enable</Nullable>
     <Platforms>x64;arm64;Any CPU</Platforms>
     <TargetFramework>net7.0-windows10.0.19041.0</TargetFramework>
-    <Version>0.6.0</Version>
+    <Version>0.7.0</Version>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="AutoFixture" />

--- a/src/Whim.Bar/Whim.Bar.csproj
+++ b/src/Whim.Bar/Whim.Bar.csproj
@@ -25,7 +25,7 @@
     <TargetFramework>net7.0-windows10.0.19041.0</TargetFramework>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <UseWinUI>true</UseWinUI>
-    <Version>0.6.0</Version>
+    <Version>0.7.0</Version>
   </PropertyGroup>
   <ItemGroup>
     <None Remove="BarWindow.xaml" />

--- a/src/Whim.CommandPalette.Tests/Whim.CommandPalette.Tests.csproj
+++ b/src/Whim.CommandPalette.Tests/Whim.CommandPalette.Tests.csproj
@@ -22,7 +22,7 @@
     <Nullable>enable</Nullable>
     <Platforms>x64;arm64;Any CPU</Platforms>
     <TargetFramework>net7.0-windows10.0.19041.0</TargetFramework>
-    <Version>0.6.0</Version>
+    <Version>0.7.0</Version>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="AutoFixture" />

--- a/src/Whim.CommandPalette/Whim.CommandPalette.csproj
+++ b/src/Whim.CommandPalette/Whim.CommandPalette.csproj
@@ -23,7 +23,7 @@
     <TargetFramework>net7.0-windows10.0.19041.0</TargetFramework>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <UseWinUI>true</UseWinUI>
-    <Version>0.6.0</Version>
+    <Version>0.7.0</Version>
   </PropertyGroup>
   <ItemGroup>
     <None Remove="CommandPaletteWindow.xaml" />

--- a/src/Whim.FloatingLayout.Tests/Whim.FloatingLayout.Tests.csproj
+++ b/src/Whim.FloatingLayout.Tests/Whim.FloatingLayout.Tests.csproj
@@ -22,7 +22,7 @@
     <Nullable>enable</Nullable>
     <Platforms>x64;arm64;Any CPU</Platforms>
     <TargetFramework>net7.0-windows10.0.19041.0</TargetFramework>
-    <Version>0.6.0</Version>
+    <Version>0.7.0</Version>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="AutoFixture" />

--- a/src/Whim.FloatingLayout/Whim.FloatingLayout.csproj
+++ b/src/Whim.FloatingLayout/Whim.FloatingLayout.csproj
@@ -22,7 +22,7 @@
     <Platforms>x64;arm64;Any CPU</Platforms>
     <RuntimeIdentifiers>win10-x64;win10-arm64</RuntimeIdentifiers>
     <TargetFramework>net7.0-windows10.0.19041.0</TargetFramework>
-    <Version>0.6.0</Version>
+    <Version>0.7.0</Version>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Whim\Whim.csproj" />

--- a/src/Whim.FocusIndicator/Whim.FocusIndicator.csproj
+++ b/src/Whim.FocusIndicator/Whim.FocusIndicator.csproj
@@ -25,7 +25,7 @@
     <TargetFramework>net7.0-windows10.0.19041.0</TargetFramework>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <UseWinUI>true</UseWinUI>
-    <Version>0.6.0</Version>
+    <Version>0.7.0</Version>
   </PropertyGroup>
   <ItemGroup>
     <None Remove="FocusIndicatorWindow.xaml" />

--- a/src/Whim.Gaps.Tests/Whim.Gaps.Tests.csproj
+++ b/src/Whim.Gaps.Tests/Whim.Gaps.Tests.csproj
@@ -22,7 +22,7 @@
     <Nullable>enable</Nullable>
     <Platforms>x64;arm64;Any CPU</Platforms>
     <TargetFramework>net7.0-windows10.0.19041.0</TargetFramework>
-    <Version>0.6.0</Version>
+    <Version>0.7.0</Version>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="AutoFixture" />

--- a/src/Whim.Gaps/Whim.Gaps.csproj
+++ b/src/Whim.Gaps/Whim.Gaps.csproj
@@ -22,7 +22,7 @@
     <Platforms>x64;arm64;Any CPU</Platforms>
     <RuntimeIdentifiers>win10-x64;win10-arm64</RuntimeIdentifiers>
     <TargetFramework>net7.0-windows10.0.19041.0</TargetFramework>
-    <Version>0.6.0</Version>
+    <Version>0.7.0</Version>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Whim\Whim.csproj" />

--- a/src/Whim.LayoutPreview.Tests/Whim.LayoutPreview.Tests.csproj
+++ b/src/Whim.LayoutPreview.Tests/Whim.LayoutPreview.Tests.csproj
@@ -22,7 +22,7 @@
     <Nullable>enable</Nullable>
     <Platforms>x64;arm64;Any CPU</Platforms>
     <TargetFramework>net7.0-windows10.0.19041.0</TargetFramework>
-    <Version>0.6.0</Version>
+    <Version>0.7.0</Version>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="coverlet.collector">

--- a/src/Whim.LayoutPreview/Whim.LayoutPreview.csproj
+++ b/src/Whim.LayoutPreview/Whim.LayoutPreview.csproj
@@ -25,7 +25,7 @@
     <TargetFramework>net7.0-windows10.0.19041.0</TargetFramework>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <UseWinUI>true</UseWinUI>
-    <Version>0.6.0</Version>
+    <Version>0.7.0</Version>
   </PropertyGroup>
   <ItemGroup>
     <None Remove="LayoutPreviewWindow.xaml" />

--- a/src/Whim.Runner/Whim.Runner.csproj
+++ b/src/Whim.Runner/Whim.Runner.csproj
@@ -29,7 +29,7 @@
     <TargetFramework>net7.0-windows10.0.19041.0</TargetFramework>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <UseWinUI>true</UseWinUI>
-    <Version>0.6.0</Version>
+    <Version>0.7.0</Version>
     <WinUISDKReferences>false</WinUISDKReferences>
     <WindowsAppSDKSelfContained>true</WindowsAppSDKSelfContained>
     <WindowsPackageType>None</WindowsPackageType>

--- a/src/Whim.SliceLayout.Tests/Whim.SliceLayout.Tests.csproj
+++ b/src/Whim.SliceLayout.Tests/Whim.SliceLayout.Tests.csproj
@@ -22,7 +22,7 @@
     <Nullable>enable</Nullable>
     <Platforms>x64;arm64;Any CPU</Platforms>
     <TargetFramework>net7.0-windows10.0.19041.0</TargetFramework>
-    <Version>0.6.0</Version>
+    <Version>0.7.0</Version>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="AutoFixture" />

--- a/src/Whim.SliceLayout/Whim.SliceLayout.csproj
+++ b/src/Whim.SliceLayout/Whim.SliceLayout.csproj
@@ -25,7 +25,7 @@
     <TargetFramework>net7.0-windows10.0.19041.0</TargetFramework>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <UseWinUI>true</UseWinUI>
-    <Version>0.6.0</Version>
+    <Version>0.7.0</Version>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.WindowsAppSDK" />

--- a/src/Whim.TestUtils/Whim.TestUtils.csproj
+++ b/src/Whim.TestUtils/Whim.TestUtils.csproj
@@ -23,7 +23,7 @@
     <Nullable>enable</Nullable>
     <Platforms>x64;arm64;Any CPU</Platforms>
     <TargetFramework>net7.0-windows10.0.19041.0</TargetFramework>
-    <Version>0.6.0</Version>
+    <Version>0.7.0</Version>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="AutoFixture" />

--- a/src/Whim.Tests/Whim.Tests.csproj
+++ b/src/Whim.Tests/Whim.Tests.csproj
@@ -23,7 +23,7 @@
     <Nullable>enable</Nullable>
     <Platforms>x64;arm64;Any CPU</Platforms>
     <TargetFramework>net7.0-windows10.0.19041.0</TargetFramework>
-    <Version>0.6.0</Version>
+    <Version>0.7.0</Version>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="AutoFixture" />

--- a/src/Whim.TreeLayout.Bar.Tests/Whim.TreeLayout.Bar.Tests.csproj
+++ b/src/Whim.TreeLayout.Bar.Tests/Whim.TreeLayout.Bar.Tests.csproj
@@ -22,7 +22,7 @@
     <Nullable>enable</Nullable>
     <Platforms>x64;arm64;Any CPU</Platforms>
     <TargetFramework>net7.0-windows10.0.19041.0</TargetFramework>
-    <Version>0.6.0</Version>
+    <Version>0.7.0</Version>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="AutoFixture" />

--- a/src/Whim.TreeLayout.Bar/Whim.TreeLayout.Bar.csproj
+++ b/src/Whim.TreeLayout.Bar/Whim.TreeLayout.Bar.csproj
@@ -25,7 +25,7 @@
     <TargetFramework>net7.0-windows10.0.19041.0</TargetFramework>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <UseWinUI>true</UseWinUI>
-    <Version>0.6.0</Version>
+    <Version>0.7.0</Version>
   </PropertyGroup>
   <ItemGroup>
     <None Remove="TreeLayoutEngineWidget.xaml" />

--- a/src/Whim.TreeLayout.CommandPalette.Tests/Whim.TreeLayout.CommandPalette.Tests.csproj
+++ b/src/Whim.TreeLayout.CommandPalette.Tests/Whim.TreeLayout.CommandPalette.Tests.csproj
@@ -22,7 +22,7 @@
     <Nullable>enable</Nullable>
     <Platforms>x64;arm64;Any CPU</Platforms>
     <TargetFramework>net7.0-windows10.0.19041.0</TargetFramework>
-    <Version>0.6.0</Version>
+    <Version>0.7.0</Version>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="coverlet.collector">

--- a/src/Whim.TreeLayout.CommandPalette/Whim.TreeLayout.CommandPalette.csproj
+++ b/src/Whim.TreeLayout.CommandPalette/Whim.TreeLayout.CommandPalette.csproj
@@ -25,7 +25,7 @@
     <TargetFramework>net7.0-windows10.0.19041.0</TargetFramework>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <UseWinUI>true</UseWinUI>
-    <Version>0.6.0</Version>
+    <Version>0.7.0</Version>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.WindowsAppSDK" />

--- a/src/Whim.TreeLayout.Tests/Whim.TreeLayout.Tests.csproj
+++ b/src/Whim.TreeLayout.Tests/Whim.TreeLayout.Tests.csproj
@@ -22,7 +22,7 @@
     <Nullable>enable</Nullable>
     <Platforms>x64;arm64;Any CPU</Platforms>
     <TargetFramework>net7.0-windows10.0.19041.0</TargetFramework>
-    <Version>0.6.0</Version>
+    <Version>0.7.0</Version>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="coverlet.collector">

--- a/src/Whim.TreeLayout/Whim.TreeLayout.csproj
+++ b/src/Whim.TreeLayout/Whim.TreeLayout.csproj
@@ -25,7 +25,7 @@
     <TargetFramework>net7.0-windows10.0.19041.0</TargetFramework>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <UseWinUI>true</UseWinUI>
-    <Version>0.6.0</Version>
+    <Version>0.7.0</Version>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.WindowsAppSDK" />

--- a/src/Whim.Updater.Tests/Whim.Updater.Tests.csproj
+++ b/src/Whim.Updater.Tests/Whim.Updater.Tests.csproj
@@ -22,7 +22,7 @@
     <Nullable>enable</Nullable>
     <Platforms>x64;arm64;Any CPU</Platforms>
     <TargetFramework>net7.0-windows10.0.19041.0</TargetFramework>
-    <Version>0.6.0</Version>
+    <Version>0.7.0</Version>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="AutoFixture" />

--- a/src/Whim.Updater/Whim.Updater.csproj
+++ b/src/Whim.Updater/Whim.Updater.csproj
@@ -25,7 +25,7 @@
     <TargetFramework>net7.0-windows10.0.19041.0</TargetFramework>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <UseWinUI>true</UseWinUI>
-    <Version>0.6.0</Version>
+    <Version>0.7.0</Version>
   </PropertyGroup>
   <ItemGroup>
     <None Remove="UpdaterWindow.xaml" />

--- a/src/Whim/Whim.csproj
+++ b/src/Whim/Whim.csproj
@@ -24,7 +24,7 @@
     <RootNamespace>Whim</RootNamespace>
     <RuntimeIdentifiers>win10-x64;win10-arm64</RuntimeIdentifiers>
     <TargetFramework>net7.0-windows10.0.19041.0</TargetFramework>
-    <Version>0.6.0</Version>
+    <Version>0.7.0</Version>
     <WarningsAsErrors>Nullable</WarningsAsErrors>
     <!-- Required for VSCode debugging -->
     <Platform>x64</Platform>


### PR DESCRIPTION
Bump Whim version to 0.7.0

This is in preparation of the following significant changes:

- #961 Rename FloatingLayout to FloatingWindow, and FreeLayout to FloatingLayout
- #965 Upgrade to .NET 8
