### PR TITLE
Resolve Roslyn warnings, switch to latest C# features

### DIFF
--- a/src/Whim.Bar.Tests/BarConfigTests.cs
+++ b/src/Whim.Bar.Tests/BarConfigTests.cs
@@ -8,12 +8,7 @@ public class BarConfigTests
 	public void Height_PropertyChanged()
 	{
 		// Given
-		BarConfig config =
-			new(
-				leftComponents: new List<BarComponent>(),
-				centerComponents: new List<BarComponent>(),
-				rightComponents: new List<BarComponent>()
-			);
+		BarConfig config = new(leftComponents: [], centerComponents: [], rightComponents: []);
 
 		// When
 		// Then

--- a/src/Whim.Bar.Tests/BarLayoutEngineTests.cs
+++ b/src/Whim.Bar.Tests/BarLayoutEngineTests.cs
@@ -10,14 +10,7 @@ public class BarLayoutEngineTests
 {
 	private static BarLayoutEngine CreateSut(ILayoutEngine innerLayoutEngine) =>
 		new(
-			new BarConfig(
-				leftComponents: new List<BarComponent>(),
-				centerComponents: new List<BarComponent>(),
-				rightComponents: new List<BarComponent>()
-			)
-			{
-				Height = 30
-			},
+			new BarConfig(leftComponents: [], centerComponents: [], rightComponents: []) { Height = 30 },
 			innerLayoutEngine
 		);
 

--- a/src/Whim.Bar.Tests/BarLayoutEngineTests.cs
+++ b/src/Whim.Bar.Tests/BarLayoutEngineTests.cs
@@ -271,8 +271,8 @@ public class BarLayoutEngineTests
 		monitor.ScaleFactor.Returns(100);
 		BarLayoutEngine engine = CreateSut(innerLayoutEngine);
 
-		IWindowState[] expectedWindowStates = new[]
-		{
+		IWindowState[] expectedWindowStates =
+		[
 			new WindowState()
 			{
 				Window = window1,
@@ -296,7 +296,7 @@ public class BarLayoutEngineTests
 				},
 				WindowSize = WindowSize.Normal
 			}
-		};
+		];
 
 		Rectangle<int> expectedGivenRect =
 			new()

--- a/src/Whim.Bar.Tests/BarPluginTests.cs
+++ b/src/Whim.Bar.Tests/BarPluginTests.cs
@@ -11,7 +11,7 @@ public class BarPluginTests
 	public void MonitorManager_MonitorsChanged_RemovedMonitors(IContext context, IMonitor monitor)
 	{
 		// Given
-		BarConfig barConfig = new(new List<BarComponent>(), new List<BarComponent>(), new List<BarComponent>());
+		BarConfig barConfig = new([], [], []);
 		BarPlugin barPlugin = new(context, barConfig);
 		NativeManagerUtils.SetupTryEnqueue(context);
 

--- a/src/Whim.Bar.Tests/BarPluginTests.cs
+++ b/src/Whim.Bar.Tests/BarPluginTests.cs
@@ -22,7 +22,7 @@ public class BarPluginTests
 			{
 				AddedMonitors = Array.Empty<IMonitor>(),
 				UnchangedMonitors = Array.Empty<IMonitor>(),
-				RemovedMonitors = new[] { monitor }
+				RemovedMonitors = [monitor]
 			}
 		);
 

--- a/src/Whim.Bar.Tests/BarPluginTests.cs
+++ b/src/Whim.Bar.Tests/BarPluginTests.cs
@@ -20,8 +20,8 @@ public class BarPluginTests
 		context.MonitorManager.MonitorsChanged += Raise.EventWith(
 			new MonitorsChangedEventArgs()
 			{
-				AddedMonitors = Array.Empty<IMonitor>(),
-				UnchangedMonitors = Array.Empty<IMonitor>(),
+				AddedMonitors = [],
+				UnchangedMonitors = [],
 				RemovedMonitors = [monitor]
 			}
 		);

--- a/src/Whim.Bar.Tests/BaseBarLayoutEngineTests.cs
+++ b/src/Whim.Bar.Tests/BaseBarLayoutEngineTests.cs
@@ -7,15 +7,7 @@ public class BaseBarLayoutEngineTests : ProxyLayoutEngineBaseTests
 	public override Func<ILayoutEngine, BaseProxyLayoutEngine> CreateLayoutEngine =>
 		(inner) =>
 		{
-			BarConfig config =
-				new(
-					leftComponents: new List<BarComponent>(),
-					centerComponents: new List<BarComponent>(),
-					rightComponents: new List<BarComponent>()
-				)
-				{
-					Height = 30
-				};
+			BarConfig config = new(leftComponents: [], centerComponents: [], rightComponents: []) { Height = 30 };
 
 			return new BarLayoutEngine(config, inner);
 		};

--- a/src/Whim.Bar.Tests/Directory.Build.props
+++ b/src/Whim.Bar.Tests/Directory.Build.props
@@ -1,5 +1,6 @@
 <Project>
 	<PropertyGroup>
-		<GenerateDocumentationFile>false</GenerateDocumentationFile>
+		<GenerateDocumentationFile>true</GenerateDocumentationFile>
+		<NoWarn>$(NoWarn);CS1591</NoWarn>
 	</PropertyGroup>
 </Project>

--- a/src/Whim.Bar.Tests/GlobalSuppressions.cs
+++ b/src/Whim.Bar.Tests/GlobalSuppressions.cs
@@ -14,4 +14,6 @@ using System.Diagnostics.CodeAnalysis;
 [assembly: SuppressMessage("Style", "IDE0042:Variable declaration can be deconstructed")]
 [assembly: SuppressMessage("Style", "IDE0058:Expression value is never used")]
 [assembly: SuppressMessage("Style", "IDE0022:Use expression body for methods")]
-[assembly: SuppressMessage("Performance", "CA1813:Avoid unsealed attributes", Justification = "It's fine for tests")]
+[assembly: SuppressMessage("Performance", "CA1813:Avoid unsealed attributes")]
+[assembly: SuppressMessage("Performance", "CA1852:Seal internal types")]
+[assembly: SuppressMessage("Performance", "CA1861:Avoid constant arrays as arguments")]

--- a/src/Whim.Bar/ActiveLayout/NextLayoutEngineCommand.cs
+++ b/src/Whim.Bar/ActiveLayout/NextLayoutEngineCommand.cs
@@ -5,24 +5,18 @@ namespace Whim.Bar;
 /// <summary>
 /// Command to switch to the next layout engine.
 /// </summary>
-internal class NextLayoutEngineCommand : System.Windows.Input.ICommand
+/// <remarks>
+/// Creates a new instance of <see cref="NextLayoutEngineCommand"/>.
+/// </remarks>
+/// <param name="context"></param>
+/// <param name="viewModel"></param>
+internal class NextLayoutEngineCommand(IContext context, ActiveLayoutWidgetViewModel viewModel) : System.Windows.Input.ICommand
 {
-	private readonly IContext _context;
-	private readonly ActiveLayoutWidgetViewModel _viewModel;
+	private readonly IContext _context = context;
+	private readonly ActiveLayoutWidgetViewModel _viewModel = viewModel;
 
 	/// <inheritdoc/>
 	public event EventHandler? CanExecuteChanged;
-
-	/// <summary>
-	/// Creates a new instance of <see cref="NextLayoutEngineCommand"/>.
-	/// </summary>
-	/// <param name="context"></param>
-	/// <param name="viewModel"></param>
-	public NextLayoutEngineCommand(IContext context, ActiveLayoutWidgetViewModel viewModel)
-	{
-		_context = context;
-		_viewModel = viewModel;
-	}
 
 	/// <inheritdoc/>
 	public bool CanExecute(object? parameter) => true;

--- a/src/Whim.Bar/ActiveLayout/NextLayoutEngineCommand.cs
+++ b/src/Whim.Bar/ActiveLayout/NextLayoutEngineCommand.cs
@@ -10,13 +10,18 @@ namespace Whim.Bar;
 /// </remarks>
 /// <param name="context"></param>
 /// <param name="viewModel"></param>
-internal class NextLayoutEngineCommand(IContext context, ActiveLayoutWidgetViewModel viewModel) : System.Windows.Input.ICommand
+internal class NextLayoutEngineCommand(IContext context, ActiveLayoutWidgetViewModel viewModel)
+	: System.Windows.Input.ICommand
 {
 	private readonly IContext _context = context;
 	private readonly ActiveLayoutWidgetViewModel _viewModel = viewModel;
 
 	/// <inheritdoc/>
-	public event EventHandler? CanExecuteChanged { add { } remove { } }
+	public event EventHandler? CanExecuteChanged
+	{
+		add { }
+		remove { }
+	}
 
 	/// <inheritdoc/>
 	public bool CanExecute(object? parameter) => true;

--- a/src/Whim.Bar/ActiveLayout/NextLayoutEngineCommand.cs
+++ b/src/Whim.Bar/ActiveLayout/NextLayoutEngineCommand.cs
@@ -16,7 +16,7 @@ internal class NextLayoutEngineCommand(IContext context, ActiveLayoutWidgetViewM
 	private readonly ActiveLayoutWidgetViewModel _viewModel = viewModel;
 
 	/// <inheritdoc/>
-	public event EventHandler? CanExecuteChanged;
+	public event EventHandler? CanExecuteChanged { add { } remove { } }
 
 	/// <inheritdoc/>
 	public bool CanExecute(object? parameter) => true;

--- a/src/Whim.Bar/BarConfig.cs
+++ b/src/Whim.Bar/BarConfig.cs
@@ -28,7 +28,7 @@ public class BarConfig(
 	IList<BarComponent> leftComponents,
 	IList<BarComponent> centerComponents,
 	IList<BarComponent> rightComponents
-	) : INotifyPropertyChanged
+) : INotifyPropertyChanged
 {
 	/// <inheritdoc/>
 	public event PropertyChangedEventHandler? PropertyChanged;

--- a/src/Whim.Bar/BarConfig.cs
+++ b/src/Whim.Bar/BarConfig.cs
@@ -18,7 +18,17 @@ public delegate UserControl BarComponent(IContext context, IMonitor monitor, Mic
 /// <remarks>
 /// The components lists can be changed up until when Whim is initialized.
 /// </remarks>
-public class BarConfig : INotifyPropertyChanged
+/// <remarks>
+/// Creates a new bar configuration.
+/// </remarks>
+/// <param name="leftComponents">The components to display on the left side of the bar.</param>
+/// <param name="centerComponents">The components to display in the center of the bar.</param>
+/// <param name="rightComponents">The components to display on the right side of the bar.</param>
+public class BarConfig(
+	IList<BarComponent> leftComponents,
+	IList<BarComponent> centerComponents,
+	IList<BarComponent> rightComponents
+	) : INotifyPropertyChanged
 {
 	/// <inheritdoc/>
 	public event PropertyChangedEventHandler? PropertyChanged;
@@ -26,17 +36,17 @@ public class BarConfig : INotifyPropertyChanged
 	/// <summary>
 	/// The components to display on the left side of the bar.
 	/// </summary>
-	internal IList<BarComponent> LeftComponents;
+	internal IList<BarComponent> LeftComponents = leftComponents;
 
 	/// <summary>
 	/// The components to display in the center of the bar.
 	/// </summary>
-	internal IList<BarComponent> CenterComponents;
+	internal IList<BarComponent> CenterComponents = centerComponents;
 
 	/// <summary>
 	/// The components to display on the right side of the bar.
 	/// </summary>
-	internal IList<BarComponent> RightComponents;
+	internal IList<BarComponent> RightComponents = rightComponents;
 
 	private int _height = GetHeightFromResourceDictionary() ?? 30;
 
@@ -74,23 +84,6 @@ public class BarConfig : INotifyPropertyChanged
 	/// To change the opacity for the bar's background color, make sure the hex color includes the alpha values.
 	/// </remarks>
 	public WindowBackdropConfig Backdrop { get; set; } = new(BackdropType.Mica, AlwaysShowBackdrop: true);
-
-	/// <summary>
-	/// Creates a new bar configuration.
-	/// </summary>
-	/// <param name="leftComponents">The components to display on the left side of the bar.</param>
-	/// <param name="centerComponents">The components to display in the center of the bar.</param>
-	/// <param name="rightComponents">The components to display on the right side of the bar.</param>
-	public BarConfig(
-		IList<BarComponent> leftComponents,
-		IList<BarComponent> centerComponents,
-		IList<BarComponent> rightComponents
-	)
-	{
-		LeftComponents = leftComponents;
-		CenterComponents = centerComponents;
-		RightComponents = rightComponents;
-	}
 
 	private static int? GetHeightFromResourceDictionary()
 	{

--- a/src/Whim.Bar/BarException.cs
+++ b/src/Whim.Bar/BarException.cs
@@ -27,15 +27,4 @@ public class BarException : System.Exception
 	/// <param name="inner">The exception that is the cause of the current exception.</param>
 	public BarException(string message, System.Exception inner)
 		: base(message, inner) { }
-
-	/// <summary>
-	/// Constructs a new BarException.
-	/// </summary>
-	/// <param name="info">The <see cref="System.Runtime.Serialization.SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
-	/// <param name="context">The <see cref="System.Runtime.Serialization.StreamingContext"/> that contains contextual information about the source or destination.</param>
-	protected BarException(
-		System.Runtime.Serialization.SerializationInfo info,
-		System.Runtime.Serialization.StreamingContext context
-	)
-		: base(info, context) { }
 }

--- a/src/Whim.Bar/BarPlugin.cs
+++ b/src/Whim.Bar/BarPlugin.cs
@@ -6,10 +6,15 @@ using Windows.Win32.Graphics.Dwm;
 namespace Whim.Bar;
 
 /// <inheritdoc/>
-public class BarPlugin : IBarPlugin
+/// <summary>
+/// Create the bar plugin.
+/// </summary>
+/// <param name="context"></param>
+/// <param name="barConfig"></param>
+public class BarPlugin(IContext context, BarConfig barConfig) : IBarPlugin
 {
-	private readonly IContext _context;
-	private readonly BarConfig _barConfig;
+	private readonly IContext _context = context;
+	private readonly BarConfig _barConfig = barConfig;
 
 	private readonly Dictionary<IMonitor, BarWindow> _monitorBarMap = [];
 	private bool _disposedValue;
@@ -18,17 +23,6 @@ public class BarPlugin : IBarPlugin
 	/// <c>whim.bar</c>
 	/// </summary>
 	public string Name => "whim.bar";
-
-	/// <summary>
-	/// Create the bar plugin.
-	/// </summary>
-	/// <param name="context"></param>
-	/// <param name="barConfig"></param>
-	public BarPlugin(IContext context, BarConfig barConfig)
-	{
-		_context = context;
-		_barConfig = barConfig;
-	}
 
 	/// <inheritdoc />
 	public void PreInitialize()

--- a/src/Whim.Bar/BarPlugin.cs
+++ b/src/Whim.Bar/BarPlugin.cs
@@ -11,7 +11,7 @@ public class BarPlugin : IBarPlugin
 	private readonly IContext _context;
 	private readonly BarConfig _barConfig;
 
-	private readonly Dictionary<IMonitor, BarWindow> _monitorBarMap = new();
+	private readonly Dictionary<IMonitor, BarWindow> _monitorBarMap = [];
 	private bool _disposedValue;
 
 	/// <summary>

--- a/src/Whim.Bar/FocusedWindow/FocusedWindowWidget.xaml.cs
+++ b/src/Whim.Bar/FocusedWindow/FocusedWindowWidget.xaml.cs
@@ -8,7 +8,7 @@ namespace Whim.Bar;
 /// </summary>
 public partial class FocusedWindowWidget : UserControl
 {
-	private static readonly char[] _titleSeparators = new[] { '-', '—', '|' };
+	private static readonly char[] _titleSeparators = ['-', '—', '|'];
 
 	/// <summary>
 	/// The focused window view model.

--- a/src/Whim.Bar/Workspace/WorkspaceWidgetViewModel.cs
+++ b/src/Whim.Bar/Workspace/WorkspaceWidgetViewModel.cs
@@ -19,7 +19,7 @@ internal class WorkspaceWidgetViewModel : IDisposable
 	/// <summary>
 	/// The workspaces for the monitor.
 	/// </summary>
-	public VeryObservableCollection<WorkspaceModel> Workspaces { get; } = new();
+	public VeryObservableCollection<WorkspaceModel> Workspaces { get; } = [];
 
 	/// <summary>
 	/// Creates a new instance of <see cref="WorkspaceWidgetViewModel"/>.

--- a/src/Whim.CommandPalette.Tests/CommandPaletteCommandsTests.cs
+++ b/src/Whim.CommandPalette.Tests/CommandPaletteCommandsTests.cs
@@ -42,8 +42,8 @@ public class CommandPaletteCommandsTests
 			Windows[2] = Substitute.For<IWindow>();
 			Windows[2].Title.Returns("Window 2");
 
-			Workspace.Windows.Returns((_) => new List<IWindow>() { Windows[0], Windows[1] });
-			OtherWorkspace.Windows.Returns((_) => new List<IWindow>() { Windows[2] });
+			Workspace.Windows.Returns((_) => [Windows[0], Windows[1]]);
+			OtherWorkspace.Windows.Returns((_) => [Windows[2]]);
 
 			Commands = new(Context, Plugin);
 		}
@@ -210,27 +210,26 @@ public class CommandPaletteCommandsTests
 		// Given
 		Wrapper wrapper = new();
 		List<SelectOption> options =
-			new()
+		[
+			new SelectOption()
 			{
-				new SelectOption()
-				{
-					Id = "0",
-					Title = "Window 0",
-					IsSelected = true
-				},
-				new SelectOption()
-				{
-					Id = "1",
-					Title = "Window 1",
-					IsSelected = false
-				},
-				new SelectOption()
-				{
-					Id = "2",
-					Title = "Window 2",
-					IsSelected = true
-				},
-			};
+				Id = "0",
+				Title = "Window 0",
+				IsSelected = true
+			},
+			new SelectOption()
+			{
+				Id = "1",
+				Title = "Window 1",
+				IsSelected = false
+			},
+			new SelectOption()
+			{
+				Id = "2",
+				Title = "Window 2",
+				IsSelected = true
+			},
+		];
 
 		// When
 		CommandPaletteCommands commands = new(wrapper.Context, wrapper.Plugin);

--- a/src/Whim.CommandPalette.Tests/CommandPaletteCommandsTests.cs
+++ b/src/Whim.CommandPalette.Tests/CommandPaletteCommandsTests.cs
@@ -236,7 +236,7 @@ public class CommandPaletteCommandsTests
 		commands.MoveMultipleWindowsToWorkspaceCallback(options);
 
 		// Then
-		string[] expectedWorkspaces = new string[] { "Workspace", "Other workspace" };
+		string[] expectedWorkspaces = ["Workspace", "Other workspace"];
 		wrapper
 			.Plugin.Received(1)
 			.Activate(

--- a/src/Whim.CommandPalette.Tests/CommandPaletteWindowViewModelTests.cs
+++ b/src/Whim.CommandPalette.Tests/CommandPaletteWindowViewModelTests.cs
@@ -81,7 +81,7 @@ public class CommandPaletteWindowViewModelTests
 		CommandPaletteWindowViewModel vm =
 			new(wrapper.Context, wrapper.Plugin, wrapper.MenuVariant, wrapper.FreeTextVariant, wrapper.SelectVariant);
 
-		vm.Activate(new MenuVariantConfig() { Commands = Array.Empty<ICommand>() }, null);
+		vm.Activate(new MenuVariantConfig() { Commands = [] }, null);
 
 		// When
 		vm.OnKeyDown(VirtualKey.Space);
@@ -102,7 +102,7 @@ public class CommandPaletteWindowViewModelTests
 		Assert.Raises<EventArgs>(
 			h => vm.SetWindowPosRequested += h,
 			h => vm.SetWindowPosRequested -= h,
-			() => vm.Activate(new MenuVariantConfig() { Commands = Array.Empty<ICommand>() }, null)
+			() => vm.Activate(new MenuVariantConfig() { Commands = [] }, null)
 		);
 
 		// Then
@@ -133,7 +133,7 @@ public class CommandPaletteWindowViewModelTests
 		MenuVariantConfig config =
 			new()
 			{
-				Commands = Array.Empty<ICommand>(),
+				Commands = [],
 				InitialText = "Initial text",
 				Hint = "Hint"
 			};
@@ -158,7 +158,7 @@ public class CommandPaletteWindowViewModelTests
 		{
 			{ new UnknownConfig(), false, "Confirm" },
 			{
-				new MenuVariantConfig() { Commands = Array.Empty<ICommand>() },
+				new MenuVariantConfig() { Commands = [] },
 				true,
 				"Confirm"
 			},
@@ -170,7 +170,7 @@ public class CommandPaletteWindowViewModelTests
 			{
 				new SelectVariantConfig()
 				{
-					Options = Array.Empty<SelectOption>(),
+					Options = [],
 					Callback = (items) => { },
 					ConfirmButtonText = "Save"
 				},
@@ -204,7 +204,7 @@ public class CommandPaletteWindowViewModelTests
 		CommandPaletteWindowViewModel vm =
 			new(wrapper.Context, wrapper.Plugin, wrapper.MenuVariant, wrapper.FreeTextVariant, wrapper.SelectVariant);
 
-		MenuVariantConfig config = new() { Commands = Array.Empty<ICommand>() };
+		MenuVariantConfig config = new() { Commands = [] };
 
 		vm.Activate(config, null);
 
@@ -223,7 +223,7 @@ public class CommandPaletteWindowViewModelTests
 		CommandPaletteWindowViewModel vm =
 			new(wrapper.Context, wrapper.Plugin, wrapper.MenuVariant, wrapper.FreeTextVariant, wrapper.SelectVariant);
 
-		MenuVariantConfig config = new() { Commands = Array.Empty<ICommand>() };
+		MenuVariantConfig config = new() { Commands = [] };
 
 		vm.Activate(config, null);
 

--- a/src/Whim.CommandPalette.Tests/CommandPaletteWindowViewModelTests.cs
+++ b/src/Whim.CommandPalette.Tests/CommandPaletteWindowViewModelTests.cs
@@ -138,7 +138,7 @@ public class CommandPaletteWindowViewModelTests
 				Hint = "Hint"
 			};
 
-		IEnumerable<ICommand> ICommands = new List<ICommand>() { new Command("id", "title", () => { }) };
+		IEnumerable<ICommand> ICommands = [new Command("id", "title", () => { })];
 
 		// When
 		Assert.Raises<EventArgs>(

--- a/src/Whim.CommandPalette.Tests/Directory.Build.props
+++ b/src/Whim.CommandPalette.Tests/Directory.Build.props
@@ -1,5 +1,6 @@
 <Project>
 	<PropertyGroup>
-		<GenerateDocumentationFile>false</GenerateDocumentationFile>
+		<GenerateDocumentationFile>true</GenerateDocumentationFile>
+		<NoWarn>$(NoWarn);CS1591</NoWarn>
 	</PropertyGroup>
 </Project>

--- a/src/Whim.CommandPalette.Tests/Filters/UtilsTests.cs
+++ b/src/Whim.CommandPalette.Tests/Filters/UtilsTests.cs
@@ -9,7 +9,7 @@ public class UtilsTests
 		return (string word, string wordToMatchAgainst) =>
 		{
 			counters[i]++;
-			return r ? new[] { new FilterTextMatch(0, word.Length) } : null;
+			return r ? [new FilterTextMatch(0, word.Length)] : null;
 		};
 	}
 
@@ -21,7 +21,7 @@ public class UtilsTests
 	{
 		int[] counters = new int[2];
 		PaletteFilter filter = PaletteFilters.Or(NewFilter(counters, i1, r1), NewFilter(counters, i2, r2));
-		FilterTestUtils.FilterOk(filter, "anything", "anything", new FilterTextMatch[] { new(0, 8) });
+		FilterTestUtils.FilterOk(filter, "anything", "anything", [new(0, 8)]);
 		Assert.Equal(expected, counters);
 	}
 

--- a/src/Whim.CommandPalette.Tests/GlobalSuppressions.cs
+++ b/src/Whim.CommandPalette.Tests/GlobalSuppressions.cs
@@ -15,3 +15,4 @@ using System.Diagnostics.CodeAnalysis;
 [assembly: SuppressMessage("Style", "IDE0058:Expression value is never used")]
 [assembly: SuppressMessage("Style", "IDE0022:Use expression body for methods")]
 [assembly: SuppressMessage("Performance", "CA1852:Seal internal types")]
+[assembly: SuppressMessage("Performance", "CA1861:Avoid constant arrays as arguments")]

--- a/src/Whim.CommandPalette.Tests/GlobalSuppressions.cs
+++ b/src/Whim.CommandPalette.Tests/GlobalSuppressions.cs
@@ -16,3 +16,4 @@ using System.Diagnostics.CodeAnalysis;
 [assembly: SuppressMessage("Style", "IDE0022:Use expression body for methods")]
 [assembly: SuppressMessage("Performance", "CA1852:Seal internal types")]
 [assembly: SuppressMessage("Performance", "CA1861:Avoid constant arrays as arguments")]
+[assembly: SuppressMessage("Performance", "CA1859:Use concrete types when possible for improved performance")]

--- a/src/Whim.CommandPalette.Tests/Matchers/MatcherResultComparerTests.cs
+++ b/src/Whim.CommandPalette.Tests/Matchers/MatcherResultComparerTests.cs
@@ -9,11 +9,7 @@ public class MatcherResultComparerTests
 	{
 		ICommand command = Substitute.For<ICommand>();
 		command.Title.Returns(title);
-		return new MatcherResult<MenuVariantRowModelData>(
-			new MenuVariantRowModel(command, null),
-			Array.Empty<FilterTextMatch>(),
-			score
-		);
+		return new MatcherResult<MenuVariantRowModelData>(new MenuVariantRowModel(command, null), [], score);
 	}
 
 	[Fact]

--- a/src/Whim.CommandPalette.Tests/Matchers/MatcherResultTests.cs
+++ b/src/Whim.CommandPalette.Tests/Matchers/MatcherResultTests.cs
@@ -10,7 +10,7 @@ public class MatcherResultTests
 	{
 		// Given
 		string text = "normal highlighted normal";
-		FilterTextMatch[] matches = new[] { new FilterTextMatch(7, 18), };
+		FilterTextMatch[] matches = [new FilterTextMatch(7, 18),];
 		IVariantRowModel<int> modelMock = Substitute.For<IVariantRowModel<int>>();
 		modelMock.Title.Returns(text);
 

--- a/src/Whim.CommandPalette.Tests/MostRecentlyUsedMatcherTests.cs
+++ b/src/Whim.CommandPalette.Tests/MostRecentlyUsedMatcherTests.cs
@@ -19,7 +19,7 @@ public class MostRecentlyUsedMatcherTests
 			MenuVariantRowModel menuItem = new(new Command(items[i], items[i], ActionSink), null);
 
 			menuItems[i] = menuItem;
-			matcherItems[i] = new(menuItem, Array.Empty<FilterTextMatch>(), 0);
+			matcherItems[i] = new(menuItem, [], 0);
 		}
 
 		return (menuItems, matcherItems);

--- a/src/Whim.CommandPalette.Tests/MostRecentlyUsedMatcherTests.cs
+++ b/src/Whim.CommandPalette.Tests/MostRecentlyUsedMatcherTests.cs
@@ -30,9 +30,7 @@ public class MostRecentlyUsedMatcherTests
 	{
 		// Given
 		MostRecentlyUsedMatcher<MenuVariantRowModelData> matcher = new();
-		(MenuVariantRowModel[] items, MatcherResult<MenuVariantRowModelData>[] matches) = CreateMocks(
-			new string[] { "A", "B" }
-		);
+		(MenuVariantRowModel[] items, MatcherResult<MenuVariantRowModelData>[] matches) = CreateMocks(["A", "B"]);
 
 		// When
 		int matchCount = matcher.GetFilteredItems("A", items, matches);
@@ -48,9 +46,7 @@ public class MostRecentlyUsedMatcherTests
 	{
 		// Given
 		MostRecentlyUsedMatcher<MenuVariantRowModelData> matcher = new();
-		(MenuVariantRowModel[] items, MatcherResult<MenuVariantRowModelData>[] matches) = CreateMocks(
-			new string[] { "A", "B" }
-		);
+		(MenuVariantRowModel[] items, MatcherResult<MenuVariantRowModelData>[] matches) = CreateMocks(["A", "B"]);
 
 		// When
 		int matchCount = matcher.GetMostRecentlyUsedItems(items, matches);
@@ -68,9 +64,7 @@ public class MostRecentlyUsedMatcherTests
 	{
 		// Given
 		MostRecentlyUsedMatcher<MenuVariantRowModelData> matcher = new();
-		(MenuVariantRowModel[] items, MatcherResult<MenuVariantRowModelData>[] matches) = CreateMocks(
-			new string[] { "A", "B" }
-		);
+		(MenuVariantRowModel[] items, MatcherResult<MenuVariantRowModelData>[] matches) = CreateMocks(["A", "B"]);
 		matcher.OnMatchExecuted(items[1]);
 
 		// When
@@ -88,9 +82,7 @@ public class MostRecentlyUsedMatcherTests
 	{
 		// Given
 		MostRecentlyUsedMatcher<MenuVariantRowModelData> matcher = new();
-		(MenuVariantRowModel[] items, MatcherResult<MenuVariantRowModelData>[] _) = CreateMocks(
-			new string[] { "A", "B" }
-		);
+		(MenuVariantRowModel[] items, MatcherResult<MenuVariantRowModelData>[] _) = CreateMocks(["A", "B"]);
 
 		// When
 		IEnumerable<MatcherResult<MenuVariantRowModelData>> rowItems = matcher.Match("C", items);
@@ -104,9 +96,7 @@ public class MostRecentlyUsedMatcherTests
 	{
 		// Given
 		MostRecentlyUsedMatcher<MenuVariantRowModelData> matcher = new();
-		(MenuVariantRowModel[] items, MatcherResult<MenuVariantRowModelData>[] _) = CreateMocks(
-			new string[] { "A", "B" }
-		);
+		(MenuVariantRowModel[] items, MatcherResult<MenuVariantRowModelData>[] _) = CreateMocks(["A", "B"]);
 
 		// When
 		MatcherResult<MenuVariantRowModelData>[] rowItems = matcher.Match("", items).ToArray();
@@ -156,9 +146,7 @@ public class MostRecentlyUsedMatcherTests
 	{
 		// Given
 		MostRecentlyUsedMatcher<MenuVariantRowModelData> matcher = new();
-		(MenuVariantRowModel[] items, MatcherResult<MenuVariantRowModelData>[] _) = CreateMocks(
-			new string[] { "C", "D" }
-		);
+		(MenuVariantRowModel[] items, MatcherResult<MenuVariantRowModelData>[] _) = CreateMocks(["C", "D"]);
 
 		// When
 		matcher.Match("", items);
@@ -198,9 +186,7 @@ public class MostRecentlyUsedMatcherTests
 	{
 		// Given
 		MostRecentlyUsedMatcher<MenuVariantRowModelData> matcher = new();
-		(MenuVariantRowModel[] items, MatcherResult<MenuVariantRowModelData>[] _) = CreateMocks(
-			new string[] { "A", "B" }
-		);
+		(MenuVariantRowModel[] items, MatcherResult<MenuVariantRowModelData>[] _) = CreateMocks(["A", "B"]);
 		matcher.Match("", items);
 		matcher.OnMatchExecuted(items[1]);
 

--- a/src/Whim.CommandPalette.Tests/Variants/Menu/MenuVariantRowViewModelTests.cs
+++ b/src/Whim.CommandPalette.Tests/Variants/Menu/MenuVariantRowViewModelTests.cs
@@ -20,7 +20,7 @@ public class MenuVariantRowViewModelTests
 		// New
 		newModelMock.Title.Returns("Test");
 
-		FilterTextMatch[] matches = new[] { new FilterTextMatch(0, 4) };
+		FilterTextMatch[] matches = [new FilterTextMatch(0, 4)];
 		MatcherResult<MenuVariantRowModelData> newMatcherResult = new(newModelMock, matches, 0);
 
 		// When

--- a/src/Whim.CommandPalette.Tests/Variants/Menu/MenuVariantRowViewModelTests.cs
+++ b/src/Whim.CommandPalette.Tests/Variants/Menu/MenuVariantRowViewModelTests.cs
@@ -14,7 +14,7 @@ public class MenuVariantRowViewModelTests
 	{
 		// Given
 		// Old
-		MatcherResult<MenuVariantRowModelData> matcherResult = new(modelMock, Array.Empty<FilterTextMatch>(), 0);
+		MatcherResult<MenuVariantRowModelData> matcherResult = new(modelMock, [], 0);
 		MenuVariantRowViewModel vm = new(matcherResult);
 
 		// New

--- a/src/Whim.CommandPalette.Tests/Variants/Menu/MenuVariantViewModelTests.cs
+++ b/src/Whim.CommandPalette.Tests/Variants/Menu/MenuVariantViewModelTests.cs
@@ -350,7 +350,7 @@ public class MenuVariantViewModelTests
 		// Given
 		MenuVariantViewModel vm = new(ctx, windowViewModel, MenuRowFactory);
 
-		vm.Activate(new MenuVariantConfig() { Commands = Array.Empty<ICommand>() });
+		vm.Activate(new MenuVariantConfig() { Commands = [] });
 
 		// When
 		vm.Update();
@@ -388,7 +388,7 @@ public class MenuVariantViewModelTests
 			.Match(Arg.Any<string>(), Arg.Any<IReadOnlyList<IVariantRowModel<MenuVariantRowModelData>>>())
 			.Returns(items);
 
-		MenuVariantConfig config = new() { Matcher = matcher, Commands = Array.Empty<ICommand>() };
+		MenuVariantConfig config = new() { Matcher = matcher, Commands = [] };
 		return config;
 	}
 

--- a/src/Whim.CommandPalette.Tests/Variants/Menu/MenuVariantViewModelTests.cs
+++ b/src/Whim.CommandPalette.Tests/Variants/Menu/MenuVariantViewModelTests.cs
@@ -56,12 +56,12 @@ public class MenuVariantViewModelTests
 	internal void Activate_MenuVariantConfig(IContext ctx, ICommandPaletteWindowViewModel windowViewModel)
 	{
 		// Given
-		IEnumerable<ICommand> items = new List<ICommand>()
-		{
+		IEnumerable<ICommand> items =
+		[
 			new Command("id", "title", () => { }),
 			new Command("id2", "title2", () => { }),
 			new Command("id3", "title3", () => { })
-		};
+		];
 		ctx.CommandManager.GetEnumerator().Returns(items.GetEnumerator());
 
 		MenuVariantViewModel vm = new(ctx, windowViewModel, MenuRowFactory);
@@ -85,12 +85,12 @@ public class MenuVariantViewModelTests
 	)
 	{
 		// Given
-		IEnumerable<ICommand> items = new List<ICommand>()
-		{
+		IEnumerable<ICommand> items =
+		[
 			new Command("id", "title", () => { }),
 			new Command("id2", "title2", () => { }),
 			new Command("id3", "title3", () => { })
-		};
+		];
 		ctx.CommandManager.GetEnumerator().Returns(items.GetEnumerator());
 
 		MenuVariantViewModel vm = new(ctx, windowViewModel, MenuRowFactory);
@@ -111,12 +111,12 @@ public class MenuVariantViewModelTests
 	internal void OnKeyDown_UnhandledKeys(IContext ctx, ICommandPaletteWindowViewModel windowViewModel)
 	{
 		// Given
-		IEnumerable<ICommand> items = new List<ICommand>()
-		{
+		IEnumerable<ICommand> items =
+		[
 			new Command("id", "title", () => { }),
 			new Command("id2", "title2", () => { }),
 			new Command("id3", "title3", () => { })
-		};
+		];
 		ctx.CommandManager.GetEnumerator().Returns(items.GetEnumerator());
 
 		MenuVariantViewModel vm = new(ctx, windowViewModel, MenuRowFactory);
@@ -134,8 +134,8 @@ public class MenuVariantViewModelTests
 	{
 		// Given
 		bool called = false;
-		IEnumerable<ICommand> items = new List<ICommand>()
-		{
+		IEnumerable<ICommand> items =
+		[
 			new Command(
 				"id",
 				"title",
@@ -144,7 +144,7 @@ public class MenuVariantViewModelTests
 					called = true;
 				}
 			)
-		};
+		];
 		ctx.CommandManager.GetEnumerator().Returns(items.GetEnumerator());
 
 		MenuVariantViewModel vm = new(ctx, windowViewModel, MenuRowFactory);
@@ -165,7 +165,7 @@ public class MenuVariantViewModelTests
 		MenuVariantViewModel vm = new(ctx, windowViewModel, MenuRowFactory);
 
 		// When
-		vm.PopulateItems(new List<ICommand>() { new Command("id", "title", () => { }, () => false) });
+		vm.PopulateItems([new Command("id", "title", () => { }, () => false)]);
 
 		// Then
 		Assert.Empty(vm._allItems);
@@ -178,7 +178,7 @@ public class MenuVariantViewModelTests
 		MenuVariantViewModel vm = new(ctx, windowViewModel, MenuRowFactory);
 
 		// When
-		vm.PopulateItems(new List<ICommand>() { new Command("id", "title", () => { }) });
+		vm.PopulateItems([new Command("id", "title", () => { })]);
 
 		// Then
 		Assert.Single(vm._allItems);
@@ -190,10 +190,10 @@ public class MenuVariantViewModelTests
 		// Given
 		MenuVariantViewModel vm = new(ctx, windowViewModel, MenuRowFactory);
 
-		vm.PopulateItems(new List<ICommand>() { new Command("id", "title", () => { }) });
+		vm.PopulateItems([new Command("id", "title", () => { })]);
 
 		// When
-		vm.PopulateItems(new List<ICommand>() { new Command("id", "new title", () => { }) });
+		vm.PopulateItems([new Command("id", "new title", () => { })]);
 
 		// Then
 		Assert.Single(vm._allItems);
@@ -206,10 +206,10 @@ public class MenuVariantViewModelTests
 		// Given
 		MenuVariantViewModel vm = new(ctx, windowViewModel, MenuRowFactory);
 
-		vm.PopulateItems(new List<ICommand>() { new Command("id", "title", () => { }) });
+		vm.PopulateItems([new Command("id", "title", () => { })]);
 
 		// When
-		vm.PopulateItems(new List<ICommand>());
+		vm.PopulateItems([]);
 
 		// Then
 		Assert.Empty(vm._allItems);
@@ -222,10 +222,10 @@ public class MenuVariantViewModelTests
 		MenuVariantViewModel vm = new(ctx, windowViewModel, MenuRowFactory);
 
 		Command command = new("id", "title", () => { });
-		vm.PopulateItems(new List<ICommand>() { command });
+		vm.PopulateItems([command]);
 
 		// When
-		vm.PopulateItems(new List<ICommand>() { command });
+		vm.PopulateItems([command]);
 
 		// Then
 		Assert.Single(vm._allItems);
@@ -237,8 +237,8 @@ public class MenuVariantViewModelTests
 	{
 		// Given
 		bool called = false;
-		IEnumerable<ICommand> items = new List<ICommand>()
-		{
+		IEnumerable<ICommand> items =
+		[
 			new Command(
 				"id",
 				"title",
@@ -247,7 +247,7 @@ public class MenuVariantViewModelTests
 					called = true;
 				}
 			)
-		};
+		];
 		ctx.CommandManager.GetEnumerator().Returns(items.GetEnumerator());
 
 		MenuVariantViewModel vm = new(ctx, windowViewModel, MenuRowFactory);
@@ -266,7 +266,7 @@ public class MenuVariantViewModelTests
 	{
 		// Given
 		string callbackText = string.Empty;
-		IEnumerable<ICommand> items = new List<ICommand>() { new Command("id", "title", () => { }) };
+		IEnumerable<ICommand> items = [new Command("id", "title", () => { })];
 		ctx.CommandManager.GetEnumerator().Returns(items.GetEnumerator());
 
 		MenuVariantViewModel vm = new(ctx, windowViewModel, MenuRowFactory);
@@ -305,9 +305,7 @@ public class MenuVariantViewModelTests
 	{
 		// Given
 		MenuVariantViewModel vm = new(ctx, windowViewModel, MenuRowFactory);
-		vm.Activate(
-			new MenuVariantConfig() { Commands = new List<ICommand>() { new Command("id", "title", () => { }) } }
-		);
+		vm.Activate(new MenuVariantConfig() { Commands = [new Command("id", "title", () => { })] });
 		vm.SelectedIndex = index;
 
 		// When
@@ -322,8 +320,8 @@ public class MenuVariantViewModelTests
 	{
 		// Given
 		bool called = false;
-		IEnumerable<ICommand> items = new List<ICommand>()
-		{
+		IEnumerable<ICommand> items =
+		[
 			new Command(
 				"id",
 				"title",
@@ -332,7 +330,7 @@ public class MenuVariantViewModelTests
 					called = true;
 				}
 			)
-		};
+		];
 		ctx.CommandManager.GetEnumerator().Returns(items.GetEnumerator());
 
 		MenuVariantViewModel vm = new(ctx, windowViewModel, MenuRowFactory);
@@ -377,7 +375,7 @@ public class MenuVariantViewModelTests
 
 	private static MenuVariantConfig CreateMenuActivationConfig(int itemCount)
 	{
-		List<MatcherResult<MenuVariantRowModelData>> items = new();
+		List<MatcherResult<MenuVariantRowModelData>> items = [];
 
 		for (int i = 0; i < itemCount; i++)
 		{

--- a/src/Whim.CommandPalette.Tests/Variants/Menu/MenuVariantViewModelTests.cs
+++ b/src/Whim.CommandPalette.Tests/Variants/Menu/MenuVariantViewModelTests.cs
@@ -379,7 +379,7 @@ public class MenuVariantViewModelTests
 
 		for (int i = 0; i < itemCount; i++)
 		{
-			FilterTextMatch[] segments = new FilterTextMatch[] { new(0, 1) };
+			FilterTextMatch[] segments = [new(0, 1)];
 			items.Add(new(new MenuVariantRowModel(new Command($"id{i}", $"title{i}", () => { }), null), segments, 0));
 		}
 

--- a/src/Whim.CommandPalette.Tests/Variants/Select/SelectVariantRowViewModelTests.cs
+++ b/src/Whim.CommandPalette.Tests/Variants/Select/SelectVariantRowViewModelTests.cs
@@ -98,7 +98,7 @@ public class SelectVariantRowViewModelTests
 		IVariantRowModel<SelectOption> newModelMock = CreateModelMock(true, false);
 		newModelMock.Title.Returns("Test");
 
-		FilterTextMatch[] matches = new FilterTextMatch[] { new(0, 4) };
+		FilterTextMatch[] matches = [new(0, 4)];
 		MatcherResult<SelectOption> newMatcherResult = new(newModelMock, matches, 0);
 
 		// When

--- a/src/Whim.CommandPalette.Tests/Variants/Select/SelectVariantRowViewModelTests.cs
+++ b/src/Whim.CommandPalette.Tests/Variants/Select/SelectVariantRowViewModelTests.cs
@@ -25,7 +25,7 @@ public class SelectVariantRowViewModelTests
 	{
 		// Given
 		IVariantRowModel<SelectOption> modelMock = CreateModelMock(false, false);
-		MatcherResult<SelectOption> matcherResult = new(modelMock, Array.Empty<FilterTextMatch>(), 0);
+		MatcherResult<SelectOption> matcherResult = new(modelMock, [], 0);
 
 		SelectVariantRowViewModel vm = new(matcherResult);
 
@@ -41,7 +41,7 @@ public class SelectVariantRowViewModelTests
 	{
 		// Given
 		IVariantRowModel<SelectOption> modelMock = CreateModelMock(true, false);
-		MatcherResult<SelectOption> matcherResult = new(modelMock, Array.Empty<FilterTextMatch>(), 0);
+		MatcherResult<SelectOption> matcherResult = new(modelMock, [], 0);
 
 		SelectVariantRowViewModel vm = new(matcherResult);
 
@@ -57,7 +57,7 @@ public class SelectVariantRowViewModelTests
 	{
 		// Given
 		IVariantRowModel<SelectOption> modelMock = CreateModelMock(false, false);
-		MatcherResult<SelectOption> matcherResult = new(modelMock, Array.Empty<FilterTextMatch>(), 0);
+		MatcherResult<SelectOption> matcherResult = new(modelMock, [], 0);
 
 		SelectVariantRowViewModel vm = new(matcherResult);
 
@@ -73,7 +73,7 @@ public class SelectVariantRowViewModelTests
 	{
 		// Given
 		IVariantRowModel<SelectOption> modelMock = CreateModelMock(false, true);
-		MatcherResult<SelectOption> matcherResult = new(modelMock, Array.Empty<FilterTextMatch>(), 0);
+		MatcherResult<SelectOption> matcherResult = new(modelMock, [], 0);
 
 		SelectVariantRowViewModel vm = new(matcherResult);
 
@@ -91,7 +91,7 @@ public class SelectVariantRowViewModelTests
 		// Old
 		IVariantRowModel<SelectOption> modelMock = CreateModelMock(false, true);
 
-		MatcherResult<SelectOption> matcherResult = new(modelMock, Array.Empty<FilterTextMatch>(), 0);
+		MatcherResult<SelectOption> matcherResult = new(modelMock, [], 0);
 		SelectVariantRowViewModel vm = new(matcherResult);
 
 		// New

--- a/src/Whim.CommandPalette.Tests/Variants/Select/SelectVariantViewModelTests.cs
+++ b/src/Whim.CommandPalette.Tests/Variants/Select/SelectVariantViewModelTests.cs
@@ -567,7 +567,7 @@ public class SelectVariantViewModelTests
 	/// <summary>
 	/// Tests <see cref="SelectVariantViewModel.LoadSelectMatches"/> via <see cref="SelectVariantViewModel.Update"/> via
 	/// <see cref="SelectVariantViewModel.Activate(BaseVariantConfig)"/>.
-	/// This test verifies that the unused row is restored, and <see cref="SelectVariantViewModel.RemoveUnusedRows"/> is called.
+	/// This test verifies that the unused row is restored, and <c>SelectVariantViewModel.RemoveUnusedRows</c> is called.
 	/// </summary>
 	[Fact]
 	public void Update_LoadSelectMatches_RestoreUnusedRow()

--- a/src/Whim.CommandPalette.Tests/Variants/Select/SelectVariantViewModelTests.cs
+++ b/src/Whim.CommandPalette.Tests/Variants/Select/SelectVariantViewModelTests.cs
@@ -27,7 +27,7 @@ public class SelectVariantViewModelTests
 		List<IVariantRowView<SelectOption, SelectVariantRowViewModel>>
 	) SelectRowFactoryWithMocks()
 	{
-		List<IVariantRowView<SelectOption, SelectVariantRowViewModel>> variantRows = new();
+		List<IVariantRowView<SelectOption, SelectVariantRowViewModel>> variantRows = [];
 
 		IVariantRowView<SelectOption, SelectVariantRowViewModel> selectRowFactory(
 			MatcherResult<SelectOption> matcherResult,
@@ -180,30 +180,29 @@ public class SelectVariantViewModelTests
 		commandPaletteWindowViewModel.Text.Returns("ti");
 
 		List<SelectOption> options =
+		[
 			new()
 			{
-				new()
-				{
-					Id = "id",
-					Title = "title",
-					IsSelected = false,
-					IsEnabled = false,
-				},
-				new()
-				{
-					Id = "id2",
-					Title = "title2",
-					IsSelected = false,
-					IsEnabled = false,
-				},
-				new()
-				{
-					Id = "id3",
-					Title = "title3",
-					IsSelected = false,
-					IsEnabled = false,
-				}
-			};
+				Id = "id",
+				Title = "title",
+				IsSelected = false,
+				IsEnabled = false,
+			},
+			new()
+			{
+				Id = "id2",
+				Title = "title2",
+				IsSelected = false,
+				IsEnabled = false,
+			},
+			new()
+			{
+				Id = "id3",
+				Title = "title3",
+				IsSelected = false,
+				IsEnabled = false,
+			}
+		];
 
 		(var selectRowFactory, var selectRowFactoryResults) = SelectRowFactoryWithMocks();
 		SelectVariantViewModel selectVariantViewModel = new(commandPaletteWindowViewModel, selectRowFactory);
@@ -252,9 +251,7 @@ public class SelectVariantViewModelTests
 			IMatcher<SelectOption> matcherMock,
 			_
 		) = CreateOptionsStubs();
-		matcherMock
-			.Match(Arg.Any<string>(), Arg.Any<IReadOnlyList<IVariantRowModel<SelectOption>>>())
-			.Returns(new List<MatcherResult<SelectOption>>());
+		matcherMock.Match(Arg.Any<string>(), Arg.Any<IReadOnlyList<IVariantRowModel<SelectOption>>>()).Returns([]);
 
 		selectVariantViewModel.Activate(activationConfig);
 
@@ -430,8 +427,7 @@ public class SelectVariantViewModelTests
 
 		// When
 		selectVariantViewModel.PopulateItems(
-			new List<SelectOption>
-			{
+			[
 				new()
 				{
 					Id = "4",
@@ -453,7 +449,7 @@ public class SelectVariantViewModelTests
 					IsSelected = false,
 					IsEnabled = false
 				},
-			}
+			]
 		);
 
 		// Then
@@ -474,8 +470,7 @@ public class SelectVariantViewModelTests
 
 		// When
 		selectVariantViewModel.PopulateItems(
-			new List<SelectOption>
-			{
+			[
 				options[0],
 				new()
 				{
@@ -484,7 +479,7 @@ public class SelectVariantViewModelTests
 					IsSelected = false,
 					IsEnabled = false
 				},
-			}
+			]
 		);
 
 		// Then
@@ -542,7 +537,7 @@ public class SelectVariantViewModelTests
 				IsEnabled = false
 			};
 
-		List<SelectOption> updatedOptions = new() { options[0], newOption, options[2], };
+		List<SelectOption> updatedOptions = [options[0], newOption, options[2],];
 
 		List<SelectVariantRowModel> updatedVariantItems = updatedOptions
 			.Select(o => new SelectVariantRowModel(o))
@@ -600,7 +595,7 @@ public class SelectVariantViewModelTests
 				IsSelected = false,
 				IsEnabled = false
 			};
-		List<SelectOption> secondOptions = new() { secondNewOption };
+		List<SelectOption> secondOptions = [secondNewOption];
 		List<SelectVariantRowModel> secondVariantItems = secondOptions
 			.Select(o => new SelectVariantRowModel(o))
 			.ToList();
@@ -627,7 +622,7 @@ public class SelectVariantViewModelTests
 				IsSelected = false,
 				IsEnabled = false
 			};
-		List<SelectOption> thirdOptions = new() { secondNewOption, thirdNewOption };
+		List<SelectOption> thirdOptions = [secondNewOption, thirdNewOption];
 		List<SelectVariantRowModel> thirdVariantItems = thirdOptions.Select(o => new SelectVariantRowModel(o)).ToList();
 
 		matcherMock

--- a/src/Whim.CommandPalette.Tests/Variants/Select/SelectVariantViewModelTests.cs
+++ b/src/Whim.CommandPalette.Tests/Variants/Select/SelectVariantViewModelTests.cs
@@ -13,7 +13,7 @@ public class SelectVariantViewModelTests
 	{
 		return variantRowModels.Select(v => new MatcherResult<SelectOption>(
 			v,
-			new[] { new FilterTextMatch(0, v.Title.Length) },
+			[new FilterTextMatch(0, v.Title.Length)],
 			0
 		));
 	}
@@ -214,7 +214,7 @@ public class SelectVariantViewModelTests
 			.Returns(
 				options.Select(o => new MatcherResult<SelectOption>(
 					new SelectVariantRowModel(o),
-					new[] { new FilterTextMatch(0, o.Title.Length) },
+					[new FilterTextMatch(0, o.Title.Length)],
 					0
 				))
 			);

--- a/src/Whim.CommandPalette/CommandPaletteCommands.cs
+++ b/src/Whim.CommandPalette/CommandPaletteCommands.cs
@@ -196,7 +196,7 @@ public class CommandPaletteCommands : PluginCommands
 	{
 		IEnumerable<string> selectedWindowNames = options.Where(o => o.IsSelected).Select(o => o.Title);
 
-		IReadOnlyList<IWorkspace> workspaces = _context.WorkspaceManager.ToArray();
+		IReadOnlyList<IWorkspace> workspaces = [.. _context.WorkspaceManager];
 		IReadOnlyList<IWindow> windows = workspaces
 			.SelectMany(w => w.Windows)
 			.Where(w => selectedWindowNames.Contains(w.Title))

--- a/src/Whim.CommandPalette/CommandPaletteCommands.cs
+++ b/src/Whim.CommandPalette/CommandPaletteCommands.cs
@@ -61,7 +61,7 @@ public class CommandPaletteCommands : PluginCommands
 				callback: () =>
 				{
 					IWorkspace activeWorkspace = _context.WorkspaceManager.ActiveWorkspace;
-					List<ICommand> items = new();
+					List<ICommand> items = [];
 					foreach (IWorkspace workspace in _context.WorkspaceManager)
 					{
 						if (workspace != activeWorkspace)
@@ -123,7 +123,7 @@ public class CommandPaletteCommands : PluginCommands
 	private void ActivateWorkspaceCallback()
 	{
 		IWorkspace activeWorkspace = _context.WorkspaceManager.ActiveWorkspace;
-		List<ICommand> items = new();
+		List<ICommand> items = [];
 		foreach (IWorkspace workspace in _context.WorkspaceManager)
 		{
 			if (workspace != activeWorkspace)

--- a/src/Whim.CommandPalette/CommandPalettePlugin.cs
+++ b/src/Whim.CommandPalette/CommandPalettePlugin.cs
@@ -125,7 +125,7 @@ public class CommandPalettePlugin : ICommandPalettePlugin
 	/// <inheritdoc/>
 	public JsonElement? SaveState()
 	{
-		Dictionary<string, JsonElement> state = new();
+		Dictionary<string, JsonElement> state = [];
 
 		if (Config.ActivationConfig.Matcher.SaveState() is JsonElement activationConfig)
 		{

--- a/src/Whim.CommandPalette/ExecuteCommand.cs
+++ b/src/Whim.CommandPalette/ExecuteCommand.cs
@@ -14,7 +14,11 @@ internal class ConfirmCommand(ICommandPaletteWindowViewModel viewModel) : System
 	private readonly ICommandPaletteWindowViewModel _viewModel = viewModel;
 
 	/// <inheritdoc/>
-	public event EventHandler? CanExecuteChanged { add { } remove { } }
+	public event EventHandler? CanExecuteChanged
+	{
+		add { }
+		remove { }
+	}
 
 	public bool CanExecute(object? parameter) => _viewModel.ActiveVariant != null;
 

--- a/src/Whim.CommandPalette/ExecuteCommand.cs
+++ b/src/Whim.CommandPalette/ExecuteCommand.cs
@@ -14,7 +14,7 @@ internal class ConfirmCommand(ICommandPaletteWindowViewModel viewModel) : System
 	private readonly ICommandPaletteWindowViewModel _viewModel = viewModel;
 
 	/// <inheritdoc/>
-	public event EventHandler? CanExecuteChanged;
+	public event EventHandler? CanExecuteChanged { add { } remove { } }
 
 	public bool CanExecute(object? parameter) => _viewModel.ActiveVariant != null;
 

--- a/src/Whim.CommandPalette/ExecuteCommand.cs
+++ b/src/Whim.CommandPalette/ExecuteCommand.cs
@@ -5,21 +5,16 @@ namespace Whim.CommandPalette;
 /// <summary>
 /// Command to save the changes made in the palette.
 /// </summary>
-internal class ConfirmCommand : System.Windows.Input.ICommand
+/// <remarks>
+/// Creates a new instance of <see cref="ConfirmCommand"/>.
+/// </remarks>
+/// <param name="viewModel"></param>
+internal class ConfirmCommand(ICommandPaletteWindowViewModel viewModel) : System.Windows.Input.ICommand
 {
-	private readonly ICommandPaletteWindowViewModel _viewModel;
+	private readonly ICommandPaletteWindowViewModel _viewModel = viewModel;
 
 	/// <inheritdoc/>
 	public event EventHandler? CanExecuteChanged;
-
-	/// <summary>
-	/// Creates a new instance of <see cref="ConfirmCommand"/>.
-	/// </summary>
-	/// <param name="viewModel"></param>
-	public ConfirmCommand(ICommandPaletteWindowViewModel viewModel)
-	{
-		_viewModel = viewModel;
-	}
 
 	public bool CanExecute(object? parameter) => _viewModel.ActiveVariant != null;
 

--- a/src/Whim.CommandPalette/Filters/CamelCase.cs
+++ b/src/Whim.CommandPalette/Filters/CamelCase.cs
@@ -1,5 +1,3 @@
-using System;
-
 namespace Whim.CommandPalette;
 
 internal record struct CamelCaseAnalysis(float Upper, float Lower, float Alpha, float Numeric);

--- a/src/Whim.CommandPalette/Filters/CamelCase.cs
+++ b/src/Whim.CommandPalette/Filters/CamelCase.cs
@@ -20,7 +20,7 @@ public static partial class PaletteFilters
 
 		if (word.Length == 0)
 		{
-			return Array.Empty<FilterTextMatch>();
+			return [];
 		}
 
 		if (!IsCamelCasePattern(word) || wordToMatchAgainst.Length > 60)
@@ -62,7 +62,7 @@ public static partial class PaletteFilters
 	{
 		if (wordStart == word.Length)
 		{
-			return Array.Empty<FilterTextMatch>();
+			return [];
 		}
 		else if (wordMatchStart == wordToMatchAgainst.Length)
 		{

--- a/src/Whim.CommandPalette/Filters/Prefix.cs
+++ b/src/Whim.CommandPalette/Filters/Prefix.cs
@@ -38,6 +38,6 @@ public static partial class PaletteFilters
 			return null;
 		}
 
-		return word.Length > 0 ? new[] { new FilterTextMatch(0, word.Length) } : Array.Empty<FilterTextMatch>();
+		return word.Length > 0 ? new[] { new FilterTextMatch(0, word.Length) } : [];
 	}
 }

--- a/src/Whim.CommandPalette/Filters/Prefix.cs
+++ b/src/Whim.CommandPalette/Filters/Prefix.cs
@@ -38,6 +38,6 @@ public static partial class PaletteFilters
 			return null;
 		}
 
-		return word.Length > 0 ? new[] { new FilterTextMatch(0, word.Length) } : [];
+		return word.Length > 0 ? [new FilterTextMatch(0, word.Length)] : [];
 	}
 }

--- a/src/Whim.CommandPalette/Filters/Regex.cs
+++ b/src/Whim.CommandPalette/Filters/Regex.cs
@@ -14,7 +14,7 @@ public static partial class PaletteFilters
 		Match match = regexp.Match(wordToMatchAgainst);
 		if (match.Success)
 		{
-			return new[] { new FilterTextMatch(match.Index, match.Index + match.Length) };
+			return [new FilterTextMatch(match.Index, match.Index + match.Length)];
 		}
 
 		return null;

--- a/src/Whim.CommandPalette/Filters/Substring.cs
+++ b/src/Whim.CommandPalette/Filters/Substring.cs
@@ -15,7 +15,7 @@ public static partial class PaletteFilters
 			return null;
 		}
 
-		return new[] { new FilterTextMatch(index, index + word.Length) };
+		return [new FilterTextMatch(index, index + word.Length)];
 	}
 
 	/// <summary>

--- a/src/Whim.CommandPalette/Filters/Substring.cs
+++ b/src/Whim.CommandPalette/Filters/Substring.cs
@@ -35,7 +35,7 @@ public static partial class PaletteFilters
 	{
 		if (wordStart == word.Length)
 		{
-			return Array.Empty<FilterTextMatch>();
+			return [];
 		}
 		if (wordMatchStart == wordToMatchAgainst.Length)
 		{

--- a/src/Whim.CommandPalette/Filters/Utils.cs
+++ b/src/Whim.CommandPalette/Filters/Utils.cs
@@ -40,7 +40,7 @@ public static partial class PaletteFilters
 	{
 		if (tail.Length == 0)
 		{
-			tail = new[] { head };
+			tail = [head];
 		}
 		else if (head.End == tail[0].Start)
 		{

--- a/src/Whim.CommandPalette/Filters/Utils.cs
+++ b/src/Whim.CommandPalette/Filters/Utils.cs
@@ -1,6 +1,4 @@
-﻿using System.Linq;
-
-namespace Whim.CommandPalette;
+﻿namespace Whim.CommandPalette;
 
 /// <summary>
 /// Utilities for palette filters.

--- a/src/Whim.CommandPalette/Filters/Utils.cs
+++ b/src/Whim.CommandPalette/Filters/Utils.cs
@@ -48,7 +48,7 @@ public static partial class PaletteFilters
 		}
 		else
 		{
-			tail = new[] { head }.Concat(tail).ToArray();
+			tail = [head, .. tail];
 		}
 
 		return tail;

--- a/src/Whim.CommandPalette/Filters/Words.cs
+++ b/src/Whim.CommandPalette/Filters/Words.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 
 namespace Whim.CommandPalette;

--- a/src/Whim.CommandPalette/Filters/Words.cs
+++ b/src/Whim.CommandPalette/Filters/Words.cs
@@ -54,7 +54,7 @@ public static partial class PaletteFilters
 	{
 		if (i == word.Length)
 		{
-			return Array.Empty<FilterTextMatch>();
+			return [];
 		}
 		else if (j == wordToMatchAgainst.Length)
 		{

--- a/src/Whim.CommandPalette/Matchers/MatcherResult.cs
+++ b/src/Whim.CommandPalette/Matchers/MatcherResult.cs
@@ -80,14 +80,8 @@ internal class MatcherItemComparer<T> : IComparer<MatcherResult<T>>
 	public int Compare(MatcherResult<T>? x, MatcherResult<T>? y)
 	{
 		// We throw here because it should never happen.
-		if (x is null)
-		{
-			throw new ArgumentNullException(nameof(x));
-		}
-		else if (y is null)
-		{
-			throw new ArgumentNullException(nameof(y));
-		}
+		ArgumentNullException.ThrowIfNull(x);
+		ArgumentNullException.ThrowIfNull(y);
 
 		// Sort by the last used time.
 		if (x.Score > y.Score)

--- a/src/Whim.CommandPalette/Matchers/MostRecentlyUsedMatcher.cs
+++ b/src/Whim.CommandPalette/Matchers/MostRecentlyUsedMatcher.cs
@@ -33,7 +33,7 @@ public class MostRecentlyUsedMatcher<T> : IMatcher<T>
 			// If there are no matches and the query is not empty, return an empty list.
 			if (!string.IsNullOrEmpty(query))
 			{
-				return Array.Empty<MatcherResult<T>>();
+				return [];
 			}
 
 			// If there are no matches and the query is empty, return the most recently used items.

--- a/src/Whim.CommandPalette/Matchers/MostRecentlyUsedMatcher.cs
+++ b/src/Whim.CommandPalette/Matchers/MostRecentlyUsedMatcher.cs
@@ -13,7 +13,7 @@ public class MostRecentlyUsedMatcher<T> : IMatcher<T>
 {
 	private static readonly MatcherItemComparer<T> _sorter = new();
 
-	internal readonly Dictionary<string, long> _commandLastExecutionTime = new();
+	internal readonly Dictionary<string, long> _commandLastExecutionTime = [];
 
 	/// <summary>
 	/// The filter to use when matching commands.

--- a/src/Whim.CommandPalette/Matchers/MostRecentlyUsedMatcher.cs
+++ b/src/Whim.CommandPalette/Matchers/MostRecentlyUsedMatcher.cs
@@ -84,7 +84,7 @@ public class MostRecentlyUsedMatcher<T> : IMatcher<T>
 		foreach (IVariantRowModel<T> item in items)
 		{
 			long lastExecutionTime = _commandLastExecutionTime.TryGetValue(item.Id, out long value) ? value : 0;
-			matches[matchCount++] = new MatcherResult<T>(item, Array.Empty<FilterTextMatch>(), lastExecutionTime);
+			matches[matchCount++] = new MatcherResult<T>(item, [], lastExecutionTime);
 		}
 
 		return matchCount;

--- a/src/Whim.CommandPalette/Model/PaletteText.cs
+++ b/src/Whim.CommandPalette/Model/PaletteText.cs
@@ -31,7 +31,7 @@ public record PaletteText
 	/// <summary>
 	/// The segments of text.
 	/// </summary>
-	public IList<PaletteTextSegment> Segments { get; } = new List<PaletteTextSegment>();
+	public IList<PaletteTextSegment> Segments { get; } = [];
 
 	/// <summary>
 	/// Creates an empty instance of the <see cref="PaletteText"/> class.

--- a/src/Whim.CommandPalette/Variants/FreeText/FreeTextVariantViewModel.cs
+++ b/src/Whim.CommandPalette/Variants/FreeText/FreeTextVariantViewModel.cs
@@ -3,9 +3,9 @@ using Windows.System;
 
 namespace Whim.CommandPalette;
 
-internal class FreeTextVariantViewModel : IVariantViewModel
+internal class FreeTextVariantViewModel(ICommandPaletteWindowViewModel windowViewModel) : IVariantViewModel
 {
-	private readonly ICommandPaletteWindowViewModel _commandPaletteWindowViewModel;
+	private readonly ICommandPaletteWindowViewModel _commandPaletteWindowViewModel = windowViewModel;
 	private FreeTextVariantConfig? _activationConfig;
 
 	public string Prompt => _activationConfig?.Prompt ?? "";
@@ -13,11 +13,6 @@ internal class FreeTextVariantViewModel : IVariantViewModel
 	public string? ConfirmButtonText => _activationConfig?.ConfirmButtonText;
 
 	public event PropertyChangedEventHandler? PropertyChanged;
-
-	public FreeTextVariantViewModel(ICommandPaletteWindowViewModel windowViewModel)
-	{
-		_commandPaletteWindowViewModel = windowViewModel;
-	}
 
 	public void Activate(BaseVariantConfig activationConfig)
 	{

--- a/src/Whim.CommandPalette/Variants/Menu/MenuVariantRowViewModel.cs
+++ b/src/Whim.CommandPalette/Variants/Menu/MenuVariantRowViewModel.cs
@@ -2,7 +2,8 @@ using System.ComponentModel;
 
 namespace Whim.CommandPalette;
 
-internal class MenuVariantRowViewModel(MatcherResult<MenuVariantRowModelData> matcherResult) : IVariantRowViewModel<MenuVariantRowModelData>
+internal class MenuVariantRowViewModel(MatcherResult<MenuVariantRowModelData> matcherResult)
+	: IVariantRowViewModel<MenuVariantRowModelData>
 {
 	public IVariantRowModel<MenuVariantRowModelData> Model { get; private set; } = matcherResult.Model;
 

--- a/src/Whim.CommandPalette/Variants/Menu/MenuVariantRowViewModel.cs
+++ b/src/Whim.CommandPalette/Variants/Menu/MenuVariantRowViewModel.cs
@@ -2,19 +2,13 @@ using System.ComponentModel;
 
 namespace Whim.CommandPalette;
 
-internal class MenuVariantRowViewModel : IVariantRowViewModel<MenuVariantRowModelData>
+internal class MenuVariantRowViewModel(MatcherResult<MenuVariantRowModelData> matcherResult) : IVariantRowViewModel<MenuVariantRowModelData>
 {
-	public IVariantRowModel<MenuVariantRowModelData> Model { get; private set; }
+	public IVariantRowModel<MenuVariantRowModelData> Model { get; private set; } = matcherResult.Model;
 
-	public PaletteText FormattedTitle { get; private set; }
+	public PaletteText FormattedTitle { get; private set; } = matcherResult.FormattedTitle;
 
 	public event PropertyChangedEventHandler? PropertyChanged;
-
-	public MenuVariantRowViewModel(MatcherResult<MenuVariantRowModelData> matcherResult)
-	{
-		Model = matcherResult.Model;
-		FormattedTitle = matcherResult.FormattedTitle;
-	}
 
 	public void Update(MatcherResult<MenuVariantRowModelData> matcherResult)
 	{

--- a/src/Whim.CommandPalette/Variants/Menu/MenuVariantViewModel.cs
+++ b/src/Whim.CommandPalette/Variants/Menu/MenuVariantViewModel.cs
@@ -18,12 +18,12 @@ internal class MenuVariantViewModel : IVariantViewModel
 	/// The rows which are currently unused and can be reused for new matches.
 	/// Keeping these around avoids the need to create new rows every time the palette is shown.
 	/// </summary>
-	private readonly List<IVariantRowView<MenuVariantRowModelData, MenuVariantRowViewModel>> _unusedRows = new();
+	private readonly List<IVariantRowView<MenuVariantRowModelData, MenuVariantRowViewModel>> _unusedRows = [];
 
 	/// <summary>
 	/// The current commands from which the matches shown in <see cref="MenuRows"/> are drawn.
 	/// </summary>
-	internal readonly List<MenuVariantRowModel> _allItems = new();
+	internal readonly List<MenuVariantRowModel> _allItems = [];
 
 	/// <summary>
 	/// Factory to create menu rows to make it possible to use xunit.
@@ -35,7 +35,7 @@ internal class MenuVariantViewModel : IVariantViewModel
 	> _menuRowFactory;
 
 	public readonly ObservableCollection<IVariantRowView<MenuVariantRowModelData, MenuVariantRowViewModel>> MenuRows =
-		new();
+	[];
 
 	public string? ConfirmButtonText => _activationConfig?.ConfirmButtonText;
 

--- a/src/Whim.CommandPalette/Variants/Select/SelectVariantRowViewModel.cs
+++ b/src/Whim.CommandPalette/Variants/Select/SelectVariantRowViewModel.cs
@@ -2,11 +2,11 @@ using System.ComponentModel;
 
 namespace Whim.CommandPalette;
 
-internal class SelectVariantRowViewModel : IVariantRowViewModel<SelectOption>
+internal class SelectVariantRowViewModel(MatcherResult<SelectOption> matcherResult) : IVariantRowViewModel<SelectOption>
 {
-	public IVariantRowModel<SelectOption> Model { get; private set; }
+	public IVariantRowModel<SelectOption> Model { get; private set; } = matcherResult.Model;
 
-	public PaletteText FormattedTitle { get; private set; }
+	public PaletteText FormattedTitle { get; private set; } = matcherResult.FormattedTitle;
 
 	public bool IsSelected
 	{
@@ -35,12 +35,6 @@ internal class SelectVariantRowViewModel : IVariantRowViewModel<SelectOption>
 	}
 
 	public event PropertyChangedEventHandler? PropertyChanged;
-
-	public SelectVariantRowViewModel(MatcherResult<SelectOption> matcherResult)
-	{
-		Model = matcherResult.Model;
-		FormattedTitle = matcherResult.FormattedTitle;
-	}
 
 	public void Update(MatcherResult<SelectOption> matcherResult)
 	{

--- a/src/Whim.CommandPalette/Variants/Select/SelectVariantViewModel.cs
+++ b/src/Whim.CommandPalette/Variants/Select/SelectVariantViewModel.cs
@@ -11,11 +11,11 @@ namespace Whim.CommandPalette;
 internal class SelectVariantViewModel(
 	ICommandPaletteWindowViewModel commandPaletteWindowViewModel,
 	Func<
-			MatcherResult<SelectOption>,
-			SelectVariantConfig,
-			IVariantRowView<SelectOption, SelectVariantRowViewModel>
-		>? selectRowFactory = null
-	) : IVariantViewModel
+		MatcherResult<SelectOption>,
+		SelectVariantConfig,
+		IVariantRowView<SelectOption, SelectVariantRowViewModel>
+	>? selectRowFactory = null
+) : IVariantViewModel
 {
 	private readonly ICommandPaletteWindowViewModel _commandPaletteWindowViewModel = commandPaletteWindowViewModel;
 
@@ -41,8 +41,8 @@ internal class SelectVariantViewModel(
 		SelectVariantConfig,
 		IVariantRowView<SelectOption, SelectVariantRowViewModel>
 	> _selectRowFactory =
-			selectRowFactory
-			?? ((MatcherResult<SelectOption> item, SelectVariantConfig config) => new SelectVariantRowView(item));
+		selectRowFactory
+		?? ((MatcherResult<SelectOption> item, SelectVariantConfig config) => new SelectVariantRowView(item));
 
 	public readonly ObservableCollection<IVariantRowView<SelectOption, SelectVariantRowViewModel>> SelectRows = [];
 

--- a/src/Whim.CommandPalette/Variants/Select/SelectVariantViewModel.cs
+++ b/src/Whim.CommandPalette/Variants/Select/SelectVariantViewModel.cs
@@ -8,9 +8,16 @@ using Windows.System;
 
 namespace Whim.CommandPalette;
 
-internal class SelectVariantViewModel : IVariantViewModel
+internal class SelectVariantViewModel(
+	ICommandPaletteWindowViewModel commandPaletteWindowViewModel,
+	Func<
+			MatcherResult<SelectOption>,
+			SelectVariantConfig,
+			IVariantRowView<SelectOption, SelectVariantRowViewModel>
+		>? selectRowFactory = null
+	) : IVariantViewModel
 {
-	private readonly ICommandPaletteWindowViewModel _commandPaletteWindowViewModel;
+	private readonly ICommandPaletteWindowViewModel _commandPaletteWindowViewModel = commandPaletteWindowViewModel;
 
 	private SelectVariantConfig? _activationConfig;
 
@@ -33,7 +40,9 @@ internal class SelectVariantViewModel : IVariantViewModel
 		MatcherResult<SelectOption>,
 		SelectVariantConfig,
 		IVariantRowView<SelectOption, SelectVariantRowViewModel>
-	> _selectRowFactory;
+	> _selectRowFactory =
+			selectRowFactory
+			?? ((MatcherResult<SelectOption> item, SelectVariantConfig config) => new SelectVariantRowView(item));
 
 	public readonly ObservableCollection<IVariantRowView<SelectOption, SelectVariantRowViewModel>> SelectRows = [];
 
@@ -84,21 +93,6 @@ internal class SelectVariantViewModel : IVariantViewModel
 	public event PropertyChangedEventHandler? PropertyChanged;
 
 	public event EventHandler<EventArgs>? ScrollIntoViewRequested;
-
-	public SelectVariantViewModel(
-		ICommandPaletteWindowViewModel commandPaletteWindowViewModel,
-		Func<
-			MatcherResult<SelectOption>,
-			SelectVariantConfig,
-			IVariantRowView<SelectOption, SelectVariantRowViewModel>
-		>? selectRowFactory = null
-	)
-	{
-		_commandPaletteWindowViewModel = commandPaletteWindowViewModel;
-		_selectRowFactory =
-			selectRowFactory
-			?? ((MatcherResult<SelectOption> item, SelectVariantConfig config) => new SelectVariantRowView(item));
-	}
 
 	public void Activate(BaseVariantConfig activationConfig)
 	{

--- a/src/Whim.CommandPalette/Variants/Select/SelectVariantViewModel.cs
+++ b/src/Whim.CommandPalette/Variants/Select/SelectVariantViewModel.cs
@@ -18,12 +18,12 @@ internal class SelectVariantViewModel : IVariantViewModel
 	/// The rows which are currently unused and can be reused for new matches.
 	/// Keeping these around avoids the need to create new rows every time the palette is shown.
 	/// </summary>
-	internal readonly List<IVariantRowView<SelectOption, SelectVariantRowViewModel>> _unusedRows = new();
+	internal readonly List<IVariantRowView<SelectOption, SelectVariantRowViewModel>> _unusedRows = [];
 
 	/// <summary>
 	/// The current commands from which the matches shown in <see cref="SelectRows"/> are drawn.
 	/// </summary>
-	internal readonly List<SelectVariantRowModel> _allItems = new();
+	internal readonly List<SelectVariantRowModel> _allItems = [];
 
 	/// <summary>
 	/// Factory to create select rows to make it possible to use xunit.
@@ -35,7 +35,7 @@ internal class SelectVariantViewModel : IVariantViewModel
 		IVariantRowView<SelectOption, SelectVariantRowViewModel>
 	> _selectRowFactory;
 
-	public readonly ObservableCollection<IVariantRowView<SelectOption, SelectVariantRowViewModel>> SelectRows = new();
+	public readonly ObservableCollection<IVariantRowView<SelectOption, SelectVariantRowViewModel>> SelectRows = [];
 
 	public string? ConfirmButtonText => _activationConfig?.ConfirmButtonText;
 

--- a/src/Whim.FloatingWindow.Tests/Directory.Build.props
+++ b/src/Whim.FloatingWindow.Tests/Directory.Build.props
@@ -1,5 +1,6 @@
 <Project>
 	<PropertyGroup>
-		<GenerateDocumentationFile>false</GenerateDocumentationFile>
+		<GenerateDocumentationFile>true</GenerateDocumentationFile>
+		<NoWarn>$(NoWarn);CS1591</NoWarn>
 	</PropertyGroup>
 </Project>

--- a/src/Whim.FloatingWindow.Tests/GlobalSuppressions.cs
+++ b/src/Whim.FloatingWindow.Tests/GlobalSuppressions.cs
@@ -16,3 +16,4 @@ using System.Diagnostics.CodeAnalysis;
 [assembly: SuppressMessage("Style", "IDE0022:Use expression body for methods")]
 [assembly: SuppressMessage("Performance", "CA1852:Seal internal types")]
 [assembly: SuppressMessage("Performance", "CA1861:Avoid constant arrays as arguments")]
+[assembly: SuppressMessage("Performance", "CA1859:Use concrete types when possible for improved performance")]

--- a/src/Whim.FloatingWindow.Tests/GlobalSuppressions.cs
+++ b/src/Whim.FloatingWindow.Tests/GlobalSuppressions.cs
@@ -14,4 +14,5 @@ using System.Diagnostics.CodeAnalysis;
 [assembly: SuppressMessage("Style", "IDE0042:Variable declaration can be deconstructed")]
 [assembly: SuppressMessage("Style", "IDE0058:Expression value is never used")]
 [assembly: SuppressMessage("Style", "IDE0022:Use expression body for methods")]
-[assembly: SuppressMessage("Performance", "CA1813:Avoid unsealed attributes")]
+[assembly: SuppressMessage("Performance", "CA1852:Seal internal types")]
+[assembly: SuppressMessage("Performance", "CA1861:Avoid constant arrays as arguments")]

--- a/src/Whim.FloatingWindow.Tests/ProxyFloatingLayoutEngineTests.cs
+++ b/src/Whim.FloatingWindow.Tests/ProxyFloatingLayoutEngineTests.cs
@@ -596,8 +596,7 @@ public class ProxyFloatingLayoutEngineTests
 		newInnerLayoutEngine
 			.DoLayout(Arg.Any<IRectangle<int>>(), Arg.Any<IMonitor>())
 			.Returns(
-				new IWindowState[]
-				{
+				[
 					new WindowState()
 					{
 						Window = window1,
@@ -610,7 +609,7 @@ public class ProxyFloatingLayoutEngineTests
 						Rectangle = new Rectangle<int>(),
 						WindowSize = WindowSize.Normal
 					}
-				}
+				]
 			);
 		newInnerLayoutEngine.Count.Returns(2);
 
@@ -633,8 +632,8 @@ public class ProxyFloatingLayoutEngineTests
 		// Then
 		Assert.Equal(3, windowStates.Length);
 
-		IWindowState[] expected = new IWindowState[]
-		{
+		IWindowState[] expected =
+		[
 			new WindowState()
 			{
 				Window = floatingWindow,
@@ -659,7 +658,7 @@ public class ProxyFloatingLayoutEngineTests
 				Rectangle = new Rectangle<int>(),
 				WindowSize = WindowSize.Normal
 			}
-		};
+		];
 
 		windowStates.Should().Equal(expected);
 

--- a/src/Whim.FloatingWindow/FloatingWindowPlugin.cs
+++ b/src/Whim.FloatingWindow/FloatingWindowPlugin.cs
@@ -13,7 +13,7 @@ public class FloatingWindowPlugin : IFloatingWindowPlugin, IInternalFloatingWind
 	/// </summary>
 	public string Name => "whim.floating_window";
 
-	private readonly Dictionary<IWindow, ISet<LayoutEngineIdentity>> _floatingWindows = new();
+	private readonly Dictionary<IWindow, ISet<LayoutEngineIdentity>> _floatingWindows = [];
 
 	/// <inheritdoc/>
 	public IReadOnlyDictionary<IWindow, ISet<LayoutEngineIdentity>> FloatingWindows => _floatingWindows;

--- a/src/Whim.FloatingWindow/FloatingWindowPlugin.cs
+++ b/src/Whim.FloatingWindow/FloatingWindowPlugin.cs
@@ -4,9 +4,13 @@ using System.Text.Json;
 namespace Whim.FloatingWindow;
 
 /// <inheritdoc />
-public class FloatingWindowPlugin : IFloatingWindowPlugin, IInternalFloatingWindowPlugin
+/// <summary>
+/// Creates a new instance of the floating window plugin.
+/// </summary>
+/// <param name="context"></param>
+public class FloatingWindowPlugin(IContext context) : IFloatingWindowPlugin, IInternalFloatingWindowPlugin
 {
-	private readonly IContext _context;
+	private readonly IContext _context = context;
 
 	/// <summary>
 	/// <c>whim.floating_window</c>
@@ -17,15 +21,6 @@ public class FloatingWindowPlugin : IFloatingWindowPlugin, IInternalFloatingWind
 
 	/// <inheritdoc/>
 	public IReadOnlyDictionary<IWindow, ISet<LayoutEngineIdentity>> FloatingWindows => _floatingWindows;
-
-	/// <summary>
-	/// Creates a new instance of the floating window plugin.
-	/// </summary>
-	/// <param name="context"></param>
-	public FloatingWindowPlugin(IContext context)
-	{
-		_context = context;
-	}
 
 	/// <inheritdoc />
 	public void PreInitialize()

--- a/src/Whim.FocusIndicator/FocusIndicatorConfig.cs
+++ b/src/Whim.FocusIndicator/FocusIndicatorConfig.cs
@@ -49,7 +49,7 @@ public class FocusIndicatorConfig : INotifyPropertyChanged
 		}
 	}
 
-	private int _borderSize = 10;
+	private int _borderSize = 4;
 
 	/// <summary>
 	/// The size of the focus indicator border, in pixels.

--- a/src/Whim.Gaps.Tests/Directory.Build.props
+++ b/src/Whim.Gaps.Tests/Directory.Build.props
@@ -1,5 +1,6 @@
 <Project>
 	<PropertyGroup>
-		<GenerateDocumentationFile>false</GenerateDocumentationFile>
+		<GenerateDocumentationFile>true</GenerateDocumentationFile>
+		<NoWarn>$(NoWarn);CS1591</NoWarn>
 	</PropertyGroup>
 </Project>

--- a/src/Whim.Gaps.Tests/GapsLayoutEngineTests.cs
+++ b/src/Whim.Gaps.Tests/GapsLayoutEngineTests.cs
@@ -19,10 +19,9 @@ public class GapsLayoutEngineTests
 			IWindow window1 = Substitute.For<IWindow>();
 			data.Add(
 				new GapsConfig() { OuterGap = 10, InnerGap = 5 },
-				new IWindow[] { window1 },
+				[window1],
 				100,
-				new IWindowState[]
-				{
+				[
 					new WindowState()
 					{
 						Window = window1,
@@ -35,17 +34,16 @@ public class GapsLayoutEngineTests
 						},
 						WindowSize = WindowSize.Normal
 					}
-				}
+				]
 			);
 
 			IWindow window2 = Substitute.For<IWindow>();
 			IWindow window3 = Substitute.For<IWindow>();
 			data.Add(
 				new GapsConfig() { OuterGap = 10, InnerGap = 5 },
-				new IWindow[] { window2, window3 },
+				[window2, window3],
 				100,
-				new IWindowState[]
-				{
+				[
 					new WindowState()
 					{
 						Window = window2,
@@ -70,16 +68,15 @@ public class GapsLayoutEngineTests
 						},
 						WindowSize = WindowSize.Normal
 					}
-				}
+				]
 			);
 
 			IWindow window4 = Substitute.For<IWindow>();
 			data.Add(
 				new GapsConfig { OuterGap = 10, InnerGap = 5 },
-				new IWindow[] { window4 },
+				[window4],
 				150,
-				new IWindowState[]
-				{
+				[
 					new WindowState()
 					{
 						Window = window4,
@@ -92,7 +89,7 @@ public class GapsLayoutEngineTests
 						},
 						WindowSize = WindowSize.Normal
 					}
-				}
+				]
 			);
 
 			return data;
@@ -151,8 +148,7 @@ public class GapsLayoutEngineTests
 					Width = -100,
 					Height = 1080
 				},
-				new IWindowState[]
-				{
+				[
 					new WindowState()
 					{
 						Window = window1,
@@ -165,7 +161,7 @@ public class GapsLayoutEngineTests
 						},
 						WindowSize = WindowSize.Normal
 					}
-				}
+				]
 			);
 
 			// A window whose width returned by the layout engine as zero should not have the gap applied
@@ -181,8 +177,7 @@ public class GapsLayoutEngineTests
 					Width = 0,
 					Height = 1080
 				},
-				new IWindowState[]
-				{
+				[
 					new WindowState()
 					{
 						Window = window2,
@@ -195,7 +190,7 @@ public class GapsLayoutEngineTests
 						},
 						WindowSize = WindowSize.Normal
 					}
-				}
+				]
 			);
 
 			// A window whose width is less than the gap should not have the gap applied in the x direction
@@ -210,8 +205,7 @@ public class GapsLayoutEngineTests
 					Width = 5,
 					Height = 1080
 				},
-				new IWindowState[]
-				{
+				[
 					new WindowState()
 					{
 						Window = window3,
@@ -224,7 +218,7 @@ public class GapsLayoutEngineTests
 						},
 						WindowSize = WindowSize.Normal
 					}
-				}
+				]
 			);
 
 			// A window whose height returned by the layout engine as less than zero should not have the
@@ -240,8 +234,7 @@ public class GapsLayoutEngineTests
 					Width = 1920,
 					Height = -100
 				},
-				new IWindowState[]
-				{
+				[
 					new WindowState()
 					{
 						Window = window4,
@@ -254,7 +247,7 @@ public class GapsLayoutEngineTests
 						},
 						WindowSize = WindowSize.Normal
 					}
-				}
+				]
 			);
 
 			// A window whose height returned by the layout engine as zero should not have the gap applied
@@ -270,8 +263,7 @@ public class GapsLayoutEngineTests
 					Width = 1920,
 					Height = 0
 				},
-				new IWindowState[]
-				{
+				[
 					new WindowState()
 					{
 						Window = window5,
@@ -284,7 +276,7 @@ public class GapsLayoutEngineTests
 						},
 						WindowSize = WindowSize.Normal
 					}
-				}
+				]
 			);
 
 			// A window whose height is less than the gap should not have the gap applied in the y direction
@@ -299,8 +291,7 @@ public class GapsLayoutEngineTests
 					Width = 1920,
 					Height = 5
 				},
-				new IWindowState[]
-				{
+				[
 					new WindowState()
 					{
 						Window = window6,
@@ -313,7 +304,7 @@ public class GapsLayoutEngineTests
 						},
 						WindowSize = WindowSize.Normal
 					}
-				}
+				]
 			);
 
 			// A window whose width and height are less than the gap should not have the gap applied in
@@ -329,8 +320,7 @@ public class GapsLayoutEngineTests
 					Width = 5,
 					Height = 5
 				},
-				new IWindowState[]
-				{
+				[
 					new WindowState()
 					{
 						Window = window7,
@@ -343,7 +333,7 @@ public class GapsLayoutEngineTests
 						},
 						WindowSize = WindowSize.Normal
 					}
-				}
+				]
 			);
 
 			// A window whose width and height are zero should not have the gap applied in either direction
@@ -358,8 +348,7 @@ public class GapsLayoutEngineTests
 					Width = 0,
 					Height = 0
 				},
-				new IWindowState[]
-				{
+				[
 					new WindowState()
 					{
 						Window = window8,
@@ -372,7 +361,7 @@ public class GapsLayoutEngineTests
 						},
 						WindowSize = WindowSize.Normal
 					}
-				}
+				]
 			);
 
 			return data;
@@ -393,15 +382,14 @@ public class GapsLayoutEngineTests
 		innerLayoutEngine
 			.DoLayout(rect, Arg.Any<IMonitor>())
 			.Returns(
-				new IWindowState[]
-				{
+				[
 					new WindowState()
 					{
 						Window = window,
 						Rectangle = rect,
 						WindowSize = WindowSize.Normal
 					}
-				}
+				]
 			);
 
 		GapsLayoutEngine gapsLayoutEngine = new(gapsConfig, innerLayoutEngine);
@@ -419,14 +407,14 @@ public class GapsLayoutEngineTests
 		// Input
 		Rectangle<int> rect = new(0, 0, -300, -300);
 		IWindowState[] inputWindowStates =
-		{
+		[
 			new WindowState()
 			{
 				Window = window,
 				Rectangle = rect,
 				WindowSize = WindowSize.Normal
 			}
-		};
+		];
 
 		// Given
 		ILayoutEngine innerLayoutEngine = Substitute.For<ILayoutEngine>();

--- a/src/Whim.Gaps.Tests/GapsLayoutEngineTests.cs
+++ b/src/Whim.Gaps.Tests/GapsLayoutEngineTests.cs
@@ -14,7 +14,7 @@ public class GapsLayoutEngineTests
 	{
 		get
 		{
-			TheoryData<GapsConfig, IWindow[], int, IWindowState[]> data = new();
+			TheoryData<GapsConfig, IWindow[], int, IWindowState[]> data = [];
 
 			IWindow window1 = Substitute.For<IWindow>();
 			data.Add(
@@ -136,7 +136,7 @@ public class GapsLayoutEngineTests
 	{
 		get
 		{
-			TheoryData<GapsConfig, IWindow, Rectangle<int>, IWindowState[]> data = new();
+			TheoryData<GapsConfig, IWindow, Rectangle<int>, IWindowState[]> data = [];
 
 			// A window whose width returned by the layout engine as less than zero should not have the
 			// gap applied in the x direction

--- a/src/Whim.Gaps.Tests/GlobalSuppressions.cs
+++ b/src/Whim.Gaps.Tests/GlobalSuppressions.cs
@@ -14,3 +14,5 @@ using System.Diagnostics.CodeAnalysis;
 [assembly: SuppressMessage("Style", "IDE0042:Variable declaration can be deconstructed")]
 [assembly: SuppressMessage("Style", "IDE0058:Expression value is never used")]
 [assembly: SuppressMessage("Style", "IDE0022:Use expression body for methods")]
+[assembly: SuppressMessage("Performance", "CA1852:Seal internal types")]
+[assembly: SuppressMessage("Performance", "CA1861:Avoid constant arrays as arguments")]

--- a/src/Whim.Gaps/GapsPlugin.cs
+++ b/src/Whim.Gaps/GapsPlugin.cs
@@ -3,30 +3,24 @@ using System.Text.Json;
 namespace Whim.Gaps;
 
 /// <inheritdoc />
-public class GapsPlugin : IGapsPlugin
+/// <summary>
+/// Creates a new instance of the gaps plugin.
+/// </summary>
+/// <param name="context"></param>
+/// <param name="gapsConfig"></param>
+public class GapsPlugin(IContext context, GapsConfig gapsConfig) : IGapsPlugin
 {
-	private readonly IContext _context;
+	private readonly IContext _context = context;
 
 	/// <summary>
 	/// The configuration for the gaps plugin.
 	/// </summary>
-	public GapsConfig GapsConfig { get; }
+	public GapsConfig GapsConfig { get; } = gapsConfig;
 
 	/// <summary>
 	/// <c>whim.gaps</c>
 	/// </summary>
 	public string Name => "whim.gaps";
-
-	/// <summary>
-	/// Creates a new instance of the gaps plugin.
-	/// </summary>
-	/// <param name="context"></param>
-	/// <param name="gapsConfig"></param>
-	public GapsPlugin(IContext context, GapsConfig gapsConfig)
-	{
-		_context = context;
-		GapsConfig = gapsConfig;
-	}
 
 	/// <inheritdoc />
 	public void PreInitialize()

--- a/src/Whim.LayoutPreview.Tests/Directory.Build.props
+++ b/src/Whim.LayoutPreview.Tests/Directory.Build.props
@@ -1,5 +1,6 @@
 <Project>
 	<PropertyGroup>
-		<GenerateDocumentationFile>false</GenerateDocumentationFile>
+		<GenerateDocumentationFile>true</GenerateDocumentationFile>
+		<NoWarn>$(NoWarn);CS1591</NoWarn>
 	</PropertyGroup>
 </Project>

--- a/src/Whim.LayoutPreview.Tests/GlobalSuppressions.cs
+++ b/src/Whim.LayoutPreview.Tests/GlobalSuppressions.cs
@@ -14,3 +14,5 @@ using System.Diagnostics.CodeAnalysis;
 [assembly: SuppressMessage("Style", "IDE0042:Variable declaration can be deconstructed")]
 [assembly: SuppressMessage("Style", "IDE0058:Expression value is never used")]
 [assembly: SuppressMessage("Style", "IDE0022:Use expression body for methods")]
+[assembly: SuppressMessage("Performance", "CA1852:Seal internal types")]
+[assembly: SuppressMessage("Performance", "CA1861:Avoid constant arrays as arguments")]

--- a/src/Whim.LayoutPreview.Tests/LayoutPreviewPluginTests.cs
+++ b/src/Whim.LayoutPreview.Tests/LayoutPreviewPluginTests.cs
@@ -1,4 +1,3 @@
-using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using AutoFixture;

--- a/src/Whim.LayoutPreview.Tests/LayoutPreviewPluginTests.cs
+++ b/src/Whim.LayoutPreview.Tests/LayoutPreviewPluginTests.cs
@@ -228,9 +228,7 @@ public class LayoutPreviewPluginTests
 		// Given
 		workspace = workspace with
 		{
-			LayoutEngines = ImmutableList<ILayoutEngine>.Empty.Add(
-				new FloatingLayoutEngine(ctx, new LayoutEngineIdentity())
-			),
+			LayoutEngines = [new FloatingLayoutEngine(ctx, new LayoutEngineIdentity())],
 			ActiveLayoutEngineIndex = 0
 		};
 		rootSector.WorkspaceSector.Workspaces = rootSector.WorkspaceSector.Workspaces.SetItem(workspace.Id, workspace);

--- a/src/Whim.LayoutPreview.Tests/LayoutPreviewWindowTests.cs
+++ b/src/Whim.LayoutPreview.Tests/LayoutPreviewWindowTests.cs
@@ -22,7 +22,7 @@ public class LayoutPreviewWindowTests
 	public void ShouldContinue_DifferentLength()
 	{
 		// Given
-		IWindowState[] prevWindowStates = Array.Empty<IWindowState>();
+		IWindowState[] prevWindowStates = [];
 		int prevHoveredIndex = -1;
 		IWindowState[] windowStates = new IWindowState[1];
 		IPoint<int> cursorPoint = new Rectangle<int>();

--- a/src/Whim.LayoutPreview.Tests/LayoutPreviewWindowTests.cs
+++ b/src/Whim.LayoutPreview.Tests/LayoutPreviewWindowTests.cs
@@ -43,8 +43,8 @@ public class LayoutPreviewWindowTests
 	public void ShouldContinue_DifferentWindowState()
 	{
 		// Given
-		IWindowState[] prevWindowStates = new IWindowState[]
-		{
+		IWindowState[] prevWindowStates =
+		[
 			new WindowState()
 			{
 				Window = Substitute.For<IWindow>(),
@@ -57,10 +57,10 @@ public class LayoutPreviewWindowTests
 				Rectangle = new Rectangle<int>(),
 				WindowSize = WindowSize.Normal
 			},
-		};
+		];
 		int prevHoveredIndex = -1;
-		IWindowState[] windowStates = new IWindowState[]
-		{
+		IWindowState[] windowStates =
+		[
 			prevWindowStates[0],
 			new WindowState()
 			{
@@ -68,7 +68,7 @@ public class LayoutPreviewWindowTests
 				Rectangle = new Rectangle<int>(),
 				WindowSize = WindowSize.Maximized
 			},
-		};
+		];
 		IPoint<int> cursorPoint = new Rectangle<int>();
 
 		// When
@@ -88,8 +88,8 @@ public class LayoutPreviewWindowTests
 	{
 		// Given
 		Rectangle<int> rect = new() { Height = 100, Width = 100 };
-		IWindowState[] prevWindowStates = new IWindowState[]
-		{
+		IWindowState[] prevWindowStates =
+		[
 			new WindowState()
 			{
 				Window = Substitute.For<IWindow>(),
@@ -102,10 +102,10 @@ public class LayoutPreviewWindowTests
 				Rectangle = new Rectangle<int>(),
 				WindowSize = WindowSize.Normal
 			},
-		};
+		];
 		int prevHoveredIndex = 0;
-		IWindowState[] windowStates = new IWindowState[]
-		{
+		IWindowState[] windowStates =
+		[
 			new WindowState()
 			{
 				Window = Substitute.For<IWindow>(),
@@ -118,7 +118,7 @@ public class LayoutPreviewWindowTests
 				Rectangle = new Rectangle<int>(),
 				WindowSize = WindowSize.Normal
 			},
-		};
+		];
 		IPoint<int> cursorPoint = new Rectangle<int>() { X = 100, Y = 101 };
 
 		// When
@@ -138,8 +138,8 @@ public class LayoutPreviewWindowTests
 	{
 		// Given
 		Rectangle<int> rect = new() { Height = 100, Width = 100 };
-		IWindowState[] prevWindowStates = new IWindowState[]
-		{
+		IWindowState[] prevWindowStates =
+		[
 			new WindowState()
 			{
 				Window = Substitute.For<IWindow>(),
@@ -152,7 +152,7 @@ public class LayoutPreviewWindowTests
 				Rectangle = new Rectangle<int>(),
 				WindowSize = WindowSize.Normal
 			},
-		};
+		];
 		int prevHoveredIndex = 0;
 		IPoint<int> cursorPoint = new Rectangle<int>() { X = 50, Y = 50 };
 

--- a/src/Whim.LayoutPreview/LayoutPreviewCommands.cs
+++ b/src/Whim.LayoutPreview/LayoutPreviewCommands.cs
@@ -16,6 +16,5 @@ internal class LayoutPreviewCommands : IPluginCommands
 
 	public IEnumerable<ICommand> Commands => [];
 
-	public IEnumerable<(string commandId, IKeybind keybind)> Keybinds =>
-		[];
+	public IEnumerable<(string commandId, IKeybind keybind)> Keybinds => [];
 }

--- a/src/Whim.LayoutPreview/LayoutPreviewCommands.cs
+++ b/src/Whim.LayoutPreview/LayoutPreviewCommands.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 
 namespace Whim.LayoutPreview;

--- a/src/Whim.LayoutPreview/LayoutPreviewCommands.cs
+++ b/src/Whim.LayoutPreview/LayoutPreviewCommands.cs
@@ -3,14 +3,9 @@ using System.Collections.Generic;
 
 namespace Whim.LayoutPreview;
 
-internal class LayoutPreviewCommands : IPluginCommands
+internal class LayoutPreviewCommands(IPlugin plugin) : IPluginCommands
 {
-	private readonly IPlugin _plugin;
-
-	public LayoutPreviewCommands(IPlugin plugin)
-	{
-		_plugin = plugin;
-	}
+	private readonly IPlugin _plugin = plugin;
 
 	public string PluginName => _plugin.Name;
 

--- a/src/Whim.LayoutPreview/LayoutPreviewCommands.cs
+++ b/src/Whim.LayoutPreview/LayoutPreviewCommands.cs
@@ -14,8 +14,8 @@ internal class LayoutPreviewCommands : IPluginCommands
 
 	public string PluginName => _plugin.Name;
 
-	public IEnumerable<ICommand> Commands => Array.Empty<ICommand>();
+	public IEnumerable<ICommand> Commands => [];
 
 	public IEnumerable<(string commandId, IKeybind keybind)> Keybinds =>
-		Array.Empty<(string commandId, IKeybind keybind)>();
+		[];
 }

--- a/src/Whim.LayoutPreview/LayoutPreviewPlugin.cs
+++ b/src/Whim.LayoutPreview/LayoutPreviewPlugin.cs
@@ -6,9 +6,12 @@ using Whim.FloatingWindow;
 namespace Whim.LayoutPreview;
 
 /// <inheritdoc/>
-public class LayoutPreviewPlugin : IPlugin, IDisposable
+/// <summary>
+/// Initializes a new instance of the <see cref="LayoutPreviewPlugin"/> class.
+/// </summary>
+public class LayoutPreviewPlugin(IContext context) : IPlugin, IDisposable
 {
-	private readonly IContext _context;
+	private readonly IContext _context = context;
 	private LayoutPreviewWindow? _layoutPreviewWindow;
 	private bool _disposedValue;
 
@@ -24,14 +27,6 @@ public class LayoutPreviewPlugin : IPlugin, IDisposable
 
 	/// <inheritdoc/>
 	public IPluginCommands PluginCommands => new LayoutPreviewCommands(this);
-
-	/// <summary>
-	/// Initializes a new instance of the <see cref="LayoutPreviewPlugin"/> class.
-	/// </summary>
-	public LayoutPreviewPlugin(IContext context)
-	{
-		_context = context;
-	}
 
 	/// <inheritdoc	/>
 	public void PreInitialize()

--- a/src/Whim.LayoutPreview/LayoutPreviewWindow.xaml.cs
+++ b/src/Whim.LayoutPreview/LayoutPreviewWindow.xaml.cs
@@ -19,7 +19,7 @@ internal sealed partial class LayoutPreviewWindow : Window, IDisposable
 	private readonly IContext _context;
 	private readonly IWindow _window;
 	private readonly TransparentWindowController _transparentWindowController;
-	private IWindowState[] _prevWindowStates = Array.Empty<IWindowState>();
+	private IWindowState[] _prevWindowStates = [];
 	private int _prevHoveredIndex = -1;
 	private bool _disposedValue;
 

--- a/src/Whim.Runner/App.xaml.cs
+++ b/src/Whim.Runner/App.xaml.cs
@@ -102,7 +102,8 @@ public partial class App : Application
 		}
 		else
 		{
-			new ExceptionWindow(this, e).Activate();
+			using ExceptionWindow window = new(this, e);
+			window.Activate();
 		}
 	}
 

--- a/src/Whim.Runner/ExceptionWindow.xaml.cs
+++ b/src/Whim.Runner/ExceptionWindow.xaml.cs
@@ -1,5 +1,5 @@
-﻿using Microsoft.UI.Xaml;
-using System;
+﻿using System;
+using Microsoft.UI.Xaml;
 
 namespace Whim.Runner;
 

--- a/src/Whim.Runner/ExceptionWindow.xaml.cs
+++ b/src/Whim.Runner/ExceptionWindow.xaml.cs
@@ -1,11 +1,12 @@
 ﻿using Microsoft.UI.Xaml;
+using System;
 
 namespace Whim.Runner;
 
 /// <summary>
 /// Exposes the exception encountered during startup to the user.
 /// </summary>
-public sealed partial class ExceptionWindow : Microsoft.UI.Xaml.Window
+public sealed partial class ExceptionWindow : Microsoft.UI.Xaml.Window, IDisposable
 {
 	private readonly App _app;
 	private readonly WindowBackdropController _backdropController;
@@ -35,5 +36,11 @@ public sealed partial class ExceptionWindow : Microsoft.UI.Xaml.Window
 	{
 		Close();
 		_app.Exit();
+	}
+
+	/// <inheritdoc/>
+	public void Dispose()
+	{
+		_backdropController.Dispose();
 	}
 }

--- a/src/Whim.SliceLayout.Tests/AreaHelpers/DoLayoutTests.cs
+++ b/src/Whim.SliceLayout.Tests/AreaHelpers/DoLayoutTests.cs
@@ -45,25 +45,25 @@ public class DoLayoutTests
 			// Empty
 			{
 				new Rectangle<int>(0, 0, 100, 100),
-				SliceLayouts.CreateMultiColumnArea(new uint[] { 2, 1, 0 }),
+				SliceLayouts.CreateMultiColumnArea([2, 1, 0]),
 				Array.Empty<IRectangle<int>>()
 			},
 			// Single window
 			{
 				new Rectangle<int>(0, 0, 100, 100),
-				SliceLayouts.CreateMultiColumnArea(new uint[] { 2, 1, 0 }),
+				SliceLayouts.CreateMultiColumnArea([2, 1, 0]),
 				new[] { new Rectangle<int>(0, 0, 100, 100), }
 			},
 			// Fill primary
 			{
 				new Rectangle<int>(0, 0, 100, 100),
-				SliceLayouts.CreateMultiColumnArea(new uint[] { 2, 1, 0 }),
+				SliceLayouts.CreateMultiColumnArea([2, 1, 0]),
 				new[] { new Rectangle<int>(0, 0, 100, 50), new Rectangle<int>(0, 50, 100, 50), }
 			},
 			// Fill secondary
 			{
 				new Rectangle<int>(0, 0, 100, 100),
-				SliceLayouts.CreateMultiColumnArea(new uint[] { 2, 1, 0 }),
+				SliceLayouts.CreateMultiColumnArea([2, 1, 0]),
 				new[]
 				{
 					new Rectangle<int>(0, 0, 50, 50),
@@ -75,7 +75,7 @@ public class DoLayoutTests
 
 			{
 				new Rectangle<int>(0, 0, 100, 100),
-				SliceLayouts.CreateMultiColumnArea(new uint[] { 2, 1, 0 }),
+				SliceLayouts.CreateMultiColumnArea([2, 1, 0]),
 				new[]
 				{
 					new Rectangle<int>(0, 0, third, 50),

--- a/src/Whim.SliceLayout.Tests/AreaHelpers/PruneTests.cs
+++ b/src/Whim.SliceLayout.Tests/AreaHelpers/PruneTests.cs
@@ -28,22 +28,22 @@ public class PruneTests
 		new()
 		{
 			// Empty
-			{ SliceLayouts.CreateMultiColumnArea(new uint[] { 2, 1, 0 }), 0, new ParentArea(isRow: true) },
+			{ SliceLayouts.CreateMultiColumnArea([2, 1, 0]), 0, new ParentArea(isRow: true) },
 			// Single window
 			{
-				SliceLayouts.CreateMultiColumnArea(new uint[] { 2, 1, 0 }),
+				SliceLayouts.CreateMultiColumnArea([2, 1, 0]),
 				1,
 				new ParentArea(isRow: true, (1.0, new SliceArea(order: 0, maxChildren: 2)))
 			},
 			// Fill primary
 			{
-				SliceLayouts.CreateMultiColumnArea(new uint[] { 2, 1, 0 }),
+				SliceLayouts.CreateMultiColumnArea([2, 1, 0]),
 				2,
 				new ParentArea(isRow: true, (1.0, new SliceArea(order: 0, maxChildren: 2)))
 			},
 			// Fill secondary
 			{
-				SliceLayouts.CreateMultiColumnArea(new uint[] { 2, 1, 0 }),
+				SliceLayouts.CreateMultiColumnArea([2, 1, 0]),
 				3,
 				new ParentArea(
 					isRow: true,
@@ -53,7 +53,7 @@ public class PruneTests
 			},
 			// Fill overflow
 			{
-				SliceLayouts.CreateMultiColumnArea(new uint[] { 2, 1, 0 }),
+				SliceLayouts.CreateMultiColumnArea([2, 1, 0]),
 				4,
 				new ParentArea(
 					isRow: true,

--- a/src/Whim.SliceLayout.Tests/AreaHelpers/SetStartIndexesTests.cs
+++ b/src/Whim.SliceLayout.Tests/AreaHelpers/SetStartIndexesTests.cs
@@ -22,7 +22,7 @@ public class SetStartIndexesTests
 			},
 			// Multi-column 2-1-0
 			{
-				SliceLayouts.CreateMultiColumnArea(new uint[] { 2, 1, 0 }),
+				SliceLayouts.CreateMultiColumnArea([2, 1, 0]),
 				new ParentArea(
 					isRow: true,
 					(1.0 / 3.0, new SliceArea(order: 0, maxChildren: 2) { StartIndex = 0 }),

--- a/src/Whim.SliceLayout.Tests/Directory.Build.props
+++ b/src/Whim.SliceLayout.Tests/Directory.Build.props
@@ -1,5 +1,6 @@
 <Project>
 	<PropertyGroup>
-		<GenerateDocumentationFile>false</GenerateDocumentationFile>
+		<GenerateDocumentationFile>true</GenerateDocumentationFile>
+		<NoWarn>$(NoWarn);CS1591</NoWarn>
 	</PropertyGroup>
 </Project>

--- a/src/Whim.SliceLayout.Tests/GlobalSuppressions.cs
+++ b/src/Whim.SliceLayout.Tests/GlobalSuppressions.cs
@@ -17,3 +17,4 @@ using System.Diagnostics.CodeAnalysis;
 [assembly: SuppressMessage("Design", "CA1024:Use properties where appropriate")]
 [assembly: SuppressMessage("Performance", "CA1852:Seal internal types")]
 [assembly: SuppressMessage("Performance", "CA1861:Avoid constant arrays as arguments")]
+[assembly: SuppressMessage("Performance", "CA1859:Use concrete types when possible for improved performance")]

--- a/src/Whim.SliceLayout.Tests/GlobalSuppressions.cs
+++ b/src/Whim.SliceLayout.Tests/GlobalSuppressions.cs
@@ -15,3 +15,5 @@ using System.Diagnostics.CodeAnalysis;
 [assembly: SuppressMessage("Style", "IDE0058:Expression value is never used")]
 [assembly: SuppressMessage("Style", "IDE0022:Use expression body for methods")]
 [assembly: SuppressMessage("Design", "CA1024:Use properties where appropriate")]
+[assembly: SuppressMessage("Performance", "CA1852:Seal internal types")]
+[assembly: SuppressMessage("Performance", "CA1861:Avoid constant arrays as arguments")]

--- a/src/Whim.SliceLayout.Tests/SliceLayoutEngine/SliceLayoutEngineTests.cs
+++ b/src/Whim.SliceLayout.Tests/SliceLayoutEngine/SliceLayoutEngineTests.cs
@@ -287,10 +287,10 @@ public class SliceLayoutEngineTests
 
 		int third = 100 / 3;
 		IRectangle<int> rectangle = new Rectangle<int>(0, 0, 100, 100);
-		ParentArea area = SliceLayouts.CreateMultiColumnArea(new uint[] { 2, 1, 0 });
+		ParentArea area = SliceLayouts.CreateMultiColumnArea([2, 1, 0]);
 
-		IWindowState[] expectedWindowStates = new IWindowState[]
-		{
+		IWindowState[] expectedWindowStates =
+		[
 			new WindowState()
 			{
 				Rectangle = new Rectangle<int>(0, 0, third, 50),
@@ -340,7 +340,7 @@ public class SliceLayoutEngineTests
 				Window = minimizedWindows[1],
 				WindowSize = WindowSize.Minimized
 			},
-		};
+		];
 
 		ILayoutEngine sut = new SliceLayoutEngine(ctx, plugin, identity, area);
 

--- a/src/Whim.SliceLayout.Tests/SliceLayoutsTests.cs
+++ b/src/Whim.SliceLayout.Tests/SliceLayoutsTests.cs
@@ -9,7 +9,7 @@ public class SliceLayoutsTests
 	public void CreateMultiColumnArea_MultipleOverflows()
 	{
 		// Given
-		ParentArea sut = SliceLayouts.CreateMultiColumnArea(new uint[] { 2, 1, 0, 0 });
+		ParentArea sut = SliceLayouts.CreateMultiColumnArea([2, 1, 0, 0]);
 
 		// Then
 		new ParentArea(

--- a/src/Whim.SliceLayout/AreaHelpers.cs
+++ b/src/Whim.SliceLayout/AreaHelpers.cs
@@ -147,9 +147,9 @@ internal static class AreaHelpers
 	private static (List<SliceArea> SliceAreas, OverflowArea? OverflowArea) GetAreasSorted(ParentArea rootArea)
 	{
 		// Iterate through the tree and add the areas to the list, using DFS.
-		List<SliceArea> sliceAreas = new();
+		List<SliceArea> sliceAreas = [];
 		OverflowArea? overflowArea = null;
-		List<IArea> areas = new() { rootArea };
+		List<IArea> areas = [rootArea];
 
 		while (areas.Count > 0)
 		{

--- a/src/Whim.SliceLayout/SliceLayoutEngine.cs
+++ b/src/Whim.SliceLayout/SliceLayoutEngine.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;

--- a/src/Whim.SliceLayout/SliceLayoutEngine.cs
+++ b/src/Whim.SliceLayout/SliceLayoutEngine.cs
@@ -97,8 +97,8 @@ public partial record SliceLayoutEngine : ILayoutEngine
 		_context = context;
 		_plugin = plugin;
 		Identity = identity;
-		_windows = ImmutableList<IWindow>.Empty;
-		_minimizedWindows = ImmutableList<IWindow>.Empty;
+		_windows = [];
+		_minimizedWindows = [];
 
 		(_rootArea, _windowAreas) = rootArea.SetStartIndexes();
 		_prunedRootArea = _rootArea.Prune(_windows.Count);
@@ -156,7 +156,7 @@ public partial record SliceLayoutEngine : ILayoutEngine
 	{
 		if (_windows.Count == 0)
 		{
-			return Array.Empty<IWindowState>();
+			return [];
 		}
 
 		// Get the rectangles for each window
@@ -182,7 +182,7 @@ public partial record SliceLayoutEngine : ILayoutEngine
 	{
 		if (_minimizedWindows.Count == 0)
 		{
-			return Array.Empty<IWindowState>();
+			return [];
 		}
 
 		IWindowState[] minimizedWindowStates = new IWindowState[_minimizedWindows.Count];

--- a/src/Whim.SliceLayout/SliceLayoutEngineHelpers.cs
+++ b/src/Whim.SliceLayout/SliceLayoutEngineHelpers.cs
@@ -72,7 +72,7 @@ public partial record SliceLayoutEngine
 		return null;
 	}
 
-	private ILayoutEngine MoveWindowToIndex(int currentIndex, int targetIndex)
+	private SliceLayoutEngine MoveWindowToIndex(int currentIndex, int targetIndex)
 	{
 		if (_plugin.WindowInsertionType == WindowInsertionType.Swap)
 		{
@@ -82,7 +82,7 @@ public partial record SliceLayoutEngine
 		return RotateWindowIndices(currentIndex, targetIndex);
 	}
 
-	private ILayoutEngine SwapWindowIndices(int currentIndex, int targetIndex)
+	private SliceLayoutEngine SwapWindowIndices(int currentIndex, int targetIndex)
 	{
 		Logger.Debug($"Swapping {currentIndex} and {targetIndex}");
 
@@ -101,7 +101,7 @@ public partial record SliceLayoutEngine
 		return new SliceLayoutEngine(this, newWindows, _minimizedWindows);
 	}
 
-	private ILayoutEngine RotateWindowIndices(int currentIndex, int targetIndex)
+	private SliceLayoutEngine RotateWindowIndices(int currentIndex, int targetIndex)
 	{
 		Logger.Debug($"Rotating {currentIndex} and {targetIndex}");
 
@@ -143,7 +143,7 @@ public partial record SliceLayoutEngine
 		return null;
 	}
 
-	private ILayoutEngine PromoteWindowInStack(IWindow window, bool promote)
+	private SliceLayoutEngine PromoteWindowInStack(IWindow window, bool promote)
 	{
 		Logger.Debug($"Promoting {window} in stack");
 		if (GetPromoteTargetIndex(window, promote) is not (int windowIndex, int targetIndex))
@@ -154,7 +154,7 @@ public partial record SliceLayoutEngine
 		return MoveWindowToIndex(windowIndex, targetIndex);
 	}
 
-	private ILayoutEngine PromoteFocusInStack(IWindow window, bool promote)
+	private SliceLayoutEngine PromoteFocusInStack(IWindow window, bool promote)
 	{
 		Logger.Debug($"Promoting focus in stack");
 		if (GetPromoteTargetIndex(window, promote) is not (int, int targetIndex))

--- a/src/Whim.SliceLayout/SliceLayoutPlugin.cs
+++ b/src/Whim.SliceLayout/SliceLayoutPlugin.cs
@@ -3,18 +3,13 @@ using System.Text.Json;
 namespace Whim.SliceLayout;
 
 /// <inheritdoc />
-public class SliceLayoutPlugin : ISliceLayoutPlugin
+/// <summary>
+/// Create a new <see cref="SliceLayoutPlugin"/>.
+/// </summary>
+/// <param name="context"></param>
+public class SliceLayoutPlugin(IContext context) : ISliceLayoutPlugin
 {
-	private readonly IContext _context;
-
-	/// <summary>
-	/// Create a new <see cref="SliceLayoutPlugin"/>.
-	/// </summary>
-	/// <param name="context"></param>
-	public SliceLayoutPlugin(IContext context)
-	{
-		_context = context;
-	}
+	private readonly IContext _context = context;
 
 	/// <summary>
 	/// <c>whim.slice_layout</c>

--- a/src/Whim.TestUtils/Assert.cs
+++ b/src/Whim.TestUtils/Assert.cs
@@ -17,8 +17,7 @@ namespace Whim.TestUtils;
 #pragma warning disable CA1032 // Implement standard exception constructors
 public class ShouldNotRaiseException(Type type) : XunitException($"Expected event of type {type} to not be raised.")
 #pragma warning restore CA1032 // Implement standard exception constructors
-{
-}
+{ }
 
 /// <summary>
 /// Exception thrown when an event is raised when it should have been.
@@ -30,8 +29,7 @@ public class ShouldNotRaiseException(Type type) : XunitException($"Expected even
 #pragma warning disable CA1032 // Implement standard exception constructors
 public class ShouldRaiseException(Type type) : XunitException($"Expected event of type {type} to be raised.")
 #pragma warning restore CA1032 // Implement standard exception constructors
-{
-}
+{ }
 
 /// <summary>
 /// Class containing methods with custom assertions.
@@ -157,7 +155,6 @@ public static class CustomAssert
 			throw new ShouldRaiseException(typeof(T));
 		}
 	}
-
 
 	/// <summary>
 	/// Asserts that the <see cref="WorkspaceLayoutCompletedEventArgs"/> is raised with the expected workspace.

--- a/src/Whim.TestUtils/Assert.cs
+++ b/src/Whim.TestUtils/Assert.cs
@@ -158,12 +158,15 @@ public static class CustomAssert
 		}
 	}
 
+
 	/// <summary>
 	/// Asserts that the <see cref="WorkspaceLayoutCompletedEventArgs"/> is raised with the expected workspace.
 	/// </summary>
 	/// <param name="rootSector">The root sector.</param>
 	/// <param name="action">The action to perform.</param>
-	/// <param name="expectedWorkspace">The expected workspace.</param>
+	/// <param name="layoutWorkspaceIds">The workspace ids to throw.</param>
+	/// <param name="noLayoutWorkspaceIds">The workspace ids to throw if they're raised.</param>
+	/// <exception cref="Exception"></exception>
 	internal static void Layout(
 		MutableRootSector rootSector,
 		Action action,

--- a/src/Whim.TestUtils/Assert.cs
+++ b/src/Whim.TestUtils/Assert.cs
@@ -177,13 +177,13 @@ public static class CustomAssert
 	{
 		// Populate the dictionaries with the remaining workspace ids for each event.
 		Dictionary<Guid, int> workspaceStartedRemainingIds = [];
-		foreach (Guid id in layoutWorkspaceIds ?? Array.Empty<Guid>())
+		foreach (Guid id in layoutWorkspaceIds ?? [])
 		{
 			workspaceStartedRemainingIds[id] = workspaceStartedRemainingIds.GetValueOrDefault(id, 0) + 1;
 		}
 
 		Dictionary<Guid, int> workspaceCompletedRemainingIds = [];
-		foreach (Guid id in layoutWorkspaceIds ?? Array.Empty<Guid>())
+		foreach (Guid id in layoutWorkspaceIds ?? [])
 		{
 			workspaceCompletedRemainingIds[id] = workspaceCompletedRemainingIds.GetValueOrDefault(id, 0) + 1;
 		}
@@ -220,7 +220,7 @@ public static class CustomAssert
 		}
 
 		// Assert that the remaining workspace ids are 0.
-		foreach (Guid id in layoutWorkspaceIds ?? Array.Empty<Guid>())
+		foreach (Guid id in layoutWorkspaceIds ?? [])
 		{
 			int remaining = workspaceStartedRemainingIds[id];
 			if (remaining != 0)
@@ -229,7 +229,7 @@ public static class CustomAssert
 			}
 		}
 
-		foreach (Guid id in layoutWorkspaceIds ?? Array.Empty<Guid>())
+		foreach (Guid id in layoutWorkspaceIds ?? [])
 		{
 			int remaining = workspaceCompletedRemainingIds[id];
 			if (remaining != 0)
@@ -238,7 +238,7 @@ public static class CustomAssert
 			}
 		}
 
-		foreach (Guid id in noLayoutWorkspaceIds ?? Array.Empty<Guid>())
+		foreach (Guid id in noLayoutWorkspaceIds ?? [])
 		{
 			if (workspaceCompletedRemainingIds.ContainsKey(id))
 			{

--- a/src/Whim.TestUtils/Assert.cs
+++ b/src/Whim.TestUtils/Assert.cs
@@ -10,31 +10,27 @@ namespace Whim.TestUtils;
 /// <summary>
 /// Exception thrown when an event is raised when it should not have been.
 /// </summary>
+/// <remarks>
+/// Creates a new instance of the <see cref="ShouldNotRaiseException"/> class.
+/// </remarks>
+/// <param name="type"></param>
 #pragma warning disable CA1032 // Implement standard exception constructors
-public class ShouldNotRaiseException : XunitException
+public class ShouldNotRaiseException(Type type) : XunitException($"Expected event of type {type} to not be raised.")
 #pragma warning restore CA1032 // Implement standard exception constructors
 {
-	/// <summary>
-	/// Creates a new instance of the <see cref="ShouldNotRaiseException"/> class.
-	/// </summary>
-	/// <param name="type"></param>
-	public ShouldNotRaiseException(Type type)
-		: base($"Expected event of type {type} to not be raised.") { }
 }
 
 /// <summary>
 /// Exception thrown when an event is raised when it should have been.
 /// </summary>
+/// <remarks>
+/// Creates a new instance of the <see cref="ShouldRaiseException"/> class.
+/// </remarks>
+/// <param name="type"></param>
 #pragma warning disable CA1032 // Implement standard exception constructors
-public class ShouldRaiseException : XunitException
+public class ShouldRaiseException(Type type) : XunitException($"Expected event of type {type} to be raised.")
 #pragma warning restore CA1032 // Implement standard exception constructors
 {
-	/// <summary>
-	/// Creates a new instance of the <see cref="ShouldRaiseException"/> class.
-	/// </summary>
-	/// <param name="type"></param>
-	public ShouldRaiseException(Type type)
-		: base($"Expected event of type {type} to be raised.") { }
 }
 
 /// <summary>

--- a/src/Whim.TestUtils/Assert.cs
+++ b/src/Whim.TestUtils/Assert.cs
@@ -176,13 +176,13 @@ public static class CustomAssert
 	)
 	{
 		// Populate the dictionaries with the remaining workspace ids for each event.
-		Dictionary<Guid, int> workspaceStartedRemainingIds = new();
+		Dictionary<Guid, int> workspaceStartedRemainingIds = [];
 		foreach (Guid id in layoutWorkspaceIds ?? Array.Empty<Guid>())
 		{
 			workspaceStartedRemainingIds[id] = workspaceStartedRemainingIds.GetValueOrDefault(id, 0) + 1;
 		}
 
-		Dictionary<Guid, int> workspaceCompletedRemainingIds = new();
+		Dictionary<Guid, int> workspaceCompletedRemainingIds = [];
 		foreach (Guid id in layoutWorkspaceIds ?? Array.Empty<Guid>())
 		{
 			workspaceCompletedRemainingIds[id] = workspaceCompletedRemainingIds.GetValueOrDefault(id, 0) + 1;

--- a/src/Whim.TestUtils/CaptureWinEventProc.cs
+++ b/src/Whim.TestUtils/CaptureWinEventProc.cs
@@ -44,7 +44,7 @@ internal class WindowManagerFakeSafeHandle : UnhookWinEventSafeHandle
 internal class CaptureWinEventProc
 {
 	public WINEVENTPROC? WinEventProc { get; private set; }
-	public List<WindowManagerFakeSafeHandle> Handles { get; } = new();
+	public List<WindowManagerFakeSafeHandle> Handles { get; } = [];
 
 	public static CaptureWinEventProc Create(
 		IInternalContext internalCtx,

--- a/src/Whim.TestUtils/Directory.Build.props
+++ b/src/Whim.TestUtils/Directory.Build.props
@@ -1,5 +1,6 @@
 <Project>
 	<PropertyGroup>
-		<GenerateDocumentationFile>false</GenerateDocumentationFile>
+		<GenerateDocumentationFile>true</GenerateDocumentationFile>
+		<NoWarn>$(NoWarn);CS1591</NoWarn>
 	</PropertyGroup>
 </Project>

--- a/src/Whim.TestUtils/GlobalSuppressions.cs
+++ b/src/Whim.TestUtils/GlobalSuppressions.cs
@@ -24,3 +24,4 @@ using System.Diagnostics.CodeAnalysis;
 	"CA1019:Define accessors for attribute arguments",
 	Justification = "It's fine for InlineData"
 )]
+[assembly: SuppressMessage("Performance", "CA1859:Use concrete types when possible for improved performance")]

--- a/src/Whim.TestUtils/ImmutableTestLayoutEngine.cs
+++ b/src/Whim.TestUtils/ImmutableTestLayoutEngine.cs
@@ -18,8 +18,7 @@ public record ImmutableTestLayoutEngine : ILayoutEngine
 
 	public bool ContainsWindow(IWindow window) => false;
 
-	public IEnumerable<IWindowState> DoLayout(IRectangle<int> rectangle, IMonitor monitor) =>
-		[];
+	public IEnumerable<IWindowState> DoLayout(IRectangle<int> rectangle, IMonitor monitor) => [];
 
 	public ILayoutEngine FocusWindowInDirection(Direction direction, IWindow window) => this;
 

--- a/src/Whim.TestUtils/ImmutableTestLayoutEngine.cs
+++ b/src/Whim.TestUtils/ImmutableTestLayoutEngine.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 
 namespace Whim.TestUtils;

--- a/src/Whim.TestUtils/ImmutableTestLayoutEngine.cs
+++ b/src/Whim.TestUtils/ImmutableTestLayoutEngine.cs
@@ -19,7 +19,7 @@ public record ImmutableTestLayoutEngine : ILayoutEngine
 	public bool ContainsWindow(IWindow window) => false;
 
 	public IEnumerable<IWindowState> DoLayout(IRectangle<int> rectangle, IMonitor monitor) =>
-		Array.Empty<IWindowState>();
+		[];
 
 	public ILayoutEngine FocusWindowInDirection(Direction direction, IWindow window) => this;
 

--- a/src/Whim.TestUtils/InlineAutoSubstituteDataAttribute.cs
+++ b/src/Whim.TestUtils/InlineAutoSubstituteDataAttribute.cs
@@ -7,14 +7,12 @@ namespace Whim.TestUtils;
 /// Creates an AutoFixture fixture with NSubstitute support and injects the given arguments, to be
 /// used like <c>InlineData</c> for an xunit <c>Theory</c>.
 /// </summary>
-public class InlineAutoSubstituteDataAttribute : InlineAutoDataAttribute
+/// <remarks>
+/// Creates a new instance of <see cref="InlineAutoSubstituteDataAttribute"/>.
+/// </remarks>
+/// <param name="arguments"></param>
+public class InlineAutoSubstituteDataAttribute(params object[] arguments) : InlineAutoDataAttribute(new AutoSubstituteDataAttribute(), arguments)
 {
-	/// <summary>
-	/// Creates a new instance of <see cref="InlineAutoSubstituteDataAttribute"/>.
-	/// </summary>
-	/// <param name="arguments"></param>
-	public InlineAutoSubstituteDataAttribute(params object[] arguments)
-		: base(new AutoSubstituteDataAttribute(), arguments) { }
 }
 
 /// <summary>
@@ -22,13 +20,11 @@ public class InlineAutoSubstituteDataAttribute : InlineAutoDataAttribute
 /// used like <c>InlineData</c> for an xunit <c>Theory</c>. An additional customization is applied.
 /// </summary>
 /// <typeparam name="TCustomization"></typeparam>
-public class InlineAutoSubstituteDataAttribute<TCustomization> : InlineAutoDataAttribute
+/// <remarks>
+/// Creates a new instance of <see cref="InlineAutoSubstituteDataAttribute{TCustomization}"/>.
+/// </remarks>
+/// <param name="arguments"></param>
+public class InlineAutoSubstituteDataAttribute<TCustomization>(params object[] arguments) : InlineAutoDataAttribute(new AutoSubstituteDataAttribute<TCustomization>(), arguments)
 	where TCustomization : ICustomization, new()
 {
-	/// <summary>
-	/// Creates a new instance of <see cref="InlineAutoSubstituteDataAttribute{TCustomization}"/>.
-	/// </summary>
-	/// <param name="arguments"></param>
-	public InlineAutoSubstituteDataAttribute(params object[] arguments)
-		: base(new AutoSubstituteDataAttribute<TCustomization>(), arguments) { }
 }

--- a/src/Whim.TestUtils/InlineAutoSubstituteDataAttribute.cs
+++ b/src/Whim.TestUtils/InlineAutoSubstituteDataAttribute.cs
@@ -11,9 +11,8 @@ namespace Whim.TestUtils;
 /// Creates a new instance of <see cref="InlineAutoSubstituteDataAttribute"/>.
 /// </remarks>
 /// <param name="arguments"></param>
-public class InlineAutoSubstituteDataAttribute(params object[] arguments) : InlineAutoDataAttribute(new AutoSubstituteDataAttribute(), arguments)
-{
-}
+public class InlineAutoSubstituteDataAttribute(params object[] arguments)
+	: InlineAutoDataAttribute(new AutoSubstituteDataAttribute(), arguments) { }
 
 /// <summary>
 /// Creates an AutoFixture fixture with NSubstitute support and injects the given arguments, to be
@@ -24,7 +23,6 @@ public class InlineAutoSubstituteDataAttribute(params object[] arguments) : Inli
 /// Creates a new instance of <see cref="InlineAutoSubstituteDataAttribute{TCustomization}"/>.
 /// </remarks>
 /// <param name="arguments"></param>
-public class InlineAutoSubstituteDataAttribute<TCustomization>(params object[] arguments) : InlineAutoDataAttribute(new AutoSubstituteDataAttribute<TCustomization>(), arguments)
-	where TCustomization : ICustomization, new()
-{
-}
+public class InlineAutoSubstituteDataAttribute<TCustomization>(params object[] arguments)
+	: InlineAutoDataAttribute(new AutoSubstituteDataAttribute<TCustomization>(), arguments)
+	where TCustomization : ICustomization, new() { }

--- a/src/Whim.TestUtils/MemberAutoSubstituteDataAttribute.cs
+++ b/src/Whim.TestUtils/MemberAutoSubstituteDataAttribute.cs
@@ -73,9 +73,8 @@ public abstract class BaseMemberAutoSubstituteDataAttribute : MemberDataAttribut
 /// </remarks>
 /// <param name="memberName"></param>
 /// <param name="parameters"></param>
-public class MemberAutoSubstituteDataAttribute(string memberName, params object[] parameters) : BaseMemberAutoSubstituteDataAttribute(memberName, parameters)
-{
-}
+public class MemberAutoSubstituteDataAttribute(string memberName, params object[] parameters)
+	: BaseMemberAutoSubstituteDataAttribute(memberName, parameters) { }
 
 /// <summary>
 /// Creates an AutoFixture fixture with NSubstitute support and injects the given arguments, to be

--- a/src/Whim.TestUtils/MemberAutoSubstituteDataAttribute.cs
+++ b/src/Whim.TestUtils/MemberAutoSubstituteDataAttribute.cs
@@ -68,15 +68,13 @@ public abstract class BaseMemberAutoSubstituteDataAttribute : MemberDataAttribut
 /// Creates an AutoFixture fixture with NSubstitute support and injects the given arguments, to be
 /// used like <c>MemberData</c> for an xunit <c>Theory</c>.
 /// </summary>
-public class MemberAutoSubstituteDataAttribute : BaseMemberAutoSubstituteDataAttribute
+/// <remarks>
+/// Creates a new instance of <see cref="MemberAutoSubstituteDataAttribute"/>.
+/// </remarks>
+/// <param name="memberName"></param>
+/// <param name="parameters"></param>
+public class MemberAutoSubstituteDataAttribute(string memberName, params object[] parameters) : BaseMemberAutoSubstituteDataAttribute(memberName, parameters)
 {
-	/// <summary>
-	/// Creates a new instance of <see cref="MemberAutoSubstituteDataAttribute"/>.
-	/// </summary>
-	/// <param name="memberName"></param>
-	/// <param name="parameters"></param>
-	public MemberAutoSubstituteDataAttribute(string memberName, params object[] parameters)
-		: base(memberName, parameters) { }
 }
 
 /// <summary>

--- a/src/Whim.TestUtils/MemberAutoSubstituteDataAttribute.cs
+++ b/src/Whim.TestUtils/MemberAutoSubstituteDataAttribute.cs
@@ -45,9 +45,7 @@ public abstract class BaseMemberAutoSubstituteDataAttribute : MemberDataAttribut
 			fixture.Customize(CreateCustomization());
 		}
 
-		return values
-			.Concat(testMethod.GetParameters().Skip(values.Length).Select(p => GetSpecimen(fixture, p)))
-			.ToArray();
+		return [.. values, .. testMethod.GetParameters().Skip(values.Length).Select(p => GetSpecimen(fixture, p))];
 	}
 
 	private static object GetSpecimen(IFixture fixture, ParameterInfo parameter)

--- a/src/Whim.TestUtils/PluginCommandsTestUtils.cs
+++ b/src/Whim.TestUtils/PluginCommandsTestUtils.cs
@@ -6,18 +6,13 @@ namespace Whim.TestUtils;
 /// <summary>
 /// Test utilities for <see cref="_pluginCommands"/>.
 /// </summary>
-public class PluginCommandsTestUtils
+/// <remarks>
+/// Create the plugin commands test utilities.
+/// </remarks>
+/// <param name="pluginCommands"></param>
+public class PluginCommandsTestUtils(PluginCommands pluginCommands)
 {
-	private readonly PluginCommands _pluginCommands;
-
-	/// <summary>
-	/// Create the plugin commands test utilities.
-	/// </summary>
-	/// <param name="pluginCommands"></param>
-	public PluginCommandsTestUtils(PluginCommands pluginCommands)
-	{
-		_pluginCommands = pluginCommands;
-	}
+	private readonly PluginCommands _pluginCommands = pluginCommands;
 
 	/// <summary>
 	/// Get the command with the given identifier.

--- a/src/Whim.TestUtils/StoreCustomization.cs
+++ b/src/Whim.TestUtils/StoreCustomization.cs
@@ -7,15 +7,12 @@ using Windows.Win32.Foundation;
 
 namespace Whim.TestUtils;
 
-internal class StoreWrapper : Store
+internal class StoreWrapper(IContext ctx, IInternalContext internalCtx) : Store(ctx, internalCtx)
 {
 	/// <summary>
 	/// All the transforms that have been executed.
 	/// </summary>
 	public List<object> Transforms { get; } = [];
-
-	public StoreWrapper(IContext ctx, IInternalContext internalCtx)
-		: base(ctx, internalCtx) { }
 
 	protected override Result<TResult> DispatchFn<TResult>(Transform<TResult> transform)
 	{

--- a/src/Whim.TestUtils/StoreCustomization.cs
+++ b/src/Whim.TestUtils/StoreCustomization.cs
@@ -12,7 +12,7 @@ internal class StoreWrapper : Store
 	/// <summary>
 	/// All the transforms that have been executed.
 	/// </summary>
-	public List<object> Transforms { get; } = new();
+	public List<object> Transforms { get; } = [];
 
 	public StoreWrapper(IContext ctx, IInternalContext internalCtx)
 		: base(ctx, internalCtx) { }

--- a/src/Whim.TestUtils/StoreTestUtils.cs
+++ b/src/Whim.TestUtils/StoreTestUtils.cs
@@ -1,7 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.Linq;
 using NSubstitute;
 using Windows.Win32.Foundation;
 using Windows.Win32.Graphics.Gdi;

--- a/src/Whim.TestUtils/StoreTestUtils.cs
+++ b/src/Whim.TestUtils/StoreTestUtils.cs
@@ -62,7 +62,7 @@ internal static class StoreTestUtils
 			return;
 		}
 
-		List<IWorkspace> workspaces = ctx.WorkspaceManager.ToList();
+		List<IWorkspace> workspaces = [.. ctx.WorkspaceManager];
 		workspaces.Add(workspace);
 		ctx.WorkspaceManager.GetEnumerator().Returns(_ => workspaces.GetEnumerator());
 
@@ -87,11 +87,11 @@ internal static class StoreTestUtils
 
 	public static void AddMonitorsToManager(IContext ctx, MutableRootSector rootSector, params IMonitor[] newMonitors)
 	{
-		List<IMonitor> monitors = ctx.MonitorManager.ToList();
+		List<IMonitor> monitors = [.. ctx.MonitorManager];
 		monitors.AddRange(newMonitors);
 
 		ctx.MonitorManager.GetEnumerator().Returns(_ => monitors.GetEnumerator());
-		rootSector.MonitorSector.Monitors = newMonitors.ToImmutableArray();
+		rootSector.MonitorSector.Monitors = [.. newMonitors];
 	}
 
 	public static void AddWindowToSector(MutableRootSector rootSector, IWindow window)

--- a/src/Whim.TestUtils/StoreTestUtils.cs
+++ b/src/Whim.TestUtils/StoreTestUtils.cs
@@ -30,11 +30,7 @@ internal static class StoreTestUtils
 
 		ILayoutEngine engine = Substitute.For<ITestLayoutEngine>();
 
-		return new Workspace(ctx, workspaceId)
-		{
-			LayoutEngines = ImmutableList.Create(engine),
-			ActiveLayoutEngineIndex = 0
-		};
+		return new Workspace(ctx, workspaceId) { LayoutEngines = [engine], ActiveLayoutEngineIndex = 0 };
 	}
 
 	public static IMonitor CreateMonitor(HMONITOR handle)

--- a/src/Whim.TestUtils/TestProxyLayoutEngine.cs
+++ b/src/Whim.TestUtils/TestProxyLayoutEngine.cs
@@ -15,5 +15,5 @@ public abstract record TestProxyLayoutEngine : BaseProxyLayoutEngine
 	/// <summary>
 	/// The proxied layout engine.
 	/// </summary>
-	public ILayoutEngine InnerLayoutEngine => base.InnerLayoutEngine;
+	public new ILayoutEngine InnerLayoutEngine => base.InnerLayoutEngine;
 }

--- a/src/Whim.Tests/Commands/CommandManagerTests.cs
+++ b/src/Whim.Tests/Commands/CommandManagerTests.cs
@@ -1,4 +1,3 @@
-using System.Linq;
 using AutoFixture;
 
 namespace Whim.Tests;

--- a/src/Whim.Tests/Commands/CommandManagerTests.cs
+++ b/src/Whim.Tests/Commands/CommandManagerTests.cs
@@ -74,7 +74,7 @@ public class CommandManagerTests
 		commandManager.AddPluginCommand(command);
 
 		// Then
-		List<ICommand> allCommands = commandManager.ToList();
+		List<ICommand> allCommands = [.. commandManager];
 		Assert.Single(allCommands);
 		Assert.Equal(command, allCommands[0]);
 	}

--- a/src/Whim.Tests/Commands/CoreCommandsTests.cs
+++ b/src/Whim.Tests/Commands/CoreCommandsTests.cs
@@ -404,7 +404,7 @@ public class CoreCommandsTests
 		// Given
 		CoreCommands commands = new(ctx);
 		PluginCommandsTestUtils testUtils = new(commands);
-		List<IWorkspace> workspaces = TestUtils.WorkspaceUtils.CreateWorkspaces(2).ToList();
+		List<IWorkspace> workspaces = [.. TestUtils.WorkspaceUtils.CreateWorkspaces(2)];
 		ctx.WorkspaceManager.GetEnumerator().Returns(workspaces.GetEnumerator());
 
 		int index = 3;
@@ -427,7 +427,7 @@ public class CoreCommandsTests
 		// Given
 		CoreCommands commands = new(ctx);
 		PluginCommandsTestUtils testUtils = new(commands);
-		List<IWorkspace> workspaces = TestUtils.WorkspaceUtils.CreateWorkspaces(10).ToList();
+		List<IWorkspace> workspaces = [.. TestUtils.WorkspaceUtils.CreateWorkspaces(10)];
 		ctx.WorkspaceManager.GetEnumerator().Returns(workspaces.GetEnumerator());
 
 		ICommand command = testUtils.GetCommand($"whim.core.activate_workspace_{index}");

--- a/src/Whim.Tests/Commands/CoreCommandsTests.cs
+++ b/src/Whim.Tests/Commands/CoreCommandsTests.cs
@@ -1,4 +1,3 @@
-using System.Linq;
 using AutoFixture;
 
 namespace Whim.Tests;

--- a/src/Whim.Tests/Context/CoreSavedStateManagerTests.cs
+++ b/src/Whim.Tests/Context/CoreSavedStateManagerTests.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using System.Text.Json;
 
 namespace Whim.Tests;

--- a/src/Whim.Tests/Directory.Build.props
+++ b/src/Whim.Tests/Directory.Build.props
@@ -1,5 +1,6 @@
 <Project>
 	<PropertyGroup>
-		<GenerateDocumentationFile>false</GenerateDocumentationFile>
+		<GenerateDocumentationFile>true</GenerateDocumentationFile>
+		<NoWarn>$(NoWarn);CS1591</NoWarn>
 	</PropertyGroup>
 </Project>

--- a/src/Whim.Tests/Files/FileManagerTests.cs
+++ b/src/Whim.Tests/Files/FileManagerTests.cs
@@ -18,7 +18,7 @@ public class FileManagerTests
 	public void WhimDir()
 	{
 		// Given
-		IFileManager fileManager = new FileManager([]);
+		FileManager fileManager = new ([]);
 
 		// When
 		string whimDir = fileManager.WhimDir;
@@ -32,7 +32,7 @@ public class FileManagerTests
 	{
 		// Given
 		string[] args = [DIR_ARG, ExpectedAltWhimDir];
-		IFileManager fileManager = new FileManager(args);
+		FileManager fileManager = new (args);
 
 		// When
 		string whimDirFromArgs = fileManager.WhimDir;
@@ -46,7 +46,7 @@ public class FileManagerTests
 	{
 		// Given
 		string[] args = [DIR_ARG, ExpectedAltWhimDir, "--extra"];
-		IFileManager fileManager = new FileManager(args);
+		FileManager fileManager = new (args);
 
 		// When
 		string whimDirFromArgs = fileManager.WhimDir;
@@ -60,7 +60,7 @@ public class FileManagerTests
 	{
 		// Given
 		string[] args = ["--extra", DIR_ARG, ExpectedAltWhimDir];
-		IFileManager fileManager = new FileManager(args);
+		FileManager fileManager = new (args);
 
 		// When
 		string whimDirFromArgs = fileManager.WhimDir;
@@ -74,7 +74,7 @@ public class FileManagerTests
 	{
 		// Given
 		string[] args = [DIR_ARG, "--extra", ExpectedAltWhimDir];
-		IFileManager fileManager = new FileManager(args);
+		FileManager fileManager = new (args);
 
 		// When
 		string whimDirFromArgs = fileManager.WhimDir;
@@ -88,7 +88,7 @@ public class FileManagerTests
 	{
 		// Given
 		string[] args = [DIR_ARG, string.Empty];
-		IFileManager fileManager = new FileManager(args);
+		FileManager fileManager = new (args);
 
 		// When
 		string whimDirFromArgs = fileManager.WhimDir;
@@ -102,7 +102,7 @@ public class FileManagerTests
 	{
 		// Given
 		string[] args = [DIR_ARG + "=" + ExpectedAltWhimDir];
-		IFileManager fileManager = new FileManager(args);
+		FileManager fileManager = new (args);
 
 		// When
 		string whimDirFromArgs = fileManager.WhimDir;
@@ -115,7 +115,7 @@ public class FileManagerTests
 	public void SavedStateDir()
 	{
 		// Given
-		IFileManager fileManager = new FileManager([]);
+		FileManager fileManager = new ([]);
 
 		// When
 		string savedStateDir = fileManager.SavedStateDir;
@@ -128,7 +128,7 @@ public class FileManagerTests
 	public void GetWhimFileDir()
 	{
 		// Given
-		IFileManager fileManager = new FileManager([]);
+		FileManager fileManager = new ([]);
 
 		// When
 		string whimFileDir = fileManager.GetWhimFileDir("test");
@@ -141,7 +141,7 @@ public class FileManagerTests
 	public void GetWhimFileDir_WithSubDir()
 	{
 		// Given
-		IFileManager fileManager = new FileManager([]);
+		FileManager fileManager = new ([]);
 
 		// When
 		string whimFileDir = fileManager.GetWhimFileDir(Path.Combine("test", "subdir"));

--- a/src/Whim.Tests/Files/FileManagerTests.cs
+++ b/src/Whim.Tests/Files/FileManagerTests.cs
@@ -18,7 +18,7 @@ public class FileManagerTests
 	public void WhimDir()
 	{
 		// Given
-		FileManager fileManager = new ([]);
+		FileManager fileManager = new([]);
 
 		// When
 		string whimDir = fileManager.WhimDir;
@@ -32,7 +32,7 @@ public class FileManagerTests
 	{
 		// Given
 		string[] args = [DIR_ARG, ExpectedAltWhimDir];
-		FileManager fileManager = new (args);
+		FileManager fileManager = new(args);
 
 		// When
 		string whimDirFromArgs = fileManager.WhimDir;
@@ -46,7 +46,7 @@ public class FileManagerTests
 	{
 		// Given
 		string[] args = [DIR_ARG, ExpectedAltWhimDir, "--extra"];
-		FileManager fileManager = new (args);
+		FileManager fileManager = new(args);
 
 		// When
 		string whimDirFromArgs = fileManager.WhimDir;
@@ -60,7 +60,7 @@ public class FileManagerTests
 	{
 		// Given
 		string[] args = ["--extra", DIR_ARG, ExpectedAltWhimDir];
-		FileManager fileManager = new (args);
+		FileManager fileManager = new(args);
 
 		// When
 		string whimDirFromArgs = fileManager.WhimDir;
@@ -74,7 +74,7 @@ public class FileManagerTests
 	{
 		// Given
 		string[] args = [DIR_ARG, "--extra", ExpectedAltWhimDir];
-		FileManager fileManager = new (args);
+		FileManager fileManager = new(args);
 
 		// When
 		string whimDirFromArgs = fileManager.WhimDir;
@@ -88,7 +88,7 @@ public class FileManagerTests
 	{
 		// Given
 		string[] args = [DIR_ARG, string.Empty];
-		FileManager fileManager = new (args);
+		FileManager fileManager = new(args);
 
 		// When
 		string whimDirFromArgs = fileManager.WhimDir;
@@ -102,7 +102,7 @@ public class FileManagerTests
 	{
 		// Given
 		string[] args = [DIR_ARG + "=" + ExpectedAltWhimDir];
-		FileManager fileManager = new (args);
+		FileManager fileManager = new(args);
 
 		// When
 		string whimDirFromArgs = fileManager.WhimDir;
@@ -115,7 +115,7 @@ public class FileManagerTests
 	public void SavedStateDir()
 	{
 		// Given
-		FileManager fileManager = new ([]);
+		FileManager fileManager = new([]);
 
 		// When
 		string savedStateDir = fileManager.SavedStateDir;
@@ -128,7 +128,7 @@ public class FileManagerTests
 	public void GetWhimFileDir()
 	{
 		// Given
-		FileManager fileManager = new ([]);
+		FileManager fileManager = new([]);
 
 		// When
 		string whimFileDir = fileManager.GetWhimFileDir("test");
@@ -141,7 +141,7 @@ public class FileManagerTests
 	public void GetWhimFileDir_WithSubDir()
 	{
 		// Given
-		FileManager fileManager = new ([]);
+		FileManager fileManager = new([]);
 
 		// When
 		string whimFileDir = fileManager.GetWhimFileDir(Path.Combine("test", "subdir"));

--- a/src/Whim.Tests/Files/FileManagerTests.cs
+++ b/src/Whim.Tests/Files/FileManagerTests.cs
@@ -18,7 +18,7 @@ public class FileManagerTests
 	public void WhimDir()
 	{
 		// Given
-		IFileManager fileManager = new FileManager(Array.Empty<string>());
+		IFileManager fileManager = new FileManager([]);
 
 		// When
 		string whimDir = fileManager.WhimDir;
@@ -115,7 +115,7 @@ public class FileManagerTests
 	public void SavedStateDir()
 	{
 		// Given
-		IFileManager fileManager = new FileManager(Array.Empty<string>());
+		IFileManager fileManager = new FileManager([]);
 
 		// When
 		string savedStateDir = fileManager.SavedStateDir;
@@ -128,7 +128,7 @@ public class FileManagerTests
 	public void GetWhimFileDir()
 	{
 		// Given
-		IFileManager fileManager = new FileManager(Array.Empty<string>());
+		IFileManager fileManager = new FileManager([]);
 
 		// When
 		string whimFileDir = fileManager.GetWhimFileDir("test");
@@ -141,7 +141,7 @@ public class FileManagerTests
 	public void GetWhimFileDir_WithSubDir()
 	{
 		// Given
-		IFileManager fileManager = new FileManager(Array.Empty<string>());
+		IFileManager fileManager = new FileManager([]);
 
 		// When
 		string whimFileDir = fileManager.GetWhimFileDir(Path.Combine("test", "subdir"));

--- a/src/Whim.Tests/Files/FileManagerTests.cs
+++ b/src/Whim.Tests/Files/FileManagerTests.cs
@@ -31,7 +31,7 @@ public class FileManagerTests
 	public void WhimDir_WithDirArg()
 	{
 		// Given
-		string[] args = { DIR_ARG, ExpectedAltWhimDir };
+		string[] args = [DIR_ARG, ExpectedAltWhimDir];
 		IFileManager fileManager = new FileManager(args);
 
 		// When
@@ -45,7 +45,7 @@ public class FileManagerTests
 	public void WhimDir_WithDirArg_WithExtraArg()
 	{
 		// Given
-		string[] args = { DIR_ARG, ExpectedAltWhimDir, "--extra" };
+		string[] args = [DIR_ARG, ExpectedAltWhimDir, "--extra"];
 		IFileManager fileManager = new FileManager(args);
 
 		// When
@@ -59,7 +59,7 @@ public class FileManagerTests
 	public void WhimDir_WithDirArg_StartsWithExtraArg()
 	{
 		// Given
-		string[] args = { "--extra", DIR_ARG, ExpectedAltWhimDir };
+		string[] args = ["--extra", DIR_ARG, ExpectedAltWhimDir];
 		IFileManager fileManager = new FileManager(args);
 
 		// When
@@ -73,7 +73,7 @@ public class FileManagerTests
 	public void WhimDir_WithDirArg_NextIsNotArg()
 	{
 		// Given
-		string[] args = { DIR_ARG, "--extra", ExpectedAltWhimDir };
+		string[] args = [DIR_ARG, "--extra", ExpectedAltWhimDir];
 		IFileManager fileManager = new FileManager(args);
 
 		// When
@@ -87,7 +87,7 @@ public class FileManagerTests
 	public void WhimDir_WithDirArg_EmptyString()
 	{
 		// Given
-		string[] args = { DIR_ARG, string.Empty };
+		string[] args = [DIR_ARG, string.Empty];
 		IFileManager fileManager = new FileManager(args);
 
 		// When
@@ -101,7 +101,7 @@ public class FileManagerTests
 	public void WhimDir_WithDirArg_Equals()
 	{
 		// Given
-		string[] args = { DIR_ARG + "=" + ExpectedAltWhimDir };
+		string[] args = [DIR_ARG + "=" + ExpectedAltWhimDir];
 		IFileManager fileManager = new FileManager(args);
 
 		// When

--- a/src/Whim.Tests/GlobalSuppressions.cs
+++ b/src/Whim.Tests/GlobalSuppressions.cs
@@ -8,10 +8,14 @@ using System.Diagnostics.CodeAnalysis;
 // The general justification for these suppression messages is that this project contains tests, and it's
 // a bit excessive to have these particular rules for tests.
 [assembly: SuppressMessage("Design", "CA1014:Mark assemblies with CLSCompliantAttribute")]
+[assembly: SuppressMessage("Design", "CA1062:Validate arguments of public methods")]
 [assembly: SuppressMessage("Naming", "CA1707:Identifiers should not contain underscores")]
 [assembly: SuppressMessage("Security", "CA5394:Do not use insecure randomness")]
 [assembly: SuppressMessage("Style", "IDE0008:Use explicit type")]
+[assembly: SuppressMessage("Style", "IDE0042:Variable declaration can be deconstructed")]
 [assembly: SuppressMessage("Style", "IDE0058:Expression value is never used")]
+[assembly: SuppressMessage("Style", "IDE0022:Use expression body for methods")]
 [assembly: SuppressMessage("Style", "IDE0028:Simplify collection initialization")]
 [assembly: SuppressMessage("Reliability", "CA2007:Consider calling ConfigureAwait on the awaited task")]
 [assembly: SuppressMessage("Performance", "CA1852:Seal internal types")]
+[assembly: SuppressMessage("Performance", "CA1861:Avoid constant arrays as arguments")]

--- a/src/Whim.Tests/GlobalSuppressions.cs
+++ b/src/Whim.Tests/GlobalSuppressions.cs
@@ -19,3 +19,4 @@ using System.Diagnostics.CodeAnalysis;
 [assembly: SuppressMessage("Reliability", "CA2007:Consider calling ConfigureAwait on the awaited task")]
 [assembly: SuppressMessage("Performance", "CA1852:Seal internal types")]
 [assembly: SuppressMessage("Performance", "CA1861:Avoid constant arrays as arguments")]
+[assembly: SuppressMessage("Performance", "CA1859:Use concrete types when possible for improved performance")]

--- a/src/Whim.Tests/Keybind/KeybindHookTests.cs
+++ b/src/Whim.Tests/Keybind/KeybindHookTests.cs
@@ -178,7 +178,7 @@ public class KeybindHookTests
 		// Given
 		CaptureKeybindHook capture = CaptureKeybindHook.Create(internalCtx);
 		KeybindHook keybindHook = new(ctx, internalCtx);
-		SetupKey(ctx, internalCtx, new VIRTUAL_KEY[] { key }, VIRTUAL_KEY.None, Array.Empty<ICommand>());
+		SetupKey(ctx, internalCtx, new VIRTUAL_KEY[] { key }, VIRTUAL_KEY.None, []);
 
 		// When
 		keybindHook.PostInitialize();
@@ -256,7 +256,7 @@ public class KeybindHookTests
 		// Given
 		CaptureKeybindHook capture = CaptureKeybindHook.Create(internalCtx);
 		KeybindHook keybindHook = new(ctx, internalCtx);
-		SetupKey(ctx, internalCtx, Array.Empty<VIRTUAL_KEY>(), VIRTUAL_KEY.VK_A, Array.Empty<ICommand>());
+		SetupKey(ctx, internalCtx, [], VIRTUAL_KEY.VK_A, []);
 
 		// When
 		keybindHook.PostInitialize();
@@ -274,7 +274,7 @@ public class KeybindHookTests
 		// Given
 		CaptureKeybindHook capture = CaptureKeybindHook.Create(internalCtx);
 		KeybindHook keybindHook = new(ctx, internalCtx);
-		SetupKey(ctx, internalCtx, new[] { VIRTUAL_KEY.VK_LWIN }, VIRTUAL_KEY.VK_U, Array.Empty<ICommand>());
+		SetupKey(ctx, internalCtx, new[] { VIRTUAL_KEY.VK_LWIN }, VIRTUAL_KEY.VK_U, []);
 
 		// When
 		keybindHook.PostInitialize();
@@ -324,7 +324,7 @@ public class KeybindHookTests
 		// Given
 		CaptureKeybindHook capture = CaptureKeybindHook.Create(internalCtx);
 		KeybindHook keybindHook = new(ctx, internalCtx);
-		SetupKey(ctx, internalCtx, Array.Empty<VIRTUAL_KEY>(), VIRTUAL_KEY.VK_A, Array.Empty<ICommand>());
+		SetupKey(ctx, internalCtx, [], VIRTUAL_KEY.VK_A, []);
 
 		// When
 		keybindHook.PostInitialize();

--- a/src/Whim.Tests/Keybind/KeybindHookTests.cs
+++ b/src/Whim.Tests/Keybind/KeybindHookTests.cs
@@ -178,7 +178,7 @@ public class KeybindHookTests
 		// Given
 		CaptureKeybindHook capture = CaptureKeybindHook.Create(internalCtx);
 		KeybindHook keybindHook = new(ctx, internalCtx);
-		SetupKey(ctx, internalCtx, new VIRTUAL_KEY[] { key }, VIRTUAL_KEY.None, []);
+		SetupKey(ctx, internalCtx, [key], VIRTUAL_KEY.None, []);
 
 		// When
 		keybindHook.PostInitialize();
@@ -274,7 +274,7 @@ public class KeybindHookTests
 		// Given
 		CaptureKeybindHook capture = CaptureKeybindHook.Create(internalCtx);
 		KeybindHook keybindHook = new(ctx, internalCtx);
-		SetupKey(ctx, internalCtx, new[] { VIRTUAL_KEY.VK_LWIN }, VIRTUAL_KEY.VK_U, []);
+		SetupKey(ctx, internalCtx, [VIRTUAL_KEY.VK_LWIN], VIRTUAL_KEY.VK_U, []);
 
 		// When
 		keybindHook.PostInitialize();

--- a/src/Whim.Tests/Keybind/KeybindHookTests.cs
+++ b/src/Whim.Tests/Keybind/KeybindHookTests.cs
@@ -18,18 +18,12 @@ public class KeybindHookCustomization : ICustomization
 [System.Diagnostics.CodeAnalysis.SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope")]
 public class KeybindHookTests
 {
-	private class FakeSafeHandle : UnhookWindowsHookExSafeHandle
+	private class FakeSafeHandle(bool isInvalid) : UnhookWindowsHookExSafeHandle(default, default)
 	{
 		public bool HasDisposed { get; private set; }
 
-		private readonly bool _isInvalid;
+		private readonly bool _isInvalid = isInvalid;
 		public override bool IsInvalid => _isInvalid;
-
-		public FakeSafeHandle(bool isInvalid)
-			: base(default, default)
-		{
-			_isInvalid = isInvalid;
-		}
 
 		protected override bool ReleaseHandle()
 		{

--- a/src/Whim.Tests/Keybind/KeybindManagerTests.cs
+++ b/src/Whim.Tests/Keybind/KeybindManagerTests.cs
@@ -8,7 +8,7 @@ public class KeybindManagerTests
 	public void SetKeybind_DoesNotContainKeybind(IContext context, ICommand command)
 	{
 		// Given
-		IKeybindManager keybindManager = new KeybindManager(context);
+		KeybindManager keybindManager = new (context);
 		IKeybind keybind = new Keybind(IKeybind.WinAlt, VIRTUAL_KEY.VK_A);
 
 		context.CommandManager.TryGetCommand("command").Returns(command);
@@ -26,7 +26,7 @@ public class KeybindManagerTests
 	public void SetKeybind_ContainsKeybind(IContext context, ICommand command, ICommand command2)
 	{
 		// Given
-		IKeybindManager keybindManager = new KeybindManager(context);
+		KeybindManager keybindManager = new (context);
 		IKeybind keybind = new Keybind(IKeybind.WinAlt, VIRTUAL_KEY.VK_A);
 
 		context.CommandManager.TryGetCommand("command").Returns(command);
@@ -47,7 +47,7 @@ public class KeybindManagerTests
 	public void SetKeybind_AlreadyContainsKeybindForCommand(IContext context, ICommand command)
 	{
 		// Given
-		IKeybindManager keybindManager = new KeybindManager(context);
+		KeybindManager keybindManager = new (context);
 		IKeybind keybind = new Keybind(IKeybind.WinAlt, VIRTUAL_KEY.VK_A);
 		IKeybind keybind2 = new Keybind(IKeybind.WinAlt, VIRTUAL_KEY.VK_B);
 
@@ -67,7 +67,7 @@ public class KeybindManagerTests
 	public void SetKeybind_UnifyKeyModifiers(IContext context, ICommand command)
 	{
 		// Given
-		IKeybindManager keybindManager = new KeybindManager(context);
+		KeybindManager keybindManager = new (context);
 		IKeybind keybind = new Keybind(KeyModifiers.RWin | KeyModifiers.RControl, VIRTUAL_KEY.VK_A);
 
 		context.CommandManager.TryGetCommand("command").Returns(command);
@@ -86,7 +86,7 @@ public class KeybindManagerTests
 	public void SetKeybind_OverriddenKeybind(IContext context, ICommand command)
 	{
 		// Given
-		IKeybindManager keybindManager = new KeybindManager(context);
+		KeybindManager keybindManager = new (context);
 		IKeybind keybind1 = new Keybind(IKeybind.WinAlt, VIRTUAL_KEY.VK_A);
 		IKeybind keybind2 = new Keybind(IKeybind.WinAlt, VIRTUAL_KEY.VK_B);
 
@@ -108,7 +108,7 @@ public class KeybindManagerTests
 	public void GetCommands_DoesNotContainKeybind(IContext context)
 	{
 		// Given
-		IKeybindManager keybindManager = new KeybindManager(context);
+		KeybindManager keybindManager = new (context);
 		IKeybind keybind = new Keybind(IKeybind.WinAlt, VIRTUAL_KEY.VK_A);
 
 		// When
@@ -122,7 +122,7 @@ public class KeybindManagerTests
 	public void GetCommands_DoesNotContainCommand(IContext context)
 	{
 		// Given
-		IKeybindManager keybindManager = new KeybindManager(context);
+		KeybindManager keybindManager = new (context);
 		IKeybind keybind = new Keybind(IKeybind.WinAlt, VIRTUAL_KEY.VK_A);
 
 		context.CommandManager.TryGetCommand("command2").Returns((ICommand?)null);
@@ -139,7 +139,7 @@ public class KeybindManagerTests
 	public void GetCommands_Success(IContext context, ICommand command, ICommand command2)
 	{
 		// Given
-		IKeybindManager keybindManager = new KeybindManager(context);
+		KeybindManager keybindManager = new (context);
 		IKeybind keybind = new Keybind(IKeybind.WinAlt, VIRTUAL_KEY.VK_A);
 
 		context.CommandManager.TryGetCommand("command").Returns(command);
@@ -160,7 +160,7 @@ public class KeybindManagerTests
 	public void GetCommands_UnifyKeyModifiers(IContext context, ICommand command)
 	{
 		// Given
-		IKeybindManager keybindManager = new KeybindManager(context);
+		KeybindManager keybindManager = new (context);
 		IKeybind leftKeybind = new Keybind(KeyModifiers.LWin | KeyModifiers.LControl, VIRTUAL_KEY.VK_A);
 		IKeybind rightKeybind = new Keybind(KeyModifiers.RWin | KeyModifiers.RControl, VIRTUAL_KEY.VK_A);
 
@@ -180,7 +180,7 @@ public class KeybindManagerTests
 	public void TryGet_DoesNotContainCommand(IContext context)
 	{
 		// Given
-		IKeybindManager keybindManager = new KeybindManager(context);
+		KeybindManager keybindManager = new (context);
 
 		// When
 		IKeybind? keybind = keybindManager.TryGetKeybind("command");
@@ -193,7 +193,7 @@ public class KeybindManagerTests
 	public void TryGet_ContainsCommand(IContext context)
 	{
 		// Given
-		IKeybindManager keybindManager = new KeybindManager(context);
+		KeybindManager keybindManager = new (context);
 		IKeybind keybind = new Keybind(IKeybind.WinAlt, VIRTUAL_KEY.VK_A);
 
 		// When
@@ -208,7 +208,7 @@ public class KeybindManagerTests
 	public void Remove_DoesNotContainCommand(IContext context)
 	{
 		// Given
-		IKeybindManager keybindManager = new KeybindManager(context);
+		KeybindManager keybindManager = new (context);
 
 		// When
 		bool result = keybindManager.Remove("command");
@@ -221,7 +221,7 @@ public class KeybindManagerTests
 	public void Remove_ContainsCommand(IContext context)
 	{
 		// Given
-		IKeybindManager keybindManager = new KeybindManager(context);
+		KeybindManager keybindManager = new (context);
 		IKeybind keybind = new Keybind(IKeybind.WinAlt, VIRTUAL_KEY.VK_A);
 
 		// When
@@ -237,7 +237,7 @@ public class KeybindManagerTests
 	public void UnifyKeyModifiers_SetToTrue(IContext context)
 	{
 		// Given
-		IKeybindManager keybindManager = new KeybindManager(context) { UnifyKeyModifiers = false };
+		KeybindManager keybindManager = new (context) { UnifyKeyModifiers = false };
 		IKeybind keybind = new Keybind(KeyModifiers.RWin | KeyModifiers.RControl, VIRTUAL_KEY.VK_A);
 
 		// When
@@ -258,7 +258,7 @@ public class KeybindManagerTests
 	public void GetCommands_Unified(KeyModifiers modifiers, VIRTUAL_KEY key, IContext context, ICommand command)
 	{
 		// Given
-		IKeybindManager keybindManager = new KeybindManager(context);
+		KeybindManager keybindManager = new (context);
 		IKeybind keybind = new Keybind(KeyModifiers.RWin | KeyModifiers.RControl, VIRTUAL_KEY.VK_A);
 
 		context.CommandManager.TryGetCommand("command").Returns(command);
@@ -276,7 +276,7 @@ public class KeybindManagerTests
 	public void GetCommands_NotUnified_FailedLookup(IContext context)
 	{
 		// Given
-		IKeybindManager keybindManager = new KeybindManager(context) { UnifyKeyModifiers = false };
+		KeybindManager keybindManager = new (context) { UnifyKeyModifiers = false };
 		IKeybind keybind = new Keybind(KeyModifiers.RWin | KeyModifiers.RControl, VIRTUAL_KEY.VK_A);
 
 		// When
@@ -301,7 +301,7 @@ public class KeybindManagerTests
 	)
 	{
 		// Given
-		IKeybindManager keybindManager = new KeybindManager(context) { UnifyKeyModifiers = false };
+		KeybindManager keybindManager = new (context) { UnifyKeyModifiers = false };
 		IKeybind keybind = new Keybind(modifiers, key);
 
 		context.CommandManager.TryGetCommand("command").Returns(command);
@@ -319,7 +319,7 @@ public class KeybindManagerTests
 	public void Clear_CommandsCleared(IContext context)
 	{
 		// Given
-		IKeybindManager keybindManager = new KeybindManager(context);
+		KeybindManager keybindManager = new (context);
 		IKeybind keybind = new Keybind(IKeybind.WinAlt, VIRTUAL_KEY.VK_A);
 
 		// When

--- a/src/Whim.Tests/Keybind/KeybindManagerTests.cs
+++ b/src/Whim.Tests/Keybind/KeybindManagerTests.cs
@@ -8,7 +8,7 @@ public class KeybindManagerTests
 	public void SetKeybind_DoesNotContainKeybind(IContext context, ICommand command)
 	{
 		// Given
-		KeybindManager keybindManager = new (context);
+		KeybindManager keybindManager = new(context);
 		IKeybind keybind = new Keybind(IKeybind.WinAlt, VIRTUAL_KEY.VK_A);
 
 		context.CommandManager.TryGetCommand("command").Returns(command);
@@ -26,7 +26,7 @@ public class KeybindManagerTests
 	public void SetKeybind_ContainsKeybind(IContext context, ICommand command, ICommand command2)
 	{
 		// Given
-		KeybindManager keybindManager = new (context);
+		KeybindManager keybindManager = new(context);
 		IKeybind keybind = new Keybind(IKeybind.WinAlt, VIRTUAL_KEY.VK_A);
 
 		context.CommandManager.TryGetCommand("command").Returns(command);
@@ -47,7 +47,7 @@ public class KeybindManagerTests
 	public void SetKeybind_AlreadyContainsKeybindForCommand(IContext context, ICommand command)
 	{
 		// Given
-		KeybindManager keybindManager = new (context);
+		KeybindManager keybindManager = new(context);
 		IKeybind keybind = new Keybind(IKeybind.WinAlt, VIRTUAL_KEY.VK_A);
 		IKeybind keybind2 = new Keybind(IKeybind.WinAlt, VIRTUAL_KEY.VK_B);
 
@@ -67,7 +67,7 @@ public class KeybindManagerTests
 	public void SetKeybind_UnifyKeyModifiers(IContext context, ICommand command)
 	{
 		// Given
-		KeybindManager keybindManager = new (context);
+		KeybindManager keybindManager = new(context);
 		IKeybind keybind = new Keybind(KeyModifiers.RWin | KeyModifiers.RControl, VIRTUAL_KEY.VK_A);
 
 		context.CommandManager.TryGetCommand("command").Returns(command);
@@ -86,7 +86,7 @@ public class KeybindManagerTests
 	public void SetKeybind_OverriddenKeybind(IContext context, ICommand command)
 	{
 		// Given
-		KeybindManager keybindManager = new (context);
+		KeybindManager keybindManager = new(context);
 		IKeybind keybind1 = new Keybind(IKeybind.WinAlt, VIRTUAL_KEY.VK_A);
 		IKeybind keybind2 = new Keybind(IKeybind.WinAlt, VIRTUAL_KEY.VK_B);
 
@@ -108,7 +108,7 @@ public class KeybindManagerTests
 	public void GetCommands_DoesNotContainKeybind(IContext context)
 	{
 		// Given
-		KeybindManager keybindManager = new (context);
+		KeybindManager keybindManager = new(context);
 		IKeybind keybind = new Keybind(IKeybind.WinAlt, VIRTUAL_KEY.VK_A);
 
 		// When
@@ -122,7 +122,7 @@ public class KeybindManagerTests
 	public void GetCommands_DoesNotContainCommand(IContext context)
 	{
 		// Given
-		KeybindManager keybindManager = new (context);
+		KeybindManager keybindManager = new(context);
 		IKeybind keybind = new Keybind(IKeybind.WinAlt, VIRTUAL_KEY.VK_A);
 
 		context.CommandManager.TryGetCommand("command2").Returns((ICommand?)null);
@@ -139,7 +139,7 @@ public class KeybindManagerTests
 	public void GetCommands_Success(IContext context, ICommand command, ICommand command2)
 	{
 		// Given
-		KeybindManager keybindManager = new (context);
+		KeybindManager keybindManager = new(context);
 		IKeybind keybind = new Keybind(IKeybind.WinAlt, VIRTUAL_KEY.VK_A);
 
 		context.CommandManager.TryGetCommand("command").Returns(command);
@@ -160,7 +160,7 @@ public class KeybindManagerTests
 	public void GetCommands_UnifyKeyModifiers(IContext context, ICommand command)
 	{
 		// Given
-		KeybindManager keybindManager = new (context);
+		KeybindManager keybindManager = new(context);
 		IKeybind leftKeybind = new Keybind(KeyModifiers.LWin | KeyModifiers.LControl, VIRTUAL_KEY.VK_A);
 		IKeybind rightKeybind = new Keybind(KeyModifiers.RWin | KeyModifiers.RControl, VIRTUAL_KEY.VK_A);
 
@@ -180,7 +180,7 @@ public class KeybindManagerTests
 	public void TryGet_DoesNotContainCommand(IContext context)
 	{
 		// Given
-		KeybindManager keybindManager = new (context);
+		KeybindManager keybindManager = new(context);
 
 		// When
 		IKeybind? keybind = keybindManager.TryGetKeybind("command");
@@ -193,7 +193,7 @@ public class KeybindManagerTests
 	public void TryGet_ContainsCommand(IContext context)
 	{
 		// Given
-		KeybindManager keybindManager = new (context);
+		KeybindManager keybindManager = new(context);
 		IKeybind keybind = new Keybind(IKeybind.WinAlt, VIRTUAL_KEY.VK_A);
 
 		// When
@@ -208,7 +208,7 @@ public class KeybindManagerTests
 	public void Remove_DoesNotContainCommand(IContext context)
 	{
 		// Given
-		KeybindManager keybindManager = new (context);
+		KeybindManager keybindManager = new(context);
 
 		// When
 		bool result = keybindManager.Remove("command");
@@ -221,7 +221,7 @@ public class KeybindManagerTests
 	public void Remove_ContainsCommand(IContext context)
 	{
 		// Given
-		KeybindManager keybindManager = new (context);
+		KeybindManager keybindManager = new(context);
 		IKeybind keybind = new Keybind(IKeybind.WinAlt, VIRTUAL_KEY.VK_A);
 
 		// When
@@ -237,7 +237,7 @@ public class KeybindManagerTests
 	public void UnifyKeyModifiers_SetToTrue(IContext context)
 	{
 		// Given
-		KeybindManager keybindManager = new (context) { UnifyKeyModifiers = false };
+		KeybindManager keybindManager = new(context) { UnifyKeyModifiers = false };
 		IKeybind keybind = new Keybind(KeyModifiers.RWin | KeyModifiers.RControl, VIRTUAL_KEY.VK_A);
 
 		// When
@@ -258,7 +258,7 @@ public class KeybindManagerTests
 	public void GetCommands_Unified(KeyModifiers modifiers, VIRTUAL_KEY key, IContext context, ICommand command)
 	{
 		// Given
-		KeybindManager keybindManager = new (context);
+		KeybindManager keybindManager = new(context);
 		IKeybind keybind = new Keybind(KeyModifiers.RWin | KeyModifiers.RControl, VIRTUAL_KEY.VK_A);
 
 		context.CommandManager.TryGetCommand("command").Returns(command);
@@ -276,7 +276,7 @@ public class KeybindManagerTests
 	public void GetCommands_NotUnified_FailedLookup(IContext context)
 	{
 		// Given
-		KeybindManager keybindManager = new (context) { UnifyKeyModifiers = false };
+		KeybindManager keybindManager = new(context) { UnifyKeyModifiers = false };
 		IKeybind keybind = new Keybind(KeyModifiers.RWin | KeyModifiers.RControl, VIRTUAL_KEY.VK_A);
 
 		// When
@@ -301,7 +301,7 @@ public class KeybindManagerTests
 	)
 	{
 		// Given
-		KeybindManager keybindManager = new (context) { UnifyKeyModifiers = false };
+		KeybindManager keybindManager = new(context) { UnifyKeyModifiers = false };
 		IKeybind keybind = new Keybind(modifiers, key);
 
 		context.CommandManager.TryGetCommand("command").Returns(command);
@@ -319,7 +319,7 @@ public class KeybindManagerTests
 	public void Clear_CommandsCleared(IContext context)
 	{
 		// Given
-		KeybindManager keybindManager = new (context);
+		KeybindManager keybindManager = new(context);
 		IKeybind keybind = new Keybind(IKeybind.WinAlt, VIRTUAL_KEY.VK_A);
 
 		// When

--- a/src/Whim.Tests/Layout/FocusLayoutEngineTests.cs
+++ b/src/Whim.Tests/Layout/FocusLayoutEngineTests.cs
@@ -168,8 +168,8 @@ public class FocusLayoutEngineTests
 		// Then
 		Assert.Equal(3, result.Length);
 
-		IWindowState[] expected = new IWindowState[]
-		{
+		IWindowState[] expected =
+		[
 			new WindowState()
 			{
 				Window = window1,
@@ -188,7 +188,7 @@ public class FocusLayoutEngineTests
 				Rectangle = rectangle,
 				WindowSize = WindowSize.Normal
 			}
-		};
+		];
 
 		expected.Should().BeEquivalentTo(result);
 	}
@@ -310,8 +310,8 @@ public class FocusLayoutEngineTests
 		Assert.NotSame(sut, result);
 		Assert.Equal(2, result.Count);
 
-		IWindowState[] expected = new IWindowState[]
-		{
+		IWindowState[] expected =
+		[
 			new WindowState()
 			{
 				Window = window1,
@@ -324,7 +324,7 @@ public class FocusLayoutEngineTests
 				Rectangle = new Rectangle<int>(),
 				WindowSize = WindowSize.Minimized
 			}
-		};
+		];
 
 		expected.Should().BeEquivalentTo(windowStates);
 	}

--- a/src/Whim.Tests/Monitor/MonitorsChangedEventArgsTests.cs
+++ b/src/Whim.Tests/Monitor/MonitorsChangedEventArgsTests.cs
@@ -34,9 +34,9 @@ public class MonitorsChangedEventArgsTests
 		MonitorsChangedEventArgs args =
 			new()
 			{
-				UnchangedMonitors = new[] { unchangedMonitor1, unchangedMonitor2 },
+				UnchangedMonitors = [unchangedMonitor1, unchangedMonitor2],
 				RemovedMonitors = Array.Empty<IMonitor>(),
-				AddedMonitors = new[] { addedMonitor1, addedMonitor2 },
+				AddedMonitors = [addedMonitor1, addedMonitor2],
 			};
 
 		// When
@@ -66,8 +66,8 @@ public class MonitorsChangedEventArgsTests
 		MonitorsChangedEventArgs args =
 			new()
 			{
-				UnchangedMonitors = new[] { unchangedMonitor1, unchangedMonitor2 },
-				RemovedMonitors = new[] { removedMonitor1, removedMonitor2 },
+				UnchangedMonitors = [unchangedMonitor1, unchangedMonitor2],
+				RemovedMonitors = [removedMonitor1, removedMonitor2],
 				AddedMonitors = Array.Empty<IMonitor>(),
 			};
 

--- a/src/Whim.Tests/Monitor/MonitorsChangedEventArgsTests.cs
+++ b/src/Whim.Tests/Monitor/MonitorsChangedEventArgsTests.cs
@@ -9,9 +9,9 @@ public class MonitorsChangedEventArgsTests
 		MonitorsChangedEventArgs args =
 			new()
 			{
-				UnchangedMonitors = Array.Empty<IMonitor>(),
-				RemovedMonitors = Array.Empty<IMonitor>(),
-				AddedMonitors = Array.Empty<IMonitor>(),
+				UnchangedMonitors = [],
+				RemovedMonitors = [],
+				AddedMonitors = [],
 			};
 
 		// When
@@ -35,7 +35,7 @@ public class MonitorsChangedEventArgsTests
 			new()
 			{
 				UnchangedMonitors = [unchangedMonitor1, unchangedMonitor2],
-				RemovedMonitors = Array.Empty<IMonitor>(),
+				RemovedMonitors = [],
 				AddedMonitors = [addedMonitor1, addedMonitor2],
 			};
 
@@ -68,7 +68,7 @@ public class MonitorsChangedEventArgsTests
 			{
 				UnchangedMonitors = [unchangedMonitor1, unchangedMonitor2],
 				RemovedMonitors = [removedMonitor1, removedMonitor2],
-				AddedMonitors = Array.Empty<IMonitor>(),
+				AddedMonitors = [],
 			};
 
 		// When

--- a/src/Whim.Tests/Native/DeferWindowPosHandleTests.cs
+++ b/src/Whim.Tests/Native/DeferWindowPosHandleTests.cs
@@ -135,7 +135,7 @@ public class DeferWindowPosHandleTests
 		DeferWindowPosState state3 = new((HWND)3, WindowSize.Maximized, new Rectangle<int>(5, 6, 7, 8));
 		DeferWindowPosState state4 = new((HWND)4, WindowSize.Normal, new Rectangle<int>(9, 10, 11, 12));
 
-		DeferWindowPosHandle sut = new(ctx, internalCtx, new[] { state1, state2, state3, state4 });
+		DeferWindowPosHandle sut = new(ctx, internalCtx, [state1, state2, state3, state4]);
 
 		AddMonitorsToManager(ctx, root, CreateMonitor((HMONITOR)1));
 

--- a/src/Whim.Tests/Plugin/PluginManagerTests.cs
+++ b/src/Whim.Tests/Plugin/PluginManagerTests.cs
@@ -223,7 +223,7 @@ public class PluginManagerTests
 
 		// I want to verify that the command passed into Add is equivalent to the one created in the mocks
 		Assert.Equal(4, commandManager.Count);
-		List<ICommand> commands = commandManager.ToList();
+		List<ICommand> commands = [.. commandManager];
 		Assert.Equal("whim.plugin1.command1", commands[0].Id);
 		Assert.Equal("whim.plugin2.command2", commands[1].Id);
 		Assert.Equal("whim.plugin2.command22", commands[2].Id);

--- a/src/Whim.Tests/Plugin/PluginManagerTests.cs
+++ b/src/Whim.Tests/Plugin/PluginManagerTests.cs
@@ -1,5 +1,4 @@
 using System.IO;
-using System.Linq;
 using System.Text.Json;
 using AutoFixture;
 using Windows.Win32.UI.Input.KeyboardAndMouse;

--- a/src/Whim.Tests/Store/MapSector/Transforms/InitializeWorkspacesTransformTests.cs
+++ b/src/Whim.Tests/Store/MapSector/Transforms/InitializeWorkspacesTransformTests.cs
@@ -110,7 +110,8 @@ public class InitializeWorkspacesTransformTests
 
 	private static void Setup_UserCreatedWorkspaces(MutableRootSector root)
 	{
-		root.WorkspaceSector.WorkspacesToCreate = ImmutableList.Create(
+		root.WorkspaceSector.WorkspacesToCreate =
+		[
 			new WorkspaceToCreate(BrowserWorkspaceName, null),
 			new WorkspaceToCreate(
 				CodeWorkspaceName,
@@ -119,8 +120,8 @@ public class InitializeWorkspacesTransformTests
 					(id) => new ImmutableTestLayoutEngine(),
 					(id) => new ImmutableTestLayoutEngine(),
 				}
-			)
-		);
+			),
+		];
 	}
 
 	private static void Setup_SavedState(IInternalContext internalCtx)

--- a/src/Whim.Tests/Store/MapSector/Transforms/InitializeWorkspacesTransformTests.cs
+++ b/src/Whim.Tests/Store/MapSector/Transforms/InitializeWorkspacesTransformTests.cs
@@ -39,7 +39,7 @@ public class InitializeWorkspacesTransformTests
 
 	private static void AddWorkspacesToSavedState(IInternalContext internalCtx, params SavedWorkspace[] workspaces)
 	{
-		internalCtx.CoreSavedStateManager.SavedState.Returns(new CoreSavedState(workspaces.ToList()));
+		internalCtx.CoreSavedStateManager.SavedState.Returns(new CoreSavedState([.. workspaces]));
 	}
 
 	[Theory, AutoSubstituteData<StoreCustomization>]

--- a/src/Whim.Tests/Store/MapSector/Transforms/InitializeWorkspacesTransformTests.cs
+++ b/src/Whim.Tests/Store/MapSector/Transforms/InitializeWorkspacesTransformTests.cs
@@ -200,8 +200,7 @@ public class InitializeWorkspacesTransformTests
 		internalCtx.CoreNativeManager.IsStandardWindow(Arg.Any<HWND>()).Returns(true);
 		internalCtx.CoreNativeManager.HasNoVisibleOwner(Arg.Any<HWND>()).Returns(true);
 
-		rootSector.WorkspaceSector.CreateLayoutEngines = () =>
-			new CreateLeafLayoutEngine[] { id => new ImmutableTestLayoutEngine() };
+		rootSector.WorkspaceSector.CreateLayoutEngines = () => [id => new ImmutableTestLayoutEngine()];
 
 		InitializeWorkspacesTransform sut = new();
 

--- a/src/Whim.Tests/Store/MapSector/Transforms/MoveWindowToAdjacentMonitorTransformTests.cs
+++ b/src/Whim.Tests/Store/MapSector/Transforms/MoveWindowToAdjacentMonitorTransformTests.cs
@@ -10,7 +10,7 @@ public class MoveWindowToAdjacentMonitorTransformTests
 		IMonitor monitor = CreateMonitor((HMONITOR)10);
 		IWindow window = CreateWindow((HWND)10);
 
-		rootSector.MonitorSector.Monitors = ImmutableArray.Create(monitor);
+		rootSector.MonitorSector.Monitors = [monitor];
 		rootSector.MonitorSector.ActiveMonitorHandle = monitor.Handle;
 		AddWindowToSector(rootSector, window);
 

--- a/src/Whim.Tests/Store/MapSector/Transforms/MoveWindowToAdjacentWorkspaceTransformTests.cs
+++ b/src/Whim.Tests/Store/MapSector/Transforms/MoveWindowToAdjacentWorkspaceTransformTests.cs
@@ -98,7 +98,7 @@ public class MoveWindowToAdjacentWorkspaceTransformTests
 
 		// When
 		Result<Unit>? result = null;
-		CustomAssert.Layout(rootSector, () => result = ctx.Store.Dispatch(sut), new[] { workspace1.Id, workspace2.Id });
+		CustomAssert.Layout(rootSector, () => result = ctx.Store.Dispatch(sut), [workspace1.Id, workspace2.Id]);
 
 		// Then
 		Assert.True(result!.Value.IsSuccessful);

--- a/src/Whim.Tests/Store/MapSector/Transforms/MoveWindowToPointTransformTests.cs
+++ b/src/Whim.Tests/Store/MapSector/Transforms/MoveWindowToPointTransformTests.cs
@@ -122,7 +122,7 @@ public class MoveWindowToPointTransformTests
 		// When we execute the transform
 		Result<Unit>? result = null;
 		// var result = ctx.Store.Dispatch(sut);
-		CustomAssert.Layout(rootSector, () => result = ctx.Store.Dispatch(sut), new[] { sourceWorkspace.Id });
+		CustomAssert.Layout(rootSector, () => result = ctx.Store.Dispatch(sut), [sourceWorkspace.Id]);
 
 		// Then we succeed
 		Assert.True(result!.Value.IsSuccessful);

--- a/src/Whim.Tests/Store/MapSector/Transforms/MoveWindowToWorkspaceTransformTests.cs
+++ b/src/Whim.Tests/Store/MapSector/Transforms/MoveWindowToWorkspaceTransformTests.cs
@@ -144,7 +144,7 @@ public class MoveWindowToWorkspaceTransformTests
 		CustomAssert.Layout(
 			rootSector,
 			() => result = AssertDoesNotRaise(ctx, rootSector, sut),
-			new[] { workspace1.Id, workspace2.Id }
+			[workspace1.Id, workspace2.Id]
 		);
 
 		// Then we succeed

--- a/src/Whim.Tests/Store/MapSector/Transforms/SwapWorkspaceWithAdjacentMonitorTransformTests.cs
+++ b/src/Whim.Tests/Store/MapSector/Transforms/SwapWorkspaceWithAdjacentMonitorTransformTests.cs
@@ -74,12 +74,12 @@ public class SwapWorkspaceWithAdjacentMonitorTransformTests
 		Workspace workspace1 = CreateWorkspace(ctx);
 		Workspace workspace2 = CreateWorkspace(ctx);
 		Workspace workspace3 = CreateWorkspace(ctx);
-		Workspace[] workspaces = { workspace1, workspace2, workspace3 };
+		Workspace[] workspaces = [workspace1, workspace2, workspace3];
 
 		IMonitor monitor1 = CreateMonitor((HMONITOR)1);
 		IMonitor monitor2 = CreateMonitor((HMONITOR)2);
 		IMonitor monitor3 = CreateMonitor((HMONITOR)3);
-		IMonitor[] monitors = { monitor1, monitor2, monitor3 };
+		IMonitor[] monitors = [monitor1, monitor2, monitor3];
 
 		ctx.MonitorManager.GetPreviousMonitor(monitor1).Returns(monitor3);
 		ctx.MonitorManager.GetNextMonitor(monitor1).Returns(monitor2);

--- a/src/Whim.Tests/Store/MonitorSector/MonitorEventListenerTests.cs
+++ b/src/Whim.Tests/Store/MonitorSector/MonitorEventListenerTests.cs
@@ -95,7 +95,7 @@ public class MonitorEventListenerTests
 	}
 
 	[Theory, AutoSubstituteData]
-	internal async void WindowMessageMonitor_SessionChanged(IContext ctx, IInternalContext internalCtx)
+	internal async Task WindowMessageMonitor_SessionChanged(IContext ctx, IInternalContext internalCtx)
 	{
 		// Given the listener is initialized
 		MonitorEventListener listener = new(ctx, internalCtx);

--- a/src/Whim.Tests/Store/MonitorSector/MonitorPickersTests.cs
+++ b/src/Whim.Tests/Store/MonitorSector/MonitorPickersTests.cs
@@ -18,7 +18,7 @@ public class MonitorPickersTests
 		IMonitor monitor4 = Substitute.For<IMonitor>();
 		monitor4.Handle.Returns((HMONITOR)4);
 
-		root.MonitorSector.Monitors = ImmutableArray.Create(monitor1, monitor2, monitor3, monitor4);
+		root.MonitorSector.Monitors = [monitor1, monitor2, monitor3, monitor4];
 	}
 
 	[Theory, AutoSubstituteData<StoreCustomization>]
@@ -158,7 +158,7 @@ public class GetMonitorAtPointPickerTests
 			.Returns(foundMonitorHandle);
 
 		monitor.Handle.Returns(monitorHandle);
-		root.MonitorSector.Monitors = ImmutableArray.Create(monitor);
+		root.MonitorSector.Monitors = [monitor];
 	}
 
 	private static readonly IPoint<int> _point = new Point<int>(10, 10);

--- a/src/Whim.Tests/Store/MonitorSector/MonitorUtilsTests.cs
+++ b/src/Whim.Tests/Store/MonitorSector/MonitorUtilsTests.cs
@@ -17,8 +17,8 @@ internal class MonitorUtilsTestCustomization : ICustomization
 
 public class MonitorUtilsTests
 {
-	private static readonly (RECT, HMONITOR)[] MULTI_MONITOR_SETUP = new[]
-	{
+	private static readonly (RECT, HMONITOR)[] MULTI_MONITOR_SETUP =
+	[
 		// right
 		(
 			new RECT()
@@ -52,7 +52,7 @@ public class MonitorUtilsTests
 			},
 			(HMONITOR)3
 		),
-	};
+	];
 
 	[Theory, AutoSubstituteData<MonitorUtilsTestCustomization>]
 	internal void SingleMonitor(IInternalContext internalCtx)

--- a/src/Whim.Tests/Store/MonitorSector/Transforms/ActivateEmptyMonitorTransformTests.cs
+++ b/src/Whim.Tests/Store/MonitorSector/Transforms/ActivateEmptyMonitorTransformTests.cs
@@ -20,7 +20,7 @@ public class ActivateEmptyMonitorTransformTests
 	{
 		// Given the store contains multiple monitors
 		HMONITOR handle = (HMONITOR)123;
-		mutableRootSector.MonitorSector.Monitors = ImmutableArray.Create(monitor, monitor1);
+		mutableRootSector.MonitorSector.Monitors = [monitor, monitor1];
 		mutableRootSector.MonitorSector.ActiveMonitorHandle = handle;
 
 		ActivateEmptyMonitorTransform sut = new(handle);

--- a/src/Whim.Tests/Store/MonitorSector/Transforms/MonitorsChangedTransformTests.cs
+++ b/src/Whim.Tests/Store/MonitorSector/Transforms/MonitorsChangedTransformTests.cs
@@ -1,8 +1,10 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using static Whim.TestUtils.MonitorTestUtils;
 
 namespace Whim.Tests;
 
+[SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope")]
 public class MonitorsChangedTransformTests
 {
 	private static readonly (RECT Rect, HMONITOR Handle) RightMonitorSetup = (

--- a/src/Whim.Tests/Store/MonitorSector/Transforms/MonitorsChangedTransformTests.cs
+++ b/src/Whim.Tests/Store/MonitorSector/Transforms/MonitorsChangedTransformTests.cs
@@ -72,7 +72,7 @@ public class MonitorsChangedTransformTests
 		Workspace workspace3 = CreateWorkspace(ctx);
 		AddWorkspacesToManager(ctx, rootSector, workspace1, workspace2, workspace3);
 		rootSector.WorkspaceSector.HasInitialized = true;
-		return new[] { workspace1, workspace2, workspace3 };
+		return [workspace1, workspace2, workspace3];
 	}
 
 	/// <summary>
@@ -105,7 +105,7 @@ public class MonitorsChangedTransformTests
 				}
 			);
 		rootSector.WorkspaceSector.HasInitialized = true;
-		return new[] { workspace1, workspace2, workspace3 };
+		return [workspace1, workspace2, workspace3];
 	}
 
 	private static void AssertContainsTransform(IContext ctx, Guid workspaceId, int times = 1)
@@ -172,8 +172,8 @@ public class MonitorsChangedTransformTests
 		var raisedEvent = DispatchTransformEvent(
 			ctx,
 			rootSector,
-			new[] { workspaces[0].Id, workspaces[2].Id },
-			new[] { workspaces[1].Id }
+			[workspaces[0].Id, workspaces[2].Id],
+			[workspaces[1].Id]
 		);
 
 		Assert.Empty(raisedEvent.Arguments.AddedMonitors);
@@ -211,7 +211,7 @@ public class MonitorsChangedTransformTests
 		var raisedEvent = DispatchTransformEvent(
 			ctx,
 			rootSector,
-			new[] { workspaces[0].Id, workspaces[1].Id, workspaces[2].Id }
+			[workspaces[0].Id, workspaces[1].Id, workspaces[2].Id]
 		);
 
 		Assert.Single(raisedEvent.Arguments.AddedMonitors);
@@ -255,7 +255,7 @@ public class MonitorsChangedTransformTests
 		var raisedEvent = DispatchTransformEvent(
 			ctx,
 			rootSector,
-			new[] { workspaces[0].Id, workspaces[1].Id, workspaces[2].Id }
+			[workspaces[0].Id, workspaces[1].Id, workspaces[2].Id]
 		);
 
 		Assert.Equal(2, raisedEvent.Arguments.AddedMonitors.Count());
@@ -283,7 +283,7 @@ public class MonitorsChangedTransformTests
 
 		// When we add monitors
 		SetupMultipleMonitors(internalCtx, new[] { RightMonitorSetup, LeftTopMonitorSetup });
-		var raisedEvent = DispatchTransformEvent(ctx, rootSector, new[] { workspaces[0].Id, workspaces[1].Id });
+		var raisedEvent = DispatchTransformEvent(ctx, rootSector, [workspaces[0].Id, workspaces[1].Id]);
 
 		// Then the resulting event will have a monitor added, and the other monitors in the sector will be set.
 		Assert.Equal(2, raisedEvent.Arguments.AddedMonitors.Count());
@@ -311,7 +311,7 @@ public class MonitorsChangedTransformTests
 
 		// When we add monitors
 		SetupMultipleMonitors(internalCtx, new[] { RightMonitorSetup, LeftTopMonitorSetup });
-		var raisedEvent = DispatchTransformEvent(ctx, rootSector, new[] { workspaces[0].Id, workspaces[1].Id });
+		var raisedEvent = DispatchTransformEvent(ctx, rootSector, [workspaces[0].Id, workspaces[1].Id]);
 
 		// Then the resulting event will have a monitor added, and the other monitors in the sector will be set.
 		Assert.Equal(2, raisedEvent.Arguments.AddedMonitors.Count());
@@ -344,7 +344,7 @@ public class MonitorsChangedTransformTests
 		var raisedEvent = DispatchTransformEvent(
 			ctx,
 			rootSector,
-			notLayoutWorkspaceIds: new[] { workspaces[0].Id, workspaces[1].Id, workspaces[2].Id }
+			notLayoutWorkspaceIds: [workspaces[0].Id, workspaces[1].Id, workspaces[2].Id]
 		);
 
 		Assert.Empty(raisedEvent.Arguments.AddedMonitors);

--- a/src/Whim.Tests/Store/RootSector/Transforms/MouseLeftButtonUpTransformTests.cs
+++ b/src/Whim.Tests/Store/RootSector/Transforms/MouseLeftButtonUpTransformTests.cs
@@ -23,7 +23,7 @@ public class MouseLeftButtonUpTransformTests
 		SetMonitorAtPoint(internalCtx, (HMONITOR)2);
 
 		monitor.Handle.Returns((HMONITOR)1);
-		mutableRootSector.MonitorSector.Monitors = ImmutableArray.Create(monitor);
+		mutableRootSector.MonitorSector.Monitors = [monitor];
 
 		Point<int> point = new(10, 10);
 		MouseLeftButtonUpTransform sut = new(point);
@@ -47,7 +47,7 @@ public class MouseLeftButtonUpTransformTests
 		SetMonitorAtPoint(internalCtx, (HMONITOR)2);
 
 		monitor.Handle.Returns((HMONITOR)2);
-		mutableRootSector.MonitorSector.Monitors = ImmutableArray.Create(monitor);
+		mutableRootSector.MonitorSector.Monitors = [monitor];
 
 		Point<int> point = new(10, 10);
 		MouseLeftButtonUpTransform sut = new(point);

--- a/src/Whim.Tests/Store/WindowSector/Processors/FirefoxWindowProcessorTests.cs
+++ b/src/Whim.Tests/Store/WindowSector/Processors/FirefoxWindowProcessorTests.cs
@@ -35,7 +35,7 @@ public class FirefoxWindowProcessorTests
 	{
 		// Given a Firefox window which was open when Whim started
 		window.ProcessFileName.Returns("firefox.exe");
-		rootSector.WindowSector.StartupWindows = new[] { window.Handle }.ToImmutableHashSet();
+		rootSector.WindowSector.StartupWindows = [window.Handle];
 		IWindowProcessor processor = FirefoxWindowProcessor.Create(ctx, window)!;
 
 		// When `ProcessEvent` is called

--- a/src/Whim.Tests/Store/WindowSector/Transforms/WindowFocusedTransformTests.cs
+++ b/src/Whim.Tests/Store/WindowSector/Transforms/WindowFocusedTransformTests.cs
@@ -15,7 +15,7 @@ public class WindowFocusedTransformTests
 		IMonitor monitor2 = CreateMonitor(HMONITOR_2);
 		IMonitor monitor3 = CreateMonitor(HMONITOR_3);
 
-		ImmutableArray<IMonitor> monitors = ImmutableArray.Create(monitor1, monitor2, monitor3);
+		ImmutableArray<IMonitor> monitors = [monitor1, monitor2, monitor3];
 		rootSector.MonitorSector.Monitors = monitors;
 		return monitors;
 	}

--- a/src/Whim.Tests/Store/WindowSector/Transforms/WindowFocusedTransformTests.cs
+++ b/src/Whim.Tests/Store/WindowSector/Transforms/WindowFocusedTransformTests.cs
@@ -164,8 +164,8 @@ public class WindowFocusedTransformTests
 		CustomAssert.Layout(
 			rootSector,
 			() => ctx.Store.Dispatch(sut),
-			layoutWorkspaceIds: new[] { workspace4.Id },
-			noLayoutWorkspaceIds: new[] { workspace1.Id, workspace2.Id, workspace3.Id }
+			layoutWorkspaceIds: [workspace4.Id],
+			noLayoutWorkspaceIds: [workspace1.Id, workspace2.Id, workspace3.Id]
 		);
 
 		// Then the active monitor index is updated based on MonitorFromWindow		Assert.Equal(HMONITOR_1, rootSector.MonitorSector.ActiveMonitorHandle);

--- a/src/Whim.Tests/Store/WindowSector/Transforms/WindowMinimizeEndedTransformTests.cs
+++ b/src/Whim.Tests/Store/WindowSector/Transforms/WindowMinimizeEndedTransformTests.cs
@@ -41,7 +41,7 @@ public class WindowMinimizeEndedTransformTests
 			h => rootSector.WindowSector.WindowMinimizeEnded -= h,
 			() =>
 			{
-				CustomAssert.Layout(rootSector, () => result = ctx.Store.Dispatch(sut), new[] { workspace.Id });
+				CustomAssert.Layout(rootSector, () => result = ctx.Store.Dispatch(sut), [workspace.Id]);
 			}
 		);
 

--- a/src/Whim.Tests/Store/WindowSector/Transforms/WindowMinimizeStartedTransformTests.cs
+++ b/src/Whim.Tests/Store/WindowSector/Transforms/WindowMinimizeStartedTransformTests.cs
@@ -1,5 +1,8 @@
+using System.Diagnostics.CodeAnalysis;
+
 namespace Whim.Tests;
 
+[SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope")]
 public class WindowMinimizeStartedTransformTests
 {
 	[Theory, AutoSubstituteData<StoreCustomization>]

--- a/src/Whim.Tests/Store/WindowSector/Transforms/WindowMinimizeStartedTransformTests.cs
+++ b/src/Whim.Tests/Store/WindowSector/Transforms/WindowMinimizeStartedTransformTests.cs
@@ -42,7 +42,7 @@ public class WindowMinimizeStartedTransformTests
 			h => rootSector.WindowSector.WindowMinimizeStarted -= h,
 			() =>
 			{
-				CustomAssert.Layout(rootSector, () => result = ctx.Store.Dispatch(sut), new[] { workspace.Id });
+				CustomAssert.Layout(rootSector, () => result = ctx.Store.Dispatch(sut), [workspace.Id]);
 			}
 		);
 

--- a/src/Whim.Tests/Store/WindowSector/WindowEventListenerTests.cs
+++ b/src/Whim.Tests/Store/WindowSector/WindowEventListenerTests.cs
@@ -68,15 +68,15 @@ public class WindowEventListenerTests
 {
 	private static void InitializeCoreNativeManagerMock(IInternalContext internalCtx)
 	{
-		(uint, uint)[] events = new[]
-		{
+		(uint, uint)[] events =
+		[
 			(PInvoke.EVENT_OBJECT_DESTROY, PInvoke.EVENT_OBJECT_HIDE),
 			(PInvoke.EVENT_OBJECT_CLOAKED, PInvoke.EVENT_OBJECT_UNCLOAKED),
 			(PInvoke.EVENT_SYSTEM_MOVESIZESTART, PInvoke.EVENT_SYSTEM_MOVESIZEEND),
 			(PInvoke.EVENT_SYSTEM_FOREGROUND, PInvoke.EVENT_SYSTEM_FOREGROUND),
 			(PInvoke.EVENT_OBJECT_LOCATIONCHANGE, PInvoke.EVENT_OBJECT_LOCATIONCHANGE),
 			(PInvoke.EVENT_SYSTEM_MINIMIZESTART, PInvoke.EVENT_SYSTEM_MINIMIZEEND)
-		};
+		];
 
 		foreach (var (eventMin, eventMax) in events)
 		{

--- a/src/Whim.Tests/Store/WorkspaceSector/Transforms/ActivateLayoutEngineTransformTests.cs
+++ b/src/Whim.Tests/Store/WorkspaceSector/Transforms/ActivateLayoutEngineTransformTests.cs
@@ -24,7 +24,7 @@ public class ActivateLayoutEngineTransformTests
 		// Given the layout engine doesn't exist
 		Workspace workspace = CreateWorkspace(ctx) with
 		{
-			LayoutEngines = ImmutableList.Create(engine)
+			LayoutEngines = [engine]
 		};
 		AddWorkspaceToManager(ctx, rootSector, workspace);
 
@@ -50,7 +50,7 @@ public class ActivateLayoutEngineTransformTests
 		// Given the layout engine exists
 		Workspace workspace = CreateWorkspace(ctx) with
 		{
-			LayoutEngines = ImmutableList.Create(engine, engine2)
+			LayoutEngines = [engine, engine2]
 		};
 		AddWorkspaceToManager(ctx, rootSector, workspace);
 
@@ -76,7 +76,7 @@ public class ActivateLayoutEngineTransformTests
 		// Given the layout engine exists
 		Workspace workspace = CreateWorkspace(ctx) with
 		{
-			LayoutEngines = ImmutableList.Create(engine, engine2)
+			LayoutEngines = [engine, engine2]
 		};
 		AddWorkspaceToManager(ctx, rootSector, workspace);
 

--- a/src/Whim.Tests/Store/WorkspaceSector/Transforms/AddWindowToWorkspaceTransformTests.cs
+++ b/src/Whim.Tests/Store/WorkspaceSector/Transforms/AddWindowToWorkspaceTransformTests.cs
@@ -10,7 +10,7 @@ public class AddWindowToWorkspaceTransformTests
 	{
 		// Given
 		Workspace workspace = CreateWorkspace(ctx);
-		workspace = workspace with { LayoutEngines = ImmutableList.Create(engine) };
+		workspace = workspace with { LayoutEngines = [engine] };
 
 		AddWorkspaceToManager(ctx, root, workspace);
 

--- a/src/Whim.Tests/Store/WorkspaceSector/Transforms/AddWorkspaceTransformTests.cs
+++ b/src/Whim.Tests/Store/WorkspaceSector/Transforms/AddWorkspaceTransformTests.cs
@@ -50,10 +50,11 @@ public class AddWorkspaceTransformTests
 		string name = "Test";
 		List<CreateLeafLayoutEngine> createLeafLayoutEngines = new() { (id) => engine1, (id) => engine2 };
 
-		root.WorkspaceSector.ProxyLayoutEngineCreators = ImmutableList.Create<ProxyLayoutEngineCreator>(
+		root.WorkspaceSector.ProxyLayoutEngineCreators =
+		[
 			(engine) => Substitute.For<TestProxyLayoutEngine>(engine),
 			(engine) => Substitute.For<TestProxyLayoutEngine>(engine)
-		);
+		];
 
 		AddWorkspaceTransform sut = new(name, createLeafLayoutEngines);
 

--- a/src/Whim.Tests/Store/WorkspaceSector/Transforms/CycleLayoutEngineTransformTests.cs
+++ b/src/Whim.Tests/Store/WorkspaceSector/Transforms/CycleLayoutEngineTransformTests.cs
@@ -26,7 +26,7 @@ public class CycleLayoutEngineTransformTests
 		// Given
 		Workspace workspace = CreateWorkspace(ctx) with
 		{
-			LayoutEngines = ImmutableList.Create(engine1, engine2, engine3),
+			LayoutEngines = [engine1, engine2, engine3],
 			ActiveLayoutEngineIndex = startIdx
 		};
 		AddWorkspaceToManager(ctx, rootSector, workspace);

--- a/src/Whim.Tests/Store/WorkspaceSector/Transforms/FocusWindowInDirectionTransformTests.cs
+++ b/src/Whim.Tests/Store/WorkspaceSector/Transforms/FocusWindowInDirectionTransformTests.cs
@@ -24,7 +24,7 @@ public class FocusWindowInDirectionTransformTests
 			window,
 			CreateWorkspace(ctx) with
 			{
-				LayoutEngines = ImmutableList.Create(engine1, engine2),
+				LayoutEngines = [engine1, engine2],
 				ActiveLayoutEngineIndex = 1
 			}
 		);
@@ -65,7 +65,7 @@ public class FocusWindowInDirectionTransformTests
 			window,
 			CreateWorkspace(ctx) with
 			{
-				LayoutEngines = ImmutableList.Create(engine1, engine2),
+				LayoutEngines = [engine1, engine2],
 				ActiveLayoutEngineIndex = 1
 			}
 		);

--- a/src/Whim.Tests/Store/WorkspaceSector/Transforms/LayoutEngineCustomActionTransformTests.cs
+++ b/src/Whim.Tests/Store/WorkspaceSector/Transforms/LayoutEngineCustomActionTransformTests.cs
@@ -31,10 +31,11 @@ public class LayoutEngineCustomActionTransformTests
 		// Given none of the layout engines support the action
 		Workspace workspace = CreateWorkspace(ctx, WorkspaceId) with
 		{
-			LayoutEngines = ImmutableList.Create(
+			LayoutEngines =
+			[
 				CreateLayoutEngineNotSupportingAction<IWindow?>(),
 				CreateLayoutEngineNotSupportingAction<IWindow?>()
-			)
+			]
 		};
 		AddWorkspaceToManager(ctx, rootSector, workspace);
 
@@ -56,11 +57,12 @@ public class LayoutEngineCustomActionTransformTests
 		// Given the first and third layout engines support the action
 		Workspace workspace = CreateWorkspace(ctx, WorkspaceId) with
 		{
-			LayoutEngines = ImmutableList.Create(
+			LayoutEngines =
+			[
 				CreateLayoutEngineSupportingAction<IWindow?>(),
 				CreateLayoutEngineNotSupportingAction<IWindow?>(),
-				CreateLayoutEngineSupportingAction<IWindow?>()
-			)
+				CreateLayoutEngineSupportingAction<IWindow?>(),
+			]
 		};
 		AddWorkspaceToManager(ctx, root, workspace);
 

--- a/src/Whim.Tests/Store/WorkspaceSector/Transforms/MinimizeWindowEndTransformTests.cs
+++ b/src/Whim.Tests/Store/WorkspaceSector/Transforms/MinimizeWindowEndTransformTests.cs
@@ -24,7 +24,7 @@ public class MinimizeWindowEndTransformTests
 			window,
 			CreateWorkspace(ctx) with
 			{
-				LayoutEngines = ImmutableList.Create(engine1, engine2),
+				LayoutEngines = [engine1, engine2],
 				ActiveLayoutEngineIndex = 1
 			}
 		);
@@ -65,7 +65,7 @@ public class MinimizeWindowEndTransformTests
 			window,
 			CreateWorkspace(ctx) with
 			{
-				LayoutEngines = ImmutableList.Create(engine1, engine2),
+				LayoutEngines = [engine1, engine2],
 				ActiveLayoutEngineIndex = 1
 			}
 		);

--- a/src/Whim.Tests/Store/WorkspaceSector/Transforms/MinimizeWindowStartTransformTests.cs
+++ b/src/Whim.Tests/Store/WorkspaceSector/Transforms/MinimizeWindowStartTransformTests.cs
@@ -16,7 +16,7 @@ public class MinimizeWindowStartTransformTests
 		// Given the window is already in the workspace
 		IWindow window = CreateWindow((HWND)1);
 
-		Workspace workspace = CreateWorkspace(ctx) with { LayoutEngines = ImmutableList.Create(engine1, engine2) };
+		Workspace workspace = CreateWorkspace(ctx) with { LayoutEngines = [engine1, engine2] };
 		workspace = PopulateWindowWorkspaceMap(ctx, root, window, workspace);
 
 		MinimizeWindowStartTransform sut = new(workspace.Id, window.Handle);
@@ -43,7 +43,7 @@ public class MinimizeWindowStartTransformTests
 		IWindow window = CreateWindow((HWND)1);
 		AddWindowToSector(root, window);
 
-		Workspace workspace = CreateWorkspace(ctx) with { LayoutEngines = ImmutableList.Create(engine1, engine2) };
+		Workspace workspace = CreateWorkspace(ctx) with { LayoutEngines = [engine1, engine2] };
 		AddWorkspaceToManager(ctx, root, workspace);
 
 		MinimizeWindowStartTransform sut = new(workspace.Id, window.Handle);

--- a/src/Whim.Tests/Store/WorkspaceSector/Transforms/MoveWindowEdgesInDirectionWorkspaceTransformTests.cs
+++ b/src/Whim.Tests/Store/WorkspaceSector/Transforms/MoveWindowEdgesInDirectionWorkspaceTransformTests.cs
@@ -25,7 +25,7 @@ public class MoveWindowEdgesInDirectionWorkspaceTransformTests
 			window,
 			CreateWorkspace(ctx) with
 			{
-				LayoutEngines = ImmutableList.Create(engine1, engine2),
+				LayoutEngines = [engine1, engine2],
 				ActiveLayoutEngineIndex = 1
 			}
 		);
@@ -73,7 +73,7 @@ public class MoveWindowEdgesInDirectionWorkspaceTransformTests
 			window,
 			CreateWorkspace(ctx) with
 			{
-				LayoutEngines = ImmutableList.Create(engine1, engine2),
+				LayoutEngines = [engine1, engine2],
 				ActiveLayoutEngineIndex = 1
 			}
 		);

--- a/src/Whim.Tests/Store/WorkspaceSector/Transforms/MoveWindowToPointInWorkspaceTransformTests.cs
+++ b/src/Whim.Tests/Store/WorkspaceSector/Transforms/MoveWindowToPointInWorkspaceTransformTests.cs
@@ -23,7 +23,7 @@ public class MoveWindowToPointInWorkspaceTransformTests
 			window,
 			CreateWorkspace(ctx) with
 			{
-				LayoutEngines = ImmutableList.Create(engine1, engine2)
+				LayoutEngines = [engine1, engine2]
 			}
 		);
 		Point<double> point = new(0.5, 0.5);
@@ -56,7 +56,7 @@ public class MoveWindowToPointInWorkspaceTransformTests
 		IWindow window = CreateWindow(handle);
 		AddWindowToSector(root, window);
 
-		Workspace workspace = CreateWorkspace(ctx) with { LayoutEngines = ImmutableList.Create(engine1, engine2) };
+		Workspace workspace = CreateWorkspace(ctx) with { LayoutEngines = [engine1, engine2] };
 		AddWorkspaceToManager(ctx, root, workspace);
 		Point<double> point = new(0.5, 0.5);
 

--- a/src/Whim.Tests/Store/WorkspaceSector/Transforms/SetCreateLayoutEnginesTransformTests.cs
+++ b/src/Whim.Tests/Store/WorkspaceSector/Transforms/SetCreateLayoutEnginesTransformTests.cs
@@ -11,8 +11,7 @@ public class SetCreateLayoutEnginesTransformTests
 	)
 	{
 		// Given
-		Func<CreateLeafLayoutEngine[]> createLayoutEnginesFn = () =>
-			new CreateLeafLayoutEngine[] { (id) => engine1, (id) => engine2 };
+		Func<CreateLeafLayoutEngine[]> createLayoutEnginesFn = () => [(id) => engine1, (id) => engine2];
 
 		// When
 		var result = ctx.Store.Dispatch(new SetCreateLayoutEnginesTransform(createLayoutEnginesFn));

--- a/src/Whim.Tests/Store/WorkspaceSector/Transforms/SwapWIndowInDirectionTransformTests.cs
+++ b/src/Whim.Tests/Store/WorkspaceSector/Transforms/SwapWIndowInDirectionTransformTests.cs
@@ -24,7 +24,7 @@ public class SwapWindowInDirectionTransformTests
 			window,
 			CreateWorkspace(ctx) with
 			{
-				LayoutEngines = ImmutableList.Create(engine1, engine2),
+				LayoutEngines = [engine1, engine2],
 				ActiveLayoutEngineIndex = 1
 			}
 		);
@@ -65,7 +65,7 @@ public class SwapWindowInDirectionTransformTests
 			window,
 			CreateWorkspace(ctx) with
 			{
-				LayoutEngines = ImmutableList.Create(engine1, engine2),
+				LayoutEngines = [engine1, engine2],
 				ActiveLayoutEngineIndex = 1
 			}
 		);

--- a/src/Whim.Tests/Store/WorkspaceSector/WorkspacePickersTests.cs
+++ b/src/Whim.Tests/Store/WorkspaceSector/WorkspacePickersTests.cs
@@ -142,7 +142,7 @@ public class WorkspacePickersTests
 
 		Workspace activeWorkspace = CreateWorkspace(ctx) with
 		{
-			LayoutEngines = ImmutableList.Create(layoutEngine1, layoutEngine2),
+			LayoutEngines = [layoutEngine1, layoutEngine2],
 			ActiveLayoutEngineIndex = 1
 		};
 		PopulateMonitorWorkspaceMap(ctx, root, CreateMonitor((HMONITOR)1), activeWorkspace);

--- a/src/Whim.Tests/Store/WorkspaceSector/WorkspacePickersTests.cs
+++ b/src/Whim.Tests/Store/WorkspaceSector/WorkspacePickersTests.cs
@@ -388,11 +388,7 @@ public class WorkspacePickersTests
 	{
 		// Given the workspaces and windows
 		Func<CreateLeafLayoutEngine[]> createLayoutEngines = () =>
-			new CreateLeafLayoutEngine[]
-			{
-				(id) => Substitute.For<ILayoutEngine>(),
-				(id) => Substitute.For<ILayoutEngine>(),
-			};
+			[(id) => Substitute.For<ILayoutEngine>(), (id) => Substitute.For<ILayoutEngine>(),];
 
 		root.WorkspaceSector.CreateLayoutEngines = createLayoutEngines;
 

--- a/src/Whim.Tests/Store/WorkspaceSector/WorkspaceSectorTests.cs
+++ b/src/Whim.Tests/Store/WorkspaceSector/WorkspaceSectorTests.cs
@@ -57,7 +57,7 @@ public class WorkspaceSectorTests
 
 		// When
 		root.WorkspaceSector.WorkspacesToLayout = root.WorkspaceSector.WorkspacesToLayout.Add(workspace.Id);
-		CustomAssert.Layout(root, root.WorkspaceSector.DoLayout, new[] { workspace.Id });
+		CustomAssert.Layout(root, root.WorkspaceSector.DoLayout, [workspace.Id]);
 
 		// Then
 		ctx.NativeManager.Received(2).TryEnqueue(Arg.Any<DispatcherQueueHandler>());
@@ -93,7 +93,7 @@ public class WorkspaceSectorTests
 		sut.WorkspacesToLayout = sut.WorkspacesToLayout.Add(workspace.Id);
 
 		// When we do the layout
-		CustomAssert.Layout(root, root.WorkspaceSector.DoLayout, new[] { workspace.Id });
+		CustomAssert.Layout(root, root.WorkspaceSector.DoLayout, [workspace.Id]);
 
 		// Then the invalid window should be removed from the workspace.
 		Assert.DoesNotContain(invalidWindow.Handle, sut.Workspaces[workspace.Id].WindowPositions.Keys);
@@ -115,7 +115,7 @@ public class WorkspaceSectorTests
 		sut.WindowHandleToFocus = window.Handle;
 
 		// When we do the layout
-		CustomAssert.Layout(root, root.WorkspaceSector.DoLayout, new[] { workspace.Id });
+		CustomAssert.Layout(root, root.WorkspaceSector.DoLayout, [workspace.Id]);
 
 		// Then the window should be focused
 		window.Received().Focus();

--- a/src/Whim.Tests/Store/WorkspaceSector/WorkspaceSectorTests.cs
+++ b/src/Whim.Tests/Store/WorkspaceSector/WorkspaceSectorTests.cs
@@ -50,7 +50,7 @@ public class WorkspaceSectorTests
 				}
 			});
 
-		Workspace workspace = CreateWorkspace(ctx) with { LayoutEngines = ImmutableList.Create(engine) };
+		Workspace workspace = CreateWorkspace(ctx) with { LayoutEngines = [engine] };
 		PopulateMonitorWorkspaceMap(ctx, root, CreateMonitor((HMONITOR)1), workspace);
 
 		ctx.NativeManager.DeferWindowPos().Returns(new DeferWindowPosHandle(ctx, internalCtx));

--- a/src/Whim.Tests/Store/WorkspaceSector/WorkspaceUtilsTests.cs
+++ b/src/Whim.Tests/Store/WorkspaceSector/WorkspaceUtilsTests.cs
@@ -47,7 +47,7 @@ public class WorkspaceUtilsTests
 		// Given
 		Workspace workspace = CreateWorkspace(ctx) with
 		{
-			LayoutEngines = ImmutableList.Create(engine1, engine2, engine3),
+			LayoutEngines = [engine1, engine2, engine3],
 			ActiveLayoutEngineIndex = 1
 		};
 		int newActiveLayoutEngineIndex = 2;
@@ -81,7 +81,7 @@ public class WorkspaceUtilsTests
 		// Given
 		Workspace workspace = CreateWorkspace(ctx) with
 		{
-			LayoutEngines = ImmutableList.Create(engine),
+			LayoutEngines = [engine],
 			ActiveLayoutEngineIndex = 0
 		};
 		int newActiveLayoutEngineIndex = 0;

--- a/src/Whim.Tests/Workspace/LegacyWorkspaceTests.cs
+++ b/src/Whim.Tests/Workspace/LegacyWorkspaceTests.cs
@@ -60,7 +60,7 @@ public class LegacyWorkspaceTests
 		// Given
 		Workspace workspace = CreateWorkspace(ctx) with
 		{
-			LayoutEngines = ImmutableList.Create(engine)
+			LayoutEngines = [engine]
 		};
 		AddWorkspaceToManager(ctx, root, workspace);
 

--- a/src/Whim.Tests/Workspace/LegacyWorkspaceTests.cs
+++ b/src/Whim.Tests/Workspace/LegacyWorkspaceTests.cs
@@ -1,5 +1,4 @@
 ﻿using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using FluentAssertions;
 
 namespace Whim.Tests;

--- a/src/Whim.Tests/Workspace/WorkspaceManagerTests.cs
+++ b/src/Whim.Tests/Workspace/WorkspaceManagerTests.cs
@@ -80,7 +80,7 @@ public class WorkspaceManagerTests
 		WorkspaceManager sut = new(ctx);
 
 		// When
-		var _ = sut.Add("test", Array.Empty<CreateLeafLayoutEngine>());
+		var _ = sut.Add("test", []);
 
 		// Then
 		ctx.Store.Received(1).Dispatch(Arg.Any<AddWorkspaceTransform>());

--- a/src/Whim.TreeLayout.Bar.Tests/Directory.Build.props
+++ b/src/Whim.TreeLayout.Bar.Tests/Directory.Build.props
@@ -1,5 +1,6 @@
 <Project>
 	<PropertyGroup>
-		<GenerateDocumentationFile>false</GenerateDocumentationFile>
+		<GenerateDocumentationFile>true</GenerateDocumentationFile>
+		<NoWarn>$(NoWarn);CS1591</NoWarn>
 	</PropertyGroup>
 </Project>

--- a/src/Whim.TreeLayout.Bar.Tests/GlobalSuppressions.cs
+++ b/src/Whim.TreeLayout.Bar.Tests/GlobalSuppressions.cs
@@ -14,3 +14,5 @@ using System.Diagnostics.CodeAnalysis;
 [assembly: SuppressMessage("Style", "IDE0042:Variable declaration can be deconstructed")]
 [assembly: SuppressMessage("Style", "IDE0058:Expression value is never used")]
 [assembly: SuppressMessage("Style", "IDE0022:Use expression body for methods")]
+[assembly: SuppressMessage("Performance", "CA1852:Seal internal types")]
+[assembly: SuppressMessage("Performance", "CA1861:Avoid constant arrays as arguments")]

--- a/src/Whim.TreeLayout.Bar/ToggleDirectionCommand.cs
+++ b/src/Whim.TreeLayout.Bar/ToggleDirectionCommand.cs
@@ -5,23 +5,19 @@ namespace Whim.TreeLayout.Bar;
 /// <summary>
 /// Command for toggling the direction to add new windows in.
 /// </summary>
-public class ToggleDirectionCommand : System.Windows.Input.ICommand
+/// <remarks>
+/// Creates a new instance of <see cref="ToggleDirectionCommand"/>.
+/// </remarks>
+/// <param name="viewModel"></param>
+public class ToggleDirectionCommand(TreeLayoutEngineWidgetViewModel viewModel) : System.Windows.Input.ICommand
 {
-	private readonly TreeLayoutEngineWidgetViewModel _viewModel;
+	private readonly TreeLayoutEngineWidgetViewModel _viewModel = viewModel;
 
 	/// <inheritdoc/>
 #pragma warning disable CS0067 // The event 'ToggleDirectionCommand.CanExecuteChanged' is never used
 	public event EventHandler? CanExecuteChanged;
-#pragma warning restore CS0067 // The event 'ToggleDirectionCommand.CanExecuteChanged' is never used
 
-	/// <summary>
-	/// Creates a new instance of <see cref="ToggleDirectionCommand"/>.
-	/// </summary>
-	/// <param name="viewModel"></param>
-	public ToggleDirectionCommand(TreeLayoutEngineWidgetViewModel viewModel)
-	{
-		_viewModel = viewModel;
-	}
+#pragma warning restore CS0067 // The event 'ToggleDirectionCommand.CanExecuteChanged' is never used
 
 	/// <inheritdoc/>
 	public bool CanExecute(object? parameter) => true;

--- a/src/Whim.TreeLayout.Bar/TreeLayoutBarPlugin.cs
+++ b/src/Whim.TreeLayout.Bar/TreeLayoutBarPlugin.cs
@@ -6,9 +6,13 @@ namespace Whim.TreeLayout.Bar;
 /// <summary>
 /// This plugin contains the tree layout engine widget for the <see cref="IBarPlugin"/>.
 /// </summary>
-public class TreeLayoutBarPlugin : IPlugin
+/// <remarks>
+/// Create a new instance of the <see cref="TreeLayoutBarPlugin"/> class.
+/// </remarks>
+/// <param name="plugin"></param>
+public class TreeLayoutBarPlugin(ITreeLayoutPlugin plugin) : IPlugin
 {
-	private readonly ITreeLayoutPlugin _plugin;
+	private readonly ITreeLayoutPlugin _plugin = plugin;
 
 	/// <summary>
 	/// <c>whim.tree_layout.bar</c>
@@ -17,15 +21,6 @@ public class TreeLayoutBarPlugin : IPlugin
 
 	/// <inheritdoc/>
 	public IPluginCommands PluginCommands => new PluginCommands(Name);
-
-	/// <summary>
-	/// Create a new instance of the <see cref="TreeLayoutBarPlugin"/> class.
-	/// </summary>
-	/// <param name="plugin"></param>
-	public TreeLayoutBarPlugin(ITreeLayoutPlugin plugin)
-	{
-		_plugin = plugin;
-	}
 
 	/// <inheritdoc/>
 	public void PreInitialize() { }

--- a/src/Whim.TreeLayout.CommandPalette.Tests/Directory.Build.props
+++ b/src/Whim.TreeLayout.CommandPalette.Tests/Directory.Build.props
@@ -1,5 +1,6 @@
 <Project>
 	<PropertyGroup>
-		<GenerateDocumentationFile>false</GenerateDocumentationFile>
+		<GenerateDocumentationFile>true</GenerateDocumentationFile>
+		<NoWarn>$(NoWarn);CS1591</NoWarn>
 	</PropertyGroup>
 </Project>

--- a/src/Whim.TreeLayout.CommandPalette/TreeLayoutCommandPaletteCommands.cs
+++ b/src/Whim.TreeLayout.CommandPalette/TreeLayoutCommandPaletteCommands.cs
@@ -11,13 +11,7 @@ public class TreeLayoutCommandPalettePluginCommands : PluginCommands
 	private readonly IContext _context;
 	private readonly ITreeLayoutPlugin _treeLayoutPlugin;
 
-	private readonly Direction[] _directions = new Direction[]
-	{
-		Direction.Left,
-		Direction.Right,
-		Direction.Up,
-		Direction.Down,
-	};
+	private readonly Direction[] _directions = [Direction.Left, Direction.Right, Direction.Up, Direction.Down,];
 
 	/// <summary>
 	/// Create the tree layout command palette plugin commands.

--- a/src/Whim.TreeLayout.CommandPalette/TreeLayoutCommandPalettePlugin.cs
+++ b/src/Whim.TreeLayout.CommandPalette/TreeLayoutCommandPalettePlugin.cs
@@ -6,33 +6,26 @@ namespace Whim.TreeLayout.CommandPalette;
 /// <summary>
 /// This plugin contains commands to interact with the tree layout via the command palette.
 /// </summary>
-public class TreeLayoutCommandPalettePlugin : IPlugin
+/// <remarks>
+/// Creates a new instance of the tree layout command palette plugin.
+/// </remarks>
+/// <param name="context"></param>
+/// <param name="treeLayoutPlugin"></param>
+/// <param name="commandPalettePlugin"></param>
+public class TreeLayoutCommandPalettePlugin(
+	IContext context,
+	ITreeLayoutPlugin treeLayoutPlugin,
+	ICommandPalettePlugin commandPalettePlugin
+	) : IPlugin
 {
-	private readonly IContext _context;
-	private readonly ITreeLayoutPlugin _treeLayoutPlugin;
-	private readonly ICommandPalettePlugin _commandLayoutPlugin;
+	private readonly IContext _context = context;
+	private readonly ITreeLayoutPlugin _treeLayoutPlugin = treeLayoutPlugin;
+	private readonly ICommandPalettePlugin _commandLayoutPlugin = commandPalettePlugin;
 
 	/// <summary>
 	/// <c>whim.tree_layout.command_palette</c>
 	/// </summary>
 	public string Name => "whim.tree_layout.command_palette";
-
-	/// <summary>
-	/// Creates a new instance of the tree layout command palette plugin.
-	/// </summary>
-	/// <param name="context"></param>
-	/// <param name="treeLayoutPlugin"></param>
-	/// <param name="commandPalettePlugin"></param>
-	public TreeLayoutCommandPalettePlugin(
-		IContext context,
-		ITreeLayoutPlugin treeLayoutPlugin,
-		ICommandPalettePlugin commandPalettePlugin
-	)
-	{
-		_context = context;
-		_treeLayoutPlugin = treeLayoutPlugin;
-		_commandLayoutPlugin = commandPalettePlugin;
-	}
 
 	/// <inheritdoc />
 	public IPluginCommands PluginCommands =>

--- a/src/Whim.TreeLayout.CommandPalette/TreeLayoutCommandPalettePlugin.cs
+++ b/src/Whim.TreeLayout.CommandPalette/TreeLayoutCommandPalettePlugin.cs
@@ -16,7 +16,7 @@ public class TreeLayoutCommandPalettePlugin(
 	IContext context,
 	ITreeLayoutPlugin treeLayoutPlugin,
 	ICommandPalettePlugin commandPalettePlugin
-	) : IPlugin
+) : IPlugin
 {
 	private readonly IContext _context = context;
 	private readonly ITreeLayoutPlugin _treeLayoutPlugin = treeLayoutPlugin;

--- a/src/Whim.TreeLayout.Tests/Directory.Build.props
+++ b/src/Whim.TreeLayout.Tests/Directory.Build.props
@@ -1,5 +1,6 @@
 <Project>
 	<PropertyGroup>
-		<GenerateDocumentationFile>false</GenerateDocumentationFile>
+		<GenerateDocumentationFile>true</GenerateDocumentationFile>
+		<NoWarn>$(NoWarn);CS1591</NoWarn>
 	</PropertyGroup>
 </Project>

--- a/src/Whim.TreeLayout.Tests/GlobalSuppressions.cs
+++ b/src/Whim.TreeLayout.Tests/GlobalSuppressions.cs
@@ -17,3 +17,4 @@ using System.Diagnostics.CodeAnalysis;
 [assembly: SuppressMessage("Design", "CA1024:Use properties where appropriate")]
 [assembly: SuppressMessage("Performance", "CA1852:Seal internal types")]
 [assembly: SuppressMessage("Performance", "CA1861:Avoid constant arrays as arguments")]
+[assembly: SuppressMessage("Performance", "CA1859:Use concrete types when possible for improved performance")]

--- a/src/Whim.TreeLayout.Tests/GlobalSuppressions.cs
+++ b/src/Whim.TreeLayout.Tests/GlobalSuppressions.cs
@@ -15,3 +15,5 @@ using System.Diagnostics.CodeAnalysis;
 [assembly: SuppressMessage("Style", "IDE0058:Expression value is never used")]
 [assembly: SuppressMessage("Style", "IDE0022:Use expression body for methods")]
 [assembly: SuppressMessage("Design", "CA1024:Use properties where appropriate")]
+[assembly: SuppressMessage("Performance", "CA1852:Seal internal types")]
+[assembly: SuppressMessage("Performance", "CA1861:Avoid constant arrays as arguments")]

--- a/src/Whim.TreeLayout.Tests/LayoutEngine/AddWindowTests.cs
+++ b/src/Whim.TreeLayout.Tests/LayoutEngine/AddWindowTests.cs
@@ -45,8 +45,7 @@ public class AddWindowTests
 		windowStates
 			.Should()
 			.Equal(
-				new IWindowState[]
-				{
+				[
 					new WindowState()
 					{
 						Window = window1,
@@ -71,7 +70,7 @@ public class AddWindowTests
 						},
 						WindowSize = WindowSize.Normal
 					}
-				}
+				]
 			);
 	}
 
@@ -104,8 +103,7 @@ public class AddWindowTests
 		windowStates
 			.Should()
 			.Equal(
-				new IWindowState[]
-				{
+				[
 					new WindowState()
 					{
 						Window = window1,
@@ -142,7 +140,7 @@ public class AddWindowTests
 						},
 						WindowSize = WindowSize.Normal
 					}
-				}
+				]
 			);
 	}
 
@@ -175,8 +173,7 @@ public class AddWindowTests
 		windowStates
 			.Should()
 			.Equal(
-				new IWindowState[]
-				{
+				[
 					new WindowState()
 					{
 						Window = window1,
@@ -213,7 +210,7 @@ public class AddWindowTests
 						},
 						WindowSize = WindowSize.Normal
 					}
-				}
+				]
 			);
 	}
 
@@ -248,8 +245,7 @@ public class AddWindowTests
 		windowStates
 			.Should()
 			.Equal(
-				new IWindowState[]
-				{
+				[
 					new WindowState()
 					{
 						Window = window1,
@@ -286,7 +282,7 @@ public class AddWindowTests
 						},
 						WindowSize = WindowSize.Normal
 					}
-				}
+				]
 			);
 	}
 
@@ -321,8 +317,7 @@ public class AddWindowTests
 		windowStates
 			.Should()
 			.Equal(
-				new IWindowState[]
-				{
+				[
 					new WindowState()
 					{
 						Window = window1,
@@ -359,7 +354,7 @@ public class AddWindowTests
 						},
 						WindowSize = WindowSize.Normal
 					}
-				}
+				]
 			);
 	}
 
@@ -387,8 +382,7 @@ public class AddWindowTests
 		windowStates
 			.Should()
 			.Equal(
-				new IWindowState[]
-				{
+				[
 					new WindowState()
 					{
 						Window = window1,
@@ -413,7 +407,7 @@ public class AddWindowTests
 						},
 						WindowSize = WindowSize.Normal
 					}
-				}
+				]
 			);
 	}
 
@@ -441,8 +435,7 @@ public class AddWindowTests
 		windowStates
 			.Should()
 			.Equal(
-				new IWindowState[]
-				{
+				[
 					new WindowState()
 					{
 						Window = window,
@@ -455,7 +448,7 @@ public class AddWindowTests
 						},
 						WindowSize = WindowSize.Normal
 					}
-				}
+				]
 			);
 	}
 }

--- a/src/Whim.TreeLayout.Tests/LayoutEngine/DoLayoutTests.cs
+++ b/src/Whim.TreeLayout.Tests/LayoutEngine/DoLayoutTests.cs
@@ -34,8 +34,8 @@ public class DoLayoutTests
 
 		IWindow[] minimizedWindows = Enumerable.Range(0, 2).Select(_ => Substitute.For<IWindow>()).ToArray();
 
-		IWindowState[] expectedWindowStates = new IWindowState[]
-		{
+		IWindowState[] expectedWindowStates =
+		[
 			new WindowState()
 			{
 				Rectangle = new Rectangle<int>(),
@@ -48,7 +48,7 @@ public class DoLayoutTests
 				Window = minimizedWindows[1],
 				WindowSize = WindowSize.Minimized
 			}
-		};
+		];
 
 		// When the windows are added, and DoLayout is called
 		for (int idx = 0; idx < minimizedWindows.Length; idx++)
@@ -76,8 +76,8 @@ public class DoLayoutTests
 		IWindow[] windows = Enumerable.Range(0, 2).Select(_ => Substitute.For<IWindow>()).ToArray();
 		IWindow[] minimizedWindows = Enumerable.Range(0, 2).Select(_ => Substitute.For<IWindow>()).ToArray();
 
-		IWindowState[] expectedWindowStates = new IWindowState[]
-		{
+		IWindowState[] expectedWindowStates =
+		[
 			new WindowState()
 			{
 				Rectangle = new Rectangle<int>()
@@ -114,7 +114,7 @@ public class DoLayoutTests
 				Window = minimizedWindows[1],
 				WindowSize = WindowSize.Minimized
 			}
-		};
+		];
 
 		// When the windows are added, and DoLayout is called
 		for (int idx = 0; idx < windows.Length; idx++)

--- a/src/Whim.TreeLayout.Tests/LayoutEngine/MoveWindowEdgesInDirectionTests.cs
+++ b/src/Whim.TreeLayout.Tests/LayoutEngine/MoveWindowEdgesInDirectionTests.cs
@@ -135,7 +135,7 @@ public class MoveSingleWindowEdgeInDirectionTests
 	{
 		get
 		{
-			TheoryData<Direction, IPoint<double>, IWindow[], IWindowState[]> data = new();
+			TheoryData<Direction, IPoint<double>, IWindow[], IWindowState[]> data = [];
 
 			// Move left edge to the left.
 			IWindow[] leftEdgeLeftWindows = CreateWindows(3);
@@ -369,7 +369,7 @@ public class MoveSingleWindowEdgeInDirectionTests
 	{
 		get
 		{
-			TheoryData<Direction, IPoint<double>, IWindow[], IWindowState[]> data = new();
+			TheoryData<Direction, IPoint<double>, IWindow[], IWindowState[]> data = [];
 
 			// Move top edge up.
 			IWindow[] topEdgeUpWindows = CreateWindows(3);
@@ -588,7 +588,7 @@ public class MoveSingleWindowEdgeInDirectionTests
 	{
 		get
 		{
-			TheoryData<string, Direction, IPoint<double>, IWindow[], IWindowState[]> data = new();
+			TheoryData<string, Direction, IPoint<double>, IWindow[], IWindowState[]> data = [];
 
 			// Move top left window's bottom-right edge up and left.
 			IWindow[] windows1 = CreateWindows(4);

--- a/src/Whim.TreeLayout.Tests/LayoutEngine/MoveWindowEdgesInDirectionTests.cs
+++ b/src/Whim.TreeLayout.Tests/LayoutEngine/MoveWindowEdgesInDirectionTests.cs
@@ -143,8 +143,7 @@ public class MoveSingleWindowEdgeInDirectionTests
 				Direction.Left,
 				new Point<double>() { X = -0.1 },
 				leftEdgeLeftWindows,
-				new IWindowState[]
-				{
+				[
 					new WindowState()
 					{
 						Window = leftEdgeLeftWindows[0],
@@ -181,7 +180,7 @@ public class MoveSingleWindowEdgeInDirectionTests
 						},
 						WindowSize = WindowSize.Normal
 					}
-				}
+				]
 			);
 
 			// Move left edge to the right.
@@ -190,8 +189,7 @@ public class MoveSingleWindowEdgeInDirectionTests
 				Direction.Left,
 				new Point<double>() { X = 0.1 },
 				leftEdgeRightWindows,
-				new IWindowState[]
-				{
+				[
 					new WindowState()
 					{
 						Window = leftEdgeRightWindows[0],
@@ -228,7 +226,7 @@ public class MoveSingleWindowEdgeInDirectionTests
 						},
 						WindowSize = WindowSize.Normal
 					}
-				}
+				]
 			);
 
 			// Move right edge to the left.
@@ -237,8 +235,7 @@ public class MoveSingleWindowEdgeInDirectionTests
 				Direction.Right,
 				new Point<double>() { X = -0.1 },
 				rightEdgeLeftWindows,
-				new IWindowState[]
-				{
+				[
 					new WindowState()
 					{
 						Window = rightEdgeLeftWindows[0],
@@ -275,7 +272,7 @@ public class MoveSingleWindowEdgeInDirectionTests
 						},
 						WindowSize = WindowSize.Normal
 					}
-				}
+				]
 			);
 
 			// Move right edge to the right.
@@ -284,8 +281,7 @@ public class MoveSingleWindowEdgeInDirectionTests
 				Direction.Right,
 				new Point<double>() { X = 0.1 },
 				rightEdgeRightWindows,
-				new IWindowState[]
-				{
+				[
 					new WindowState()
 					{
 						Window = rightEdgeRightWindows[0],
@@ -322,7 +318,7 @@ public class MoveSingleWindowEdgeInDirectionTests
 						},
 						WindowSize = WindowSize.Normal
 					}
-				}
+				]
 			);
 
 			return data;
@@ -377,8 +373,7 @@ public class MoveSingleWindowEdgeInDirectionTests
 				Direction.Up,
 				new Point<double>() { Y = -0.1 },
 				topEdgeUpWindows,
-				new IWindowState[]
-				{
+				[
 					new WindowState()
 					{
 						Window = topEdgeUpWindows[0],
@@ -415,7 +410,7 @@ public class MoveSingleWindowEdgeInDirectionTests
 						},
 						WindowSize = WindowSize.Normal
 					}
-				}
+				]
 			);
 
 			// Move top edge down.
@@ -424,8 +419,7 @@ public class MoveSingleWindowEdgeInDirectionTests
 				Direction.Up,
 				new Point<double>() { Y = 0.1 },
 				topEdgeDownWindows,
-				new IWindowState[]
-				{
+				[
 					new WindowState()
 					{
 						Window = topEdgeDownWindows[0],
@@ -462,7 +456,7 @@ public class MoveSingleWindowEdgeInDirectionTests
 						},
 						WindowSize = WindowSize.Normal
 					}
-				}
+				]
 			);
 
 			// Move bottom edge up.
@@ -471,8 +465,7 @@ public class MoveSingleWindowEdgeInDirectionTests
 				Direction.Down,
 				new Point<double>() { Y = -0.1 },
 				bottomEdgeUpWindows,
-				new IWindowState[]
-				{
+				[
 					new WindowState()
 					{
 						Window = bottomEdgeUpWindows[0],
@@ -501,7 +494,7 @@ public class MoveSingleWindowEdgeInDirectionTests
 						},
 						WindowSize = WindowSize.Normal
 					}
-				}
+				]
 			);
 
 			// Move bottom edge down.
@@ -510,8 +503,7 @@ public class MoveSingleWindowEdgeInDirectionTests
 				Direction.Down,
 				new Point<double>() { Y = 0.1 },
 				bottomEdgeDownWindows,
-				new IWindowState[]
-				{
+				[
 					new WindowState()
 					{
 						Window = bottomEdgeDownWindows[0],
@@ -540,7 +532,7 @@ public class MoveSingleWindowEdgeInDirectionTests
 						},
 						WindowSize = WindowSize.Normal
 					}
-				}
+				]
 			);
 
 			return data;
@@ -597,8 +589,7 @@ public class MoveSingleWindowEdgeInDirectionTests
 				Direction.RightDown,
 				new Point<double>() { X = -0.1, Y = -0.1 },
 				windows1,
-				new IWindowState[]
-				{
+				[
 					new WindowState()
 					{
 						Window = windows1[0],
@@ -639,7 +630,7 @@ public class MoveSingleWindowEdgeInDirectionTests
 						},
 						WindowSize = WindowSize.Normal
 					}
-				}
+				]
 			);
 
 			// Move top left window's bottom-right edge down and right.
@@ -649,8 +640,7 @@ public class MoveSingleWindowEdgeInDirectionTests
 				Direction.RightDown,
 				new Point<double>() { X = 0.1, Y = 0.1 },
 				windows2,
-				new IWindowState[]
-				{
+				[
 					new WindowState()
 					{
 						Window = windows2[0],
@@ -691,7 +681,7 @@ public class MoveSingleWindowEdgeInDirectionTests
 						},
 						WindowSize = WindowSize.Normal
 					}
-				}
+				]
 			);
 
 			// Move top right window's bottom-left edge up and right.
@@ -701,8 +691,7 @@ public class MoveSingleWindowEdgeInDirectionTests
 				Direction.LeftDown,
 				new Point<double>() { X = 0.1, Y = -0.1 },
 				windows3,
-				new IWindowState[]
-				{
+				[
 					new WindowState()
 					{
 						Window = windows3[0],
@@ -743,7 +732,7 @@ public class MoveSingleWindowEdgeInDirectionTests
 						},
 						WindowSize = WindowSize.Normal
 					}
-				}
+				]
 			);
 
 			// Move top right window's bottom-left edge down and left.
@@ -753,8 +742,7 @@ public class MoveSingleWindowEdgeInDirectionTests
 				Direction.LeftDown,
 				new Point<double>() { X = -0.1, Y = 0.1 },
 				windows4,
-				new IWindowState[]
-				{
+				[
 					new WindowState()
 					{
 						Window = windows4[0],
@@ -795,7 +783,7 @@ public class MoveSingleWindowEdgeInDirectionTests
 						},
 						WindowSize = WindowSize.Normal
 					}
-				}
+				]
 			);
 
 			// Move bottom left window's top-right edge up and left.
@@ -805,8 +793,7 @@ public class MoveSingleWindowEdgeInDirectionTests
 				Direction.RightUp,
 				new Point<double>() { X = -0.1, Y = -0.1 },
 				windows5,
-				new IWindowState[]
-				{
+				[
 					new WindowState()
 					{
 						Window = windows5[0],
@@ -847,7 +834,7 @@ public class MoveSingleWindowEdgeInDirectionTests
 						},
 						WindowSize = WindowSize.Normal
 					}
-				}
+				]
 			);
 
 			// Move bottom left window's top-right edge down and right.
@@ -857,8 +844,7 @@ public class MoveSingleWindowEdgeInDirectionTests
 				Direction.RightUp,
 				new Point<double>() { X = 0.1, Y = 0.1 },
 				windows6,
-				new IWindowState[]
-				{
+				[
 					new WindowState()
 					{
 						Window = windows6[0],
@@ -899,7 +885,7 @@ public class MoveSingleWindowEdgeInDirectionTests
 						},
 						WindowSize = WindowSize.Normal
 					}
-				}
+				]
 			);
 
 			// Move bottom right window's top-left edge up and right.
@@ -909,8 +895,7 @@ public class MoveSingleWindowEdgeInDirectionTests
 				Direction.LeftUp,
 				new Point<double>() { X = 0.1, Y = -0.1 },
 				windows7,
-				new IWindowState[]
-				{
+				[
 					new WindowState()
 					{
 						Window = windows7[0],
@@ -951,7 +936,7 @@ public class MoveSingleWindowEdgeInDirectionTests
 						},
 						WindowSize = WindowSize.Normal
 					}
-				}
+				]
 			);
 
 			// Move bottom right window's top-left edge down and left.
@@ -961,8 +946,7 @@ public class MoveSingleWindowEdgeInDirectionTests
 				Direction.LeftUp,
 				new Point<double>() { X = -0.1, Y = 0.1 },
 				windows8,
-				new IWindowState[]
-				{
+				[
 					new WindowState()
 					{
 						Window = windows8[0],
@@ -1003,7 +987,7 @@ public class MoveSingleWindowEdgeInDirectionTests
 						},
 						WindowSize = WindowSize.Normal
 					}
-				}
+				]
 			);
 
 			return data;

--- a/src/Whim.TreeLayout.Tests/LayoutEngine/MoveWindowToPointTests.cs
+++ b/src/Whim.TreeLayout.Tests/LayoutEngine/MoveWindowToPointTests.cs
@@ -49,8 +49,7 @@ public class MoveWindowToPointTests
 		windowStates
 			.Should()
 			.Equal(
-				new IWindowState[]
-				{
+				[
 					new WindowState()
 					{
 						Window = window1,
@@ -75,7 +74,7 @@ public class MoveWindowToPointTests
 						},
 						WindowSize = WindowSize.Normal
 					}
-				}
+				]
 			);
 	}
 
@@ -104,8 +103,7 @@ public class MoveWindowToPointTests
 		windowStates
 			.Should()
 			.Equal(
-				new IWindowState[]
-				{
+				[
 					new WindowState()
 					{
 						Window = window1,
@@ -130,7 +128,7 @@ public class MoveWindowToPointTests
 						},
 						WindowSize = WindowSize.Normal
 					}
-				}
+				]
 			);
 	}
 
@@ -159,8 +157,7 @@ public class MoveWindowToPointTests
 		windowStates
 			.Should()
 			.Equal(
-				new IWindowState[]
-				{
+				[
 					new WindowState()
 					{
 						Window = window2,
@@ -185,7 +182,7 @@ public class MoveWindowToPointTests
 						},
 						WindowSize = WindowSize.Normal
 					}
-				}
+				]
 			);
 	}
 
@@ -214,8 +211,7 @@ public class MoveWindowToPointTests
 		windowStates
 			.Should()
 			.Equal(
-				new IWindowState[]
-				{
+				[
 					new WindowState()
 					{
 						Window = window2,
@@ -240,7 +236,7 @@ public class MoveWindowToPointTests
 						},
 						WindowSize = WindowSize.Normal
 					}
-				}
+				]
 			);
 	}
 
@@ -298,8 +294,7 @@ public class MoveWindowToPointTests
 		windowStates
 			.Should()
 			.Equal(
-				new IWindowState[]
-				{
+				[
 					new WindowState()
 					{
 						Window = window1,
@@ -336,7 +331,7 @@ public class MoveWindowToPointTests
 						},
 						WindowSize = WindowSize.Normal
 					}
-				}
+				]
 			);
 	}
 
@@ -372,8 +367,7 @@ public class MoveWindowToPointTests
 		windowStates
 			.Should()
 			.Equal(
-				new IWindowState[]
-				{
+				[
 					new WindowState()
 					{
 						Window = window1,
@@ -410,7 +404,7 @@ public class MoveWindowToPointTests
 						},
 						WindowSize = WindowSize.Normal
 					}
-				}
+				]
 			);
 	}
 
@@ -443,8 +437,7 @@ public class MoveWindowToPointTests
 		windowStates
 			.Should()
 			.Equal(
-				new IWindowState[]
-				{
+				[
 					new WindowState()
 					{
 						Window = window,
@@ -457,7 +450,7 @@ public class MoveWindowToPointTests
 						},
 						WindowSize = WindowSize.Normal
 					}
-				}
+				]
 			);
 	}
 }

--- a/src/Whim.TreeLayout.Tests/Tree/SplitNodeTests.cs
+++ b/src/Whim.TreeLayout.Tests/Tree/SplitNodeTests.cs
@@ -518,7 +518,7 @@ public class SplitNodeTests
 
 		// When
 		IEnumerator enumerator = (splitNode as IEnumerable).GetEnumerator();
-		List<(double, INode)> items = new();
+		List<(double, INode)> items = [];
 		while (enumerator.MoveNext())
 		{
 			if (enumerator.Current is (double weight, INode node))

--- a/src/Whim.TreeLayout.Tests/Tree/SplitNodeTests.cs
+++ b/src/Whim.TreeLayout.Tests/Tree/SplitNodeTests.cs
@@ -22,7 +22,7 @@ public class SplitNodeTests
 
 		// When
 		SplitNode splitNode = new(focusedNode, newNode, Direction.Right);
-		(double, INode)[] children = splitNode.ToArray();
+		(double, INode)[] children = [.. splitNode];
 
 		// Then
 		Assert.Equal(2, children.Length);
@@ -40,7 +40,7 @@ public class SplitNodeTests
 
 		// When
 		SplitNode splitNode = new(focusedNode, newNode, Direction.Left);
-		(double, INode)[] children = splitNode.ToArray();
+		(double, INode)[] children = [.. splitNode];
 
 		// Then
 		Assert.Equal(2, children.Length);
@@ -58,7 +58,7 @@ public class SplitNodeTests
 
 		// When
 		SplitNode splitNode = new(focusedNode, newNode, Direction.Up);
-		(double, INode)[] children = splitNode.ToArray();
+		(double, INode)[] children = [.. splitNode];
 
 		// Then
 		Assert.Equal(2, children.Length);
@@ -76,7 +76,7 @@ public class SplitNodeTests
 
 		// When
 		SplitNode splitNode = new(focusedNode, newNode, Direction.Down);
-		(double, INode)[] children = splitNode.ToArray();
+		(double, INode)[] children = [.. splitNode];
 
 		// Then
 		Assert.Equal(2, children.Length);
@@ -113,7 +113,7 @@ public class SplitNodeTests
 
 		// When
 		ISplitNode result = splitNode.Add(focusedNode, newNode, insertAfter: false);
-		(double, INode)[] children = result.ToArray();
+		(double, INode)[] children = [.. result];
 
 		// Then
 		double aThird = 1d / 3;
@@ -133,7 +133,7 @@ public class SplitNodeTests
 
 		// When
 		ISplitNode result = splitNode.Add(focusedNode, newNode, insertAfter: true);
-		(double, INode)[] children = result.ToArray();
+		(double, INode)[] children = [.. result];
 
 		// Then
 		double aThird = 1d / 3;
@@ -155,7 +155,7 @@ public class SplitNodeTests
 		// When
 		ISplitNode result = splitNode.ToggleEqualWeight();
 		ISplitNode result2 = result.Add(focusedNode, newNode, insertAfter: true);
-		(double, INode)[] children = result2.ToArray();
+		(double, INode)[] children = [.. result2];
 
 		// Then
 		Assert.NotSame(splitNode, result);
@@ -368,7 +368,7 @@ public class SplitNodeTests
 
 		// When
 		ISplitNode result = splitNode.Replace(oldNodeIndex, newNode);
-		(double, INode)[] children = result.ToArray();
+		(double, INode)[] children = [.. result];
 
 		// Then
 		Assert.NotSame(splitNode, result);
@@ -412,7 +412,7 @@ public class SplitNodeTests
 
 		// When
 		ISplitNode result = splitNode.Swap(aIndex, bIndex);
-		(double, INode)[] children = result.ToArray();
+		(double, INode)[] children = [.. result];
 
 		// Then
 		Assert.NotSame(splitNode, result);
@@ -453,7 +453,7 @@ public class SplitNodeTests
 
 		// When
 		ISplitNode result = splitNode.AdjustChildWeight(index, 0.1);
-		(double, INode)[] children = result.ToArray();
+		(double, INode)[] children = [.. result];
 
 		// Then
 		Assert.NotSame(splitNode, result);
@@ -478,7 +478,7 @@ public class SplitNodeTests
 
 		// When
 		ISplitNode result = splitNode.AdjustChildWeight(index, 0.1);
-		(double, INode)[] children = result.ToArray();
+		(double, INode)[] children = [.. result];
 
 		// Then
 		Assert.NotSame(splitNode, result);

--- a/src/Whim.TreeLayout.Tests/Tree/SplitNodeTests.cs
+++ b/src/Whim.TreeLayout.Tests/Tree/SplitNodeTests.cs
@@ -192,8 +192,8 @@ public class SplitNodeTests
 		INode node1 = CreateWindowNode();
 		INode node2 = CreateWindowNode();
 
-		ImmutableList<INode> nodes = ImmutableList.Create(node1, node2);
-		ImmutableList<double> weights = ImmutableList.Create(0.75, 0.25);
+		ImmutableList<INode> nodes = [node1, node2];
+		ImmutableList<double> weights = [0.75, 0.25];
 		SplitNode splitNode = new(equalWeight: false, isHorizontal: true, nodes, weights);
 
 		// When
@@ -215,8 +215,8 @@ public class SplitNodeTests
 		INode node1 = CreateWindowNode();
 		INode node2 = CreateWindowNode();
 
-		ImmutableList<INode> nodes = ImmutableList.Create(node1, node2);
-		ImmutableList<double> weights = ImmutableList.Create(0.75, 0.25);
+		ImmutableList<INode> nodes = [node1, node2];
+		ImmutableList<double> weights = [0.75, 0.25];
 		SplitNode splitNode = new(equalWeight: false, isHorizontal: true, nodes, weights);
 
 		// When
@@ -239,8 +239,8 @@ public class SplitNodeTests
 		INode node2 = CreateWindowNode();
 		INode node3 = CreateWindowNode();
 
-		ImmutableList<INode> nodes = ImmutableList.Create(node1, node2, node3);
-		ImmutableList<double> weights = ImmutableList.Create(0.5, 0.25, 0.25);
+		ImmutableList<INode> nodes = [node1, node2, node3];
+		ImmutableList<double> weights = [0.5, 0.25, 0.25];
 		SplitNode splitNode = new(equalWeight: false, isHorizontal: true, nodes, weights);
 
 		// When
@@ -265,8 +265,8 @@ public class SplitNodeTests
 		INode node2 = CreateWindowNode();
 		INode node3 = CreateWindowNode();
 
-		ImmutableList<INode> nodes = ImmutableList.Create(node1, node2, node3);
-		ImmutableList<double> weights = ImmutableList.Create(0.25, 0.25, 0.5);
+		ImmutableList<INode> nodes = [node1, node2, node3];
+		ImmutableList<double> weights = [0.25, 0.25, 0.5];
 		SplitNode splitNode = new(equalWeight: false, isHorizontal: true, nodes, weights);
 
 		// When
@@ -291,8 +291,8 @@ public class SplitNodeTests
 		INode node2 = CreateWindowNode();
 		INode node3 = CreateWindowNode();
 
-		ImmutableList<INode> nodes = ImmutableList.Create(node1, node2, node3);
-		ImmutableList<double> weights = ImmutableList.Create(0.5, 0.25, 0.25);
+		ImmutableList<INode> nodes = [node1, node2, node3];
+		ImmutableList<double> weights = [0.5, 0.25, 0.25];
 		SplitNode splitNode = new(equalWeight: false, isHorizontal: true, nodes, weights);
 
 		// When

--- a/src/Whim.TreeLayout.Tests/Tree/TreeHelpersTests.cs
+++ b/src/Whim.TreeLayout.Tests/Tree/TreeHelpersTests.cs
@@ -38,7 +38,7 @@ public class TreeHelpersTests
 	internal void GetNodeAtPath_WithEmptyPath_ReturnsRoot(INode root)
 	{
 		// When
-		var result = root.GetNodeAtPath(Array.Empty<int>());
+		var result = root.GetNodeAtPath([]);
 
 		// Then
 		Assert.NotNull(result);
@@ -630,7 +630,7 @@ public class TreeHelpersTests
 	{
 		// Given
 		WindowNode root = new(window);
-		IReadOnlyList<int> pathToNode = Array.Empty<int>();
+		IReadOnlyList<int> pathToNode = [];
 
 		// When
 		WindowNodeStateAtPoint? result = TreeHelpers.GetAdjacentWindowNode(root, pathToNode, Direction.Right, monitor);
@@ -643,7 +643,7 @@ public class TreeHelpersTests
 	internal void GetAdjacentNode_RootIsNotISplitNode(INode root, IMonitor monitor)
 	{
 		// Given
-		IReadOnlyList<int> pathToNode = Array.Empty<int>();
+		IReadOnlyList<int> pathToNode = [];
 
 		// When
 		WindowNodeStateAtPoint? result = TreeHelpers.GetAdjacentWindowNode(root, pathToNode, Direction.Right, monitor);
@@ -848,8 +848,8 @@ public class TreeHelpersTests
 	internal void GetLastCommonAncestor_EmptyList()
 	{
 		// Given
-		IReadOnlyList<int> pathToNode1 = Array.Empty<int>();
-		IReadOnlyList<int> pathToNode2 = Array.Empty<int>();
+		IReadOnlyList<int> pathToNode1 = [];
+		IReadOnlyList<int> pathToNode2 = [];
 
 		// When
 		int? result = TreeHelpers.GetLastCommonAncestorIndex(pathToNode1, pathToNode2);

--- a/src/Whim.TreeLayout.Tests/Tree/TreeHelpersTests.cs
+++ b/src/Whim.TreeLayout.Tests/Tree/TreeHelpersTests.cs
@@ -911,7 +911,7 @@ public class TreeHelpersTests
 			IWindow,
 			ImmutableArray<int>
 		>.Empty;
-		ImmutableArray<int> pathToNode = ImmutableArray.Create(1, 0, 0, 1, 0);
+		ImmutableArray<int> pathToNode = [1, 0, 0, 1, 0];
 
 		// When
 		ImmutableDictionary<IWindow, ImmutableArray<int>> result = TreeHelpers.CreateUpdatedPaths(
@@ -967,8 +967,8 @@ public class TreeHelpersTests
 	{
 		// Given
 		TestTree tree = new();
-		ImmutableArray<int> initialPath = ImmutableArray.Create(0);
-		ImmutableArray<int> pathToNode = ImmutableArray.Create(1, 0, 1);
+		ImmutableArray<int> initialPath = [0];
+		ImmutableArray<int> pathToNode = [1, 0, 1];
 
 		// When
 		ImmutableDictionary<IWindow, ImmutableArray<int>> originalDict = TreeHelpers.CreateUpdatedPaths(
@@ -1006,8 +1006,8 @@ public class TreeHelpersTests
 	{
 		// Given
 		TestTree tree = new();
-		ImmutableArray<int> initialPath = ImmutableArray.Create(0);
-		ImmutableArray<int> pathToNode = ImmutableArray.Create(0, 0);
+		ImmutableArray<int> initialPath = [0];
+		ImmutableArray<int> pathToNode = [0, 0];
 
 		// When
 		ImmutableDictionary<IWindow, ImmutableArray<int>> originalDict = TreeHelpers.CreateUpdatedPaths(

--- a/src/Whim.TreeLayout.Tests/Tree/TreeHelpersTests.cs
+++ b/src/Whim.TreeLayout.Tests/Tree/TreeHelpersTests.cs
@@ -299,12 +299,8 @@ public class TreeHelpersTests
 			new(
 				equalWeight: false,
 				isHorizontal: true,
-				new INode[]
-				{
-					new WindowNode(Substitute.For<IWindow>()),
-					new WindowNode(Substitute.For<IWindow>())
-				}.ToImmutableList(),
-				new double[] { 0.5, 0.25 }.ToImmutableList()
+				[new WindowNode(Substitute.For<IWindow>()), new WindowNode(Substitute.For<IWindow>())],
+				[0.5, 0.25]
 			);
 
 		Point<double> point = new() { X = 0.8, Y = 0.4 };
@@ -597,8 +593,9 @@ public class TreeHelpersTests
 		TestTree tree = new();
 		IRectangle<int> rectangle = new Rectangle<int>() { Width = 1920, Height = 1080 };
 
-		IWindowState[] expectedStates = TestTreeWindowStates
-			.GetAllWindowStates(
+		IWindowState[] expectedStates =
+		[
+			.. TestTreeWindowStates.GetAllWindowStates(
 				rectangle,
 				tree.Left.Window,
 				tree.RightTopLeftTop.Window,
@@ -610,7 +607,7 @@ public class TreeHelpersTests
 				tree.RightTopRight3.Window,
 				tree.RightBottom.Window
 			)
-			.ToArray();
+		];
 
 		// When
 		WindowNodeRectangleState[] windowRectangles = tree.Root.GetWindowRectangles(rectangle).ToArray();

--- a/src/Whim.TreeLayout.Tests/Tree/TreeHelpersTests.cs
+++ b/src/Whim.TreeLayout.Tests/Tree/TreeHelpersTests.cs
@@ -51,7 +51,7 @@ public class TreeHelpersTests
 	internal void GetNodeAtPath_CurrentNodeIsNotSplitNode(INode root)
 	{
 		// Given
-		int[] path = { 0 };
+		int[] path = [0];
 
 		// When
 		var result = root.GetNodeAtPath(path);
@@ -65,7 +65,7 @@ public class TreeHelpersTests
 	{
 		// Given
 		TestTree tree = new();
-		int[] path = { 1 };
+		int[] path = [1];
 
 		// When
 		var result = tree.Root.GetNodeAtPath(path);
@@ -89,7 +89,7 @@ public class TreeHelpersTests
 	{
 		// Given
 		TestTree tree = new();
-		int[] path = { 1, 0 };
+		int[] path = [1, 0];
 
 		// When
 		var result = tree.Root.GetNodeAtPath(path);
@@ -114,7 +114,7 @@ public class TreeHelpersTests
 	{
 		// Given
 		TestTree tree = new();
-		int[] path = { 1, 0, 0, 1, 1, 1 };
+		int[] path = [1, 0, 0, 1, 1, 1];
 
 		// When
 		var result = tree.Root.GetNodeAtPath(path);
@@ -657,7 +657,7 @@ public class TreeHelpersTests
 	{
 		// Given
 		TestTree tree = new();
-		IReadOnlyList<int> pathToNode = new[] { 0, 0, 0, 0, 0 };
+		IReadOnlyList<int> pathToNode = [0, 0, 0, 0, 0];
 
 		// When
 		WindowNodeStateAtPoint? result = TreeHelpers.GetAdjacentWindowNode(
@@ -676,7 +676,7 @@ public class TreeHelpersTests
 	{
 		// Given
 		TestTree tree = new();
-		IReadOnlyList<int> pathToNode = new[] { 0 };
+		IReadOnlyList<int> pathToNode = [0];
 
 		// When
 		WindowNodeStateAtPoint? result = TreeHelpers.GetAdjacentWindowNode(
@@ -695,7 +695,7 @@ public class TreeHelpersTests
 	{
 		// Given
 		TestTree tree = new();
-		IReadOnlyList<int> pathToNode = new[] { 1, 0, 0, 1, 0 };
+		IReadOnlyList<int> pathToNode = [1, 0, 0, 1, 0];
 
 		// When
 		WindowNodeStateAtPoint? result = TreeHelpers.GetAdjacentWindowNode(
@@ -714,7 +714,7 @@ public class TreeHelpersTests
 	{
 		// Given
 		TestTree tree = new();
-		IReadOnlyList<int> pathToNode = new[] { 1, 0, 0, 1, 0 };
+		IReadOnlyList<int> pathToNode = [1, 0, 0, 1, 0];
 
 		// When
 		WindowNodeStateAtPoint? result = TreeHelpers.GetAdjacentWindowNode(
@@ -733,7 +733,7 @@ public class TreeHelpersTests
 	{
 		// Given
 		TestTree tree = new();
-		IReadOnlyList<int> pathToNode = new[] { 1, 0, 0, 1, 0 };
+		IReadOnlyList<int> pathToNode = [1, 0, 0, 1, 0];
 
 		// When
 		WindowNodeStateAtPoint? result = TreeHelpers.GetAdjacentWindowNode(
@@ -752,7 +752,7 @@ public class TreeHelpersTests
 	{
 		// Given
 		TestTree tree = new();
-		IReadOnlyList<int> pathToNode = new[] { 1, 0, 0, 1, 0 };
+		IReadOnlyList<int> pathToNode = [1, 0, 0, 1, 0];
 
 		// When
 		WindowNodeStateAtPoint? result = TreeHelpers.GetAdjacentWindowNode(
@@ -771,7 +771,7 @@ public class TreeHelpersTests
 	{
 		// Given
 		SimpleTestTree tree = new();
-		IReadOnlyList<int> pathToNode = new[] { 1, 0 };
+		IReadOnlyList<int> pathToNode = [1, 0];
 
 		// When
 		WindowNodeStateAtPoint? result = TreeHelpers.GetAdjacentWindowNode(
@@ -790,7 +790,7 @@ public class TreeHelpersTests
 	{
 		// Given
 		SimpleTestTree tree = new();
-		IReadOnlyList<int> pathToNode = new[] { 0, 0 };
+		IReadOnlyList<int> pathToNode = [0, 0];
 
 		// When
 		WindowNodeStateAtPoint? result = TreeHelpers.GetAdjacentWindowNode(
@@ -809,7 +809,7 @@ public class TreeHelpersTests
 	{
 		// Given
 		SimpleTestTree tree = new();
-		IReadOnlyList<int> pathToNode = new[] { 1, 1 };
+		IReadOnlyList<int> pathToNode = [1, 1];
 
 		// When
 		WindowNodeStateAtPoint? result = TreeHelpers.GetAdjacentWindowNode(
@@ -828,7 +828,7 @@ public class TreeHelpersTests
 	{
 		// Given
 		SimpleTestTree tree = new();
-		IReadOnlyList<int> pathToNode = new[] { 0, 1 };
+		IReadOnlyList<int> pathToNode = [0, 1];
 
 		// When
 		WindowNodeStateAtPoint? result = TreeHelpers.GetAdjacentWindowNode(
@@ -862,8 +862,8 @@ public class TreeHelpersTests
 	internal void GetLastCommonAncestor_SomeCommonAncestor()
 	{
 		// Given
-		IReadOnlyList<int> pathToNode1 = new[] { 1, 0, 0, 1, 0 };
-		IReadOnlyList<int> pathToNode2 = new[] { 1, 0, 0, 1, 1 };
+		IReadOnlyList<int> pathToNode1 = [1, 0, 0, 1, 0];
+		IReadOnlyList<int> pathToNode2 = [1, 0, 0, 1, 1];
 
 		// When
 		int? result = TreeHelpers.GetLastCommonAncestorIndex(pathToNode1, pathToNode2);
@@ -876,8 +876,8 @@ public class TreeHelpersTests
 	internal void GetLastCommonAncestor_NoCommonAncestor()
 	{
 		// Given
-		IReadOnlyList<int> pathToNode1 = new[] { 1, 0, 0, 1, 0 };
-		IReadOnlyList<int> pathToNode2 = new[] { 0, 0, 0, 1, 1 };
+		IReadOnlyList<int> pathToNode1 = [1, 0, 0, 1, 0];
+		IReadOnlyList<int> pathToNode2 = [0, 0, 0, 1, 1];
 
 		// When
 		int? result = TreeHelpers.GetLastCommonAncestorIndex(pathToNode1, pathToNode2);
@@ -890,8 +890,8 @@ public class TreeHelpersTests
 	internal void GetLastCommonAncestor_SamePath()
 	{
 		// Given
-		IReadOnlyList<int> pathToNode1 = new[] { 1, 0, 0, 1, 0 };
-		IReadOnlyList<int> pathToNode2 = new[] { 1, 0, 0, 1, 0 };
+		IReadOnlyList<int> pathToNode1 = [1, 0, 0, 1, 0];
+		IReadOnlyList<int> pathToNode2 = [1, 0, 0, 1, 0];
 
 		// When
 		int? result = TreeHelpers.GetLastCommonAncestorIndex(pathToNode1, pathToNode2);

--- a/src/Whim.TreeLayout.Tests/Utils/SimpleTestTree.cs
+++ b/src/Whim.TreeLayout.Tests/Utils/SimpleTestTree.cs
@@ -47,22 +47,12 @@ internal sealed class SimpleTestTree
 		Bottom = new SplitNode(
 			equalWeight: true,
 			isHorizontal: true,
-			children: ImmutableList.Create<INode>(BottomLeft, BottomRight),
-			weights: ImmutableList.Create(0.5, 0.5)
+			children: [BottomLeft, BottomRight],
+			weights: [0.5, 0.5]
 		);
 
-		Top = new SplitNode(
-			equalWeight: true,
-			isHorizontal: true,
-			children: ImmutableList.Create<INode>(TopLeft, TopRight),
-			weights: ImmutableList.Create(0.5, 0.5)
-		);
+		Top = new SplitNode(equalWeight: true, isHorizontal: true, children: [TopLeft, TopRight], weights: [0.5, 0.5]);
 
-		Root = new SplitNode(
-			equalWeight: true,
-			isHorizontal: false,
-			children: ImmutableList.Create<INode>(Top, Bottom),
-			weights: ImmutableList.Create(0.5, 0.5)
-		);
+		Root = new SplitNode(equalWeight: true, isHorizontal: false, children: [Top, Bottom], weights: [0.5, 0.5]);
 	}
 }

--- a/src/Whim.TreeLayout.Tests/Utils/SimpleTestTree.cs
+++ b/src/Whim.TreeLayout.Tests/Utils/SimpleTestTree.cs
@@ -1,4 +1,3 @@
-using System.Collections.Immutable;
 using NSubstitute;
 
 namespace Whim.TreeLayout.Tests;

--- a/src/Whim.TreeLayout.Tests/Utils/TestTree.cs
+++ b/src/Whim.TreeLayout.Tests/Utils/TestTree.cs
@@ -88,8 +88,8 @@ internal sealed class TestTree
 		RightTopRight = new SplitNode(
 			equalWeight: true,
 			isHorizontal: false,
-			new INode[] { RightTopRight1, RightTopRight2, RightTopRight3 }.ToImmutableList(),
-			new double[] { 1d / 3, 1d / 3, 1d / 3 }.ToImmutableList()
+			[RightTopRight1, RightTopRight2, RightTopRight3],
+			[1d / 3, 1d / 3, 1d / 3]
 		);
 
 		RightTopLeftBottomRightBottom = new WindowNode(rightTopLeftBottomRightBottomWindow);
@@ -99,8 +99,8 @@ internal sealed class TestTree
 		RightTopLeftBottomRight = new SplitNode(
 			equalWeight: false,
 			isHorizontal: false,
-			new INode[] { RightTopLeftBottomRightTop, RightTopLeftBottomRightBottom }.ToImmutableList(),
-			new double[] { 0.7, 0.3 }.ToImmutableList()
+			[RightTopLeftBottomRightTop, RightTopLeftBottomRightBottom],
+			[0.7, 0.3]
 		);
 
 		RightTopLeftBottomLeft = new WindowNode(rightTopLeftBottomLeftWindow);
@@ -108,8 +108,8 @@ internal sealed class TestTree
 		RightTopLeftBottom = new SplitNode(
 			equalWeight: true,
 			isHorizontal: true,
-			new INode[] { RightTopLeftBottomLeft, RightTopLeftBottomRight }.ToImmutableList(),
-			new double[] { 0.5, 0.5 }.ToImmutableList()
+			[RightTopLeftBottomLeft, RightTopLeftBottomRight],
+			[0.5, 0.5]
 		);
 
 		RightTopLeftTop = new WindowNode(rightTopLeftTopWindow);
@@ -119,31 +119,16 @@ internal sealed class TestTree
 		RightTopLeft = new SplitNode(
 			equalWeight: true,
 			isHorizontal: false,
-			new INode[] { RightTopLeftTop, RightTopLeftBottom }.ToImmutableList(),
-			new double[] { 0.5, 0.5 }.ToImmutableList()
+			[RightTopLeftTop, RightTopLeftBottom],
+			[0.5, 0.5]
 		);
 
-		RightTop = new SplitNode(
-			equalWeight: true,
-			isHorizontal: true,
-			new INode[] { RightTopLeft, RightTopRight }.ToImmutableList(),
-			new double[] { 0.5, 0.5 }.ToImmutableList()
-		);
+		RightTop = new SplitNode(equalWeight: true, isHorizontal: true, [RightTopLeft, RightTopRight], [0.5, 0.5]);
 
-		Right = new SplitNode(
-			equalWeight: true,
-			isHorizontal: false,
-			new INode[] { RightTop, RightBottom }.ToImmutableList(),
-			new double[] { 0.5, 0.5 }.ToImmutableList()
-		);
+		Right = new SplitNode(equalWeight: true, isHorizontal: false, [RightTop, RightBottom], [0.5, 0.5]);
 
 		Left = new WindowNode(leftWindow);
 
-		Root = new SplitNode(
-			equalWeight: true,
-			isHorizontal: true,
-			new INode[] { Left, Right }.ToImmutableList(),
-			new double[] { 0.5, 0.5 }.ToImmutableList()
-		);
+		Root = new SplitNode(equalWeight: true, isHorizontal: true, [Left, Right], [0.5, 0.5]);
 	}
 }

--- a/src/Whim.TreeLayout.Tests/Utils/TestTree.cs
+++ b/src/Whim.TreeLayout.Tests/Utils/TestTree.cs
@@ -1,4 +1,3 @@
-using System.Collections.Immutable;
 using NSubstitute;
 
 namespace Whim.TreeLayout.Tests;

--- a/src/Whim.TreeLayout.Tests/Utils/TestTreeWindowStates.cs
+++ b/src/Whim.TreeLayout.Tests/Utils/TestTreeWindowStates.cs
@@ -63,8 +63,8 @@ internal static class TestTreeWindowStates
 		Height = 0.5 * 1d / 3
 	};
 
-	public static IRectangle<double>[] All = new IRectangle<double>[]
-	{
+	public static IRectangle<double>[] All =
+	[
 		Left,
 		RightTopLeftTop,
 		RightTopLeftBottomLeft,
@@ -74,7 +74,7 @@ internal static class TestTreeWindowStates
 		RightTopRight2,
 		RightTopRight3,
 		RightBottom
-	};
+	];
 
 	public static IWindowState[] GetAllWindowStates(
 		IRectangle<int> screen,
@@ -89,8 +89,8 @@ internal static class TestTreeWindowStates
 		IWindow rightBottomWindow
 	)
 	{
-		return new IWindowState[]
-		{
+		return
+		[
 			new WindowState()
 			{
 				Window = leftWindow,
@@ -145,6 +145,6 @@ internal static class TestTreeWindowStates
 				Rectangle = RightBottom.Scale(screen),
 				WindowSize = WindowSize.Normal
 			}
-		};
+		];
 	}
 }

--- a/src/Whim.TreeLayout/Tree/TreeHelpers.cs
+++ b/src/Whim.TreeLayout/Tree/TreeHelpers.cs
@@ -118,7 +118,7 @@ internal static class TreeHelpers
 	/// <returns></returns>
 	public static WindowNodeState GetRightMostWindow(this ISplitNode ISplitNode)
 	{
-		List<ISplitNode> splitNodes = new();
+		List<ISplitNode> splitNodes = [];
 		ImmutableArray<int>.Builder pathBuilder = ImmutableArray.CreateBuilder<int>();
 
 		INode currentNode = ISplitNode;
@@ -140,8 +140,8 @@ internal static class TreeHelpers
 	/// <returns></returns>
 	public static WindowNodeState GetLeftMostWindow(this ISplitNode rootSplitNode)
 	{
-		List<ISplitNode> splitNodes = new();
-		List<int> pathBuilder = new();
+		List<ISplitNode> splitNodes = [];
+		List<int> pathBuilder = [];
 
 		INode currentNode = rootSplitNode;
 		while (currentNode is ISplitNode split)
@@ -513,7 +513,7 @@ internal static class TreeHelpers
 		ISplitNode root
 	)
 	{
-		List<(INode, ImmutableArray<int>)> stack = new() { };
+		List<(INode, ImmutableArray<int>)> stack = [];
 		if (windowPaths.IsEmpty)
 		{
 			stack.Add((root, ImmutableArray<int>.Empty));
@@ -538,7 +538,7 @@ internal static class TreeHelpers
 		}
 
 		// Iterate over the tree in-order, and create the updated paths.
-		List<KeyValuePair<IWindow, ImmutableArray<int>>> updatedPaths = new();
+		List<KeyValuePair<IWindow, ImmutableArray<int>>> updatedPaths = [];
 		while (stack.Count > 0)
 		{
 			(INode current, ImmutableArray<int> path) = stack[^1];

--- a/src/Whim.TreeLayout/Tree/TreeHelpers.cs
+++ b/src/Whim.TreeLayout/Tree/TreeHelpers.cs
@@ -164,7 +164,7 @@ internal static class TreeHelpers
 	/// <returns></returns>
 	public static WindowNodeStateAtPoint? GetNodeContainingPoint(this INode rootNode, IPoint<double> searchPoint)
 	{
-		IRectangle<double> parentRect = Rectangle.UnitSquare<double>();
+		Rectangle<double> parentRect = Rectangle.UnitSquare<double>();
 		if (!parentRect.ContainsPoint(searchPoint))
 		{
 			return null;

--- a/src/Whim.TreeLayout/Tree/TreeHelpers.cs
+++ b/src/Whim.TreeLayout/Tree/TreeHelpers.cs
@@ -172,12 +172,7 @@ internal static class TreeHelpers
 
 		if (rootNode is WindowNode rootWindowNode)
 		{
-			return new WindowNodeStateAtPoint(
-				rootWindowNode,
-				ImmutableArray.Create<ISplitNode>(),
-				ImmutableArray.Create<int>(),
-				parentRect.GetDirectionToPoint(searchPoint)
-			);
+			return new WindowNodeStateAtPoint(rootWindowNode, [], [], parentRect.GetDirectionToPoint(searchPoint));
 		}
 
 		if (rootNode is not SplitNode rootSplitNode)

--- a/src/Whim.TreeLayout/Tree/TreeHelpers.cs
+++ b/src/Whim.TreeLayout/Tree/TreeHelpers.cs
@@ -152,7 +152,7 @@ internal static class TreeHelpers
 		}
 
 		// NOTE: This assumes that window nodes are always at the end of the path.
-		return new WindowNodeState((WindowNode)currentNode, splitNodes, pathBuilder.ToImmutableArray());
+		return new WindowNodeState((WindowNode)currentNode, splitNodes, [.. pathBuilder]);
 	}
 
 	/// <summary>

--- a/src/Whim.TreeLayout/Tree/TreeHelpers.cs
+++ b/src/Whim.TreeLayout/Tree/TreeHelpers.cs
@@ -62,7 +62,7 @@ internal static class TreeHelpers
 		Rectangle<double> rect = Rectangle.UnitSquare<double>();
 		if (path.Count == 0)
 		{
-			return new NodeState(root, Array.Empty<ISplitNode>(), rect);
+			return new NodeState(root, [], rect);
 		}
 
 		ISplitNode[] ancestors = new ISplitNode[path.Count];

--- a/src/Whim.TreeLayout/Tree/WindowNode.cs
+++ b/src/Whim.TreeLayout/Tree/WindowNode.cs
@@ -3,21 +3,16 @@ namespace Whim.TreeLayout;
 /// <summary>
 /// WindowNodes represent the location of a window within the layout engine.
 /// </summary>
-internal class WindowNode : INode
+/// <remarks>
+/// Creates a new window node for the given <paramref name="window"/>/
+/// </remarks>
+/// <param name="window"></param>
+internal class WindowNode(IWindow window) : INode
 {
 	/// <summary>
 	/// The window contained by the node.
 	/// </summary>
-	public IWindow Window { get; }
-
-	/// <summary>
-	/// Creates a new window node for the given <paramref name="window"/>/
-	/// </summary>
-	/// <param name="window"></param>
-	public WindowNode(IWindow window)
-	{
-		Window = window;
-	}
+	public IWindow Window { get; } = window;
 
 	/// <summary>
 	/// Moves the focus to this node.

--- a/src/Whim.TreeLayout/TreeLayoutEngine.cs
+++ b/src/Whim.TreeLayout/TreeLayoutEngine.cs
@@ -70,7 +70,7 @@ public record TreeLayoutEngine : ILayoutEngine
 		Identity = identity;
 		_root = null;
 		_windows = WindowPathDict.Empty;
-		_minimizedWindows = ImmutableHashSet<IWindow>.Empty;
+		_minimizedWindows = [];
 	}
 
 	/// <summary>

--- a/src/Whim.TreeLayout/TreeLayoutEngine.cs
+++ b/src/Whim.TreeLayout/TreeLayoutEngine.cs
@@ -116,7 +116,7 @@ public record TreeLayoutEngine : ILayoutEngine
 	/// <param name="window"></param>
 	/// <returns></returns>
 	private static WindowPathDict CreateRootNodeDict(IWindow window) =>
-		ImmutableDictionary.Create<IWindow, ImmutableArray<int>>().Add(window, ImmutableArray.Create(0));
+		ImmutableDictionary.Create<IWindow, ImmutableArray<int>>().Add(window, [0]);
 
 	/// <summary>
 	/// Creates a new dictionary with the top-level split node.
@@ -130,7 +130,7 @@ public record TreeLayoutEngine : ILayoutEngine
 		int idx = 0;
 		foreach (INode child in splitNode.Children)
 		{
-			dictBuilder.Add(((WindowNode)child).Window, ImmutableArray.Create(idx));
+			dictBuilder.Add(((WindowNode)child).Window, [idx]);
 			idx++;
 		}
 

--- a/src/Whim.TreeLayout/TreeLayoutEngine.cs
+++ b/src/Whim.TreeLayout/TreeLayoutEngine.cs
@@ -167,7 +167,7 @@ public record TreeLayoutEngine : ILayoutEngine
 		}
 	}
 
-	private ILayoutEngine AddToSplitNode(
+	private TreeLayoutEngine AddToSplitNode(
 		WindowNode newWindowNode,
 		ISplitNode rootNode,
 		ImmutableHashSet<IWindow> minimizedWindows
@@ -223,7 +223,7 @@ public record TreeLayoutEngine : ILayoutEngine
 		return intermediateTree.AddWindowAtPoint(window, point);
 	}
 
-	private ILayoutEngine AddWindowAtPoint(IWindow window, IPoint<double> point)
+	private TreeLayoutEngine AddWindowAtPoint(IWindow window, IPoint<double> point)
 	{
 		ImmutableHashSet<IWindow> minimizedWindows = _minimizedWindows.Remove(window);
 		WindowNode newWindowNode = new(window);
@@ -246,7 +246,7 @@ public record TreeLayoutEngine : ILayoutEngine
 		return new TreeLayoutEngine(this, newWindowNode, CreateRootNodeDict(window), minimizedWindows);
 	}
 
-	private ILayoutEngine MoveWindowToPointSplitNode(
+	private TreeLayoutEngine MoveWindowToPointSplitNode(
 		IPoint<double> point,
 		WindowNode newWindowNode,
 		ISplitNode rootNode

--- a/src/Whim.TreeLayout/TreeLayoutPlugin.cs
+++ b/src/Whim.TreeLayout/TreeLayoutPlugin.cs
@@ -9,7 +9,7 @@ public class TreeLayoutPlugin : ITreeLayoutPlugin
 {
 	private readonly IContext _context;
 
-	private readonly Dictionary<LayoutEngineIdentity, Direction> _addNodeDirections = new();
+	private readonly Dictionary<LayoutEngineIdentity, Direction> _addNodeDirections = [];
 	private const Direction DefaultAddNodeDirection = Direction.Right;
 
 	/// <summary>

--- a/src/Whim.TreeLayout/TreeLayoutPlugin.cs
+++ b/src/Whim.TreeLayout/TreeLayoutPlugin.cs
@@ -5,9 +5,12 @@ using System.Text.Json;
 namespace Whim.TreeLayout;
 
 /// <inheritdoc/>
-public class TreeLayoutPlugin : ITreeLayoutPlugin
+/// <summary>
+/// Initializes a new instance of the <see cref="TreeLayoutPlugin"/> class.
+/// </summary>
+public class TreeLayoutPlugin(IContext context) : ITreeLayoutPlugin
 {
-	private readonly IContext _context;
+	private readonly IContext _context = context;
 
 	private readonly Dictionary<LayoutEngineIdentity, Direction> _addNodeDirections = [];
 	private const Direction DefaultAddNodeDirection = Direction.Right;
@@ -22,14 +25,6 @@ public class TreeLayoutPlugin : ITreeLayoutPlugin
 
 	/// <inheritdoc	/>
 	public event EventHandler<AddWindowDirectionChangedEventArgs>? AddWindowDirectionChanged;
-
-	/// <summary>
-	/// Initializes a new instance of the <see cref="TreeLayoutPlugin"/> class.
-	/// </summary>
-	public TreeLayoutPlugin(IContext context)
-	{
-		_context = context;
-	}
 
 	/// <inheritdoc	/>
 	public void PreInitialize() { }

--- a/src/Whim.Updater.Tests/Directory.Build.props
+++ b/src/Whim.Updater.Tests/Directory.Build.props
@@ -1,5 +1,6 @@
 <Project>
 	<PropertyGroup>
-		<GenerateDocumentationFile>false</GenerateDocumentationFile>
+		<GenerateDocumentationFile>true</GenerateDocumentationFile>
+		<NoWarn>$(NoWarn);CS1591</NoWarn>
 	</PropertyGroup>
 </Project>

--- a/src/Whim.Updater.Tests/GlobalSuppressions.cs
+++ b/src/Whim.Updater.Tests/GlobalSuppressions.cs
@@ -14,3 +14,5 @@ using System.Diagnostics.CodeAnalysis;
 [assembly: SuppressMessage("Style", "IDE0042:Variable declaration can be deconstructed")]
 [assembly: SuppressMessage("Style", "IDE0058:Expression value is never used")]
 [assembly: SuppressMessage("Style", "IDE0022:Use expression body for methods")]
+[assembly: SuppressMessage("Performance", "CA1852:Seal internal types")]
+[assembly: SuppressMessage("Performance", "CA1861:Avoid constant arrays as arguments")]

--- a/src/Whim.Updater.Tests/UpdaterPluginTests.cs
+++ b/src/Whim.Updater.Tests/UpdaterPluginTests.cs
@@ -242,7 +242,7 @@ public class UpdaterPluginTests
 	{
 		// Given
 		IUpdaterPlugin plugin = new UpdaterPlugin(ctx, new UpdaterConfig());
-		Release release = Data.CreateRelease242(assets: Array.Empty<ReleaseAsset>());
+		Release release = Data.CreateRelease242(assets: []);
 
 		// When
 		await plugin.InstallRelease(release);

--- a/src/Whim.Updater.Tests/UpdaterPluginTests.cs
+++ b/src/Whim.Updater.Tests/UpdaterPluginTests.cs
@@ -44,7 +44,7 @@ public class UpdaterPluginTests
 
 	#region GetNotInstalledReleases
 	[Theory, AutoSubstituteData<UpdaterPluginCustomization>]
-	public async void GetNotInstalledReleases_WhenNoReleases(IContext ctx, IGitHubClient client)
+	public async Task GetNotInstalledReleases_WhenNoReleases(IContext ctx, IGitHubClient client)
 	{
 		// Given
 		IUpdaterPlugin plugin = new UpdaterPlugin(ctx, new UpdaterConfig());
@@ -57,7 +57,7 @@ public class UpdaterPluginTests
 	}
 
 	[Theory, AutoSubstituteData<UpdaterPluginCustomization>]
-	public async void GetNotInstalledReleases_InvalidVersion(IContext ctx, IGitHubClient client)
+	public async Task GetNotInstalledReleases_InvalidVersion(IContext ctx, IGitHubClient client)
 	{
 		// Given
 		IUpdaterPlugin plugin = new UpdaterPlugin(ctx, new UpdaterConfig());
@@ -73,7 +73,7 @@ public class UpdaterPluginTests
 	}
 
 	[Theory, AutoSubstituteData<UpdaterPluginCustomization>]
-	public async void GetNotInstalledReleases_DifferentChannel(IContext ctx, IGitHubClient client)
+	public async Task GetNotInstalledReleases_DifferentChannel(IContext ctx, IGitHubClient client)
 	{
 		// Given
 		IUpdaterPlugin plugin = new UpdaterPlugin(ctx, new UpdaterConfig());
@@ -89,7 +89,7 @@ public class UpdaterPluginTests
 	}
 
 	[Theory, AutoSubstituteData<UpdaterPluginCustomization>]
-	public async void GetNotInstalledReleases_OlderVersion(IContext ctx, IGitHubClient client)
+	public async Task GetNotInstalledReleases_OlderVersion(IContext ctx, IGitHubClient client)
 	{
 		// Given
 		IUpdaterPlugin plugin = new UpdaterPlugin(ctx, new UpdaterConfig());
@@ -105,7 +105,7 @@ public class UpdaterPluginTests
 	}
 
 	[Theory, AutoSubstituteData<UpdaterPluginCustomization>]
-	public async void GetNotInstalledReleases_Ordered(IContext ctx, IGitHubClient client)
+	public async Task GetNotInstalledReleases_Ordered(IContext ctx, IGitHubClient client)
 	{
 		// Given
 		IUpdaterPlugin plugin = new UpdaterPlugin(ctx, new UpdaterConfig() { ReleaseChannel = ReleaseChannel.Alpha });
@@ -170,7 +170,7 @@ public class UpdaterPluginTests
 
 	#region CheckForUpdates
 	[Theory, AutoSubstituteData<UpdaterPluginCustomization>]
-	public async void CheckForUpdates_WhenNoReleases(IContext ctx, IGitHubClient client)
+	public async Task CheckForUpdates_WhenNoReleases(IContext ctx, IGitHubClient client)
 	{
 		// Given
 		IUpdaterPlugin plugin = new UpdaterPlugin(ctx, new UpdaterConfig());
@@ -183,7 +183,7 @@ public class UpdaterPluginTests
 	}
 
 	[Theory, AutoSubstituteData<UpdaterPluginCustomization>]
-	public async void CheckForUpdates_ReleaseIsSkipped(IContext ctx, IGitHubClient client)
+	public async Task CheckForUpdates_ReleaseIsSkipped(IContext ctx, IGitHubClient client)
 	{
 		// Given
 		Release release = Data.CreateRelease242(tagName: "v0.1.265-alpha+bc5c56c4");
@@ -233,7 +233,7 @@ public class UpdaterPluginTests
 
 	#region InstallRelease
 	[Theory, AutoSubstituteData<UpdaterPluginCustomization>]
-	public async void InstallRelease_NoAssets(IContext ctx)
+	public async Task InstallRelease_NoAssets(IContext ctx)
 	{
 		// Given
 		IUpdaterPlugin plugin = new UpdaterPlugin(ctx, new UpdaterConfig());
@@ -247,7 +247,7 @@ public class UpdaterPluginTests
 	}
 
 	[Theory, AutoSubstituteData<UpdaterPluginCustomization>]
-	public async void InstallRelease_DownloadThrows(IContext ctx)
+	public async Task InstallRelease_DownloadThrows(IContext ctx)
 	{
 		// Given
 		IUpdaterPlugin plugin = new UpdaterPlugin(ctx, new UpdaterConfig());
@@ -264,7 +264,7 @@ public class UpdaterPluginTests
 	}
 
 	[Theory, AutoSubstituteData<UpdaterPluginCustomization>]
-	public async void InstallRelease_InstallerExitsWithNonZeroCode(IContext ctx)
+	public async Task InstallRelease_InstallerExitsWithNonZeroCode(IContext ctx)
 	{
 		// Given
 		IUpdaterPlugin plugin = new UpdaterPlugin(ctx, new UpdaterConfig());
@@ -282,7 +282,7 @@ public class UpdaterPluginTests
 	}
 
 	[Theory, AutoSubstituteData<UpdaterPluginCustomization>]
-	public async void InstallRelease_InstallerThrows(IContext ctx)
+	public async Task InstallRelease_InstallerThrows(IContext ctx)
 	{
 		// Given
 		IUpdaterPlugin plugin = new UpdaterPlugin(ctx, new UpdaterConfig());
@@ -301,7 +301,7 @@ public class UpdaterPluginTests
 	}
 
 	[Theory, AutoSubstituteData<UpdaterPluginCustomization>]
-	public async void InstallRelease_InstallerExitsWithZeroCode(IContext ctx)
+	public async Task InstallRelease_InstallerExitsWithZeroCode(IContext ctx)
 	{
 		// Given
 		IUpdaterPlugin plugin = new UpdaterPlugin(ctx, new UpdaterConfig());

--- a/src/Whim.Updater.Tests/UpdaterPluginTests.cs
+++ b/src/Whim.Updater.Tests/UpdaterPluginTests.cs
@@ -29,7 +29,7 @@ public class UpdaterPluginTests
 	public void PreInitialize(IContext ctx)
 	{
 		// Given
-		IUpdaterPlugin plugin = new UpdaterPlugin(ctx, new UpdaterConfig());
+		UpdaterPlugin plugin = new(ctx, new UpdaterConfig());
 
 		// When
 		plugin.PreInitialize();
@@ -47,7 +47,7 @@ public class UpdaterPluginTests
 	public async Task GetNotInstalledReleases_WhenNoReleases(IContext ctx, IGitHubClient client)
 	{
 		// Given
-		IUpdaterPlugin plugin = new UpdaterPlugin(ctx, new UpdaterConfig());
+		UpdaterPlugin plugin = new(ctx, new UpdaterConfig());
 
 		// When
 		IEnumerable<ReleaseInfo> releases = await plugin.GetNotInstalledReleases(client);
@@ -60,7 +60,7 @@ public class UpdaterPluginTests
 	public async Task GetNotInstalledReleases_InvalidVersion(IContext ctx, IGitHubClient client)
 	{
 		// Given
-		IUpdaterPlugin plugin = new UpdaterPlugin(ctx, new UpdaterConfig());
+		UpdaterPlugin plugin = new(ctx, new UpdaterConfig());
 		client
 			.Repository.Release.GetAll("dalyIsaac", "Whim", Arg.Any<ApiOptions>())
 			.Returns([Data.CreateRelease242(tagName: "welp")]);
@@ -76,7 +76,7 @@ public class UpdaterPluginTests
 	public async Task GetNotInstalledReleases_DifferentChannel(IContext ctx, IGitHubClient client)
 	{
 		// Given
-		IUpdaterPlugin plugin = new UpdaterPlugin(ctx, new UpdaterConfig());
+		UpdaterPlugin plugin = new(ctx, new UpdaterConfig());
 		client
 			.Repository.Release.GetAll("dalyIsaac", "Whim", Arg.Any<ApiOptions>())
 			.Returns([Data.CreateRelease242(tagName: "v0.1.263-beta+bc5c56c4")]);
@@ -92,7 +92,7 @@ public class UpdaterPluginTests
 	public async Task GetNotInstalledReleases_OlderVersion(IContext ctx, IGitHubClient client)
 	{
 		// Given
-		IUpdaterPlugin plugin = new UpdaterPlugin(ctx, new UpdaterConfig());
+		UpdaterPlugin plugin = new(ctx, new UpdaterConfig());
 		client
 			.Repository.Release.GetAll("dalyIsaac", "Whim", Arg.Any<ApiOptions>())
 			.Returns([Data.CreateRelease242(tagName: "v0.1.261-alpha+bc5c56c4")]);
@@ -108,7 +108,7 @@ public class UpdaterPluginTests
 	public async Task GetNotInstalledReleases_Ordered(IContext ctx, IGitHubClient client)
 	{
 		// Given
-		IUpdaterPlugin plugin = new UpdaterPlugin(ctx, new UpdaterConfig() { ReleaseChannel = ReleaseChannel.Alpha });
+		UpdaterPlugin plugin = new(ctx, new UpdaterConfig() { ReleaseChannel = ReleaseChannel.Alpha });
 
 		string[] orderedReleases =
 		[
@@ -138,7 +138,7 @@ public class UpdaterPluginTests
 	public void LoadState_InvalidFormat(IContext ctx)
 	{
 		// Given
-		IUpdaterPlugin plugin = new UpdaterPlugin(ctx, new UpdaterConfig());
+		UpdaterPlugin plugin = new(ctx, new UpdaterConfig());
 		JsonElement json = JsonDocument.Parse("[]").RootElement;
 
 		// When
@@ -152,7 +152,7 @@ public class UpdaterPluginTests
 	public void LoadState_Valid(IContext ctx)
 	{
 		// Given
-		IUpdaterPlugin plugin = new UpdaterPlugin(ctx, new UpdaterConfig());
+		UpdaterPlugin plugin = new(ctx, new UpdaterConfig());
 		JsonElement json = JsonDocument
 			.Parse(
 				"{\"SkippedReleaseTagName\":\"v0.1.263-alpha+bc5c56c4\",\"LastCheckedForUpdates\":\"2021-09-05T21:00:00.0000000Z\"}"
@@ -173,7 +173,7 @@ public class UpdaterPluginTests
 	public async Task CheckForUpdates_WhenNoReleases(IContext ctx, IGitHubClient client)
 	{
 		// Given
-		IUpdaterPlugin plugin = new UpdaterPlugin(ctx, new UpdaterConfig());
+		UpdaterPlugin plugin = new(ctx, new UpdaterConfig());
 
 		// When
 		await plugin.CheckForUpdates(client);
@@ -189,7 +189,7 @@ public class UpdaterPluginTests
 		Release release = Data.CreateRelease242(tagName: "v0.1.265-alpha+bc5c56c4");
 		client.Repository.Release.GetAll("dalyIsaac", "Whim", Arg.Any<ApiOptions>()).Returns([release]);
 
-		IUpdaterPlugin plugin = new UpdaterPlugin(ctx, new UpdaterConfig() { ReleaseChannel = ReleaseChannel.Alpha });
+		UpdaterPlugin plugin = new(ctx, new UpdaterConfig() { ReleaseChannel = ReleaseChannel.Alpha });
 		plugin.SkipRelease(release);
 
 		// When
@@ -204,7 +204,7 @@ public class UpdaterPluginTests
 	public void SkipRelease(IContext ctx)
 	{
 		// Given
-		IUpdaterPlugin plugin = new UpdaterPlugin(ctx, new UpdaterConfig());
+		UpdaterPlugin plugin = new(ctx, new UpdaterConfig());
 		Release release = Data.CreateRelease242();
 
 		// When
@@ -218,7 +218,7 @@ public class UpdaterPluginTests
 	public void SaveState(IContext ctx)
 	{
 		// Given
-		IUpdaterPlugin plugin = new UpdaterPlugin(ctx, new UpdaterConfig());
+		UpdaterPlugin plugin = new(ctx, new UpdaterConfig());
 		Release skippedRelease = Data.CreateRelease242();
 		plugin.SkipRelease(skippedRelease);
 
@@ -236,7 +236,7 @@ public class UpdaterPluginTests
 	public async Task InstallRelease_NoAssets(IContext ctx)
 	{
 		// Given
-		IUpdaterPlugin plugin = new UpdaterPlugin(ctx, new UpdaterConfig());
+		UpdaterPlugin plugin = new(ctx, new UpdaterConfig());
 		Release release = Data.CreateRelease242(assets: []);
 
 		// When
@@ -250,7 +250,7 @@ public class UpdaterPluginTests
 	public async Task InstallRelease_DownloadThrows(IContext ctx)
 	{
 		// Given
-		IUpdaterPlugin plugin = new UpdaterPlugin(ctx, new UpdaterConfig());
+		UpdaterPlugin plugin = new(ctx, new UpdaterConfig());
 		Release release = Data.CreateRelease242();
 
 		ctx.NativeManager.DownloadFileAsync(Arg.Any<Uri>(), Arg.Any<string>()).ThrowsAsync(new Exception());
@@ -267,7 +267,7 @@ public class UpdaterPluginTests
 	public async Task InstallRelease_InstallerExitsWithNonZeroCode(IContext ctx)
 	{
 		// Given
-		IUpdaterPlugin plugin = new UpdaterPlugin(ctx, new UpdaterConfig());
+		UpdaterPlugin plugin = new(ctx, new UpdaterConfig());
 		Release release = Data.CreateRelease242();
 
 		ctx.NativeManager.DownloadFileAsync(Arg.Any<Uri>(), Arg.Any<string>()).Returns(Task.CompletedTask);
@@ -285,7 +285,7 @@ public class UpdaterPluginTests
 	public async Task InstallRelease_InstallerThrows(IContext ctx)
 	{
 		// Given
-		IUpdaterPlugin plugin = new UpdaterPlugin(ctx, new UpdaterConfig());
+		UpdaterPlugin plugin = new(ctx, new UpdaterConfig());
 		Release release = Data.CreateRelease242();
 
 		ctx.NativeManager.DownloadFileAsync(Arg.Any<Uri>(), Arg.Any<string>()).Returns(Task.CompletedTask);
@@ -304,7 +304,7 @@ public class UpdaterPluginTests
 	public async Task InstallRelease_InstallerExitsWithZeroCode(IContext ctx)
 	{
 		// Given
-		IUpdaterPlugin plugin = new UpdaterPlugin(ctx, new UpdaterConfig());
+		UpdaterPlugin plugin = new(ctx, new UpdaterConfig());
 		Release release = Data.CreateRelease242();
 
 		ctx.NativeManager.DownloadFileAsync(Arg.Any<Uri>(), Arg.Any<string>()).Returns(Task.CompletedTask);
@@ -324,7 +324,7 @@ public class UpdaterPluginTests
 	public void Dispose(IContext ctx)
 	{
 		// Given
-		IUpdaterPlugin plugin = new UpdaterPlugin(ctx, new UpdaterConfig());
+		UpdaterPlugin plugin = new(ctx, new UpdaterConfig());
 
 		// When
 		plugin.Dispose();
@@ -338,7 +338,7 @@ public class UpdaterPluginTests
 	public void PluginCommands(IContext ctx)
 	{
 		// Given
-		IUpdaterPlugin plugin = new UpdaterPlugin(ctx, new UpdaterConfig());
+		UpdaterPlugin plugin = new(ctx, new UpdaterConfig());
 
 		// When
 		IPluginCommands pluginCommands = plugin.PluginCommands;

--- a/src/Whim.Updater.Tests/UpdaterPluginTests.cs
+++ b/src/Whim.Updater.Tests/UpdaterPluginTests.cs
@@ -63,7 +63,7 @@ public class UpdaterPluginTests
 		IUpdaterPlugin plugin = new UpdaterPlugin(ctx, new UpdaterConfig());
 		client
 			.Repository.Release.GetAll("dalyIsaac", "Whim", Arg.Any<ApiOptions>())
-			.Returns(new[] { Data.CreateRelease242(tagName: "welp") });
+			.Returns([Data.CreateRelease242(tagName: "welp")]);
 
 		// When
 		IEnumerable<ReleaseInfo> releases = await plugin.GetNotInstalledReleases(client);
@@ -79,7 +79,7 @@ public class UpdaterPluginTests
 		IUpdaterPlugin plugin = new UpdaterPlugin(ctx, new UpdaterConfig());
 		client
 			.Repository.Release.GetAll("dalyIsaac", "Whim", Arg.Any<ApiOptions>())
-			.Returns(new[] { Data.CreateRelease242(tagName: "v0.1.263-beta+bc5c56c4") });
+			.Returns([Data.CreateRelease242(tagName: "v0.1.263-beta+bc5c56c4")]);
 
 		// When
 		IEnumerable<ReleaseInfo> releases = await plugin.GetNotInstalledReleases(client);
@@ -95,7 +95,7 @@ public class UpdaterPluginTests
 		IUpdaterPlugin plugin = new UpdaterPlugin(ctx, new UpdaterConfig());
 		client
 			.Repository.Release.GetAll("dalyIsaac", "Whim", Arg.Any<ApiOptions>())
-			.Returns(new[] { Data.CreateRelease242(tagName: "v0.1.261-alpha+bc5c56c4") });
+			.Returns([Data.CreateRelease242(tagName: "v0.1.261-alpha+bc5c56c4")]);
 
 		// When
 		IEnumerable<ReleaseInfo> releases = await plugin.GetNotInstalledReleases(client);
@@ -111,20 +111,15 @@ public class UpdaterPluginTests
 		IUpdaterPlugin plugin = new UpdaterPlugin(ctx, new UpdaterConfig() { ReleaseChannel = ReleaseChannel.Alpha });
 
 		string[] orderedReleases =
-		{
+		[
 			"v0.1.261-alpha+bc5c56c4",
 			"v0.1.262-beta+bc5c56c4",
 			"v0.1.263-stable+bc5c56c4",
 			"v0.1.264-alpha+bc5c56c4",
 			"v0.2.265-alpha+bc5c56c4",
 			"v1.1.266-alpha+bc5c56c4"
-		};
-		string[] expectedReleases = new[]
-		{
-			"v0.1.264-alpha+bc5c56c4",
-			"v0.2.265-alpha+bc5c56c4",
-			"v1.1.266-alpha+bc5c56c4"
-		};
+		];
+		string[] expectedReleases = ["v0.1.264-alpha+bc5c56c4", "v0.2.265-alpha+bc5c56c4", "v1.1.266-alpha+bc5c56c4"];
 
 		client
 			.Repository.Release.GetAll("dalyIsaac", "Whim", Arg.Any<ApiOptions>())
@@ -192,7 +187,7 @@ public class UpdaterPluginTests
 	{
 		// Given
 		Release release = Data.CreateRelease242(tagName: "v0.1.265-alpha+bc5c56c4");
-		client.Repository.Release.GetAll("dalyIsaac", "Whim", Arg.Any<ApiOptions>()).Returns(new[] { release });
+		client.Repository.Release.GetAll("dalyIsaac", "Whim", Arg.Any<ApiOptions>()).Returns([release]);
 
 		IUpdaterPlugin plugin = new UpdaterPlugin(ctx, new UpdaterConfig() { ReleaseChannel = ReleaseChannel.Alpha });
 		plugin.SkipRelease(release);

--- a/src/Whim.Updater.Tests/UpdaterWindow/Data.cs
+++ b/src/Whim.Updater.Tests/UpdaterWindow/Data.cs
@@ -39,40 +39,39 @@ internal static class Data
 
 	public static Release CreateRelease242(string? tagName = null, ReleaseAsset[]? assets = null)
 	{
-		ReleaseAsset[] defaultAssets = new ReleaseAsset[2];
-
-		defaultAssets[0] = new ReleaseAsset(
-			url: "https://api.github.com/repos/dalyIsaac/Whim/releases/assets/137453491",
-			id: 137453491,
-			nodeId: "RA_kwDOGWZ1Ts4IMV-z",
-			name: "WhimInstaller-arm64-0.1.242-alpha+823a398d.823a398db7a01e1c50dc296c9dd62782007025dd.exe",
-			label: "",
-			contentType: "application/x-msdownload",
-			state: "uploaded",
-			size: 24339890,
-			downloadCount: 1,
-			createdAt: DateTimeOffset.Parse("2023-11-26T02:09:15Z"),
-			updatedAt: DateTimeOffset.Parse("2023-11-26T02:09:16Z"),
-			browserDownloadUrl: "https://github.com/dalyIsaac/Whim/releases/download/v0.1.242-alpha%2B823a398d/WhimInstaller-arm64-0.1.242-alpha%2B823a398d.823a398db7a01e1c50dc296c9dd62782007025dd.exe",
-			uploader: CreateAuthor()
-		);
-
-		defaultAssets[1] = new ReleaseAsset(
-			url: "https://api.github.com/repos/dalyIsaac/Whim/releases/assets/137453051",
-			id: 137453051,
-			nodeId: "RA_kwDOGWZ1Ts4IMV37",
-			name: "WhimInstaller-x64-0.1.242-alpha+823a398d.823a398db7a01e1c50dc296c9dd62782007025dd.exe",
-			label: "",
-			contentType: "application/x-msdownload",
-			state: "uploaded",
-			size: 25963657,
-			downloadCount: 1,
-			createdAt: DateTimeOffset.Parse("2023-11-26T02:04:03Z"),
-			updatedAt: DateTimeOffset.Parse("2023-11-26T02:04:04Z"),
-			browserDownloadUrl: "https://github.com/dalyIsaac/Whim/releases/download/v0.1.242-alpha%2B823a398d/WhimInstaller-x64-0.1.242-alpha%2B823a398d.823a398db7a01e1c50dc296c9dd62782007025dd.exe",
-			uploader: CreateAuthor()
-		);
-
+		ReleaseAsset[] defaultAssets =
+		[
+			new ReleaseAsset(
+				url: "https://api.github.com/repos/dalyIsaac/Whim/releases/assets/137453491",
+				id: 137453491,
+				nodeId: "RA_kwDOGWZ1Ts4IMV-z",
+				name: "WhimInstaller-arm64-0.1.242-alpha+823a398d.823a398db7a01e1c50dc296c9dd62782007025dd.exe",
+				label: "",
+				contentType: "application/x-msdownload",
+				state: "uploaded",
+				size: 24339890,
+				downloadCount: 1,
+				createdAt: DateTimeOffset.Parse("2023-11-26T02:09:15Z"),
+				updatedAt: DateTimeOffset.Parse("2023-11-26T02:09:16Z"),
+				browserDownloadUrl: "https://github.com/dalyIsaac/Whim/releases/download/v0.1.242-alpha%2B823a398d/WhimInstaller-arm64-0.1.242-alpha%2B823a398d.823a398db7a01e1c50dc296c9dd62782007025dd.exe",
+				uploader: CreateAuthor()
+			),
+			new ReleaseAsset(
+				url: "https://api.github.com/repos/dalyIsaac/Whim/releases/assets/137453051",
+				id: 137453051,
+				nodeId: "RA_kwDOGWZ1Ts4IMV37",
+				name: "WhimInstaller-x64-0.1.242-alpha+823a398d.823a398db7a01e1c50dc296c9dd62782007025dd.exe",
+				label: "",
+				contentType: "application/x-msdownload",
+				state: "uploaded",
+				size: 25963657,
+				downloadCount: 1,
+				createdAt: DateTimeOffset.Parse("2023-11-26T02:04:03Z"),
+				updatedAt: DateTimeOffset.Parse("2023-11-26T02:04:04Z"),
+				browserDownloadUrl: "https://github.com/dalyIsaac/Whim/releases/download/v0.1.242-alpha%2B823a398d/WhimInstaller-x64-0.1.242-alpha%2B823a398d.823a398db7a01e1c50dc296c9dd62782007025dd.exe",
+				uploader: CreateAuthor()
+			),
+		];
 		return new Release(
 			url: "https://api.github.com/repos/dalyIsaac/Whim/releases/131450677",
 			assetsUrl: "https://api.github.com/repos/dalyIsaac/Whim/releases/131450677/assets",
@@ -108,40 +107,39 @@ internal static class Data
 
 	public static Release CreateRelease243()
 	{
-		ReleaseAsset[] assets = new ReleaseAsset[2];
-
-		assets[0] = new ReleaseAsset(
-			url: "https://api.github.com/repos/dalyIsaac/Whim/releases/assets/137468755",
-			id: 137468755,
-			nodeId: "RA_kwDOGWZ1Ts4IMZtT",
-			name: "WhimInstaller-arm64-0.1.243-alpha+2ae89a20.2ae89a204825f950e0be5b712b56cd5929e94adb.exe",
-			label: "",
-			contentType: "application/x-msdownload",
-			state: "uploaded",
-			size: 24362101,
-			downloadCount: 1,
-			createdAt: DateTimeOffset.Parse("2023-11-26T05:03:23Z"),
-			updatedAt: DateTimeOffset.Parse("2023-11-26T05:03:25Z"),
-			browserDownloadUrl: "https://github.com/dalyIsaac/Whim/releases/download/v0.1.243-alpha%2B2ae89a20/WhimInstaller-arm64-0.1.243-alpha%2B2ae89a20.2ae89a204825f950e0be5b712b56cd5929e94adb.exe",
-			uploader: CreateAuthor()
-		);
-
-		assets[1] = new ReleaseAsset(
-			url: "https://api.github.com/repos/dalyIsaac/Whim/releases/assets/137468478",
-			id: 137468478,
-			nodeId: "RA_kwDOGWZ1Ts4IMZo-",
-			name: "WhimInstaller-x64-0.1.243-alpha+2ae89a20.2ae89a204825f950e0be5b712b56cd5929e94adb.exe",
-			label: "",
-			contentType: "application/x-msdownload",
-			state: "uploaded",
-			size: 25945113,
-			downloadCount: 8,
-			createdAt: DateTimeOffset.Parse("2023-11-26T05:00:29Z"),
-			updatedAt: DateTimeOffset.Parse("2023-11-26T05:00:30Z"),
-			browserDownloadUrl: "https://github.com/dalyIsaac/Whim/releases/download/v0.1.243-alpha%2B2ae89a20/WhimInstaller-x64-0.1.243-alpha%2B2ae89a20.2ae89a204825f950e0be5b712b56cd5929e94adb.exe",
-			uploader: CreateAuthor()
-		);
-
+		ReleaseAsset[] assets =
+		[
+			new ReleaseAsset(
+				url: "https://api.github.com/repos/dalyIsaac/Whim/releases/assets/137468755",
+				id: 137468755,
+				nodeId: "RA_kwDOGWZ1Ts4IMZtT",
+				name: "WhimInstaller-arm64-0.1.243-alpha+2ae89a20.2ae89a204825f950e0be5b712b56cd5929e94adb.exe",
+				label: "",
+				contentType: "application/x-msdownload",
+				state: "uploaded",
+				size: 24362101,
+				downloadCount: 1,
+				createdAt: DateTimeOffset.Parse("2023-11-26T05:03:23Z"),
+				updatedAt: DateTimeOffset.Parse("2023-11-26T05:03:25Z"),
+				browserDownloadUrl: "https://github.com/dalyIsaac/Whim/releases/download/v0.1.243-alpha%2B2ae89a20/WhimInstaller-arm64-0.1.243-alpha%2B2ae89a20.2ae89a204825f950e0be5b712b56cd5929e94adb.exe",
+				uploader: CreateAuthor()
+			),
+			new ReleaseAsset(
+				url: "https://api.github.com/repos/dalyIsaac/Whim/releases/assets/137468478",
+				id: 137468478,
+				nodeId: "RA_kwDOGWZ1Ts4IMZo-",
+				name: "WhimInstaller-x64-0.1.243-alpha+2ae89a20.2ae89a204825f950e0be5b712b56cd5929e94adb.exe",
+				label: "",
+				contentType: "application/x-msdownload",
+				state: "uploaded",
+				size: 25945113,
+				downloadCount: 8,
+				createdAt: DateTimeOffset.Parse("2023-11-26T05:00:29Z"),
+				updatedAt: DateTimeOffset.Parse("2023-11-26T05:00:30Z"),
+				browserDownloadUrl: "https://github.com/dalyIsaac/Whim/releases/download/v0.1.243-alpha%2B2ae89a20/WhimInstaller-x64-0.1.243-alpha%2B2ae89a20.2ae89a204825f950e0be5b712b56cd5929e94adb.exe",
+				uploader: CreateAuthor()
+			),
+		];
 		return new Release(
 			url: "https://api.github.com/repos/dalyIsaac/Whim/releases/131453811",
 			assetsUrl: "https://api.github.com/repos/dalyIsaac/Whim/releases/131453811/assets",

--- a/src/Whim.Updater.Tests/UpdaterWindow/UpdaterWindowViewModelTests.cs
+++ b/src/Whim.Updater.Tests/UpdaterWindow/UpdaterWindowViewModelTests.cs
@@ -18,7 +18,7 @@ public class UpdaterWindowViewModelCustomization : ICustomization
 		Version version242 = Version.Parse(release242.TagName)!;
 		ReleaseInfo releaseInfo242 = new(release242, version242);
 
-		IReadOnlyList<ReleaseInfo> releases = new List<ReleaseInfo> { releaseInfo243, releaseInfo242 };
+		IReadOnlyList<ReleaseInfo> releases = [releaseInfo243, releaseInfo242];
 		fixture.Inject(releases);
 	}
 }
@@ -76,7 +76,7 @@ public class UpdaterWindowViewModelTests
 		UpdaterWindowViewModel viewModel = new(updaterPlugin);
 
 		// When
-		viewModel.Update(new List<ReleaseInfo>());
+		viewModel.Update([]);
 
 		// Then
 		Assert.Null(viewModel.LastRelease);

--- a/src/Whim.Updater/UpdaterPlugin.cs
+++ b/src/Whim.Updater/UpdaterPlugin.cs
@@ -77,7 +77,7 @@ public class UpdaterPlugin : IUpdaterPlugin
 		}
 	}
 
-	private IGitHubClient CreateGitHubClient() => new GitHubClient(new ProductHeaderValue(Name));
+	private GitHubClient CreateGitHubClient() => new (new ProductHeaderValue(Name));
 
 	/// <inheritdoc />
 	public void PreInitialize()

--- a/src/Whim.Updater/UpdaterPlugin.cs
+++ b/src/Whim.Updater/UpdaterPlugin.cs
@@ -77,7 +77,7 @@ public class UpdaterPlugin : IUpdaterPlugin
 		}
 	}
 
-	private GitHubClient CreateGitHubClient() => new (new ProductHeaderValue(Name));
+	private GitHubClient CreateGitHubClient() => new(new ProductHeaderValue(Name));
 
 	/// <inheritdoc />
 	public void PreInitialize()

--- a/src/Whim.Updater/UpdaterPlugin.cs
+++ b/src/Whim.Updater/UpdaterPlugin.cs
@@ -41,7 +41,7 @@ public class UpdaterPlugin : IUpdaterPlugin
 
 	private readonly Timer _timer = new();
 
-	private List<ReleaseInfo> _notInstalledReleases = new();
+	private List<ReleaseInfo> _notInstalledReleases = [];
 	private bool _disposedValue;
 
 	/// <inheritdoc />
@@ -207,7 +207,7 @@ public class UpdaterPlugin : IUpdaterPlugin
 			.ConfigureAwait(false);
 
 		// Sort the releases by semver
-		List<ReleaseInfo> sortedReleases = new();
+		List<ReleaseInfo> sortedReleases = [];
 		foreach (Release r in releases)
 		{
 			Version? version = Version.Parse(r.TagName);

--- a/src/Whim.Updater/UpdaterWindow/GitHubUserProfileExtension.cs
+++ b/src/Whim.Updater/UpdaterWindow/GitHubUserProfileExtension.cs
@@ -26,7 +26,7 @@ internal partial class GitHubUserProfileParser : InlineParser
 {
 	public GitHubUserProfileParser()
 	{
-		OpeningCharacters = new[] { 'b' };
+		OpeningCharacters = ['b'];
 	}
 
 	public override bool Match(InlineProcessor processor, ref StringSlice slice)

--- a/src/Whim.Updater/UpdaterWindow/UpdaterWindowCommands.cs
+++ b/src/Whim.Updater/UpdaterWindow/UpdaterWindowCommands.cs
@@ -2,18 +2,12 @@ using System;
 
 namespace Whim.Updater;
 
-internal class SkipReleaseCommand : System.Windows.Input.ICommand
+internal class SkipReleaseCommand(IUpdaterPlugin plugin, UpdaterWindowViewModel viewModel) : System.Windows.Input.ICommand
 {
-	private readonly IUpdaterPlugin _plugin;
-	private readonly UpdaterWindowViewModel _viewModel;
+	private readonly IUpdaterPlugin _plugin = plugin;
+	private readonly UpdaterWindowViewModel _viewModel = viewModel;
 
 	public event EventHandler? CanExecuteChanged;
-
-	public SkipReleaseCommand(IUpdaterPlugin plugin, UpdaterWindowViewModel viewModel)
-	{
-		_plugin = plugin;
-		_viewModel = viewModel;
-	}
 
 	public bool CanExecute(object? parameter) => true;
 
@@ -27,18 +21,12 @@ internal class SkipReleaseCommand : System.Windows.Input.ICommand
 	}
 }
 
-internal class InstallReleaseCommand : System.Windows.Input.ICommand
+internal class InstallReleaseCommand(IUpdaterPlugin plugin, UpdaterWindowViewModel viewModel) : System.Windows.Input.ICommand
 {
-	private readonly IUpdaterPlugin _plugin;
-	private readonly UpdaterWindowViewModel _viewModel;
+	private readonly IUpdaterPlugin _plugin = plugin;
+	private readonly UpdaterWindowViewModel _viewModel = viewModel;
 
 	public event EventHandler? CanExecuteChanged;
-
-	public InstallReleaseCommand(IUpdaterPlugin plugin, UpdaterWindowViewModel viewModel)
-	{
-		_plugin = plugin;
-		_viewModel = viewModel;
-	}
 
 	public bool CanExecute(object? parameter) => true;
 
@@ -53,16 +41,11 @@ internal class InstallReleaseCommand : System.Windows.Input.ICommand
 	}
 }
 
-internal class CloseUpdaterWindowCommand : System.Windows.Input.ICommand
+internal class CloseUpdaterWindowCommand(IUpdaterPlugin plugin) : System.Windows.Input.ICommand
 {
-	private readonly IUpdaterPlugin _plugin;
+	private readonly IUpdaterPlugin _plugin = plugin;
 
 	public event EventHandler? CanExecuteChanged;
-
-	public CloseUpdaterWindowCommand(IUpdaterPlugin plugin)
-	{
-		_plugin = plugin;
-	}
 
 	public bool CanExecute(object? parameter) => true;
 

--- a/src/Whim.Updater/UpdaterWindow/UpdaterWindowCommands.cs
+++ b/src/Whim.Updater/UpdaterWindow/UpdaterWindowCommands.cs
@@ -2,12 +2,17 @@ using System;
 
 namespace Whim.Updater;
 
-internal class SkipReleaseCommand(IUpdaterPlugin plugin, UpdaterWindowViewModel viewModel) : System.Windows.Input.ICommand
+internal class SkipReleaseCommand(IUpdaterPlugin plugin, UpdaterWindowViewModel viewModel)
+	: System.Windows.Input.ICommand
 {
 	private readonly IUpdaterPlugin _plugin = plugin;
 	private readonly UpdaterWindowViewModel _viewModel = viewModel;
 
-	public event EventHandler? CanExecuteChanged { add { } remove { } }
+	public event EventHandler? CanExecuteChanged
+	{
+		add { }
+		remove { }
+	}
 
 	public bool CanExecute(object? parameter) => true;
 
@@ -21,12 +26,17 @@ internal class SkipReleaseCommand(IUpdaterPlugin plugin, UpdaterWindowViewModel 
 	}
 }
 
-internal class InstallReleaseCommand(IUpdaterPlugin plugin, UpdaterWindowViewModel viewModel) : System.Windows.Input.ICommand
+internal class InstallReleaseCommand(IUpdaterPlugin plugin, UpdaterWindowViewModel viewModel)
+	: System.Windows.Input.ICommand
 {
 	private readonly IUpdaterPlugin _plugin = plugin;
 	private readonly UpdaterWindowViewModel _viewModel = viewModel;
 
-	public event EventHandler? CanExecuteChanged { add { } remove { } }
+	public event EventHandler? CanExecuteChanged
+	{
+		add { }
+		remove { }
+	}
 
 	public bool CanExecute(object? parameter) => true;
 
@@ -45,7 +55,11 @@ internal class CloseUpdaterWindowCommand(IUpdaterPlugin plugin) : System.Windows
 {
 	private readonly IUpdaterPlugin _plugin = plugin;
 
-	public event EventHandler? CanExecuteChanged { add { } remove { } }
+	public event EventHandler? CanExecuteChanged
+	{
+		add { }
+		remove { }
+	}
 
 	public bool CanExecute(object? parameter) => true;
 

--- a/src/Whim.Updater/UpdaterWindow/UpdaterWindowCommands.cs
+++ b/src/Whim.Updater/UpdaterWindow/UpdaterWindowCommands.cs
@@ -7,7 +7,7 @@ internal class SkipReleaseCommand(IUpdaterPlugin plugin, UpdaterWindowViewModel 
 	private readonly IUpdaterPlugin _plugin = plugin;
 	private readonly UpdaterWindowViewModel _viewModel = viewModel;
 
-	public event EventHandler? CanExecuteChanged;
+	public event EventHandler? CanExecuteChanged { add { } remove { } }
 
 	public bool CanExecute(object? parameter) => true;
 
@@ -26,7 +26,7 @@ internal class InstallReleaseCommand(IUpdaterPlugin plugin, UpdaterWindowViewMod
 	private readonly IUpdaterPlugin _plugin = plugin;
 	private readonly UpdaterWindowViewModel _viewModel = viewModel;
 
-	public event EventHandler? CanExecuteChanged;
+	public event EventHandler? CanExecuteChanged { add { } remove { } }
 
 	public bool CanExecute(object? parameter) => true;
 
@@ -45,7 +45,7 @@ internal class CloseUpdaterWindowCommand(IUpdaterPlugin plugin) : System.Windows
 {
 	private readonly IUpdaterPlugin _plugin = plugin;
 
-	public event EventHandler? CanExecuteChanged;
+	public event EventHandler? CanExecuteChanged { add { } remove { } }
 
 	public bool CanExecute(object? parameter) => true;
 

--- a/src/Whim.Updater/UpdaterWindow/UpdaterWindowViewModel.cs
+++ b/src/Whim.Updater/UpdaterWindow/UpdaterWindowViewModel.cs
@@ -69,7 +69,7 @@ internal class UpdaterWindowViewModel : INotifyPropertyChanged
 
 	public event PropertyChangedEventHandler? PropertyChanged;
 
-	private IReadOnlyList<ReleaseInfo> _releases = new List<ReleaseInfo>();
+	private IReadOnlyList<ReleaseInfo> _releases = [];
 
 	public string LastCheckedForUpdates => _plugin.LastCheckedForUpdates?.ToString() ?? "Never";
 

--- a/src/Whim/Butler/ButlerPantry.cs
+++ b/src/Whim/Butler/ButlerPantry.cs
@@ -1,13 +1,8 @@
 namespace Whim;
 
-internal class ButlerPantry : IButlerPantry
+internal class ButlerPantry(IContext context) : IButlerPantry
 {
-	private readonly IContext _ctx;
-
-	public ButlerPantry(IContext context)
-	{
-		_ctx = context;
-	}
+	private readonly IContext _ctx = context;
 
 	public IWorkspace? GetAdjacentWorkspace(IWorkspace workspace, bool reverse = false, bool skipActive = false) =>
 		_ctx.Store.Pick(PickAdjacentWorkspace(workspace.Id, reverse, skipActive)).ValueOrDefault;

--- a/src/Whim/Commands/Command.cs
+++ b/src/Whim/Commands/Command.cs
@@ -1,42 +1,34 @@
 namespace Whim;
 
 /// <inheritdoc />
-public class Command : ICommand
+/// <summary>
+/// Initializes a new instance of the <see cref="Command"/> class.
+/// </summary>
+/// <param name="identifier">The identifier of the command.</param>
+/// <param name="title">The title of the command.</param>
+/// <param name="callback">
+/// The callback to execute.
+/// This can include triggering a menu to be shown by Whim.CommandPalette,
+/// or to perform some other action.
+/// </param>
+/// <param name="condition">
+/// A condition to determine if the command should be visible, or able to be
+/// executed.
+///
+/// When this evaluates to false, the <paramref name="callback"/> will not be executed.
+///
+/// If this is null, the command will always be accessible.
+/// </param>
+public class Command(string identifier, string title, Action callback, Func<bool>? condition = null) : ICommand
 {
-	private readonly Action _callback;
-	private readonly Func<bool>? _condition;
+	private readonly Action _callback = callback;
+	private readonly Func<bool>? _condition = condition;
 
 	/// <inheritdoc />
-	public string Id { get; }
+	public string Id { get; } = identifier;
 
 	/// <inheritdoc />
-	public string Title { get; }
-
-	/// <summary>
-	/// Initializes a new instance of the <see cref="Command"/> class.
-	/// </summary>
-	/// <param name="identifier">The identifier of the command.</param>
-	/// <param name="title">The title of the command.</param>
-	/// <param name="callback">
-	/// The callback to execute.
-	/// This can include triggering a menu to be shown by Whim.CommandPalette,
-	/// or to perform some other action.
-	/// </param>
-	/// <param name="condition">
-	/// A condition to determine if the command should be visible, or able to be
-	/// executed.
-	///
-	/// When this evaluates to false, the <paramref name="callback"/> will not be executed.
-	///
-	/// If this is null, the command will always be accessible.
-	/// </param>
-	public Command(string identifier, string title, Action callback, Func<bool>? condition = null)
-	{
-		Id = identifier;
-		Title = title;
-		_callback = callback;
-		_condition = condition;
-	}
+	public string Title { get; } = title;
 
 	/// <inheritdoc />
 	public bool CanExecute()

--- a/src/Whim/Commands/CommandManager.cs
+++ b/src/Whim/Commands/CommandManager.cs
@@ -4,7 +4,7 @@ namespace Whim;
 
 internal class CommandManager : ICommandManager
 {
-	private readonly Dictionary<string, ICommand> _commands = new();
+	private readonly Dictionary<string, ICommand> _commands = [];
 
 	public int Count => _commands.Count;
 

--- a/src/Whim/Commands/CoreCommands.cs
+++ b/src/Whim/Commands/CoreCommands.cs
@@ -1,4 +1,3 @@
-using System.Linq;
 using Windows.Win32.UI.Input.KeyboardAndMouse;
 
 namespace Whim;

--- a/src/Whim/Commands/CoreCommands.cs
+++ b/src/Whim/Commands/CoreCommands.cs
@@ -315,7 +315,7 @@ internal class CoreCommands : PluginCommands
 	{
 		public void Execute(IContext context)
 		{
-			IWorkspace[] workspaces = context.WorkspaceManager.ToArray();
+			IWorkspace[] workspaces = [.. context.WorkspaceManager];
 			if (Index <= workspaces.Length)
 			{
 				context.Butler.Activate(workspaces[Index - 1]);

--- a/src/Whim/ConfigLoader/ConfigLoaderException.cs
+++ b/src/Whim/ConfigLoader/ConfigLoaderException.cs
@@ -16,11 +16,4 @@ public class ConfigLoaderException : Exception
 	/// <inheritdoc/>
 	public ConfigLoaderException(string message, Exception inner)
 		: base(message, inner) { }
-
-	/// <inheritdoc/>
-	protected ConfigLoaderException(
-		System.Runtime.Serialization.SerializationInfo info,
-		System.Runtime.Serialization.StreamingContext context
-	)
-		: base(info, context) { }
 }

--- a/src/Whim/Context/Context.cs
+++ b/src/Whim/Context/Context.cs
@@ -11,7 +11,7 @@ namespace Whim;
 /// </summary>
 internal class Context : IContext
 {
-	private readonly IInternalContext _internalContext;
+	private readonly InternalContext _internalContext;
 	public IButler Butler { get; }
 	public IFileManager FileManager { get; }
 	public IResourceManager ResourceManager { get; }

--- a/src/Whim/Context/Context.cs
+++ b/src/Whim/Context/Context.cs
@@ -56,7 +56,7 @@ internal class Context : IContext
 		WindowManager = new WindowManager(this, _internalContext);
 		MonitorManager = new MonitorManager(this);
 		WorkspaceManager = new WorkspaceManager(this);
-		_commandManager = new CommandManager();
+		_commandManager = [];
 		PluginManager = new PluginManager(this, _commandManager);
 		KeybindManager = new KeybindManager(this);
 		NotificationManager = new NotificationManager(this);

--- a/src/Whim/Context/Context.cs
+++ b/src/Whim/Context/Context.cs
@@ -55,6 +55,7 @@ internal class Context : IContext
 		FilterManager = new FilterManager();
 		WindowManager = new WindowManager(this, _internalContext);
 		MonitorManager = new MonitorManager(this);
+
 		WorkspaceManager = new WorkspaceManager(this);
 		_commandManager = [];
 		PluginManager = new PluginManager(this, _commandManager);

--- a/src/Whim/Context/CoreSavedStateManager.cs
+++ b/src/Whim/Context/CoreSavedStateManager.cs
@@ -76,13 +76,13 @@ internal class CoreSavedStateManager : ICoreSavedStateManager
 
 	private void SaveState()
 	{
-		List<SavedWorkspace> savedWorkspaces = new();
+		List<SavedWorkspace> savedWorkspaces = [];
 		IMonitor monitor = _context.MonitorManager.PrimaryMonitor;
 		IRectangle<int> fakeMonitorRect = new Rectangle<int>() { Height = 1000, Width = 1000 };
 
 		foreach (IWorkspace workspace in _context.WorkspaceManager)
 		{
-			List<SavedWindow> savedWindows = new();
+			List<SavedWindow> savedWindows = [];
 
 			foreach (IWindowState windowState in workspace.ActiveLayoutEngine.DoLayout(fakeMonitorRect, monitor))
 			{

--- a/src/Whim/Context/IInternalContext.cs
+++ b/src/Whim/Context/IInternalContext.cs
@@ -3,7 +3,7 @@ namespace Whim;
 /// <summary>
 /// This contains internal core functionality for Whim which should not be exposed to plugins.
 /// </summary>
-internal interface IInternalContext : IDisposable
+internal interface IInternalContext
 {
 	ICoreSavedStateManager CoreSavedStateManager { get; }
 

--- a/src/Whim/Context/InternalContext.cs
+++ b/src/Whim/Context/InternalContext.cs
@@ -1,6 +1,6 @@
 namespace Whim;
 
-internal class InternalContext : IInternalContext
+internal class InternalContext : IInternalContext, IDisposable
 {
 	private bool _disposedValue;
 

--- a/src/Whim/Filter/FilterManager.cs
+++ b/src/Whim/Filter/FilterManager.cs
@@ -6,15 +6,15 @@ namespace Whim;
 internal class FilterManager : IFilterManager
 {
 	#region Filters for specific properties
-	private readonly HashSet<string> _ignoreWindowClasses = new();
-	private readonly HashSet<string> _ignoreProcessFileNames = new();
-	private readonly HashSet<string> _ignoreTitles = new();
+	private readonly HashSet<string> _ignoreWindowClasses = [];
+	private readonly HashSet<string> _ignoreProcessFileNames = [];
+	private readonly HashSet<string> _ignoreTitles = [];
 	#endregion
 
 	/// <summary>
 	/// Generic filter for windows.
 	/// </summary>
-	private readonly List<Filter> _filters = new();
+	private readonly List<Filter> _filters = [];
 
 	public void Add(Filter filter)
 	{

--- a/src/Whim/GlobalSuppressions.cs
+++ b/src/Whim/GlobalSuppressions.cs
@@ -19,18 +19,6 @@ using System.Diagnostics.CodeAnalysis;
 	Target = "~T:Whim.ICommandManager"
 )]
 [assembly: SuppressMessage(
-	"Design",
-	"CA1051:Do not declare visible instance fields",
-	Justification = "They are used by subclasses",
-	Scope = "module"
-)]
-[assembly: SuppressMessage(
-	"Design",
-	"CA1002:Do not expose generic lists",
-	Justification = "They are used by subclasses",
-	Scope = "module"
-)]
-[assembly: SuppressMessage(
 	"Naming",
 	"CA1716:Identifiers should not match keywords",
 	Justification = "Not concerned about Visual Basic",
@@ -72,7 +60,7 @@ using System.Diagnostics.CodeAnalysis;
 [assembly: SuppressMessage(
 	"Naming",
 	"CA1707:Identifiers should not contain underscores",
-	Justification = "This is Windows.Win32 ",
+	Justification = "This is Windows.Win32",
 	Scope = "namespaceanddescendants",
 	Target = "~N:Windows.Win32"
 )]
@@ -86,7 +74,21 @@ using System.Diagnostics.CodeAnalysis;
 [assembly: SuppressMessage(
 	"Design",
 	"CA1001:Types that own disposable fields should be disposable",
-	Justification = "Context isn't supposed to be disposable",
+	Justification = "Items are disposed by the context when it exits - a deliberate decision",
 	Scope = "type",
 	Target = "~T:Whim.Context"
+)]
+[assembly: SuppressMessage(
+	"Naming",
+	"CA1724:Type names should not match namespaces",
+	Justification = "Whim has no paid functionality, thus there is no risk of conflict with ABI.Windows.ApplicationModel.Store",
+	Scope = "type",
+	Target = "~T:Whim.Store"
+)]
+[assembly: SuppressMessage(
+	"Naming",
+	"CA1724:Type names should not match namespaces",
+	Justification = "At this stage, Whim does not directly allow the user to interact with the file system via the UI",
+	Scope = "type",
+	Target = "~T:Whim.Pickers"
 )]

--- a/src/Whim/Keybind/KeybindManager.cs
+++ b/src/Whim/Keybind/KeybindManager.cs
@@ -1,5 +1,3 @@
-using System.Linq;
-
 namespace Whim;
 
 internal class KeybindManager(IContext context) : IKeybindManager

--- a/src/Whim/Keybind/KeybindManager.cs
+++ b/src/Whim/Keybind/KeybindManager.cs
@@ -5,8 +5,8 @@ namespace Whim;
 internal class KeybindManager : IKeybindManager
 {
 	private readonly IContext _context;
-	private readonly Dictionary<IKeybind, List<string>> _keybindsCommandsMap = new();
-	private readonly Dictionary<string, IKeybind> _commandsKeybindsMap = new();
+	private readonly Dictionary<IKeybind, List<string>> _keybindsCommandsMap = [];
+	private readonly Dictionary<string, IKeybind> _commandsKeybindsMap = [];
 
 	public KeybindManager(IContext context)
 	{
@@ -53,7 +53,7 @@ internal class KeybindManager : IKeybindManager
 
 		if (!_keybindsCommandsMap.TryGetValue(keybind, out List<string>? value))
 		{
-			value = new List<string>();
+			value = [];
 			_keybindsCommandsMap.Add(keybind, value);
 		}
 
@@ -68,7 +68,7 @@ internal class KeybindManager : IKeybindManager
 
 		if (_keybindsCommandsMap.TryGetValue(keybind, out List<string>? commandIds))
 		{
-			List<ICommand> commands = new();
+			List<ICommand> commands = [];
 
 			foreach (string commandId in commandIds)
 			{

--- a/src/Whim/Keybind/KeybindManager.cs
+++ b/src/Whim/Keybind/KeybindManager.cs
@@ -2,17 +2,11 @@ using System.Linq;
 
 namespace Whim;
 
-internal class KeybindManager : IKeybindManager
+internal class KeybindManager(IContext context) : IKeybindManager
 {
-	private readonly IContext _context;
+	private readonly IContext _context = context;
 	private readonly Dictionary<IKeybind, List<string>> _keybindsCommandsMap = [];
 	private readonly Dictionary<string, IKeybind> _commandsKeybindsMap = [];
-
-	public KeybindManager(IContext context)
-	{
-		_context = context;
-	}
-
 	private bool _uniqueKeyModifiers = true;
 	public bool UnifyKeyModifiers
 	{

--- a/src/Whim/Keybind/KeybindManager.cs
+++ b/src/Whim/Keybind/KeybindManager.cs
@@ -87,7 +87,7 @@ internal class KeybindManager : IKeybindManager
 			return [.. commands];
 		}
 
-		return Array.Empty<ICommand>();
+		return [];
 	}
 
 	public IKeybind? TryGetKeybind(string commandId)

--- a/src/Whim/Keybind/KeybindManager.cs
+++ b/src/Whim/Keybind/KeybindManager.cs
@@ -31,7 +31,7 @@ internal class KeybindManager : IKeybindManager
 
 	private void UnifyKeybinds()
 	{
-		KeyValuePair<string, IKeybind>[] keybinds = _commandsKeybindsMap.ToArray();
+		KeyValuePair<string, IKeybind>[] keybinds = [.. _commandsKeybindsMap];
 		_commandsKeybindsMap.Clear();
 		_keybindsCommandsMap.Clear();
 
@@ -84,7 +84,7 @@ internal class KeybindManager : IKeybindManager
 				}
 			}
 
-			return commands.ToArray();
+			return [.. commands];
 		}
 
 		return Array.Empty<ICommand>();

--- a/src/Whim/Layout/ColumnLayoutEngine.cs
+++ b/src/Whim/Layout/ColumnLayoutEngine.cs
@@ -35,8 +35,8 @@ public record ColumnLayoutEngine : ILayoutEngine
 	public ColumnLayoutEngine(LayoutEngineIdentity identity)
 	{
 		Identity = identity;
-		_stack = ImmutableList<IWindow>.Empty;
-		_minimizedWindows = ImmutableHashSet<IWindow>.Empty;
+		_stack = [];
+		_minimizedWindows = [];
 	}
 
 	private ColumnLayoutEngine(

--- a/src/Whim/Layout/FocusLayoutEngine.cs
+++ b/src/Whim/Layout/FocusLayoutEngine.cs
@@ -70,7 +70,7 @@ public record FocusLayoutEngine : ILayoutEngine
 	{
 		Identity = identity;
 		_maximized = maximized;
-		_list = ImmutableList<IWindow>.Empty;
+		_list = [];
 	}
 
 	private FocusLayoutEngine(

--- a/src/Whim/Logging/Logger.cs
+++ b/src/Whim/Logging/Logger.cs
@@ -17,7 +17,7 @@ public class Logger : IDisposable
 	/// <summary>
 	/// Serilog <see cref="ILogger"/> instance.
 	/// </summary>
-	private ILogger? _logger;
+	private Serilog.Core.Logger? _logger;
 
 	/// <summary>
 	/// Serilog <see cref="LoggerConfiguration"/> instance.

--- a/src/Whim/Monitor/MonitorEnumCallback.cs
+++ b/src/Whim/Monitor/MonitorEnumCallback.cs
@@ -2,7 +2,7 @@ namespace Whim;
 
 internal class MonitorEnumCallback
 {
-	public List<HMONITOR> Monitors { get; } = new();
+	public List<HMONITOR> Monitors { get; } = [];
 
 	[System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0060:Remove unused parameter")]
 	public unsafe BOOL Callback(HMONITOR monitor, HDC _hdc, RECT* _rect, LPARAM _param)

--- a/src/Whim/Monitor/MonitorManager.cs
+++ b/src/Whim/Monitor/MonitorManager.cs
@@ -5,9 +5,16 @@ namespace Whim;
 /// <summary>
 /// Implementation of <see cref="IMonitorManager"/>.
 /// </summary>
-internal class MonitorManager : IInternalMonitorManager, IMonitorManager
+/// <remarks>
+/// Creates a new instance of <see cref="MonitorManager"/>.
+/// </remarks>
+/// <exception cref="Exception">
+/// When no monitors are found, or there is no primary monitor.
+/// </exception>
+/// <param name="context"></param>
+internal class MonitorManager(IContext context) : IInternalMonitorManager, IMonitorManager
 {
-	private readonly IContext _context;
+	private readonly IContext _context = context;
 
 	private bool _disposedValue;
 
@@ -24,18 +31,6 @@ internal class MonitorManager : IInternalMonitorManager, IMonitorManager
 	IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
 	public event EventHandler<MonitorsChangedEventArgs>? MonitorsChanged;
-
-	/// <summary>
-	/// Creates a new instance of <see cref="MonitorManager"/>.
-	/// </summary>
-	/// <exception cref="Exception">
-	/// When no monitors are found, or there is no primary monitor.
-	/// </exception>
-	/// <param name="context"></param>
-	public MonitorManager(IContext context)
-	{
-		_context = context;
-	}
 
 	public void Initialize()
 	{

--- a/src/Whim/Monitor/MonitorsChangedEventArgs.cs
+++ b/src/Whim/Monitor/MonitorsChangedEventArgs.cs
@@ -44,7 +44,7 @@ public class MonitorsChangedEventArgs : EventArgs
 		}
 	}
 
-	private static IEnumerable<IMonitor> Concat(IEnumerable<IMonitor> first, IEnumerable<IMonitor> second)
+	private static List<IMonitor> Concat(IEnumerable<IMonitor> first, IEnumerable<IMonitor> second)
 	{
 		List<IMonitor> result = [.. first, .. second];
 		return result;

--- a/src/Whim/Monitor/MonitorsChangedEventArgs.cs
+++ b/src/Whim/Monitor/MonitorsChangedEventArgs.cs
@@ -46,9 +46,7 @@ public class MonitorsChangedEventArgs : EventArgs
 
 	private static IEnumerable<IMonitor> Concat(IEnumerable<IMonitor> first, IEnumerable<IMonitor> second)
 	{
-		List<IMonitor> result = new(first.Count() + second.Count());
-		result.AddRange(first);
-		result.AddRange(second);
+		List<IMonitor> result = [.. first, .. second];
 		return result;
 	}
 

--- a/src/Whim/Native/CoreNativeManager.cs
+++ b/src/Whim/Native/CoreNativeManager.cs
@@ -12,14 +12,9 @@ using Windows.Win32.UI.WindowsAndMessaging;
 
 namespace Whim;
 
-internal class CoreNativeManager : ICoreNativeManager
+internal class CoreNativeManager(IContext context) : ICoreNativeManager
 {
-	private readonly IContext _context;
-
-	public CoreNativeManager(IContext context)
-	{
-		_context = context;
-	}
+	private readonly IContext _context = context;
 
 	public UnhookWinEventSafeHandle SetWinEventHook(uint eventMin, uint eventMax, WINEVENTPROC lpfnWinEventProc) =>
 		PInvoke.SetWinEventHook(eventMin, eventMax, null, lpfnWinEventProc, 0, 0, PInvoke.WINEVENT_OUTOFCONTEXT);

--- a/src/Whim/Native/CoreNativeManager.cs
+++ b/src/Whim/Native/CoreNativeManager.cs
@@ -116,7 +116,7 @@ internal class CoreNativeManager : ICoreNativeManager
 
 	public IEnumerable<HWND> GetAllWindows()
 	{
-		List<HWND> windows = new();
+		List<HWND> windows = [];
 
 		PInvoke.EnumWindows(
 			(handle, param) =>
@@ -132,7 +132,7 @@ internal class CoreNativeManager : ICoreNativeManager
 
 	public IEnumerable<HWND> GetChildWindows(HWND hwnd)
 	{
-		List<HWND> windows = new();
+		List<HWND> windows = [];
 
 		PInvoke.EnumChildWindows(
 			hwnd,
@@ -188,7 +188,13 @@ internal class CoreNativeManager : ICoreNativeManager
 	}
 
 	private readonly HashSet<string> _systemClasses =
-		new() { "SysListView32", "WorkerW", "Shell_TrayWnd", "Shell_SecondaryTrayWnd", "Progman" };
+	[
+		"SysListView32",
+		"WorkerW",
+		"Shell_TrayWnd",
+		"Shell_SecondaryTrayWnd",
+		"Progman"
+	];
 
 	public bool IsSystemWindow(HWND hwnd, string className)
 	{

--- a/src/Whim/Native/DeferWindowPosHandle.cs
+++ b/src/Whim/Native/DeferWindowPosHandle.cs
@@ -17,8 +17,8 @@ public sealed class DeferWindowPosHandle : IDisposable
 	private readonly IContext _context;
 	private readonly IInternalContext _internalContext;
 
-	private readonly List<DeferWindowPosState> _windowStates = new();
-	private readonly List<DeferWindowPosState> _minimizedWindowStates = new();
+	private readonly List<DeferWindowPosState> _windowStates = [];
+	private readonly List<DeferWindowPosState> _minimizedWindowStates = [];
 
 	private bool _forceTwoPasses;
 

--- a/src/Whim/Native/IMouseHook.cs
+++ b/src/Whim/Native/IMouseHook.cs
@@ -3,14 +3,9 @@ namespace Whim;
 /// <summary>
 /// Event arguments for mouse events.
 /// </summary>
-internal class MouseEventArgs : EventArgs
+internal class MouseEventArgs(IPoint<int> point) : EventArgs
 {
-	public IPoint<int> Point { get; }
-
-	public MouseEventArgs(IPoint<int> point)
-	{
-		Point = point;
-	}
+	public IPoint<int> Point { get; } = point;
 }
 
 internal interface IMouseHook : IDisposable

--- a/src/Whim/Native/InitializeWindowException.cs
+++ b/src/Whim/Native/InitializeWindowException.cs
@@ -25,15 +25,4 @@ public class InitializeWindowException : System.Exception
 	/// <param name="inner">The exception that is the cause of the current exception.</param>
 	public InitializeWindowException(string message, System.Exception inner)
 		: base(message, inner) { }
-
-	/// <summary>
-	/// Constructs a new InitializeWindowException.
-	/// </summary>
-	/// <param name="info">The <see cref="System.Runtime.Serialization.SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
-	/// <param name="context">The <see cref="System.Runtime.Serialization.StreamingContext"/> that contains contextual information about the source or destination.</param>
-	protected InitializeWindowException(
-		System.Runtime.Serialization.SerializationInfo info,
-		System.Runtime.Serialization.StreamingContext context
-	)
-		: base(info, context) { }
 }

--- a/src/Whim/Native/NativeManager.cs
+++ b/src/Whim/Native/NativeManager.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Net.Http;
 // We do use this in non-DEBUG.
 #pragma warning disable IDE0005 // Using directive is unnecessary.
+using System.Reflection;
 #pragma warning restore IDE0005 // Using directive is unnecessary.
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;

--- a/src/Whim/Native/NativeManager.cs
+++ b/src/Whim/Native/NativeManager.cs
@@ -3,7 +3,6 @@ using System.IO;
 using System.Net.Http;
 // We do use this in non-DEBUG.
 #pragma warning disable IDE0005 // Using directive is unnecessary.
-using System.Reflection;
 #pragma warning restore IDE0005 // Using directive is unnecessary.
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;

--- a/src/Whim/Native/NativeManager.cs
+++ b/src/Whim/Native/NativeManager.cs
@@ -272,6 +272,7 @@ internal partial class NativeManager : INativeManager
 
 	[LibraryImport("UXTheme.dll", EntryPoint = "#138", SetLastError = true)]
 	[return: MarshalAs(UnmanagedType.Bool)]
+	[DefaultDllImportSearchPaths(DllImportSearchPath.SafeDirectories)]
 	private static partial bool _ShouldSystemUseDarkMode();
 
 	public bool ShouldSystemUseDarkMode() => _ShouldSystemUseDarkMode();

--- a/src/Whim/Notification/NotificationManager.cs
+++ b/src/Whim/Notification/NotificationManager.cs
@@ -8,7 +8,7 @@ internal class NotificationManager : INotificationManager
 	private bool _initialized;
 
 	private readonly IContext _context;
-	private readonly Dictionary<string, Action<AppNotificationActivatedEventArgs>> _notificationHandlers = new();
+	private readonly Dictionary<string, Action<AppNotificationActivatedEventArgs>> _notificationHandlers = [];
 
 	public NotificationManager(IContext context)
 	{

--- a/src/Whim/Notification/NotificationManager.cs
+++ b/src/Whim/Notification/NotificationManager.cs
@@ -2,18 +2,13 @@ using Microsoft.Windows.AppNotifications;
 
 namespace Whim;
 
-internal class NotificationManager : INotificationManager
+internal class NotificationManager(IContext context) : INotificationManager
 {
 	private bool _disposedValue;
 	private bool _initialized;
 
-	private readonly IContext _context;
+	private readonly IContext _context = context;
 	private readonly Dictionary<string, Action<AppNotificationActivatedEventArgs>> _notificationHandlers = [];
-
-	public NotificationManager(IContext context)
-	{
-		_context = context;
-	}
 
 	public void Initialize()
 	{

--- a/src/Whim/Plugin/PluginCommands.cs
+++ b/src/Whim/Plugin/PluginCommands.cs
@@ -1,28 +1,23 @@
 namespace Whim;
 
 /// <inheritdoc />
-public class PluginCommands : IPluginCommands
+/// <summary>
+/// Creates a new instance of the plugin commands.
+/// </summary>
+/// <param name="pluginName">The name of the plugin.</param>
+public class PluginCommands(string pluginName) : IPluginCommands
 {
 	private readonly List<ICommand> _commands = [];
 	private readonly List<(string commandId, IKeybind keybind)> _keybinds = [];
 
 	/// <inheritdoc />
-	public string PluginName { get; init; }
+	public string PluginName { get; init; } = pluginName;
 
 	/// <inheritdoc />
 	public IEnumerable<ICommand> Commands => _commands;
 
 	/// <inheritdoc />
 	public IEnumerable<(string commandId, IKeybind keybind)> Keybinds => _keybinds;
-
-	/// <summary>
-	/// Creates a new instance of the plugin commands.
-	/// </summary>
-	/// <param name="pluginName">The name of the plugin.</param>
-	public PluginCommands(string pluginName)
-	{
-		PluginName = pluginName;
-	}
 
 	/// <summary>
 	/// Add a command to the plugin.

--- a/src/Whim/Plugin/PluginCommands.cs
+++ b/src/Whim/Plugin/PluginCommands.cs
@@ -3,8 +3,8 @@ namespace Whim;
 /// <inheritdoc />
 public class PluginCommands : IPluginCommands
 {
-	private readonly List<ICommand> _commands = new();
-	private readonly List<(string commandId, IKeybind keybind)> _keybinds = new();
+	private readonly List<ICommand> _commands = [];
+	private readonly List<(string commandId, IKeybind keybind)> _keybinds = [];
 
 	/// <inheritdoc />
 	public string PluginName { get; init; }

--- a/src/Whim/Plugin/PluginManager.cs
+++ b/src/Whim/Plugin/PluginManager.cs
@@ -9,7 +9,7 @@ internal partial class PluginManager : IPluginManager
 	private readonly IContext _context;
 	private readonly CommandManager _commandManager;
 	private readonly string _savedStateFilePath;
-	private readonly List<IPlugin> _plugins = new();
+	private readonly List<IPlugin> _plugins = [];
 	private bool _disposedValue;
 
 	[GeneratedRegex(@"^\w+\.\w+(\.\w+)*$")]

--- a/src/Whim/Plugin/PluginManagerSavedState.cs
+++ b/src/Whim/Plugin/PluginManagerSavedState.cs
@@ -7,5 +7,5 @@ internal class PluginManagerSavedState
 	/// <summary>
 	/// The saved state of all plugins.
 	/// </summary>
-	public Dictionary<string, JsonElement> Plugins { get; set; } = new();
+	public Dictionary<string, JsonElement> Plugins { get; set; } = [];
 }

--- a/src/Whim/Router/RouterManager.cs
+++ b/src/Whim/Router/RouterManager.cs
@@ -2,17 +2,12 @@ using System.Text.RegularExpressions;
 
 namespace Whim;
 
-internal class RouterManager : IRouterManager
+internal class RouterManager(IContext context) : IRouterManager
 {
-	private readonly IContext _context;
+	private readonly IContext _context = context;
 	private readonly List<Router> _routers = [];
 
 	public RouterOptions RouterOptions { get; set; } = RouterOptions.RouteToLaunchedWorkspace;
-
-	public RouterManager(IContext context)
-	{
-		_context = context;
-	}
 
 	public void Add(Router router)
 	{

--- a/src/Whim/Router/RouterManager.cs
+++ b/src/Whim/Router/RouterManager.cs
@@ -57,7 +57,7 @@ internal class RouterManager(IContext context) : IRouterManager
 		Logger.Debug($"Routing title: {title} to workspace {workspaceName}");
 		Add(window =>
 		{
-			if (window.Title.ToLower() == title)
+			if (window.Title.Equals(title, StringComparison.CurrentCultureIgnoreCase))
 			{
 				return _context.WorkspaceManager.TryGet(workspaceName);
 			}
@@ -72,7 +72,7 @@ internal class RouterManager(IContext context) : IRouterManager
 		Logger.Debug($"Routing title: {title} to workspace {workspace}");
 		Add(window =>
 		{
-			if (window.Title.ToLower() == title)
+			if (window.Title.Equals(title, StringComparison.CurrentCultureIgnoreCase))
 			{
 				return workspace;
 			}
@@ -134,7 +134,7 @@ internal class RouterManager(IContext context) : IRouterManager
 		Logger.Debug($"Routing window class: {windowClass} to workspace {workspaceName}");
 		Add(window =>
 		{
-			if (window.WindowClass.ToLower() == windowClass)
+			if (window.WindowClass.Equals(windowClass, StringComparison.CurrentCultureIgnoreCase))
 			{
 				return _context.WorkspaceManager.TryGet(workspaceName);
 			}
@@ -149,7 +149,7 @@ internal class RouterManager(IContext context) : IRouterManager
 		Logger.Debug($"Routing window class: {windowClass} to workspace {workspace}");
 		Add(window =>
 		{
-			if (window.WindowClass.ToLower() == windowClass)
+			if (window.WindowClass.Equals(windowClass, StringComparison.CurrentCultureIgnoreCase))
 			{
 				return workspace;
 			}

--- a/src/Whim/Router/RouterManager.cs
+++ b/src/Whim/Router/RouterManager.cs
@@ -5,7 +5,7 @@ namespace Whim;
 internal class RouterManager : IRouterManager
 {
 	private readonly IContext _context;
-	private readonly List<Router> _routers = new();
+	private readonly List<Router> _routers = [];
 
 	public RouterOptions RouterOptions { get; set; } = RouterOptions.RouteToLaunchedWorkspace;
 

--- a/src/Whim/Store/MapSector/MapPickers.cs
+++ b/src/Whim/Store/MapSector/MapPickers.cs
@@ -12,7 +12,7 @@ public static partial class Pickers
 	public static PurePicker<IEnumerable<IWorkspace>> PickAllActiveWorkspaces() =>
 		rootSector =>
 		{
-			List<IWorkspace> workspaces = new();
+			List<IWorkspace> workspaces = [];
 			foreach (WorkspaceId id in rootSector.MapSector.MonitorWorkspaceMap.Values)
 			{
 				workspaces.Add(rootSector.WorkspaceSector.Workspaces[id]);

--- a/src/Whim/Store/MonitorSector/MonitorEventListener.cs
+++ b/src/Whim/Store/MonitorSector/MonitorEventListener.cs
@@ -2,17 +2,11 @@ using System.Threading.Tasks;
 
 namespace Whim;
 
-internal class MonitorEventListener : IDisposable
+internal class MonitorEventListener(IContext ctx, IInternalContext internalCtx) : IDisposable
 {
-	private readonly IContext _ctx;
-	private readonly IInternalContext _internalCtx;
+	private readonly IContext _ctx = ctx;
+	private readonly IInternalContext _internalCtx = internalCtx;
 	private bool _disposedValue;
-
-	public MonitorEventListener(IContext ctx, IInternalContext internalCtx)
-	{
-		_ctx = ctx;
-		_internalCtx = internalCtx;
-	}
 
 	public void Initialize()
 	{

--- a/src/Whim/Store/MonitorSector/MonitorSector.cs
+++ b/src/Whim/Store/MonitorSector/MonitorSector.cs
@@ -1,6 +1,10 @@
 namespace Whim;
 
-internal class MonitorSector(IContext ctx, IInternalContext internalCtx) : SectorBase, IDisposable, IMonitorSector, IMonitorSectorEvents
+internal class MonitorSector(IContext ctx, IInternalContext internalCtx)
+	: SectorBase,
+		IDisposable,
+		IMonitorSector,
+		IMonitorSectorEvents
 {
 	private readonly IContext _ctx = ctx;
 	private readonly MonitorEventListener _listener = new(ctx, internalCtx);

--- a/src/Whim/Store/MonitorSector/MonitorSector.cs
+++ b/src/Whim/Store/MonitorSector/MonitorSector.cs
@@ -1,9 +1,9 @@
 namespace Whim;
 
-internal class MonitorSector : SectorBase, IDisposable, IMonitorSector, IMonitorSectorEvents
+internal class MonitorSector(IContext ctx, IInternalContext internalCtx) : SectorBase, IDisposable, IMonitorSector, IMonitorSectorEvents
 {
-	private readonly IContext _ctx;
-	private readonly MonitorEventListener _listener;
+	private readonly IContext _ctx = ctx;
+	private readonly MonitorEventListener _listener = new(ctx, internalCtx);
 	private bool _disposedValue;
 
 	public int MonitorsChangingTasks { get; set; }
@@ -14,12 +14,6 @@ internal class MonitorSector : SectorBase, IDisposable, IMonitorSector, IMonitor
 	public HMONITOR LastWhimActiveMonitorHandle { get; set; }
 
 	public event EventHandler<MonitorsChangedEventArgs>? MonitorsChanged;
-
-	public MonitorSector(IContext ctx, IInternalContext internalCtx)
-	{
-		_ctx = ctx;
-		_listener = new(ctx, internalCtx);
-	}
 
 	public override void Initialize()
 	{

--- a/src/Whim/Store/MonitorSector/MonitorSector.cs
+++ b/src/Whim/Store/MonitorSector/MonitorSector.cs
@@ -8,7 +8,7 @@ internal class MonitorSector : SectorBase, IDisposable, IMonitorSector, IMonitor
 
 	public int MonitorsChangingTasks { get; set; }
 	public int MonitorsChangedDelay { get; set; } = 3 * 1000;
-	public ImmutableArray<IMonitor> Monitors { get; set; } = ImmutableArray<IMonitor>.Empty;
+	public ImmutableArray<IMonitor> Monitors { get; set; } = [];
 	public HMONITOR ActiveMonitorHandle { get; set; }
 	public HMONITOR PrimaryMonitorHandle { get; set; }
 	public HMONITOR LastWhimActiveMonitorHandle { get; set; }

--- a/src/Whim/Store/MonitorSector/MonitorUtils.cs
+++ b/src/Whim/Store/MonitorSector/MonitorUtils.cs
@@ -42,7 +42,7 @@ internal static class MonitorUtils
 			currentMonitors[i] = new Monitor(internalCtx, hmonitor, isPrimaryHMonitor);
 		}
 
-		return currentMonitors.OrderBy(m => m.WorkingArea.X).ThenBy(m => m.WorkingArea.Y).ToArray().ToImmutableArray();
+		return [.. currentMonitors.OrderBy(m => m.WorkingArea.X).ThenBy(m => m.WorkingArea.Y)];
 	}
 
 	public static HMONITOR OrActiveMonitor(this HMONITOR handle, IRootSector rootSector) =>

--- a/src/Whim/Store/MonitorSector/MonitorUtils.cs
+++ b/src/Whim/Store/MonitorSector/MonitorUtils.cs
@@ -13,7 +13,7 @@ internal static class MonitorUtils
 	/// <exception cref="Exception">When no monitors are found.</exception>
 	public static unsafe ImmutableArray<IMonitor> GetCurrentMonitors(IInternalContext internalCtx)
 	{
-		List<HMONITOR> hmonitors = new();
+		List<HMONITOR> hmonitors = [];
 		HMONITOR primaryHMonitor = internalCtx.CoreNativeManager.MonitorFromPoint(
 			new Point(0, 0),
 			MONITOR_FROM_FLAGS.MONITOR_DEFAULTTOPRIMARY

--- a/src/Whim/Store/MonitorSector/Transforms/MonitorsChangedTransform.cs
+++ b/src/Whim/Store/MonitorSector/Transforms/MonitorsChangedTransform.cs
@@ -20,9 +20,9 @@ internal record MonitorsChangedTransform : Transform
 		ImmutableArray<IMonitor> previousMonitors = sector.Monitors;
 		UpdateMonitorSector(ctx, internalCtx, mutableRootSector);
 
-		List<IMonitor> unchangedMonitors = new();
-		List<IMonitor> removedMonitors = new();
-		List<IMonitor> addedMonitors = new();
+		List<IMonitor> unchangedMonitors = [];
+		List<IMonitor> removedMonitors = [];
+		List<IMonitor> addedMonitors = [];
 
 		// For each monitor in the previous set, check if it's in the current set.
 		foreach (IMonitor monitor in previousMonitors)

--- a/src/Whim/Store/RootSector/MutableRootSector.cs
+++ b/src/Whim/Store/RootSector/MutableRootSector.cs
@@ -1,16 +1,16 @@
 namespace Whim;
 
-internal class MutableRootSector : SectorBase, IDisposable
+internal class MutableRootSector(IContext ctx, IInternalContext internalCtx) : SectorBase, IDisposable
 {
-	private readonly IContext _ctx;
+	private readonly IContext _ctx = ctx;
 	private readonly object _lock = new();
 	private bool _disposedValue;
 	private bool _dispatchEventsScheduled;
 
-	public MonitorSector MonitorSector { get; }
-	public WindowSector WindowSector { get; }
-	public WorkspaceSector WorkspaceSector { get; }
-	public MapSector MapSector { get; }
+	public MonitorSector MonitorSector { get; } = new MonitorSector(ctx, internalCtx);
+	public WindowSector WindowSector { get; } = new WindowSector(ctx, internalCtx);
+	public WorkspaceSector WorkspaceSector { get; } = new WorkspaceSector(ctx, internalCtx);
+	public MapSector MapSector { get; } = new MapSector();
 
 	/// <inheritdoc/>
 	public override bool HasQueuedEvents =>
@@ -18,15 +18,6 @@ internal class MutableRootSector : SectorBase, IDisposable
 		|| WindowSector.HasQueuedEvents
 		|| WorkspaceSector.HasQueuedEvents
 		|| MapSector.HasQueuedEvents;
-
-	public MutableRootSector(IContext ctx, IInternalContext internalCtx)
-	{
-		_ctx = ctx;
-		MonitorSector = new MonitorSector(ctx, internalCtx);
-		WindowSector = new WindowSector(ctx, internalCtx);
-		WorkspaceSector = new WorkspaceSector(ctx, internalCtx);
-		MapSector = new MapSector();
-	}
 
 	public override void Initialize()
 	{

--- a/src/Whim/Store/RootSector/RootEventListener.cs
+++ b/src/Whim/Store/RootSector/RootEventListener.cs
@@ -3,17 +3,11 @@ namespace Whim;
 /// <summary>
 /// Listens for events which aren't specific to slices.
 /// </summary>
-internal class RootEventListener : IDisposable
+internal class RootEventListener(IContext ctx, IInternalContext internalCtx) : IDisposable
 {
-	private readonly IContext _ctx;
-	private readonly IInternalContext _internalCtx;
+	private readonly IContext _ctx = ctx;
+	private readonly IInternalContext _internalCtx = internalCtx;
 	private bool _disposedValue;
-
-	public RootEventListener(IContext ctx, IInternalContext internalCtx)
-	{
-		_ctx = ctx;
-		_internalCtx = internalCtx;
-	}
 
 	public void Initialize()
 	{

--- a/src/Whim/Store/SectorBase.cs
+++ b/src/Whim/Store/SectorBase.cs
@@ -8,7 +8,7 @@ internal abstract class SectorBase
 	/// <summary>
 	/// Queue of events to dispatch.
 	/// </summary>
-	protected readonly List<EventArgs> _events = new();
+	protected readonly List<EventArgs> _events = [];
 
 	/// <summary>
 	/// Whether there are events queued.

--- a/src/Whim/Store/WindowSector/Processors/WindowProcessorManager.cs
+++ b/src/Whim/Store/WindowSector/Processors/WindowProcessorManager.cs
@@ -6,9 +6,9 @@ internal class WindowProcessorManager
 {
 	private readonly IContext _ctx;
 
-	private readonly List<Func<IContext, IWindow, IWindowProcessor?>> _processorCreators = new();
+	private readonly List<Func<IContext, IWindow, IWindowProcessor?>> _processorCreators = [];
 
-	private readonly Dictionary<HWND, IWindowProcessor> _processors = new();
+	private readonly Dictionary<HWND, IWindowProcessor> _processors = [];
 
 	public WindowProcessorManager(IContext ctx)
 	{

--- a/src/Whim/Store/WindowSector/Transforms/WindowMovedTransform.cs
+++ b/src/Whim/Store/WindowSector/Transforms/WindowMovedTransform.cs
@@ -1,5 +1,3 @@
-using System.Threading.Tasks;
-
 namespace Whim;
 
 internal record WindowMovedTransform(IWindow Window) : Transform

--- a/src/Whim/Store/WindowSector/WindowSector.cs
+++ b/src/Whim/Store/WindowSector/WindowSector.cs
@@ -5,7 +5,7 @@ namespace Whim;
 /// </summary>
 internal class WindowSector(IContext ctx, IInternalContext internalCtx) : SectorBase, IWindowSector, IDisposable, IWindowSectorEvents
 {
-	private readonly WindowEventListener _listener = new WindowEventListener(ctx, internalCtx);
+	private readonly WindowEventListener _listener = new(ctx, internalCtx);
 	private bool _disposedValue;
 
 	public ImmutableDictionary<HWND, IWindow> Windows { get; internal set; } = ImmutableDictionary<HWND, IWindow>.Empty;

--- a/src/Whim/Store/WindowSector/WindowSector.cs
+++ b/src/Whim/Store/WindowSector/WindowSector.cs
@@ -3,7 +3,11 @@ namespace Whim;
 /// <summary>
 /// The sector containing windows.
 /// </summary>
-internal class WindowSector(IContext ctx, IInternalContext internalCtx) : SectorBase, IWindowSector, IDisposable, IWindowSectorEvents
+internal class WindowSector(IContext ctx, IInternalContext internalCtx)
+	: SectorBase,
+		IWindowSector,
+		IDisposable,
+		IWindowSectorEvents
 {
 	private readonly WindowEventListener _listener = new(ctx, internalCtx);
 	private bool _disposedValue;

--- a/src/Whim/Store/WindowSector/WindowSector.cs
+++ b/src/Whim/Store/WindowSector/WindowSector.cs
@@ -10,7 +10,7 @@ internal class WindowSector : SectorBase, IWindowSector, IDisposable, IWindowSec
 
 	public ImmutableDictionary<HWND, IWindow> Windows { get; internal set; } = ImmutableDictionary<HWND, IWindow>.Empty;
 
-	public ImmutableHashSet<HWND> StartupWindows { get; internal set; } = ImmutableHashSet<HWND>.Empty;
+	public ImmutableHashSet<HWND> StartupWindows { get; internal set; } = [];
 
 	public bool IsMovingWindow { get; internal set; }
 

--- a/src/Whim/Store/WindowSector/WindowSector.cs
+++ b/src/Whim/Store/WindowSector/WindowSector.cs
@@ -3,9 +3,9 @@ namespace Whim;
 /// <summary>
 /// The sector containing windows.
 /// </summary>
-internal class WindowSector : SectorBase, IWindowSector, IDisposable, IWindowSectorEvents
+internal class WindowSector(IContext ctx, IInternalContext internalCtx) : SectorBase, IWindowSector, IDisposable, IWindowSectorEvents
 {
-	private readonly WindowEventListener _listener;
+	private readonly WindowEventListener _listener = new WindowEventListener(ctx, internalCtx);
 	private bool _disposedValue;
 
 	public ImmutableDictionary<HWND, IWindow> Windows { get; internal set; } = ImmutableDictionary<HWND, IWindow>.Empty;
@@ -24,11 +24,6 @@ internal class WindowSector : SectorBase, IWindowSector, IDisposable, IWindowSec
 	public event EventHandler<WindowMovedEventArgs>? WindowMoved;
 	public event EventHandler<WindowMinimizeStartedEventArgs>? WindowMinimizeStarted;
 	public event EventHandler<WindowMinimizeEndedEventArgs>? WindowMinimizeEnded;
-
-	public WindowSector(IContext ctx, IInternalContext internalCtx)
-	{
-		_listener = new WindowEventListener(ctx, internalCtx);
-	}
 
 	public override void Initialize()
 	{

--- a/src/Whim/Store/WindowSector/WindowUtils.cs
+++ b/src/Whim/Store/WindowSector/WindowUtils.cs
@@ -99,7 +99,7 @@ internal static class WindowUtils
 		{
 			INPUT input = new() { type = INPUT_TYPE.INPUT_MOUSE };
 			// Send empty mouse event. This makes this thread the last to send input, and hence allows it to pass foreground permission checks
-			_ = internalCtx.CoreNativeManager.SendInput(new[] { input }, sizeof(INPUT));
+			_ = internalCtx.CoreNativeManager.SendInput([input], sizeof(INPUT));
 		}
 
 		internalCtx.CoreNativeManager.SetForegroundWindow(handle);

--- a/src/Whim/Store/WorkspaceSector/Transforms/InitializeWorkspacesTransform.cs
+++ b/src/Whim/Store/WorkspaceSector/Transforms/InitializeWorkspacesTransform.cs
@@ -53,10 +53,10 @@ internal record InitializeWorkspacesTransform : Transform
 
 		// Add the saved windows at their saved locations inside their saved workspaces.
 		// Other windows are routed to the monitor they're on.
-		List<HWND> processedWindows = new();
+		List<HWND> processedWindows = [];
 
 		// Route windows to their saved workspaces.
-		foreach (SavedWorkspace savedWorkspace in internalCtx.CoreSavedStateManager.SavedState?.Workspaces ?? new())
+		foreach (SavedWorkspace savedWorkspace in internalCtx.CoreSavedStateManager.SavedState?.Workspaces ?? [])
 		{
 			Workspace? workspace = workspaceSector.Workspaces.Values.FirstOrDefault(w =>
 				w.BackingName == savedWorkspace.Name

--- a/src/Whim/Store/WorkspaceSector/WorkspaceSector.cs
+++ b/src/Whim/Store/WorkspaceSector/WorkspaceSector.cs
@@ -26,7 +26,7 @@ internal class WorkspaceSector : SectorBase, IWorkspaceSector, IWorkspaceSectorE
 		ImmutableDictionary<WorkspaceId, Workspace>.Empty;
 
 	public Func<CreateLeafLayoutEngine[]> CreateLayoutEngines { get; set; } =
-		() => new CreateLeafLayoutEngine[] { (id) => new ColumnLayoutEngine(id) };
+		() => [(id) => new ColumnLayoutEngine(id)];
 
 	public ImmutableList<ProxyLayoutEngineCreator> ProxyLayoutEngineCreators { get; set; } = [];
 

--- a/src/Whim/Store/WorkspaceSector/WorkspaceSector.cs
+++ b/src/Whim/Store/WorkspaceSector/WorkspaceSector.cs
@@ -7,10 +7,10 @@ namespace Whim;
 /// <param name="CreateLeafLayoutEngines"></param>
 internal record WorkspaceToCreate(string? Name, IEnumerable<CreateLeafLayoutEngine>? CreateLeafLayoutEngines);
 
-internal class WorkspaceSector : SectorBase, IWorkspaceSector, IWorkspaceSectorEvents, IDisposable
+internal class WorkspaceSector(IContext ctx, IInternalContext internalCtx) : SectorBase, IWorkspaceSector, IWorkspaceSectorEvents, IDisposable
 {
-	private readonly IContext _ctx;
-	private readonly IInternalContext _internalCtx;
+	private readonly IContext _ctx = ctx;
+	private readonly IInternalContext _internalCtx = internalCtx;
 
 	public bool HasInitialized { get; set; }
 
@@ -41,12 +41,6 @@ internal class WorkspaceSector : SectorBase, IWorkspaceSector, IWorkspaceSectorE
 	public event EventHandler<WorkspaceLayoutStartedEventArgs>? WorkspaceLayoutStarted;
 
 	public event EventHandler<WorkspaceLayoutCompletedEventArgs>? WorkspaceLayoutCompleted;
-
-	public WorkspaceSector(IContext ctx, IInternalContext internalCtx)
-	{
-		_ctx = ctx;
-		_internalCtx = internalCtx;
-	}
 
 	public override void Initialize()
 	{

--- a/src/Whim/Store/WorkspaceSector/WorkspaceSector.cs
+++ b/src/Whim/Store/WorkspaceSector/WorkspaceSector.cs
@@ -7,7 +7,11 @@ namespace Whim;
 /// <param name="CreateLeafLayoutEngines"></param>
 internal record WorkspaceToCreate(string? Name, IEnumerable<CreateLeafLayoutEngine>? CreateLeafLayoutEngines);
 
-internal class WorkspaceSector(IContext ctx, IInternalContext internalCtx) : SectorBase, IWorkspaceSector, IWorkspaceSectorEvents, IDisposable
+internal class WorkspaceSector(IContext ctx, IInternalContext internalCtx)
+	: SectorBase,
+		IWorkspaceSector,
+		IWorkspaceSectorEvents,
+		IDisposable
 {
 	private readonly IContext _ctx = ctx;
 	private readonly IInternalContext _internalCtx = internalCtx;

--- a/src/Whim/Store/WorkspaceSector/WorkspaceSector.cs
+++ b/src/Whim/Store/WorkspaceSector/WorkspaceSector.cs
@@ -14,13 +14,13 @@ internal class WorkspaceSector : SectorBase, IWorkspaceSector, IWorkspaceSectorE
 
 	public bool HasInitialized { get; set; }
 
-	public ImmutableList<WorkspaceToCreate> WorkspacesToCreate { get; set; } = ImmutableList<WorkspaceToCreate>.Empty;
+	public ImmutableList<WorkspaceToCreate> WorkspacesToCreate { get; set; } = [];
 
-	public ImmutableHashSet<WorkspaceId> WorkspacesToLayout { get; set; } = ImmutableHashSet<WorkspaceId>.Empty;
+	public ImmutableHashSet<WorkspaceId> WorkspacesToLayout { get; set; } = [];
 
 	public HWND WindowHandleToFocus { get; set; }
 
-	public ImmutableArray<WorkspaceId> WorkspaceOrder { get; set; } = ImmutableArray<WorkspaceId>.Empty;
+	public ImmutableArray<WorkspaceId> WorkspaceOrder { get; set; } = [];
 
 	public ImmutableDictionary<WorkspaceId, Workspace> Workspaces { get; set; } =
 		ImmutableDictionary<WorkspaceId, Workspace>.Empty;
@@ -28,8 +28,7 @@ internal class WorkspaceSector : SectorBase, IWorkspaceSector, IWorkspaceSectorE
 	public Func<CreateLeafLayoutEngine[]> CreateLayoutEngines { get; set; } =
 		() => new CreateLeafLayoutEngine[] { (id) => new ColumnLayoutEngine(id) };
 
-	public ImmutableList<ProxyLayoutEngineCreator> ProxyLayoutEngineCreators { get; set; } =
-		ImmutableList<ProxyLayoutEngineCreator>.Empty;
+	public ImmutableList<ProxyLayoutEngineCreator> ProxyLayoutEngineCreators { get; set; } = [];
 
 	public event EventHandler<WorkspaceAddedEventArgs>? WorkspaceAdded;
 

--- a/src/Whim/Utils/ColorExtensions.cs
+++ b/src/Whim/Utils/ColorExtensions.cs
@@ -16,7 +16,7 @@ public static class ColorExtensions
 	/// <returns></returns>
 	public static Color GetTextColor(this Color backgroundColor)
 	{
-		double[] uiColors = new double[] { backgroundColor.R / 255, backgroundColor.G / 255, backgroundColor.B / 255 };
+		double[] uiColors = [backgroundColor.R / 255, backgroundColor.G / 255, backgroundColor.B / 255];
 
 		double[] cColors = new double[3];
 		for (int idx = 0; idx < 3; idx++)

--- a/src/Whim/Utils/VeryObservableCollection.cs
+++ b/src/Whim/Utils/VeryObservableCollection.cs
@@ -15,14 +15,6 @@ public class VeryObservableCollection<T> : ObservableCollection<T>
 		: base() { }
 
 	/// <inheritdoc/>
-	public VeryObservableCollection(IEnumerable<T> collection)
-		: base(collection) { }
-
-	/// <inheritdoc/>
-	public VeryObservableCollection(List<T> list)
-		: base(list) { }
-
-	/// <inheritdoc/>
 	protected override void OnCollectionChanged(System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
 	{
 		base.OnCollectionChanged(e);

--- a/src/Whim/Window/WindowManager.cs
+++ b/src/Whim/Window/WindowManager.cs
@@ -2,10 +2,10 @@ using System.Collections;
 
 namespace Whim;
 
-internal class WindowManager : IWindowManager, IInternalWindowManager
+internal class WindowManager(IContext context, IInternalContext internalContext) : IWindowManager, IInternalWindowManager
 {
-	private readonly IContext _context;
-	private readonly IInternalContext _internalContext;
+	private readonly IContext _context = context;
+	private readonly IInternalContext _internalContext = internalContext;
 
 	public event EventHandler<WindowAddedEventArgs>? WindowAdded;
 	public event EventHandler<WindowFocusedEventArgs>? WindowFocused;
@@ -20,12 +20,6 @@ internal class WindowManager : IWindowManager, IInternalWindowManager
 	/// Indicates whether values have been disposed.
 	/// </summary>
 	private bool _disposedValue;
-
-	public WindowManager(IContext context, IInternalContext internalContext)
-	{
-		_context = context;
-		_internalContext = internalContext;
-	}
 
 	public void Initialize()
 	{

--- a/src/Whim/Window/WindowManager.cs
+++ b/src/Whim/Window/WindowManager.cs
@@ -2,7 +2,9 @@ using System.Collections;
 
 namespace Whim;
 
-internal class WindowManager(IContext context, IInternalContext internalContext) : IWindowManager, IInternalWindowManager
+internal class WindowManager(IContext context, IInternalContext internalContext)
+	: IWindowManager,
+		IInternalWindowManager
 {
 	private readonly IContext _context = context;
 	private readonly IInternalContext _internalContext = internalContext;

--- a/src/Whim/Workspace/Workspace.cs
+++ b/src/Whim/Workspace/Workspace.cs
@@ -21,7 +21,7 @@ public sealed partial record Workspace : IWorkspace
 	public HWND LastFocusedWindowHandle { get; internal set; }
 
 	/// <inheritdoc />
-	public ImmutableList<ILayoutEngine> LayoutEngines { get; internal set; } = ImmutableList<ILayoutEngine>.Empty;
+	public ImmutableList<ILayoutEngine> LayoutEngines { get; internal set; } = [];
 
 	/// <inheritdoc />
 	public ImmutableDictionary<HWND, WindowPosition> WindowPositions { get; internal set; } =

--- a/src/Whim/Workspace/WorkspaceManager.cs
+++ b/src/Whim/Workspace/WorkspaceManager.cs
@@ -3,9 +3,9 @@ using System.Linq;
 
 namespace Whim;
 
-internal class WorkspaceManager : IWorkspaceManager
+internal class WorkspaceManager(IContext context) : IWorkspaceManager
 {
-	private readonly IContext _context;
+	private readonly IContext _context = context;
 
 	public event EventHandler<WorkspaceAddedEventArgs>? WorkspaceAdded;
 
@@ -35,11 +35,6 @@ internal class WorkspaceManager : IWorkspaceManager
 			Logger.Debug($"Getting active workspace for monitor {activeMonitor}");
 			return _context.Store.Pick(PickActiveWorkspace());
 		}
-	}
-
-	public WorkspaceManager(IContext context)
-	{
-		_context = context;
 	}
 
 	public IWorkspace? Add(string? name = null, IEnumerable<CreateLeafLayoutEngine>? createLayoutEngines = null) =>


### PR DESCRIPTION
This PR addresses or suppresses all (but one) of the warnings. Some existed prior to .NET 8 in #966, but the majority were introduced in #966.

| Code       | Description                                                                                                                                                                               | Outcome                                               |
| ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
| CA1724     | Type names should not match namespaces                                                                                                                                                    | Suppressed in limited cases for `Pickers` and `Store` |
| CA1859     | Use concrete types when possible for improved performance                                                                                                                                 | Fixed in production code, suppressed for tests        |
| CA1861     | Avoid constant arrays as arguments                                                                                                                                                        | Suppressed for tests                                  |
| CA1862     | Use the 'StringComparison' method overloads to perform case-insensitive string comparisons                                                                                                | Fixed                                                 |
| CA2000     | Dispose objects before losing scope                                                                                                                                                       | Fixed                                                 |
| CA2213     | Disposable fields should be disposed                                                                                                                                                      | Fixed, suppressed for most tests                      |
| CA5392     | Use DefaultDllImportSearchPaths attribute for P/Invokes                                                                                                                                   | Fixed                                                 |
| CS0108     | 'TestProxyLayoutEngine.InnerLayoutEngine' hides inherited member 'BaseProxyLayoutEngine.InnerLayoutEngine'. Use the new keyword if hiding was intended.                                   | Fixed                                                 |
| IDE0005    | Remove unnecessary using directives                                                                                                                                                       | Fixed                                                 |
| IDE0028    | Use collection initializers or expressions                                                                                                                                                | Fixed                                                 |
| IDE0290    | Use primary constructor                                                                                                                                                                   | Fixed                                                 |
| IDE0300    | Use collection expression for array                                                                                                                                                       | Fixed                                                 |
| IDE0301    | Use collection expression for empty                                                                                                                                                       | Fixed                                                 |
| IDE0303    | Use collection expression for Create()                                                                                                                                                    | Fixed                                                 |
| IDE0305    | Use collection expression for fluent                                                                                                                                                      | Fixed                                                 |
| SYSLIB0051 | Legacy serialization support APIs are obsolete                                                                                                                                            | Fixed                                                 |
| xUnit1048  | Avoid using 'async void' for test methods as it is deprecated in xUnit.net v3                                                                                                             | Fixed                                                 |
| -          | Set MSBuild property 'GenerateDocumentationFile' to 'true' in project file to enable IDE0005 (Remove unnecessary usings/imports) on build (https://github.com/dotnet/roslyn/issues/41640) | Fixed                                                 |

The only remaining warning is:

```log
NETSDK1206 Found version-specific or distribution-specific runtime identifier(s): win10-arm64, win10-x64, win10-x86.
Affected libraries: Microsoft.WindowsAppSDK. In .NET 8.0 and higher, assets for version-specific and distribution-specific
runtime identifiers will not be found by default. See https://aka.ms/dotnet/rid-usage for details.
```

I also cheekily decreased the default focus indicator size in this PR.
