### PR TITLE
Mark `ColumnLayoutEngine` as deprecated

### DIFF
--- a/docs/docs/customize/layout-engines.md
+++ b/docs/docs/customize/layout-engines.md
@@ -44,9 +44,9 @@ Each `SliceLayoutEngine` is divided into a number of <xref:Whim.SliceLayout.IAre
 `OverflowArea`s are implicitly the last ordered area in the layout engine, in comparison to all `SliceArea`s.
 Internally, `SliceLayoutEngine` stores a list of <xref:Whim.IWindow>s. Each `IArea` corresponds to a "slice" of the `IWindow` list.
 
-#### Defining `SliceLayoutEngine`s
+#### Defining different `SliceLayouts`
 
-The `SliceLayouts` contains methods to create a few common layouts:
+The <xref:Whim.SliceLayout.SliceLayouts> static class contains methods to create a few common layouts:
 
 - primary/stack (master/stack)
 - multi-column layout

--- a/src/Whim.SliceLayout.Tests/SliceLayoutsTests.cs
+++ b/src/Whim.SliceLayout.Tests/SliceLayoutsTests.cs
@@ -1,10 +1,75 @@
 using FluentAssertions;
+using Whim.TestUtils;
 using Xunit;
 
 namespace Whim.SliceLayout.Tests;
 
 public class SliceLayoutsTests
 {
+	[Theory, AutoSubstituteData]
+	public void CreateColumnLayout(IContext ctx, ISliceLayoutPlugin plugin)
+	{
+		// Given
+		LayoutEngineIdentity identity = new();
+		ILayoutEngine sut = SliceLayouts.CreateColumnLayout(ctx, plugin, identity);
+
+		// Then
+		new SliceLayoutEngine(
+			ctx,
+			plugin,
+			identity,
+			new ParentArea(isRow: false, (1, new SliceArea(order: 0, maxChildren: 0)))
+		)
+		{
+			Name = "Column"
+		}
+			.Should()
+			.BeEquivalentTo(sut);
+	}
+
+	[Theory, AutoSubstituteData]
+	public void CreateRowLayout(IContext ctx, ISliceLayoutPlugin plugin)
+	{
+		// Given
+		LayoutEngineIdentity identity = new();
+		ILayoutEngine sut = SliceLayouts.CreateRowLayout(ctx, plugin, identity);
+
+		// Then
+		// Then
+		new SliceLayoutEngine(
+			ctx,
+			plugin,
+			identity,
+			new ParentArea(isRow: true, (1, new SliceArea(order: 0, maxChildren: 0)))
+		)
+		{
+			Name = "Row"
+		}
+			.Should()
+			.BeEquivalentTo(sut);
+	}
+
+	[Theory, AutoSubstituteData]
+	public void CreatePrimaryStackLayout(IContext ctx, ISliceLayoutPlugin plugin)
+	{
+		// Given
+		LayoutEngineIdentity identity = new();
+		ILayoutEngine sut = SliceLayouts.CreatePrimaryStackLayout(ctx, plugin, identity);
+
+		// Then
+		new SliceLayoutEngine(
+			ctx,
+			plugin,
+			identity,
+			new ParentArea(isRow: true, (0.5, new SliceArea(order: 0, maxChildren: 0)), (0.5, new OverflowArea()))
+		)
+		{
+			Name = "Primary stack"
+		}
+			.Should()
+			.BeEquivalentTo(sut);
+	}
+
 	[Fact]
 	public void CreateMultiColumnArea_MultipleOverflows()
 	{

--- a/src/Whim.SliceLayout/SliceLayouts.cs
+++ b/src/Whim.SliceLayout/SliceLayouts.cs
@@ -8,10 +8,123 @@ namespace Whim.SliceLayout;
 public static class SliceLayouts
 {
 	/// <summary>
+	/// Creates a column layout, where windows are stacked vertically.
+	/// </summary>
+	/// <example>
+	/// Usage:
+	/// <code>
+	/// context.Store.Dispatch(
+	/// 	new SetCreateLayoutEnginesTransform(
+	/// 		() => new CreateLeafLayoutEngine[]
+	/// 		{
+	/// 			(id) => SliceLayouts.CreateColumnLayout(context, sliceLayoutPlugin, id)
+	/// 		}
+	/// 	)
+	/// );
+	/// </code>
+	///
+	/// Layout:
+	/// <code>
+	/// ---------------------------------------------------------
+	/// |                                                       |
+	/// |                                                       |
+	/// |                                                       |
+	/// |                                                       |
+	/// |                                |                      |
+	/// |                                |                      |
+	/// |                       Overflow |                      |
+	/// |                                |                      |
+	/// |                                ↓                      |
+	/// |                                                       |
+	/// |                                                       |
+	/// |                                                       |
+	/// |                                                       |
+	/// |                                                       |
+	/// |                                                       |
+	/// ---------------------------------------------------------
+	/// </code>
+	/// </example>
+	/// <param name="context"></param>
+	/// <param name="plugin"></param>
+	/// <param name="identity"></param>
+	/// <param name="leftToRight"></param>
+	/// <returns></returns>
+	public static ILayoutEngine CreateColumnLayout(
+		IContext context,
+		ISliceLayoutPlugin plugin,
+		LayoutEngineIdentity identity,
+		bool leftToRight = true
+	) =>
+		new SliceLayoutEngine(context, plugin, identity, new(isRow: false, (1, new OverflowArea())))
+		{
+			Name = "Column"
+		};
+
+	/// <summary>
+	/// Creates a row layout, where windows are stacked horizontally.
+	/// </summary>
+	/// <example>
+	/// Usage:
+	/// <code>
+	/// context.Store.Dispatch(
+	/// 	new SetCreateLayoutEnginesTransform(
+	/// 		() => new CreateLeafLayoutEngine[]
+	/// 		{
+	/// 			(id) => SliceLayouts.CreateRowLayout(context, sliceLayoutPlugin, id)
+	/// 		}
+	/// 	)
+	/// );
+	/// </code>
+	///
+	/// Layout:
+	/// <code>
+	/// ---------------------------------------------------------
+	/// |                                                       |
+	/// |                                                       |
+	/// |                                                       |
+	/// |                                                       |
+	/// |                                                       |
+	/// |                                                       |
+	/// |                       Overflow                        |
+	/// |                       -------→                        |
+	/// |                                                       |
+	/// |                                                       |
+	/// |                                                       |
+	/// |                                                       |
+	/// |                                                       |
+	/// |                                                       |
+	/// |                                                       |
+	/// ---------------------------------------------------------
+	/// </code>
+	/// </example>
+	/// <param name="context"></param>
+	/// <param name="plugin"></param>
+	/// <param name="identity"></param>
+	/// <returns></returns>
+	public static ILayoutEngine CreateRowLayout(
+		IContext context,
+		ISliceLayoutPlugin plugin,
+		LayoutEngineIdentity identity
+	) => new SliceLayoutEngine(context, plugin, identity, new(isRow: true, (1, new OverflowArea()))) { Name = "Row" };
+
+	/// <summary>
 	/// Creates a primary stack layout, where the first window takes up half the screen, and the
 	/// remaining windows are stacked vertically on the other half.
-	///
+	/// </summary>
 	/// <example>
+	/// Usage:
+	/// <code>
+	/// context.Store.Dispatch(
+	/// 	new SetCreateLayoutEnginesTransform(
+	/// 		() => new CreateLeafLayoutEngine[]
+	/// 		{
+	/// 			(id) => SliceLayouts.CreatePrimaryStackLayout(context, sliceLayoutPlugin, id)
+	/// 		}
+	/// 	)
+	/// );
+	/// </code>
+	///
+	/// Layout:
 	/// <code>
 	/// ----------------------------------------------------------------
 	/// |                              |                               |
@@ -22,11 +135,11 @@ public static class SliceLayouts
 	/// |                              |                               |
 	/// |                              |                               |
 	/// |                              |                               |
-	/// |                              |                               |
-	/// |                              |                               |
-	/// |           Primary            |           Overflow            |
-	/// |          1 window            |                               |
-	/// |                              |                               |
+	/// |                              |                     |         |
+	/// |                              |                     |         |
+	/// |           Primary            |           Overflow  |         |
+	/// |          1 window            |                     |         |
+	/// |                              |                     ↓         |
 	/// |                              |                               |
 	/// |                              |                               |
 	/// |                              |                               |
@@ -40,7 +153,6 @@ public static class SliceLayouts
 	/// ----------------------------------------------------------------
 	/// </code>
 	/// </example>
-	/// </summary>
 	/// <param name="context"></param>
 	/// <param name="plugin"></param>
 	/// <param name="identity"></param>
@@ -59,10 +171,21 @@ public static class SliceLayouts
 	/// <br />
 	/// For example, new <c>uint[] { 2, 1, 0 }</c> will create a layout with 3 columns, where the
 	/// first column has 2 rows, the second column has 1 row, and the third column has infinite rows.
-	///
-	/// For example:
-	///
+	/// </summary>
 	/// <example>
+	/// Usage:
+	/// <code>
+	/// context.Store.Dispatch(
+	/// 	new SetCreateLayoutEnginesTransform(
+	/// 		() => new CreateLeafLayoutEngine[]
+	/// 		{
+	/// 			(id) => SliceLayouts.CreateMultiColumnLayout(context, sliceLayoutPlugin, id)
+	/// 		}
+	/// 	)
+	/// );
+	/// </code>
+	///
+	/// Layout:
 	/// <code>
 	/// -------------------------------------------------------------------------------------------------
 	/// |                               |                               |                               |
@@ -73,11 +196,11 @@ public static class SliceLayouts
 	/// |                               |                               |                               |
 	/// |                               |                               |                               |
 	/// |                               |                               |                               |
-	/// |                               |                               |                               |
-	/// |                               |                               |                               |
-	/// |           Slice 1             |           Slice 2             |           Overflow            |
-	/// |          2 windows            |          1 window             |                               |
-	/// |                               |                               |                               |
+	/// |                    |          |                               |                    |          |
+	/// |                    |          |                               |                    |          |
+	/// |           Slice 1  |          |           Slice 2             |           Overflow |          |
+	/// |          2 windows |          |          1 window             |                    |          |
+	/// |                    ↓          |                               |                    ↓          |
 	/// |                               |                               |                               |
 	/// |                               |                               |                               |
 	/// |                               |                               |                               |
@@ -91,13 +214,11 @@ public static class SliceLayouts
 	/// -------------------------------------------------------------------------------------------------
 	/// </code>
 	/// </example>
-	/// </summary>
 	/// <param name="context">The <see cref="IContext"/> to use</param>
 	/// <param name="plugin">The <see cref="ISliceLayoutPlugin"/> to use</param>
 	/// <param name="identity">The identity of the layout engine</param>
 	/// <param name="capacities">The number of rows in each column</param>
 	/// <returns></returns>
-	/// <exception cref="ArgumentException"></exception>
 	public static ILayoutEngine CreateMultiColumnLayout(
 		IContext context,
 		ISliceLayoutPlugin plugin,
@@ -140,10 +261,21 @@ public static class SliceLayouts
 	/// column is on the left, and the overflow column is on the right.
 	///
 	/// The middle column takes up 50% of the screen, and the left and right columns take up 25%.
-	///
-	/// For example:
-	///
+	/// </summary>
 	/// <example>
+	/// Usage:
+	/// <code>
+	/// context.Store.Dispatch(
+	/// 	new SetCreateLayoutEnginesTransform(
+	/// 		() => new CreateLeafLayoutEngine[]
+	/// 		{
+	/// 			(id) => SliceLayouts.CreateSecondaryPrimaryLayout(context, sliceLayoutPlugin, id)
+	/// 		}
+	/// 	)
+	/// );
+	/// </code>
+	///
+	/// Layout:
 	/// <code>
 	/// ------------------------------------------------------------------------
 	/// |                 |                             |                      |
@@ -154,11 +286,11 @@ public static class SliceLayouts
 	/// |                 |                             |                      |
 	/// |                 |                             |                      |
 	/// |                 |                             |                      |
-	/// |                 |                             |                      |
-	/// |                 |                             |                      |
-	/// |     Slice 2     |           Slice 1           |       Overflow       |
-	/// |    2 windows    |          1 window           |                      |
-	/// |                 |                             |                      |
+	/// |              |  |                             |                |     |
+	/// |              |  |                             |                |     |
+	/// |     Slice 2  |  |           Slice 1           |       Overflow |     |
+	/// |    2 windows |  |          1 window           |                |     |
+	/// |              ↓  |                             |                ↓     |
 	/// |                 |                             |                      |
 	/// |                 |                             |                      |
 	/// |                 |                             |                      |
@@ -172,7 +304,6 @@ public static class SliceLayouts
 	/// ------------------------------------------------------------------------
 	/// </code>
 	/// </example>
-	/// </summary>
 	/// <param name="context"></param>
 	/// <param name="plugin"></param>
 	/// <param name="identity"></param>

--- a/src/Whim.SliceLayout/SliceLayouts.cs
+++ b/src/Whim.SliceLayout/SliceLayouts.cs
@@ -1,5 +1,3 @@
-using System;
-
 namespace Whim.SliceLayout;
 
 /// <summary>

--- a/src/Whim.Tests/Store/Root/MutableRootSectorTests.cs
+++ b/src/Whim.Tests/Store/Root/MutableRootSectorTests.cs
@@ -3,11 +3,19 @@ namespace Whim.Tests;
 public class MutableRootSectorTests
 {
 	[Theory, AutoSubstituteData<StoreCustomization>]
-	internal void Initialize_Dispose(IContext ctx, IInternalContext internalCtx, MutableRootSector rootSector)
+	internal void Initialize_Dispose(
+		IContext ctx,
+		IInternalContext internalCtx,
+		MutableRootSector rootSector,
+		ILayoutEngine engine1,
+		ILayoutEngine engine2
+	)
 	{
-		// Given
+		// Given there is a populated layout engine creator
 		MutableRootSector sut = new(ctx, internalCtx);
 		var capture = CaptureWinEventProc.Create(internalCtx);
+
+		rootSector.WorkspaceSector.CreateLayoutEngines = () => [(id) => engine1, (id) => engine2];
 
 		ctx.Store.Dispatch(new AddWorkspaceTransform());
 

--- a/src/Whim/Layout/ColumnLayoutEngine.cs
+++ b/src/Whim/Layout/ColumnLayoutEngine.cs
@@ -5,6 +5,7 @@ namespace Whim;
 /// <summary>
 /// Layout engine that lays out windows in columns.
 /// </summary>
+[Obsolete("Use SliceLayoutEngine instead - see SliceLayouts instead")]
 public record ColumnLayoutEngine : ILayoutEngine
 {
 	/// <summary>

--- a/src/Whim/Layout/ColumnLayoutEngine.cs
+++ b/src/Whim/Layout/ColumnLayoutEngine.cs
@@ -5,7 +5,7 @@ namespace Whim;
 /// <summary>
 /// Layout engine that lays out windows in columns.
 /// </summary>
-[Obsolete("Use SliceLayoutEngine instead - see SliceLayouts instead")]
+[Obsolete("Use SliceLayoutEngine instead - see SliceLayouts")]
 public record ColumnLayoutEngine : ILayoutEngine
 {
 	/// <summary>

--- a/src/Whim/Store/WorkspaceSector/WorkspaceSector.cs
+++ b/src/Whim/Store/WorkspaceSector/WorkspaceSector.cs
@@ -34,8 +34,7 @@ internal class WorkspaceSector(IContext ctx, IInternalContext internalCtx)
 	public ImmutableDictionary<WorkspaceId, Workspace> Workspaces { get; set; } =
 		ImmutableDictionary<WorkspaceId, Workspace>.Empty;
 
-	public Func<CreateLeafLayoutEngine[]> CreateLayoutEngines { get; set; } =
-		() => [(id) => new ColumnLayoutEngine(id)];
+	public Func<CreateLeafLayoutEngine[]> CreateLayoutEngines { get; set; } = () => [];
 
 	public ImmutableList<ProxyLayoutEngineCreator> ProxyLayoutEngineCreators { get; set; } = [];
 


### PR DESCRIPTION
Marked `ColumnLayoutEngine` as deprecated. Added equivalent the equivalent `SliceLayouts.CreateRowLayout` and `SliceLayouts.CreateColumnLayout`.