### PR TITLE
Extract UpdateWindowRectangle from Floating and ProxyFloating layout

### DIFF
--- a/src/Whim.FloatingWindow/FloatingLayoutEngine.cs
+++ b/src/Whim.FloatingWindow/FloatingLayoutEngine.cs
@@ -7,7 +7,7 @@ namespace Whim.FloatingWindow;
 /// <summary>
 /// Layout engine that lays out all windows as free-floating.
 /// </summary>
-public class FloatingLayoutEngine : ILayoutEngine
+public record FloatingLayoutEngine : ILayoutEngine
 {
 	private readonly IContext _context;
 	private readonly ImmutableDictionary<IWindow, IRectangle<double>> _dict;

--- a/src/Whim.FloatingWindow/FloatingLayoutEngine.cs
+++ b/src/Whim.FloatingWindow/FloatingLayoutEngine.cs
@@ -122,9 +122,17 @@ public record FloatingLayoutEngine : ILayoutEngine
 
 	private FloatingLayoutEngine UpdateWindowRectangle(IWindow window)
 	{
-		(ImmutableDictionary<IWindow, IRectangle<double>> maybeNewDict, UpdateWindowStatus status) =
-			FloatingUtils.UpdateWindowRectangle(_context, _dict, window);
+		ImmutableDictionary<IWindow, IRectangle<double>>? newDict = FloatingUtils.UpdateWindowRectangle(
+			_context,
+			_dict,
+			window
+		);
 
-		return status == UpdateWindowStatus.Updated ? new FloatingLayoutEngine(this, maybeNewDict) : this;
+		if (newDict == null || newDict == _dict)
+		{
+			return this;
+		}
+
+		return new FloatingLayoutEngine(this, newDict);
 	}
 }

--- a/src/Whim.FloatingWindow/FloatingUtils.cs
+++ b/src/Whim.FloatingWindow/FloatingUtils.cs
@@ -3,27 +3,6 @@
 namespace Whim.FloatingWindow;
 
 /// <summary>
-/// Describe the result of the UpdateWindowRectangle
-/// </summary>
-internal enum UpdateWindowStatus
-{
-	/// <summary>
-	/// Could not obtain the rectangle for the window
-	/// </summary>
-	Error,
-
-	/// <summary>
-	/// Nothing was changed.
-	/// </summary>
-	NoChange,
-
-	/// <summary>
-	/// The new position was calculated, and the dict updated.
-	/// </summary>
-	Updated,
-}
-
-/// <summary>
 /// Provide methods for the floating engines
 /// </summary>
 internal static class FloatingUtils
@@ -34,11 +13,12 @@ internal static class FloatingUtils
 	/// <param name="context"></param>
 	/// <param name="dict"></param>
 	/// <param name="window"></param>
-	/// <returns>A tuple with the maybe updated <paramref name="dict"/>, and its <param cref="UpdateWindowStatus"></param></returns>
-	public static (
-		ImmutableDictionary<IWindow, IRectangle<double>> maybeNewDict,
-		UpdateWindowStatus status
-	) UpdateWindowRectangle(IContext context, ImmutableDictionary<IWindow, IRectangle<double>> dict, IWindow window)
+	/// <returns></returns>
+	public static ImmutableDictionary<IWindow, IRectangle<double>>? UpdateWindowRectangle(
+		IContext context,
+		ImmutableDictionary<IWindow, IRectangle<double>> dict,
+		IWindow window
+	)
 	{
 		// Try get the old rectangle.
 		IRectangle<double>? oldRectangle = dict.TryGetValue(window, out IRectangle<double>? rectangle)
@@ -50,7 +30,7 @@ internal static class FloatingUtils
 		if (newActualRectangle == null)
 		{
 			Logger.Error($"Could not obtain rectangle for floating window {window}");
-			return (dict, UpdateWindowStatus.Error);
+			return null;
 		}
 
 		IMonitor newMonitor = context.MonitorManager.GetMonitorAtPoint(newActualRectangle);
@@ -58,11 +38,11 @@ internal static class FloatingUtils
 		if (newUnitSquareRectangle.Equals(oldRectangle))
 		{
 			Logger.Debug($"Rectangle for window {window} has not changed");
-			return (dict, UpdateWindowStatus.NoChange);
+			return dict;
 		}
 
 		ImmutableDictionary<IWindow, IRectangle<double>> newDict = dict.SetItem(window, newUnitSquareRectangle);
 
-		return (newDict, UpdateWindowStatus.Updated);
+		return newDict;
 	}
 }

