### PR TITLE
Open workspaces on a specific monitor without activation

### DIFF
--- a/docs/docs/customize/snippets.md
+++ b/docs/docs/customize/snippets.md
@@ -25,7 +25,7 @@ context.CommandManager.Add(
 );
 ```
 
-## Skip over active workspaces
+## Activate adjacent workspace, skipping over active workspaces
 
 The following commands can be useful on multi-monitor setups. When bound to keybinds, these can be used to cycle through the list of workspaces, skipping over those that are active on other monitors to avoid accidental swapping.
 
@@ -79,4 +79,30 @@ context.CommandManager.Add("move_window_to_browser_workspace", "Move window to b
         context.Store.Dispatch(new ActivateWorkspaceTransform(workspaceId));
     }
 });
+```
+
+## Activate a workspace on a specific monitor without changing focus
+
+The following command can be used to activate a workspace on a specific monitor without focusing the workspace you are activating. In this example, I am activating a specific workspace on the 3rd monitor.
+
+```csharp
+Guid? browserWorkspaceId = context.WorkspaceManager.Add("Browser workspace");
+
+context.CommandManager.Add(
+    identifier: "activate_browser_workspace_on_monitor_3_no_focus",
+    title: "Activate browser workspace on monitor 3 no focus",
+    callback: () =>
+    {
+        if (browserWorkspaceId is Guid workspaceId)
+        {
+            IMonitor? monitor = context.Store.Pick(Pickers.PickMonitorByIndex(2)).ValueOrDefault;
+            if (monitor is null)
+            {
+                return;
+            }
+
+            context.Store.Dispatch(new ActivateWorkspaceTransform(workspaceId, monitor.Handle, FocusWorkspaceWindow: false));
+        }
+    }
+);
 ```

--- a/src/Whim.TestUtils/StoreCustomization.cs
+++ b/src/Whim.TestUtils/StoreCustomization.cs
@@ -42,6 +42,7 @@ public class StoreCustomization : ICustomization
 
 		fixture.Inject(_store._root);
 		fixture.Inject(_store._root.MutableRootSector);
+		fixture.Inject(_store.Transforms);
 
 		_store._root.MutableRootSector.MonitorSector.MonitorsChangedDelay = 0;
 

--- a/src/Whim/Store/MapSector/Transforms/ActivateWorkspaceTransform.cs
+++ b/src/Whim/Store/MapSector/Transforms/ActivateWorkspaceTransform.cs
@@ -42,9 +42,6 @@ public record ActivateWorkspaceTransform(
 			return Result.FromException<Unit>(targetMonitorResult.Error!);
 		}
 
-		// Get the active workspace for later.
-		IWorkspace activeWorkspace = ctx.Store.Pick(PickActiveWorkspace());
-
 		// Get the old workspace for the event.
 		IWorkspace? oldWorkspace = ctx.Store.Pick(PickWorkspaceByMonitor(targetMonitorHandle)).ValueOrDefault;
 
@@ -88,14 +85,14 @@ public record ActivateWorkspaceTransform(
 		// Layout the new workspace.
 		ctx.Store.Dispatch(new DoWorkspaceLayoutTransform(workspace.Id));
 
-		// Focus the new workspace if told to, or if the active workspace is the old workspace.
-		if (FocusWorkspaceWindow || activeWorkspace.Id == oldWorkspace?.Id)
+		if (FocusWorkspaceWindow)
 		{
 			ctx.Store.Dispatch(new FocusWindowTransform(workspace.Id));
 		}
 		else
 		{
-			ctx.Store.Dispatch(new FocusWindowTransform(activeWorkspace.Id));
+			WorkspaceId activeWorkspaceId = ctx.Store.Pick(PickActiveWorkspaceId());
+			ctx.Store.Dispatch(new FocusWindowTransform(activeWorkspaceId));
 		}
 
 		mapSector.QueueEvent(


### PR DESCRIPTION
This PR updates the existing `ActivateWorkspaceTransform` to optionally disable whether the workspace being activated gains focus.

For an example of how this can be used, see the example included in the snippets.
