### PR TITLE
Focus last focused window when switching to a layout engine

### DIFF
--- a/src/Whim.Tests/Store/WorkspaceSector/WorkspaceSectorTests.cs
+++ b/src/Whim.Tests/Store/WorkspaceSector/WorkspaceSectorTests.cs
@@ -1,6 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.UI.Dispatching;
-using Microsoft.UI.Xaml;
 
 namespace Whim.Tests;
 

--- a/src/Whim.Tests/Store/WorkspaceSector/WorkspaceSectorTests.cs
+++ b/src/Whim.Tests/Store/WorkspaceSector/WorkspaceSectorTests.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.UI.Dispatching;
+using Microsoft.UI.Xaml;
 
 namespace Whim.Tests;
 
@@ -100,7 +101,7 @@ public class WorkspaceSectorTests
 	}
 
 	[Theory, AutoSubstituteData<StoreCustomization>]
-	internal void DoLayout_FocusWindow(IContext ctx, IInternalContext internalCtx, MutableRootSector root)
+	internal void DoLayout_FocusWindow(IContext ctx, MutableRootSector root, List<object> transforms)
 	{
 		// Given
 		IWindow window = CreateWindow((HWND)1);
@@ -119,13 +120,14 @@ public class WorkspaceSectorTests
 
 		// Then the window should be focused
 		window.Received().Focus();
-		internalCtx.WindowManager.Received().OnWindowFocused(window);
+		Assert.Contains(transforms, t => t.Equals(new WindowFocusedTransform(window)));
+		Assert.Contains(transforms, t => t.Equals(new MinimizeWindowEndTransform(workspace.Id, window.Handle)));
 
 		Assert.Equal(default, sut.WindowHandleToFocus);
 	}
 
 	[Theory, AutoSubstituteData<StoreCustomization>]
-	internal void DoLayout_FocusHandle(IInternalContext internalCtx, MutableRootSector root)
+	internal void DoLayout_FocusHandle(IInternalContext internalCtx, MutableRootSector root, List<object> transforms)
 	{
 		// Given
 		HWND handle = (HWND)1;
@@ -140,5 +142,7 @@ public class WorkspaceSectorTests
 		internalCtx.CoreNativeManager.Received().SetForegroundWindow(handle);
 
 		Assert.Equal(default, sut.WindowHandleToFocus);
+		Assert.Contains(transforms, t => t.Equals(new WindowFocusedTransform(null)));
+		Assert.DoesNotContain(transforms, t => t is MinimizeWindowEndTransform);
 	}
 }

--- a/src/Whim.Tests/Store/WorkspaceSector/WorkspaceUtilsTests.cs
+++ b/src/Whim.Tests/Store/WorkspaceSector/WorkspaceUtilsTests.cs
@@ -45,10 +45,12 @@ public class WorkspaceUtilsTests
 	)
 	{
 		// Given
+		HWND lastFocusedWindowHandle = new(1);
 		Workspace workspace = CreateWorkspace(ctx) with
 		{
 			LayoutEngines = [engine1, engine2, engine3],
-			ActiveLayoutEngineIndex = 1
+			ActiveLayoutEngineIndex = 1,
+			LastFocusedWindowHandle = lastFocusedWindowHandle
 		};
 		int newActiveLayoutEngineIndex = 2;
 
@@ -69,6 +71,7 @@ public class WorkspaceUtilsTests
 		Assert.NotSame(workspace, result);
 		Assert.Equal(2, result.ActiveLayoutEngineIndex);
 		Assert.Equal(workspace.Id, result.Id);
+		Assert.Equal(lastFocusedWindowHandle, root.WorkspaceSector.WindowHandleToFocus);
 	}
 
 	[Theory, AutoSubstituteData]
@@ -103,6 +106,7 @@ public class WorkspaceUtilsTests
 		Assert.Same(workspace, result);
 		Assert.Equal(0, result.ActiveLayoutEngineIndex);
 		Assert.Equal(workspace.Id, result.Id);
+		Assert.Equal(default, root.WorkspaceSector.WindowHandleToFocus);
 	}
 
 	[Theory, AutoSubstituteData]

