### PR TITLE
More docs improvements

### DIFF
--- a/docs/docs/customize/monitors.md
+++ b/docs/docs/customize/monitors.md
@@ -9,3 +9,30 @@ For example, the ordering (with 0-based indexing) of the monitor configuration b
 ![Example monitor layout](../../images/example-monitor-layout.png)
 
 To interact with the monitors, use the monitor pickers from the <xref:Whim.Pickers> to retrieve them from the store. For more on how to use the store, see the [Store](./store.md) page.
+
+## Example Command
+
+```csharp
+Guid browserWorkspaceId = context.Store.Dispatch(new AddWorkspaceTransform("Browser")).Value;
+Guid ideWorkspaceId = context.Store.Dispatch(new AddWorkspaceTransform("IDE")).Value;
+
+context.CommandManager.Add(
+    "move_last_focused_browser_window_to_first_monitor",
+    "Move last focused browser window to the first monitor",
+    () => {
+        if (!context.Store.Pick(Pickers.PickMonitorsByIndex(0)).TryGet(out IMonitor firstMonitor))
+        {
+            return;
+        }
+
+        if (!context.Store.Pick(Pickers.PickLastFocusedWindowHandle(browserWorkspaceId)).TryGet(out HWND lastFocusedWindowHandle))
+        {
+            return;
+        }
+
+        context.Store.Dispatch(new MoveWindowToMonitorTransform(lastFocusedWindowHandle, firstMonitor.Handle));
+    }
+);
+```
+
+For more, see the [Store](./store.md) and [Commands](./commands.md) pages.

--- a/docs/docs/customize/snippets.md
+++ b/docs/docs/customize/snippets.md
@@ -64,7 +64,7 @@ The following command can be used to move the active window to a specific worksp
 
 ```csharp
 // Once the workspace has been created, it will have this ID.
-Guid? browserWorkspaceId = context.Store.Dispatch(new AddWorkspaceTransform("Browser")).ValueOrDefault;
+Guid browserWorkspaceId = context.Store.Dispatch(new AddWorkspaceTransform("Browser")).Value;
 
 context.CommandManager.Add("move_window_to_browser_workspace", "Move window to browser workspace", () =>
 {
@@ -88,7 +88,7 @@ context.CommandManager.Add("move_window_to_browser_workspace", "Move window to b
 The following command can be used to activate a workspace on a specific monitor without focusing the workspace you are activating. In this example, I am activating a specific workspace on the 3rd monitor.
 
 ```csharp