--- a/src/Whim.FloatingWindow/FloatingUtils.cs
+++ b/src/Whim.FloatingWindow/FloatingUtils.cs
@@ -1,0 +1,68 @@
+﻿using System.Collections.Immutable;
+
+namespace Whim.FloatingWindow;
+
+/// <summary>
+/// Describe the result of the UpdateWindowRectangle
+/// </summary>
+internal enum UpdateWindowStatus
+{
+	/// <summary>
+	/// Could not obtain the rectangle for the window
+	/// </summary>
+	Error,
+
+	/// <summary>
+	/// Nothing was changed.
+	/// </summary>
+	NoChange,
+
+	/// <summary>
+	/// The new position was calculated, and the dict updated.
+	/// </summary>
+	Updated,
+}
+
+/// <summary>
+/// Provide methods for the floating engines
+/// </summary>
+internal static class FloatingUtils
+{
+	/// <summary>
+	/// Update the position of a <paramref name="window"/> from the <paramref name="dict"/>.
+	/// </summary>
+	/// <param name="context"></param>
+	/// <param name="dict"></param>
+	/// <param name="window"></param>
+	/// <returns>A tuple with the maybe updated <paramref name="dict"/>, and its <param cref="UpdateWindowStatus"></param></returns>
+	public static (
+		ImmutableDictionary<IWindow, IRectangle<double>> maybeNewDict,
+		UpdateWindowStatus status
+	) UpdateWindowRectangle(IContext context, ImmutableDictionary<IWindow, IRectangle<double>> dict, IWindow window)
+	{
+		// Try get the old rectangle.
+		IRectangle<double>? oldRectangle = dict.TryGetValue(window, out IRectangle<double>? rectangle)
+			? rectangle
+			: null;
+
+		// Since the window is floating, we update the rectangle, and return.
+		IRectangle<int>? newActualRectangle = context.NativeManager.DwmGetWindowRectangle(window.Handle);
+		if (newActualRectangle == null)
+		{
+			Logger.Error($"Could not obtain rectangle for floating window {window}");
+			return (dict, UpdateWindowStatus.Error);
+		}
+
+		IMonitor newMonitor = context.MonitorManager.GetMonitorAtPoint(newActualRectangle);
+		IRectangle<double> newUnitSquareRectangle = newMonitor.WorkingArea.NormalizeRectangle(newActualRectangle);
+		if (newUnitSquareRectangle.Equals(oldRectangle))
+		{
+			Logger.Debug($"Rectangle for window {window} has not changed");
+			return (dict, UpdateWindowStatus.NoChange);
+		}
+
+		ImmutableDictionary<IWindow, IRectangle<double>> newDict = dict.SetItem(window, newUnitSquareRectangle);
+
+		return (newDict, UpdateWindowStatus.Updated);
+	}
+}

--- a/src/Whim.FloatingWindow/ProxyFloatingLayoutEngine.cs
+++ b/src/Whim.FloatingWindow/ProxyFloatingLayoutEngine.cs
@@ -204,20 +204,8 @@ internal record ProxyFloatingLayoutEngine : BaseProxyLayoutEngine
 	}
 
 	/// <inheritdoc />
-	public override IWindow? GetFirstWindow()
-	{
-		if (InnerLayoutEngine.GetFirstWindow() is IWindow window)
-		{
-			return window;
-		}
-
-		if (_floatingWindowRects.Count > 0)
-		{
-			return _floatingWindowRects.Keys.First();
-		}
-
-		return null;
-	}
+	public override IWindow? GetFirstWindow() =>
+		InnerLayoutEngine.GetFirstWindow() ?? _floatingWindowRects.Keys.FirstOrDefault();
 
 	/// <inheritdoc />
 	public override ILayoutEngine FocusWindowInDirection(Direction direction, IWindow window)

