### PR TITLE
Always expose the workspace id when adding a workspace

### DIFF
--- a/docs/docs/customize/snippets.md
+++ b/docs/docs/customize/snippets.md
@@ -44,3 +44,31 @@ context.CommandManager.Add(
     callback: () => context.WorkspaceManager.ActivateAdjacent(skipActive: true)
 );
 ```
+
+## Move a window to a specific monitor
+
+The following command can be used to move the active window to a specific monitor. The index of the monitor is zero-based, so the primary monitor is index 0, the second monitor is index 1, and so on.
+
+```csharp
+context.CommandManager.Add("move_window_to_monitor_2", "Move window to monitor 2", () =>
+{
+    context.Store.Dispatch(new MoveWindowToMonitorIndexTransform(1));
+});
+```
+
+## Move a window to a specific workspace
+
+The following command can be used to move the active window to a specific workspace. The index of the workspace is zero-based.
+
+```csharp
+Guid? browserWorkspaceId = context.WorkspaceManager.Add("Browser workspace");
+context.CommandManager.Add("move_window_to_browser_workspace", "Move window to browser workspace", () =>
+{
+    // This `if` statement protects against workspaces being created with no layout engines.
+    if (browserWorkspaceId is Guid workspaceId)
+    {
+        // This defaults to the active window, but you can also pass in a specific window as the second argument to the transform.
+        context.Store.Dispatch(new MoveWindowToWorkspaceTransform(workspaceId));
+    }
+});
+```

--- a/src/Whim.Tests/Store/MapSector/Transforms/InitializeWorkspacesTransformTests.cs
+++ b/src/Whim.Tests/Store/MapSector/Transforms/InitializeWorkspacesTransformTests.cs
@@ -112,8 +112,9 @@ public class InitializeWorkspacesTransformTests
 	{
 		root.WorkspaceSector.WorkspacesToCreate =
 		[
-			new WorkspaceToCreate(BrowserWorkspaceName, null),
+			new WorkspaceToCreate(Guid.NewGuid(), BrowserWorkspaceName, null),
 			new WorkspaceToCreate(
+				Guid.NewGuid(),
 				CodeWorkspaceName,
 				new List<CreateLeafLayoutEngine>()
 				{

--- a/src/Whim.Tests/Store/MonitorSector/Transforms/MonitorsChangedTransformTests.cs
+++ b/src/Whim.Tests/Store/MonitorSector/Transforms/MonitorsChangedTransformTests.cs
@@ -93,17 +93,17 @@ public class MonitorsChangedTransformTests
 				_ =>
 				{
 					AddWorkspaceToManager(ctx, rootSector, workspace1);
-					return workspace1;
+					return workspace1.Id;
 				},
 				_ =>
 				{
 					AddWorkspaceToManager(ctx, rootSector, workspace2);
-					return workspace2;
+					return workspace2.Id;
 				},
 				_ =>
 				{
 					AddWorkspaceToManager(ctx, rootSector, workspace3);
-					return workspace3;
+					return workspace3.Id;
 				}
 			);
 		rootSector.WorkspaceSector.HasInitialized = true;

--- a/src/Whim.Tests/Store/WorkspaceSector/Transforms/AddWorkspaceTransformTests.cs
+++ b/src/Whim.Tests/Store/WorkspaceSector/Transforms/AddWorkspaceTransformTests.cs
@@ -13,11 +13,10 @@ public class AddWorkspaceTransformTests
 		AddWorkspaceTransform sut = new(name, createLeafLayoutEngines);
 
 		// When we execute the transform
-		Result<IWorkspace?> result = ctx.Store.Dispatch(sut);
+		Result<Guid> result = ctx.Store.Dispatch(sut);
 
 		// Then we get null, and the workspace is added to the workspaces to create
 		Assert.True(result.IsSuccessful);
-		Assert.Null(result.Value);
 
 		Assert.Single(root.WorkspaceSector.WorkspacesToCreate);
 		Assert.Equal(name, root.WorkspaceSector.WorkspacesToCreate[0].Name);
@@ -36,7 +35,7 @@ public class AddWorkspaceTransformTests
 		AddWorkspaceTransform sut = new(name);
 
 		// When we execute the transform
-		Result<IWorkspace?> result = ctx.Store.Dispatch(sut);
+		Result<Guid> result = ctx.Store.Dispatch(sut);
 
 		// Then we get an error
 		Assert.False(result.IsSuccessful);
@@ -59,7 +58,7 @@ public class AddWorkspaceTransformTests
 		AddWorkspaceTransform sut = new(name, createLeafLayoutEngines);
 
 		// When we execute the transform
-		Result<IWorkspace?>? result = null;
+		Result<Guid>? result = null;
 		var raisedEvent = Assert.Raises<WorkspaceAddedEventArgs>(
 			h => ctx.Store.WorkspaceEvents.WorkspaceAdded += h,
 			h => ctx.Store.WorkspaceEvents.WorkspaceAdded -= h,
@@ -69,7 +68,7 @@ public class AddWorkspaceTransformTests
 		// Then we get the created workspace
 		Assert.True(result!.Value.IsSuccessful);
 
-		IWorkspace? workspace = result!.Value.Value;
+		IWorkspace workspace = root.WorkspaceSector.Workspaces[result!.Value.Value];
 		Assert.NotNull(workspace);
 		Assert.Single(root.WorkspaceSector.Workspaces);
 		Assert.Single(root.WorkspaceSector.WorkspaceOrder);
@@ -98,7 +97,7 @@ public class AddWorkspaceTransformTests
 		AddWorkspaceTransform sut = new();
 
 		// When we execute the transform
-		Result<IWorkspace?>? result = null;
+		Result<Guid>? result = null;
 		var raisedEvent = Assert.Raises<WorkspaceAddedEventArgs>(
 			h => ctx.Store.WorkspaceEvents.WorkspaceAdded += h,
 			h => ctx.Store.WorkspaceEvents.WorkspaceAdded -= h,
@@ -108,7 +107,7 @@ public class AddWorkspaceTransformTests
 		// Then we get the created workspace
 		Assert.True(result!.Value.IsSuccessful);
 
-		IWorkspace? workspace = result!.Value.Value;
+		IWorkspace workspace = root.WorkspaceSector.Workspaces[result!.Value.Value];
 		Assert.NotNull(workspace);
 		Assert.Single(root.WorkspaceSector.Workspaces);
 		Assert.Single(root.WorkspaceSector.WorkspaceOrder);

--- a/src/Whim/Store/MonitorSector/Transforms/MonitorsChangedTransform.cs
+++ b/src/Whim/Store/MonitorSector/Transforms/MonitorsChangedTransform.cs
@@ -149,11 +149,11 @@ internal record MonitorsChangedTransform : Transform
 			// If there's no workspace, create one.
 			if (workspaceId == default)
 			{
-				if (ctx.WorkspaceManager.Add() is IWorkspace newWorkspace)
+				if (ctx.WorkspaceManager.Add() is WorkspaceId newWorkspaceId)
 				{
 					mapSector.MonitorWorkspaceMap = mapSector.MonitorWorkspaceMap.SetItem(
 						monitor.Handle,
-						newWorkspace.Id
+						newWorkspaceId
 					);
 				}
 				else

--- a/src/Whim/Store/WorkspaceSector/Transforms/InitializeWorkspacesTransform.cs
+++ b/src/Whim/Store/WorkspaceSector/Transforms/InitializeWorkspacesTransform.cs
@@ -27,7 +27,7 @@ internal record InitializeWorkspacesTransform : Transform
 		workspaceSector.HasInitialized = true;
 		foreach (WorkspaceToCreate w in workspaceSector.WorkspacesToCreate)
 		{
-			ctx.Store.Dispatch(new AddWorkspaceTransform(w.Name, w.CreateLeafLayoutEngines));
+			ctx.Store.Dispatch(new AddWorkspaceTransform(w.Name, w.CreateLeafLayoutEngines, w.WorkspaceId));
 		}
 
 		workspaceSector.WorkspacesToCreate = workspaceSector.WorkspacesToCreate.Clear();

--- a/src/Whim/Store/WorkspaceSector/WorkspaceSector.cs
+++ b/src/Whim/Store/WorkspaceSector/WorkspaceSector.cs
@@ -3,9 +3,14 @@ namespace Whim;
 /// <summary>
 /// A workspace's name and layout engines.
 /// </summary>
+/// <param name="WorkspaceId"></param>
 /// <param name="Name"></param>
 /// <param name="CreateLeafLayoutEngines"></param>
-internal record WorkspaceToCreate(string? Name, IEnumerable<CreateLeafLayoutEngine>? CreateLeafLayoutEngines);
+internal record WorkspaceToCreate(
+	WorkspaceId WorkspaceId,
+	string? Name,
+	IEnumerable<CreateLeafLayoutEngine>? CreateLeafLayoutEngines
+);
 
 internal class WorkspaceSector(IContext ctx, IInternalContext internalCtx)
 	: SectorBase,

--- a/src/Whim/Workspace/IWorkspaceManager.cs
+++ b/src/Whim/Workspace/IWorkspaceManager.cs
@@ -82,11 +82,11 @@ public interface IWorkspaceManager : IEnumerable<IWorkspace>, IDisposable
 	/// </description>
 	/// </item>
 	/// <item>
-	/// <description>Otherwise, returns the created workspace.</description>
+	/// <description>Otherwise, returns the ID of the created workspace.</description>
 	/// </item>
 	/// </list>
 	/// </returns>
-	IWorkspace? Add(string? name = null, IEnumerable<CreateLeafLayoutEngine>? createLayoutEngines = null);
+	WorkspaceId? Add(string? name = null, IEnumerable<CreateLeafLayoutEngine>? createLayoutEngines = null);
 
 	/// <summary>
 	/// Whether the manager contains the given workspace.

--- a/src/Whim/Workspace/WorkspaceManager.cs
+++ b/src/Whim/Workspace/WorkspaceManager.cs
@@ -37,8 +37,10 @@ internal class WorkspaceManager(IContext context) : IWorkspaceManager
 		}
 	}
 
-	public IWorkspace? Add(string? name = null, IEnumerable<CreateLeafLayoutEngine>? createLayoutEngines = null) =>
-		_context.Store.Dispatch(new AddWorkspaceTransform(name, createLayoutEngines)).ValueOrDefault;
+	public WorkspaceId? Add(string? name = null, IEnumerable<CreateLeafLayoutEngine>? createLayoutEngines = null) =>
+		_context.Store.Dispatch(new AddWorkspaceTransform(name, createLayoutEngines)).TryGet(out WorkspaceId id)
+			? id
+			: null;
 
 	public void AddProxyLayoutEngine(ProxyLayoutEngineCreator proxyLayoutEngineCreator) =>
 		_context.Store.Dispatch(new AddProxyLayoutEngineTransform(proxyLayoutEngineCreator));


### PR DESCRIPTION
Previously, `context.WorkspaceManager.Add()` would return `null` in the csx. This was because it would only return `IWorkspace` once Whim had completed initialization.

Now, `context.WorkspaceManager.Add()` will return the `Guid` of the workspace that was added. This allows you to utilize the workspace id when setting up commands or other functionality that requires the workspace id.