-Guid? browserWorkspaceId = context.Store.Dispatch(new AddWorkspaceTransform("Browser")).ValueOrDefault;
+Guid browserWorkspaceId = context.Store.Dispatch(new AddWorkspaceTransform("Browser")).Value;
 
 context.CommandManager.Add(
     identifier: "activate_browser_workspace_on_monitor_3_no_focus",
@@ -97,7 +97,7 @@ context.CommandManager.Add(
     {
         if (browserWorkspaceId is Guid workspaceId)
         {
-            IMonitor? monitor = context.Store.Pick(Pickers.PickMonitorByIndex(2)).ValueOrDefault;
+            IMonitor monitor = context.Store.Pick(Pickers.PickMonitorByIndex(2)).Value;
             if (monitor is null)
             {
                 return;

--- a/docs/docs/customize/store.md
+++ b/docs/docs/customize/store.md
@@ -2,33 +2,44 @@
 
 The <xref:Whim.IStore> contains the state of windows, workspaces, and monitors in Whim. For a more in-depth look at the store, see the [Store](../architecture/store.md) page in the architecture section.
 
-## Core Concepts
+## Pickers and Transforms
 
-- Use <xref:Whim.Pickers> to retrieve values from the store - see [Reading from the Store](#reading-from-the-store)
-- Use <xref:Whim.Transform>s to update the store - see [Writing to the Store](#writing-to-the-store)
-- Use handles and IDs to reference windows, workspaces, and monitors - see [Handles and IDs](#handles-and-ids)
-- Use `Result<T>` to handle errors - see [Result<T>](#resultt)
-
-## Reading from the Store
-
-To retrieve values from the store, use the <xref href="Whim.IStore.Pick``1(Whim.Picker{``0})" /> method. For example:
+To **retrieve values from the store**, use the <xref href="Whim.IStore.Pick``1(Whim.Picker{``0})" /> method. For example:
 
 ```csharp
 IMonitor primaryMonitor = context.Store.Pick(Pickers.PickPrimaryMonitor());
-IMonitor? thirdMonitor = context.Store.Pick(Pickers.PickMonitorByIndex(2)).ValueOrDefault;
+IMonitor thirdMonitor = context.Store.Pick(Pickers.PickMonitorByIndex(2)).Value;
 ```
 
-Pickers can be found in the <xref:Whim.Pickers> static class.
+Pickers will typically take in [handles or IDs as arguments](#handles-and-ids). Pickers can be found in the <xref:Whim.Pickers> static class.
 
-## Writing to the Store
-
-To update Whim's state, use the <xref href="Whim.IStore.Dispatch``1(Whim.Transform{``0})" /> method. For example:
+To **update Whim's state**, use the <xref href="Whim.IStore.Dispatch``1(Whim.Transform{``0})" /> method. For example:
 
 ```csharp
 context.Store.Dispatch(new ActivateWorkspaceTransform(workspaceId, monitor.Handle));
 ```
 
 Transforms can be found in the API documentation for the <xref:Whim> namespace.
+
+As an example of using pickers and transforms together:
+
+```csharp
+Guid browserWorkspaceId = context.Store.Dispatch(new AddWorkspaceTransform("Browser")).Value;
+
+context.CommandManager.Add(
+    identifier: "last_focused_to_browser",
+    title: "Move the last focused window to the browser workspace",
+    callback: () =>
+    {
+        if (context.Store.Pick(Pickers.PickLastFocusedWindow()).TryGet(out IWindow window))
+        {
+            context.Store.Dispatch(new MoveWindowToWorkspaceTransform(browserWorkspaceId, window.Handle));
+        }
+    }
+);
+```
+
+For examples on how to interact with the store, see the [Snippets](snippets.md) page.
 
 ## Handles and IDs
 
@@ -44,23 +55,7 @@ A handle is a token that represents a resource that is managed by the Windows ke
 
 ## `Result<T>`
 
-All transforms and some pickers return a `Result<T>`. This is a type that can either contain a value or an error. For example:
-
-```csharp
-Result<IMonitor> monitorResult = context.Store.Pick(Pickers.PickMonitorByIndex(2));
-if (monitorResult.TryGet(out IMonitor monitor))
-{
-    // Do something with the monitor
-}
-else
-{
-    // Handle the error
-}
-```
-
-If you're sure the operation will succeed, you can use the `ValueOrDefault` property. However, it is recommended to use the `TryGet` method to handle errors.
-
-## `Unit`
+All transforms and some pickers return a `Result<T>`. This is a type that can either contain a value or an error.
 
 Some transforms will return a `Result<Unit>` This represents an operation that does not return a value. For example:
 
@@ -72,25 +67,53 @@ if (!result.IsSuccessful)
 }
 ```
 
-### `ValueOrDefault` Examples
+### Error Handling
 
-The return type of `PickMonitorByIndex` is `Result<IMonitor>`. As the value returned is a complex
-type, when you use `ValueOrDefault`, the return type will be nullable.
-
-```csharp
-IMonitor? monitor = context.Store.Pick(Pickers.PickMonitorByIndex(2)).ValueOrDefault;
-```
-
-The `AddWorkspaceTransform` implements `Transform<Guid>`, so the return type of dispatching it will be
-`Result<Guid>`. As the value returned is a value type, when you use `ValueOrDefault`, the return type will be the value type itself.
-However, if it fails, the return type will be the default value of the value type, which in this
-case is `Guid.Empty`.
+To handle errors for reference types (classes, interfaces):
 
 ```csharp
-Guid workspaceId = context.Store.Dispatch(new AddWorkspaceTransform("Workspace name")).ValueOrDefault;
+// The return type of PickMonitorByIndex is Result<IMonitor>.
+
+// If this fails, monitor1 will be null.
+IMonitor? monitor1 = context.Store.Pick(Pickers.PickMonitorByIndex(0)).ValueOrDefault;
+
+// If this fails, an exception will throw.
+IMonitor monitor2 = context.Store.Pick(Pickers.PickMonitorByIndex(0)).Value;
+
+// If this fails, the else block will execute.
+if (context.Store.Pick(Pickers.PickMonitorByIndex(0)).TryGet(out IMonitor monitor3))
+{
+    // Do something with the monitor
+}
+else
+{
+    // Handle the error
+}
 ```
 
-The return type of `PickPrimaryMonitor` is `PurePicker<IMonitor>`, so there will always be a value.
+To handle errors for value types (handles, IDs, etc.):
+
+```csharp
+// The return type of AddWorkspaceTransform is Result<Guid>.
+
+// If this fails, workspaceId will be the default value, equivalent to all bits being 0.
+Guid workspace1 = context.Store.Dispatch(new AddWorkspaceTransform("Workspace 1")).ValueOrDefault;
+
+// If this fails, an exception will throw.
+Guid workspace2 = context.Store.Dispatch(new AddWorkspaceTransform("Workspace 2")).Value;
+
+// If this fails, the else block will execute.
+if (context.Store.Dispatch(new AddWorkspaceTransform("Workspace 3")).TryGet(out Guid workspace3))
+{
+    // Do something with the workspace
+}
+else
+{
+    // Handle the error
+}
+```
+
+Items which don't return a `Result` do not need to be handled in this way - they can be used directly.
 
 ```csharp
 IMonitor primaryMonitor = context.Store.Pick(Pickers.PickPrimaryMonitor());

--- a/docs/docs/customize/store.md
+++ b/docs/docs/customize/store.md
@@ -4,22 +4,22 @@ The <xref:Whim.IStore> contains the state of windows, workspaces, and monitors i
 
 ## Pickers and Transforms
 
-To **retrieve values from the store**, use the <xref href="Whim.IStore.Pick``1(Whim.Picker{``0})" /> method. For example:
+To **retrieve values from the store**, pass a "picker" from the <xref:Whim.Pickers> static class to the <xref href="Whim.IStore.Pick``1(Whim.Picker{``0})" /> method. Pickers will typically take in [handles or IDs as arguments](#handles-and-ids).
+
+For example:
 
 ```csharp
 IMonitor primaryMonitor = context.Store.Pick(Pickers.PickPrimaryMonitor());
 IMonitor thirdMonitor = context.Store.Pick(Pickers.PickMonitorByIndex(2)).Value;
 ```
 
-Pickers will typically take in [handles or IDs as arguments](#handles-and-ids). Pickers can be found in the <xref:Whim.Pickers> static class.
+To **update Whim's state**, pass a "transform" to the <xref href="Whim.IStore.Dispatch``1(Whim.Transform{``0})" /> method. Transforms can be found in the API documentation for the <xref:Whim> namespace.
 
-To **update Whim's state**, use the <xref href="Whim.IStore.Dispatch``1(Whim.Transform{``0})" /> method. For example:
+For example:
 
 ```csharp
 context.Store.Dispatch(new ActivateWorkspaceTransform(workspaceId, monitor.Handle));
 ```
-
-Transforms can be found in the API documentation for the <xref:Whim> namespace.
 
 As an example of using pickers and transforms together:
 

--- a/docs/docs/customize/workspaces.md
+++ b/docs/docs/customize/workspaces.md
@@ -6,9 +6,9 @@ The <xref:Whim.SetCreateLayoutEnginesTransform> lets you specify the default lay
 
 ```csharp
 // Set up workspaces.
-context.Store.Dispatch(new AddWorkspaceTransform("Browser"));
-context.Store.Dispatch(new AddWorkspaceTransform("IDE"));
-context.Store.Dispatch(new AddWorkspaceTransform("Alt"));
+Guid browserWorkspaceId = context.Store.Dispatch(new AddWorkspaceTransform("Browser")).Value;
+Guid ideWorkspaceId = context.Store.Dispatch(new AddWorkspaceTransform("IDE")).Value;
+Guid altWorkspaceId = context.Store.Dispatch(new AddWorkspaceTransform("Alt")).Value;
 
 // Set up layout engines.
 context.Store.Dispatch(
@@ -42,5 +42,20 @@ If no name is provided, the name will default to `Workspace {workspaces.Count + 
 
 When Whim exits, it will save the current workspaces and the current positions of each window within them. When Whim is started again, it will attempt to merge the saved workspaces with the workspaces defined in the config.
 
-> [!NOTE]
-> Whim does not support Windows' native "virtual" desktops, as they lack the ability to activate "desktops" independently of monitors.
+## Example Command
+
+```csharp
+Guid browserWorkspaceId = context.Store.Dispatch(new AddWorkspaceTransform("Browser")).Value;
+Guid ideWorkspaceId = context.Store.Dispatch(new AddWorkspaceTransform("IDE")).Value;
+
+context.CommandManager.Add(
+    "merge_workspace_with_browser",
+    "Merge current workspace with Browser workspace",
+    () => {
+        Guid activeWorkspaceId = context.Store.Pick(Pickers.PickActiveWorkspaceId());
+        context.Store.Dispatch(new MergeWorkspaceTransform(activeWorkspaceId, browserWorkspaceId));
+    }
+);
+```
+
+For more, see the [Store](./store.md) and [Commands](./commands.md) pages.

--- a/src/Whim/Store/IStore.cs
+++ b/src/Whim/Store/IStore.cs
@@ -1,8 +1,7 @@
 namespace Whim;
 
 /// <summary>
-/// Whim's store.
-/// WARNING: Currently non-functional - use managers instead.
+/// Contains the state of Whim's monitors, windows, and workspaces.
 /// </summary>
 public interface IStore : IDisposable
 {
@@ -69,13 +68,13 @@ public interface IStore : IDisposable
 	/// <example>
 	/// If you want to get the full result and handle it appropriately:
 	/// <code>
-	/// Result&lt;IWorkspace> workspace = context.Store.Pick(PickWorkspaceByWindow(window.Handle));
+	/// Result&lt;IMonitor&gt; monitor = context.Store.Pick(PickMonitorAtPoint(new Point&lt;int&gt;(100, 200)));
 	/// </code>
 	///
 	/// If you want to assume the result is successful and get the value (this will throw an exception
 	/// if it fails):
 	/// <code>
-	/// IWorkspace workspace = context.Store.Pick(PickWorkspaceByWindow(window.Handle)).Value;
+	/// IMonitor monitor = context.Store.Pick(PickMonitorAtPoint(new Point&lt;int&gt;(100, 200))).Value;
 	/// </code>
 	/// </example>
 	public TResult Pick<TResult>(Picker<TResult> picker);
@@ -93,7 +92,16 @@ public interface IStore : IDisposable
 	/// The result of the picker applied to Whim's state.
 	/// </returns>
 	/// <example>
-	/// This is used exactly the same as <see cref="Pick{TResult}(Picker{TResult})"/>.
+	/// If you want to get the full result and handle it appropriately:
+	/// <code>
+	/// Result&lt;IWorkspace> workspace = context.Store.Pick(PickWorkspaceByWindow(window.Handle));
+	/// </code>
+	///
+	/// If you want to assume the result is successful and get the value (this will throw an exception
+	/// if it fails):
+	/// <code>
+	/// IWorkspace workspace = context.Store.Pick(PickWorkspaceByWindow(window.Handle)).Value;
+	/// </code>
 	/// </example>
 	public TResult Pick<TResult>(PurePicker<TResult> picker);
 }

--- a/src/Whim/Store/IStore.cs
+++ b/src/Whim/Store/IStore.cs
@@ -37,7 +37,21 @@ public interface IStore : IDisposable
 	/// <param name="transform">
 	/// The record implementing <see cref="Dispatch"/> to update Whim's state.
 	/// </param>
-	/// <returns></returns>
+	/// <returns>
+	/// The result of the transformation.
+	/// </returns>
+	/// <example>
+	/// If you want to get the full result and handle it appropriately:
+	/// <code>
+	/// Result&lt;Guid:gt; firstWorkspace = context.Store.Dispatch(new AddWorkspaceTransform("First Workspace"));
+	/// </code>
+	///
+	/// If you want to assume the result is successful and get the value (this will throw an exception
+	/// if it fails):
+	/// <code>
+	/// Guid firstWorkspace = context.Store.Dispatch(new AddWorkspaceTransform("First Workspace")).Value;
+	/// </code>
+	/// </example>
 	public Result<TResult> Dispatch<TResult>(Transform<TResult> transform);
 
 	/// <summary>
@@ -49,7 +63,21 @@ public interface IStore : IDisposable
 	/// <param name="picker">
 	/// The record implementing <see cref="Picker{TResult}"/> to fetch from Whim's state.
 	/// </param>
-	/// <returns></returns>
+	/// <returns>
+	/// The result of the picker applied to Whim's state.
+	/// </returns>
+	/// <example>
+	/// If you want to get the full result and handle it appropriately:
+	/// <code>
+	/// Result&lt;IWorkspace> workspace = context.Store.Pick(PickWorkspaceByWindow(window.Handle));
+	/// </code>
+	///
+	/// If you want to assume the result is successful and get the value (this will throw an exception
+	/// if it fails):
+	/// <code>
+	/// IWorkspace workspace = context.Store.Pick(PickWorkspaceByWindow(window.Handle)).Value;
+	/// </code>
+	/// </example>
 	public TResult Pick<TResult>(Picker<TResult> picker);
 
 	/// <summary>
@@ -61,6 +89,11 @@ public interface IStore : IDisposable
 	/// <param name="picker">
 	/// Pure picker to fetch from Whim's state.
 	/// </param>
-	/// <returns></returns>
+	/// <returns>
+	/// The result of the picker applied to Whim's state.
+	/// </returns>
+	/// <example>
+	/// This is used exactly the same as <see cref="Pick{TResult}(Picker{TResult})"/>.
+	/// </example>
 	public TResult Pick<TResult>(PurePicker<TResult> picker);
 }

--- a/src/Whim/Store/MapSector/MapPickers.cs
+++ b/src/Whim/Store/MapSector/MapPickers.cs
@@ -8,7 +8,9 @@ public static partial class Pickers
 	/// <summary>
 	/// Gets all the workspaces which are active on any monitor.
 	/// </summary>
-	/// <returns></returns>
+	/// <returns>
+	/// All the active workspaces, when passed to <see cref="IStore.Pick{TResult}(PurePicker{TResult})"/>.
+	/// </returns>
 	public static PurePicker<IEnumerable<IWorkspace>> PickAllActiveWorkspaces() =>
 		rootSector =>
 		{
@@ -26,7 +28,10 @@ public static partial class Pickers
 	/// <param name="monitorHandle">
 	/// The handle of the monitor to get the workspace for.
 	/// </param>
-	/// <returns></returns>
+	/// <returns>
+	/// The workspace shown on the monitor, when passed to <see cref="IStore.Pick{TResult}(PurePicker{TResult})"/>.
+	/// If the monitor is not found, then <see cref="Result{T, TError}.Error"/> will be returned.
+	/// </returns>
 	public static PurePicker<Result<IWorkspace>> PickWorkspaceByMonitor(HMONITOR monitorHandle) =>
 		rootSector =>
 			rootSector.MapSector.MonitorWorkspaceMap.TryGetValue(monitorHandle, out WorkspaceId workspaceId)
@@ -37,7 +42,10 @@ public static partial class Pickers
 	/// Retrieves the workspace for the given window.
 	/// </summary>
 	/// <param name="windowHandle"></param>
-	/// <returns></returns>
+	/// <returns>
+	/// The workspace for the window, when passed to <see cref="IStore.Pick{TResult}(PurePicker{TResult})"/>.
+	/// If the window is not tracked or does not belong to any workspace, then <see cref="Result{T, TError}.Error"/> will be returned.
+	/// </returns>
 	public static PurePicker<Result<IWorkspace>> PickWorkspaceByWindow(HWND windowHandle) =>
 		rootSector =>
 		{
@@ -58,7 +66,10 @@ public static partial class Pickers
 	/// <param name="searchWorkspaceId">
 	/// The ID of the workspace to get the monitor for.
 	/// </param>
-	/// <returns></returns>
+	/// <returns>
+	/// The monitor for the workspace, when passed to <see cref="IStore.Pick{TResult}(PurePicker{TResult})"/>.
+	/// If the workspace is not found or does not appear on any monitor, then <see cref="Result{T, TError}.Error"/> will be returned.
+	/// </returns>
 	public static PurePicker<Result<IMonitor>> PickMonitorByWorkspace(WorkspaceId searchWorkspaceId) =>
 		rootSector =>
 		{
@@ -75,7 +86,10 @@ public static partial class Pickers
 	/// <param name="windowHandle">
 	/// The handle of the window to get the monitor for.
 	/// </param>
-	/// <returns></returns>
+	/// <returns>
+	/// The monitor for the window, when passed to <see cref="IStore.Pick{TResult}(PurePicker{TResult})"/>.
+	/// If the window is not tracked or does not appear on any monitor, then <see cref="Result{T, TError}.Error"/> will be returned.
+	/// </returns>
 	public static PurePicker<Result<IMonitor>> PickMonitorByWindow(HWND windowHandle) =>
 		rootSector =>
 			rootSector.MapSector.WindowWorkspaceMap.TryGetValue(windowHandle, out WorkspaceId workspaceId)
@@ -94,7 +108,10 @@ public static partial class Pickers
 	/// <param name="skipActive">
 	/// When <see langword="true"/>, skips all workspaces that are active on any other monitor. Defaults to <see langword="false"/>.
 	/// </param>
-	/// <returns></returns>
+	/// <returns>
+	/// The adjacent workspace, when passed to <see cref="IStore.Pick{TResult}(PurePicker{TResult})"/>.
+	/// If the workspace is not found or there are no adjacent workspaces, then <see cref="Result{T, TError}.Error"/> will be returned.
+	/// </returns>
 	public static PurePicker<Result<IWorkspace>> PickAdjacentWorkspace(
 		WorkspaceId workspaceId,
 		bool reverse = false,

--- a/src/Whim/Store/MonitorSector/MonitorPickers.cs
+++ b/src/Whim/Store/MonitorSector/MonitorPickers.cs
@@ -6,7 +6,10 @@ public static partial class Pickers
 	/// Get a monitor by its <see cref="HMONITOR"/> handle.
 	/// </summary>
 	/// <param name="handle"></param>
-	/// <returns></returns>
+	/// <returns>
+	/// The monitor with the given handle, when passed to <see cref="IStore.Pick{TResult}(PurePicker{TResult})"/>.
+	/// If the monitor is not found, then <see cref="Result{T, TError}.Error"/> will be returned.
+	/// </returns>
 	public static PurePicker<Result<IMonitor>> PickMonitorByHandle(HMONITOR handle) =>
 		(rootSector) =>
 		{
@@ -24,18 +27,27 @@ public static partial class Pickers
 	/// <summary>
 	/// Get the currently active monitor.
 	/// </summary>
+	/// <returns>
+	/// The active monitor, when passed to <see cref="IStore.Pick{TResult}(PurePicker{TResult})"/>.
+	/// </returns>
 	public static PurePicker<IMonitor> PickActiveMonitor() =>
 		static (rootSector) => PickMonitorByHandle(rootSector.MonitorSector.ActiveMonitorHandle)(rootSector).Value;
 
 	/// <summary>
 	/// Get the primary monitor.
 	/// </summary>
+	/// <returns>
+	/// The primary monitor, when passed to <see cref="IStore.Pick{TResult}(PurePicker{TResult})"/>.
+	/// </returns>
 	public static PurePicker<IMonitor> PickPrimaryMonitor() =>
 		static (rootSector) => PickMonitorByHandle(rootSector.MonitorSector.PrimaryMonitorHandle)(rootSector).Value;
 
 	/// <summary>
 	/// Get the last <see cref="IMonitor"/> which received an event sent by Windows which Whim did not ignore.
 	/// </summary>
+	/// <returns>
+	/// The last monitor which received an event, when passed to <see cref="IStore.Pick{TResult}(PurePicker{TResult})"/>.
+	/// </returns>
 	public static PurePicker<IMonitor> PickLastWhimActiveMonitor() =>
 		static (rootSector) =>
 			PickMonitorByHandle(rootSector.MonitorSector.LastWhimActiveMonitorHandle)(rootSector).Value;
@@ -43,6 +55,9 @@ public static partial class Pickers
 	/// <summary>
 	/// Get all the <see cref="IMonitor"/>s tracked by Whim.
 	/// </summary>
+	/// <returns>
+	/// Tll the monitors, when passed to <see cref="IStore.Pick{TResult}(PurePicker{TResult})"/>.
+	/// </returns>
 	public static PurePicker<IReadOnlyList<IMonitor>> PickAllMonitors() =>
 		static (rootSector) => rootSector.MonitorSector.Monitors;
 
@@ -59,7 +74,10 @@ public static partial class Pickers
 	/// When <see langword="true"/>, then returns the first monitor. Otherwise returns an exception in the
 	/// result.
 	/// </param>
-	/// <returns></returns>
+	/// <returns>
+	/// The monitor adjacent to the given monitor, when passed to <see cref="IStore.Pick{TResult}(PurePicker{TResult})"/>.
+	/// If the monitor is not found, then <see cref="Result{T, TError}.Error"/> will be returned.
+	/// </returns>
 	public static PurePicker<Result<IMonitor>> PickAdjacentMonitor(
 		HMONITOR handle = default,
 		bool reverse = false,
@@ -100,7 +118,10 @@ public static partial class Pickers
 	/// <param name="index">
 	/// The 0-based index of the monitor to get.
 	/// </param>
-	/// <returns></returns>
+	/// <returns>
+	/// The monitor at the given index, when passed to <see cref="IStore.Pick{TResult}(PurePicker{TResult})"/>.
+	/// If the monitor is not found, then <see cref="Result{T, TError}.Error"/> will be returned.
+	/// </returns>
 	public static PurePicker<Result<IMonitor>> PickMonitorByIndex(int index) =>
 		(rootSector) =>
 		{
@@ -123,7 +144,10 @@ public static partial class Pickers
 	/// When <see langword="true"/>, then returns the first monitor. Otherwise returns an exception in the
 	/// result.
 	/// </param>
-	/// <returns></returns>
+	/// <returns>
+	/// The monitor at the given point, when passed to <see cref="IStore.Pick{TResult}(PurePicker{TResult})"/>.
+	/// If the monitor is not found, then <see cref="Result{T, TError}.Error"/> will be returned.
+	/// </returns>
 	public static Picker<Result<IMonitor>> PickMonitorAtPoint(IPoint<int> point, bool getFirst = false) =>
 		new GetMonitorAtPointPicker(point, getFirst);
 }

--- a/src/Whim/Store/MonitorSector/MonitorPickers.cs
+++ b/src/Whim/Store/MonitorSector/MonitorPickers.cs
@@ -56,7 +56,7 @@ public static partial class Pickers
 	/// Get all the <see cref="IMonitor"/>s tracked by Whim.
 	/// </summary>
 	/// <returns>
-	/// Tll the monitors, when passed to <see cref="IStore.Pick{TResult}(PurePicker{TResult})"/>.
+	/// The monitors, when passed to <see cref="IStore.Pick{TResult}(PurePicker{TResult})"/>.
 	/// </returns>
 	public static PurePicker<IReadOnlyList<IMonitor>> PickAllMonitors() =>
 		static (rootSector) => rootSector.MonitorSector.Monitors;

--- a/src/Whim/Store/WorkspaceSector/WorkspacePickers.cs
+++ b/src/Whim/Store/WorkspaceSector/WorkspacePickers.cs
@@ -6,13 +6,19 @@ public static partial class Pickers
 	/// Get the workspace with the provided <paramref name="workspaceId"/>.
 	/// </summary>
 	/// <param name="workspaceId"></param>
+	/// <returns>
+	/// The workspace with the provided <paramref name="workspaceId"/>, when passed to <see cref="IStore.Pick{TResult}(PurePicker{TResult})"/>.
+	/// If the workspace is not found, then <see cref="Result{T, TError}.Error"/> will be returned.
+	/// </returns>
 	public static PurePicker<Result<IWorkspace>> PickWorkspaceById(WorkspaceId workspaceId) =>
 		(IRootSector rootSector) => BaseWorkspacePicker(workspaceId, rootSector, workspace => workspace);
 
 	/// <summary>
 	/// Get all workspaces.
 	/// </summary>
-	/// <returns></returns>
+	/// <returns>
+	/// All workspaces, when passed to <see cref="IStore.Pick{TResult}(PurePicker{TResult})"/>.
+	/// </returns>
 	public static PurePicker<IEnumerable<IWorkspace>> PickAllWorkspaces() =>
 		static (IRootSector rootSector) => GetAllActiveWorkspaces(rootSector.WorkspaceSector);
 
@@ -28,6 +34,10 @@ public static partial class Pickers
 	/// Get the workspace with the provided <paramref name="name"/>.
 	/// </summary>
 	/// <param name="name"></param>
+	/// <returns>
+	/// The workspace with the provided <paramref name="name"/>, when passed to <see cref="IStore.Pick{TResult}(PurePicker{TResult})"/>.
+	/// If the workspace is not found, then <see cref="Result{T, TError}.Error"/> will be returned.
+	/// </returns>
 	public static PurePicker<Result<IWorkspace>> PickWorkspaceByName(string name) =>
 		(IRootSector rootSector) =>
 		{
@@ -49,7 +59,6 @@ public static partial class Pickers
 	/// <param name="rootSector">The root sector.</param>
 	/// <param name="operation">The operation to determine what to get.</param>
 	/// <typeparam name="TResult">The result.</typeparam>
-	/// <returns></returns>
 	private static Result<TResult> BaseWorkspacePicker<TResult>(
 		WorkspaceId workspaceId,
 		IRootSector rootSector,
@@ -96,7 +105,9 @@ public static partial class Pickers
 	/// <summary>
 	/// Get the active workspace.
 	/// </summary>
-	/// <returns></returns>
+	/// <returns>
+	/// The active workspace, when passed to <see cref="IStore.Pick{TResult}(PurePicker{TResult})"/>.
+	/// </returns>
 	public static PurePicker<IWorkspace> PickActiveWorkspace() =>
 		static (IRootSector rootSector) =>
 			rootSector.WorkspaceSector.Workspaces[
@@ -111,7 +122,9 @@ public static partial class Pickers
 	/// <summary>
 	/// Get the id of the active workspace.
 	/// </summary>
-	/// <returns></returns>
+	/// <returns>
+	/// The id of the active workspace, when passed to <see cref="IStore.Pick{TResult}(PurePicker{TResult})"/>.
+	/// </returns>
 	public static PurePicker<WorkspaceId> PickActiveWorkspaceId() =>
 		static (IRootSector rootSector) =>
 			rootSector.MapSector.MonitorWorkspaceMap[rootSector.MonitorSector.ActiveMonitorHandle];
@@ -120,6 +133,10 @@ public static partial class Pickers
 	/// Get the active layout engine in the provided workspace.
 	/// </summary>
 	/// <param name="workspaceId"></param>
+	/// <returns>
+	/// The active layout engine in the provided workspace, when passed to <see cref="IStore.Pick{TResult}(PurePicker{TResult})"/>.
+	/// If the workspace is not found, then <see cref="Result{T, TError}.Error"/> will be returned.
+	/// </returns>
 	public static PurePicker<Result<ILayoutEngine>> PickActiveLayoutEngine(WorkspaceId workspaceId) =>
 		(IRootSector rootSector) =>
 			BaseWorkspacePicker(
@@ -132,6 +149,10 @@ public static partial class Pickers
 	/// Get all the windows in the provided workspace.
 	/// </summary>
 	/// <param name="workspaceId"></param>
+	/// <returns>
+	/// All the windows in the provided workspace, when passed to <see cref="IStore.Pick{TResult}(PurePicker{TResult})"/>.
+	/// If the workspace is not found, then <see cref="Result{T, TError}.Error"/> will be returned.
+	/// </returns>
 	public static PurePicker<Result<IEnumerable<IWindow>>> PickAllWindowsInWorkspace(WorkspaceId workspaceId) =>
 		(IRootSector rootSector) =>
 			BaseWorkspacePicker(workspaceId, rootSector, workspace => GetWorkspaceWindows(rootSector, workspace));
@@ -151,6 +172,10 @@ public static partial class Pickers
 	/// Get the last focused window in the provided workspace.
 	/// </summary>
 	/// <param name="workspaceId">The workspace to get the last focused window for. Defaults to the active workspace</param>
+	/// <returns>
+	/// The last focused window in the provided workspace, when passed to <see cref="IStore.Pick{TResult}(PurePicker{TResult})"/>.
+	/// If the workspace is not found or there is no last focused window, then <see cref="Result{T, TError}.Error"/> will be returned.
+	/// </returns>
 	public static PurePicker<Result<IWindow>> PickLastFocusedWindow(WorkspaceId workspaceId = default) =>
 		(IRootSector rootSector) =>
 			BaseWorkspacePicker(
@@ -171,7 +196,9 @@ public static partial class Pickers
 	/// Get the last focused window handle in the provided workspace.
 	/// </summary>
 	/// <param name="workspaceId">The workspace to get the last focused window handle for. Defaults to the active workspace</param>
-	/// <returns></returns>
+	/// <returns>
+	/// If the workspace is not found or there is no last focused window, then <see cref="Result{T, TError}.Error"/> will be returned.
+	/// </returns>
 	public static PurePicker<Result<HWND>> PickLastFocusedWindowHandle(WorkspaceId workspaceId = default) =>
 		(IRootSector rootSector) =>
 			BaseWorkspacePicker(
@@ -193,6 +220,10 @@ public static partial class Pickers
 	/// </summary>
 	/// <param name="workspaceId">The workspace to get the window position for.</param>
 	/// <param name="windowHandle">The window handle to get the position for.</param>
+	/// <returns>
+	/// The window position in the provided workspace, when passed to <see cref="IStore.Pick{TResult}(PurePicker{TResult})"/>.
+	/// If the workspace is not found or the window is not found in the workspace, then <see cref="Result{T, TError}.Error"/> will be returned.
+	/// </returns>
 	public static PurePicker<Result<WindowPosition>> PickWindowPosition(WorkspaceId workspaceId, HWND windowHandle) =>
 		(IRootSector rootSector) =>
 			BaseWorkspacePicker(
@@ -212,7 +243,9 @@ public static partial class Pickers
 	/// <summary>
 	/// Picks the function used to create the default layout engines to add to a workspace.
 	/// </summary>
-	/// <returns></returns>
+	/// <returns>
+	/// The function used to create the default layout engines to add to a workspace, when passed to <see cref="IStore.Pick{TResult}(PurePicker{TResult})"/>.
+	/// </returns>
 	public static PurePicker<Func<CreateLeafLayoutEngine[]>> PickCreateLeafLayoutEngines() =>
 		static (IRootSector rootSector) => rootSector.WorkspaceSector.CreateLayoutEngines;
 }

--- a/src/Whim/Template/whim.config.csx
+++ b/src/Whim/Template/whim.config.csx
@@ -100,10 +100,10 @@ void DoConfig(IContext context)
 	context.PluginManager.AddPlugin(updaterPlugin);
 
 	// Set up workspaces.
-	Guid? firstWorkspace = context.Store.Dispatch(new AddWorkspaceTransform("1")).ValueOrDefault;
-	Guid? secondWorkspace = context.Store.Dispatch(new AddWorkspaceTransform("2")).ValueOrDefault;
-	Guid? thirdWorkspace = context.Store.Dispatch(new AddWorkspaceTransform("3")).ValueOrDefault;
-	Guid? fourthWorkspace = context.Store.Dispatch(new AddWorkspaceTransform("4")).ValueOrDefault;
+	Guid firstWorkspace = context.Store.Dispatch(new AddWorkspaceTransform("1")).Value;
+	Guid secondWorkspace = context.Store.Dispatch(new AddWorkspaceTransform("2")).Value;
+	Guid thirdWorkspace = context.Store.Dispatch(new AddWorkspaceTransform("3")).Value;
+	Guid fourthWorkspace = context.Store.Dispatch(new AddWorkspaceTransform("4")).Value;
 
 	// Set up layout engines.
 	context.Store.Dispatch(


### PR DESCRIPTION
- Switched to using `.Value` instead of `.ValueOrDefault` in documentation and examples
- Added an example command for the workspaces and monitors pages.
- Added return type documentation for the pickers
- Added examples for `Pick` and `Dispatch` in `IStore`
- (Hopefully) simplified the store docs a bit more