--- a/src/Whim.FloatingWindow/ProxyFloatingLayoutEngine.cs
+++ b/src/Whim.FloatingWindow/ProxyFloatingLayoutEngine.cs
@@ -143,8 +143,9 @@ internal record ProxyFloatingLayoutEngine : BaseProxyLayoutEngine
 		return UpdateInner(InnerLayoutEngine.MoveWindowEdgesInDirection(edge, deltas, window), window);
 	}
 
-	private bool IsWindowFloating(IWindow window) =>
-		_plugin.FloatingWindows.TryGetValue(window, out ISet<LayoutEngineIdentity>? layoutEngines)
+	private bool IsWindowFloating(IWindow? window) =>
+		window != null
+		&& _plugin.FloatingWindows.TryGetValue(window, out ISet<LayoutEngineIdentity>? layoutEngines)
 		&& layoutEngines.Contains(InnerLayoutEngine.Identity);
 
 	private (ProxyFloatingLayoutEngine, bool error) UpdateWindowRectangle(IWindow window)
@@ -262,7 +263,7 @@ internal record ProxyFloatingLayoutEngine : BaseProxyLayoutEngine
 	/// <inheritdoc />
 	public override ILayoutEngine PerformCustomAction<T>(LayoutEngineCustomAction<T> action)
 	{
-		if (action.Window != null && IsWindowFloating(action.Window))
+		if (IsWindowFloating(action.Window))
 		{
 			// At this stage, we don't have a way to get the window in a child layout engine at
 			// a given point.

--- a/src/Whim.FloatingWindow/ProxyFloatingLayoutEngine.cs
+++ b/src/Whim.FloatingWindow/ProxyFloatingLayoutEngine.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
@@ -150,36 +151,21 @@ internal record ProxyFloatingLayoutEngine : BaseProxyLayoutEngine
 
 	private (ProxyFloatingLayoutEngine, bool error) UpdateWindowRectangle(IWindow window)
 	{
-		// Try get the old rectangle.
-		IRectangle<double>? oldRectangle = _floatingWindowRects.TryGetValue(window, out IRectangle<double>? rectangle)
-			? rectangle
-			: null;
+		(ImmutableDictionary<IWindow, IRectangle<double>> maybeNewDict, UpdateWindowStatus status) =
+			FloatingUtils.UpdateWindowRectangle(_context, _floatingWindowRects, window);
 
-		// Since the window is floating, we update the rectangle, and return.
-		IRectangle<int>? newActualRectangle = _context.NativeManager.DwmGetWindowRectangle(window.Handle);
-		if (newActualRectangle == null)
+		switch (status)
 		{
-			Logger.Error($"Could not obtain rectangle for floating window {window}");
-			return (this, true);
+			case UpdateWindowStatus.Error:
+				return (this, true);
+			case UpdateWindowStatus.NoChange:
+				return (this, false);
+			case UpdateWindowStatus.Updated:
+				ILayoutEngine innerLayoutEngine = InnerLayoutEngine.RemoveWindow(window);
+				return (new ProxyFloatingLayoutEngine(this, innerLayoutEngine, maybeNewDict), false);
+			default:
+				throw new ArgumentOutOfRangeException($"UpdateWindowStatus ${status} does not exists");
 		}
-
-		IMonitor newMonitor = _context.MonitorManager.GetMonitorAtPoint(newActualRectangle);
-		IRectangle<double> newUnitSquareRectangle = newMonitor.WorkingArea.NormalizeRectangle(newActualRectangle);
-		if (newUnitSquareRectangle.Equals(oldRectangle))
-		{
-			Logger.Debug($"Rectangle for window {window} has not changed");
-			return (this, false);
-		}
-
-		ILayoutEngine innerLayoutEngine = InnerLayoutEngine.RemoveWindow(window);
-		return (
-			new ProxyFloatingLayoutEngine(
-				this,
-				innerLayoutEngine,
-				_floatingWindowRects.SetItem(window, newUnitSquareRectangle)
-			),
-			false
-		);
 	}
 
 	/// <inheritdoc />


### PR DESCRIPTION
As mentioned in the previous pr (#961), I abandoned the idea of directly reusing one layout into the other as it complexifies too much the code for low return value.

However, I still think it would be good to use the same `UpdateWindowRectangle` logic.
So I extracted it into a `FloatingUtils` static class.

The pull request contains also some small code changes.

- [x] This code is up-to-date with the `main` branch.
- [x] I have updated relevant (if any) areas in the docs.