--- a/src/Whim/Native/NativeManager.cs
+++ b/src/Whim/Native/NativeManager.cs
@@ -1,5 +1,6 @@
 // We do use this in non-DEBUG.
 #pragma warning disable IDE0005 // Using directive is unnecessary.
+using System.Diagnostics;
 using System.Reflection;
 #pragma warning restore IDE0005 // Using directive is unnecessary.
 using System.Runtime.InteropServices;

--- a/src/Whim/Native/NativeManager.cs
+++ b/src/Whim/Native/NativeManager.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics;
 // We do use this in non-DEBUG.
 #pragma warning disable IDE0005 // Using directive is unnecessary.
 using System.Reflection;

--- a/src/Whim/Store/WindowSector/Transforms/WindowMinimizeEndedTransform.cs
+++ b/src/Whim/Store/WindowSector/Transforms/WindowMinimizeEndedTransform.cs
@@ -14,8 +14,8 @@ internal record WindowMinimizeEndedTransform(IWindow Window) : Transform
 			return Result.FromException<Unit>(workspaceResult.Error!);
 		}
 
-		workspace.MinimizeWindowEnd(Window);
-		workspace.DoLayout();
+		ctx.Store.Dispatch(new MinimizeWindowEndTransform(workspace.Id, Window.Handle));
+		ctx.Store.Dispatch(new DoWorkspaceLayoutTransform(workspace.Id));
 
 		mutableRootSector.WindowSector.QueueEvent(new WindowMinimizeEndedEventArgs() { Window = Window });
 

--- a/src/Whim/Store/WorkspaceSector/WorkspaceSector.cs
+++ b/src/Whim/Store/WorkspaceSector/WorkspaceSector.cs
@@ -150,7 +150,7 @@ internal class WorkspaceSector(IContext ctx, IInternalContext internalCtx)
 			WindowHandleToFocus.Focus(_internalCtx);
 		}
 
-		_internalCtx.WindowManager.OnWindowFocused(window);
+		_ctx.Store.Dispatch(new WindowFocusedTransform(window));
 		WindowHandleToFocus = default;
 	}
 

--- a/src/Whim/Store/WorkspaceSector/WorkspaceSector.cs
+++ b/src/Whim/Store/WorkspaceSector/WorkspaceSector.cs
@@ -87,6 +87,7 @@ internal class WorkspaceSector(IContext ctx, IInternalContext internalCtx)
 	{
 		Logger.Debug("Doing layout");
 
+		// Force the window to focus to not be minimized.
 		if (WindowHandleToFocus != default)
 		{
 			if (_ctx.Store.Pick(PickWorkspaceByWindow(WindowHandleToFocus)).TryGet(out IWorkspace workspace))

--- a/src/Whim/Store/WorkspaceSector/WorkspaceSector.cs
+++ b/src/Whim/Store/WorkspaceSector/WorkspaceSector.cs
@@ -87,6 +87,17 @@ internal class WorkspaceSector(IContext ctx, IInternalContext internalCtx)
 	{
 		Logger.Debug("Doing layout");
 
+		if (WindowHandleToFocus != default)
+		{
+			if (_ctx.Store.Pick(PickWorkspaceByWindow(WindowHandleToFocus)).TryGet(out IWorkspace workspace))
+			{
+				WorkspacesToLayout = WorkspacesToLayout.Add(workspace.Id);
+
+				// Force the window to not be minimized.
+				_ctx.Store.Dispatch(new MinimizeWindowEndTransform(workspace.Id, WindowHandleToFocus));
+			}
+		}
+
 		GarbageCollect();
 		LayoutAllWorkspaces();
 		FocusHandle();

--- a/src/Whim/Store/WorkspaceSector/WorkspaceUtils.cs
+++ b/src/Whim/Store/WorkspaceSector/WorkspaceUtils.cs
@@ -31,6 +31,8 @@ internal static class WorkspaceUtils
 			}
 		);
 
+		sector.WindowHandleToFocus = workspace.LastFocusedWindowHandle;
+
 		return workspace;
 	}
 


### PR DESCRIPTION
Whim now forces the `WindowHandleToFocus` to not be minimized before a layout. While the original intention for this was to have it be configurable, I think this behavior is a sensible default.