### PR TITLE
Fix window jump and size change while moving a floating window in between monitors

### DIFF
--- a/app_rules/requirements.txt
+++ b/app_rules/requirements.txt
@@ -2,7 +2,7 @@
 PyYAML==6.0.2
 requests==2.32.3
 # indirect dependencies, frozen to use cache by `actions/setup-python`
-certifi==2024.7.4
+certifi==2024.8.30
 charset-normalizer==3.3.2
 idna==3.8
 urllib3==2.2.2

--- a/src/Whim.FloatingWindow.Tests/FloatingLayoutEngineTests.cs
+++ b/src/Whim.FloatingWindow.Tests/FloatingLayoutEngineTests.cs
@@ -1,28 +1,8 @@
-﻿using AutoFixture;
-using NSubstitute;
+﻿using NSubstitute;
 using Whim.TestUtils;
-using Windows.Win32.Foundation;
 using Xunit;
 
 namespace Whim.FloatingWindow.Tests;
-
-public class FloatingLayoutEngineCustomization : ICustomization
-{
-	public void Customize(IFixture fixture)
-	{
-		IContext context = fixture.Freeze<IContext>();
-		IMonitor monitor = fixture.Freeze<IMonitor>();
-
-		context.MonitorManager.GetMonitorAtPoint(Arg.Any<IRectangle<int>>()).Returns(monitor);
-		monitor.WorkingArea.Returns(new Rectangle<int>() { Width = 1000, Height = 1000 });
-		context
-			.NativeManager.DwmGetWindowRectangle(Arg.Any<HWND>())
-			.Returns(new Rectangle<int>() { Width = 100, Height = 100 });
-
-		fixture.Inject(context);
-		fixture.Inject(monitor);
-	}
-}
 
 public class FloatingLayoutEngineTests
 {
@@ -42,7 +22,7 @@ public class FloatingLayoutEngineTests
 	}
 
 	#region AddWindow
-	[Theory, AutoSubstituteData<FloatingLayoutEngineCustomization>]
+	[Theory, AutoSubstituteData<FloatingWindowCustomization>]
 	public void AddWindow(IContext context, IWindow window)
 	{
 		// Given
@@ -56,7 +36,7 @@ public class FloatingLayoutEngineTests
 		Assert.Equal(1, newLayoutEngine.Count);
 	}
 
-	[Theory, AutoSubstituteData<FloatingLayoutEngineCustomization>]
+	[Theory, AutoSubstituteData<FloatingWindowCustomization>]
 	public void AddWindow_WindowAlreadyPresent(IContext context, IWindow window)
 	{
 		// Given
@@ -72,7 +52,7 @@ public class FloatingLayoutEngineTests
 	#endregion
 
 	#region RemoveWindow
-	[Theory, AutoSubstituteData<FloatingLayoutEngineCustomization>]
+	[Theory, AutoSubstituteData<FloatingWindowCustomization>]
 	public void Remove(IContext context, IWindow window)
 	{
 		// Given
@@ -86,7 +66,7 @@ public class FloatingLayoutEngineTests
 		Assert.Equal(0, newLayoutEngine.Count);
 	}
 
-	[Theory, AutoSubstituteData<FloatingLayoutEngineCustomization>]
+	[Theory, AutoSubstituteData<FloatingWindowCustomization>]
 	public void Remove_NoChanges(IContext context, IWindow window)
 	{
 		// Given
@@ -102,7 +82,7 @@ public class FloatingLayoutEngineTests
 	#endregion RemoveWindow
 
 	#region Contains
-	[Theory, AutoSubstituteData<FloatingLayoutEngineCustomization>]
+	[Theory, AutoSubstituteData<FloatingWindowCustomization>]
 	public void Contains(IContext context, IWindow window)
 	{
 		// Given
@@ -115,7 +95,7 @@ public class FloatingLayoutEngineTests
 		Assert.True(contains);
 	}
 
-	[Theory, AutoSubstituteData<FloatingLayoutEngineCustomization>]
+	[Theory, AutoSubstituteData<FloatingWindowCustomization>]
 	public void Contains_False(IContext context, IWindow window)
 	{
 		// Given
@@ -130,7 +110,7 @@ public class FloatingLayoutEngineTests
 	#endregion
 
 	#region DoLayout
-	[Theory, AutoSubstituteData<FloatingLayoutEngineCustomization>]
+	[Theory, AutoSubstituteData<FloatingWindowCustomization>]
 	public void DoLayout_Empty(IContext context)
 	{
 		// Given
@@ -145,15 +125,15 @@ public class FloatingLayoutEngineTests
 		Assert.Empty(windowStates);
 	}
 
-	[Theory, AutoSubstituteData<FloatingLayoutEngineCustomization>]
-	public void DoLayout_KeepWindowSize(
-		IContext context,
-		IWindow windowNormal,
-		IWindow windowMinimized,
-		IWindow windowMaximized
-	)
+	[Theory, AutoSubstituteData<FloatingWindowCustomization>]
+	internal void DoLayout_KeepWindowSize(IContext context, MutableRootSector root)
 	{
 		// Given
+		IWindow[] allWindows = root.WindowSector.Windows.Values.ToArray();
+		IWindow windowNormal = allWindows[0];
+		IWindow windowMinimized = allWindows[1];
+		IWindow windowMaximized = allWindows[2];
+
 		windowMinimized.IsMinimized.Returns(true);
 		windowMaximized.IsMaximized.Returns(true);
 		ILayoutEngine engine = new FloatingLayoutEngine(context, identity)
@@ -189,7 +169,7 @@ public class FloatingLayoutEngineTests
 		Assert.Null(result);
 	}
 
-	[Theory, AutoSubstituteData<FloatingLayoutEngineCustomization>]
+	[Theory, AutoSubstituteData<FloatingWindowCustomization>]
 	public void GetFirstWindow_SingleWindow(IContext context, IWindow window)
 	{
 		// Given
@@ -204,7 +184,7 @@ public class FloatingLayoutEngineTests
 	#endregion
 
 	#region WindowRelated
-	[Theory, AutoSubstituteData<FloatingLayoutEngineCustomization>]
+	[Theory, AutoSubstituteData<FloatingWindowCustomization>]
 	public void MoveWindowToPoint(IContext context, IWindow window)
 	{
 		// Given
@@ -218,7 +198,7 @@ public class FloatingLayoutEngineTests
 		Assert.Equal(engine, newEngine);
 	}
 
-	[Theory, AutoSubstituteData<FloatingLayoutEngineCustomization>]
+	[Theory, AutoSubstituteData<FloatingWindowCustomization>]
 	public void MoveWindowEdgesInDirection(IContext context, IWindow window)
 	{
 		// Given
@@ -232,7 +212,7 @@ public class FloatingLayoutEngineTests
 		Assert.Equal(engine, newEngine);
 	}
 
-	[Theory, AutoSubstituteData<FloatingLayoutEngineCustomization>]
+	[Theory, AutoSubstituteData<FloatingWindowCustomization>]
 	public void MinimizeWindowStart(IContext context, IWindow window)
 	{
 		// Given
@@ -245,7 +225,7 @@ public class FloatingLayoutEngineTests
 		Assert.Equal(engine, newEngine);
 	}
 
-	[Theory, AutoSubstituteData<FloatingLayoutEngineCustomization>]
+	[Theory, AutoSubstituteData<FloatingWindowCustomization>]
 	public void MinimizeWindowEnd(IContext context, IWindow window)
 	{
 		// Given
@@ -258,7 +238,7 @@ public class FloatingLayoutEngineTests
 		Assert.Equal(engine, newEngine);
 	}
 
-	[Theory, AutoSubstituteData<FloatingLayoutEngineCustomization>]
+	[Theory, AutoSubstituteData<FloatingWindowCustomization>]
 	public void FocusWindowInDirection(IContext context, IWindow window)
 	{
 		// Given
@@ -271,7 +251,7 @@ public class FloatingLayoutEngineTests
 		Assert.Equal(engine, newEngine);
 	}
 
-	[Theory, AutoSubstituteData<FloatingLayoutEngineCustomization>]
+	[Theory, AutoSubstituteData<FloatingWindowCustomization>]
 	public void SwapWindowInDirection(IContext context, IWindow window)
 	{
 		// Given
@@ -285,7 +265,7 @@ public class FloatingLayoutEngineTests
 	}
 	#endregion
 
-	[Theory, AutoSubstituteData<FloatingLayoutEngineCustomization>]
+	[Theory, AutoSubstituteData<FloatingWindowCustomization>]
 	public void PerformCustomAction(IContext context, IWindow window)
 	{
 		// Given

--- a/src/Whim.FloatingWindow.Tests/FloatingLayoutEngineTests.cs
+++ b/src/Whim.FloatingWindow.Tests/FloatingLayoutEngineTests.cs
@@ -37,6 +37,21 @@ public class FloatingLayoutEngineTests
 	}
 
 	[Theory, AutoSubstituteData<FloatingWindowCustomization>]
+	public void AddWindow_UntrackedWindow(IContext context)
+	{
+		// Given a window which isn't tracked by the store
+		IWindow window = Substitute.For<IWindow>();
+		ILayoutEngine engine = new FloatingLayoutEngine(context, identity);
+
+		// When
+		ILayoutEngine newLayoutEngine = engine.AddWindow(window);
+
+		// Then
+		Assert.Equal(0, engine.Count);
+		Assert.Same(engine, newLayoutEngine);
+	}
+
+	[Theory, AutoSubstituteData<FloatingWindowCustomization>]
 	public void AddWindow_WindowAlreadyPresent(IContext context, IWindow window)
 	{
 		// Given

--- a/src/Whim.FloatingWindow.Tests/FloatingWindowCustomization.cs
+++ b/src/Whim.FloatingWindow.Tests/FloatingWindowCustomization.cs
@@ -1,0 +1,46 @@
+using System.Diagnostics.CodeAnalysis;
+using AutoFixture;
+using NSubstitute;
+using Whim.TestUtils;
+using Windows.Win32.Foundation;
+using Windows.Win32.Graphics.Gdi;
+
+namespace Whim.FloatingWindow.Tests;
+
+public class FloatingWindowCustomization : ICustomization
+{
+	[SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope")]
+	public void Customize(IFixture fixture)
+	{
+		IContext ctx = fixture.Freeze<IContext>();
+		IInternalContext internalCtx = fixture.Freeze<IInternalContext>();
+
+		Store store = new(ctx, internalCtx);
+		ctx.Store.Returns(store);
+
+		IWindow window1 = StoreTestUtils.CreateWindow((HWND)1);
+		IWindow window2 = StoreTestUtils.CreateWindow((HWND)2);
+		IWindow window3 = StoreTestUtils.CreateWindow((HWND)3);
+		Workspace workspace = StoreTestUtils.CreateWorkspace(ctx);
+
+		IMonitor monitor = StoreTestUtils.CreateMonitor((HMONITOR)123);
+		monitor.WorkingArea.Returns(new Rectangle<int>() { Width = 1000, Height = 1000 });
+
+		StoreTestUtils.SetupMonitorAtPoint(ctx, internalCtx, store._root.MutableRootSector, monitor);
+
+		StoreTestUtils.PopulateThreeWayMap(ctx, store._root.MutableRootSector, monitor, workspace, window1);
+		StoreTestUtils.PopulateThreeWayMap(ctx, store._root.MutableRootSector, monitor, workspace, window2);
+		StoreTestUtils.PopulateThreeWayMap(ctx, store._root.MutableRootSector, monitor, workspace, window3);
+
+		ctx.NativeManager.DwmGetWindowRectangle(Arg.Any<HWND>())
+			.Returns(new Rectangle<int>() { Width = 100, Height = 100 });
+
+		fixture.Inject(monitor);
+		fixture.Inject(store._root);
+		fixture.Inject(store._root.MutableRootSector);
+		fixture.Inject(workspace);
+
+		// Only inject the first window. Other windows can be retrieved from the WindowSector.
+		fixture.Inject(window1);
+	}
+}

--- a/src/Whim.FloatingWindow.Tests/ProxyFloatingLayoutEngineTests.cs
+++ b/src/Whim.FloatingWindow.Tests/ProxyFloatingLayoutEngineTests.cs
@@ -1,4 +1,3 @@
-using AutoFixture;
 using FluentAssertions;
 using NSubstitute;
 using Whim.TestUtils;
@@ -6,24 +5,6 @@ using Windows.Win32.Foundation;
 using Xunit;
 
 namespace Whim.FloatingWindow.Tests;
-
-public class ProxyFloatingLayoutEngineCustomization : ICustomization
-{
-	public void Customize(IFixture fixture)
-	{
-		IContext context = fixture.Freeze<IContext>();
-		IMonitor monitor = fixture.Freeze<IMonitor>();
-
-		context.MonitorManager.GetMonitorAtPoint(Arg.Any<IRectangle<int>>()).Returns(monitor);
-		monitor.WorkingArea.Returns(new Rectangle<int>() { Width = 1000, Height = 1000 });
-		context
-			.NativeManager.DwmGetWindowRectangle(Arg.Any<HWND>())
-			.Returns(new Rectangle<int>() { Width = 100, Height = 100 });
-
-		fixture.Inject(context);
-		fixture.Inject(monitor);
-	}
-}
 
 public class ProxyFloatingLayoutEngineTests
 {
@@ -70,7 +51,7 @@ public class ProxyFloatingLayoutEngineTests
 	}
 
 	#region AddWindow
-	[Theory, AutoSubstituteData<ProxyFloatingLayoutEngineCustomization>]
+	[Theory, AutoSubstituteData<FloatingWindowCustomization>]
 	internal void AddWindow_UseInner(
 		IContext context,
 		IInternalFloatingWindowPlugin plugin,
@@ -89,7 +70,7 @@ public class ProxyFloatingLayoutEngineTests
 		innerLayoutEngine.Received(1).AddWindow(window);
 	}
 
-	[Theory, AutoSubstituteData<ProxyFloatingLayoutEngineCustomization>]
+	[Theory, AutoSubstituteData<FloatingWindowCustomization>]
 	internal void AddWindow_UseInner_SameInner(
 		IContext context,
 		IInternalFloatingWindowPlugin plugin,
@@ -110,7 +91,7 @@ public class ProxyFloatingLayoutEngineTests
 		innerLayoutEngine.Received(1).AddWindow(window);
 	}
 
-	[Theory, AutoSubstituteData<ProxyFloatingLayoutEngineCustomization>]
+	[Theory, AutoSubstituteData<FloatingWindowCustomization>]
 	internal void AddWindow_FloatingInPlugin_Succeed(
 		IContext context,
 		IInternalFloatingWindowPlugin plugin,
@@ -130,7 +111,7 @@ public class ProxyFloatingLayoutEngineTests
 		innerLayoutEngine.DidNotReceive().AddWindow(window);
 	}
 
-	[Theory, AutoSubstituteData<ProxyFloatingLayoutEngineCustomization>]
+	[Theory, AutoSubstituteData<FloatingWindowCustomization>]
 	internal void AddWindow_FloatingInPlugin_FailOnNoRectangle(
 		IContext context,
 		IInternalFloatingWindowPlugin plugin,
@@ -152,7 +133,7 @@ public class ProxyFloatingLayoutEngineTests
 		innerLayoutEngine.Received(1).AddWindow(window);
 	}
 
-	[Theory, AutoSubstituteData<ProxyFloatingLayoutEngineCustomization>]
+	[Theory, AutoSubstituteData<FloatingWindowCustomization>]
 	internal void AddWindow_FloatingInPlugin_FailOnSameRectangle(
 		IContext context,
 		IInternalFloatingWindowPlugin plugin,
@@ -177,7 +158,7 @@ public class ProxyFloatingLayoutEngineTests
 		newInnerLayoutEngine.DidNotReceive().AddWindow(window);
 	}
 
-	[Theory, AutoSubstituteData<ProxyFloatingLayoutEngineCustomization>]
+	[Theory, AutoSubstituteData<FloatingWindowCustomization>]
 	internal void AddWindow_FloatingInPlugin_RemoveFromInner(
 		IContext context,
 		IInternalFloatingWindowPlugin plugin,
@@ -204,7 +185,7 @@ public class ProxyFloatingLayoutEngineTests
 	#endregion
 
 	#region RemoveWindow
-	[Theory, AutoSubstituteData<ProxyFloatingLayoutEngineCustomization>]
+	[Theory, AutoSubstituteData<FloatingWindowCustomization>]
 	internal void RemoveWindow_UseInner(
 		IContext context,
 		IInternalFloatingWindowPlugin plugin,
@@ -223,7 +204,7 @@ public class ProxyFloatingLayoutEngineTests
 		innerLayoutEngine.Received(1).RemoveWindow(window);
 	}
 
-	[Theory, AutoSubstituteData<ProxyFloatingLayoutEngineCustomization>]
+	[Theory, AutoSubstituteData<FloatingWindowCustomization>]
 	internal void RemoveWindow_UseInner_SameInner(
 		IContext context,
 		IInternalFloatingWindowPlugin plugin,
@@ -243,7 +224,7 @@ public class ProxyFloatingLayoutEngineTests
 		innerLayoutEngine.Received(1).RemoveWindow(window);
 	}
 
-	[Theory, AutoSubstituteData<ProxyFloatingLayoutEngineCustomization>]
+	[Theory, AutoSubstituteData<FloatingWindowCustomization>]
 	internal void RemoveWindow_FloatingInPlugin(
 		IContext context,
 		IInternalFloatingWindowPlugin plugin,
@@ -273,7 +254,7 @@ public class ProxyFloatingLayoutEngineTests
 	#endregion
 
 	#region MoveWindowToPoint
-	[Theory, AutoSubstituteData<ProxyFloatingLayoutEngineCustomization>]
+	[Theory, AutoSubstituteData<FloatingWindowCustomization>]
 	internal void MoveWindowToPoint_UseInner(
 		IContext context,
 		IInternalFloatingWindowPlugin plugin,
@@ -293,7 +274,7 @@ public class ProxyFloatingLayoutEngineTests
 		innerLayoutEngine.Received(1).MoveWindowToPoint(window, rect);
 	}
 
-	[Theory, AutoSubstituteData<ProxyFloatingLayoutEngineCustomization>]
+	[Theory, AutoSubstituteData<FloatingWindowCustomization>]
 	internal void MoveWindowToPoint_UseInner_SameInner(
 		IContext context,
 		IInternalFloatingWindowPlugin plugin,
@@ -315,7 +296,7 @@ public class ProxyFloatingLayoutEngineTests
 		innerLayoutEngine.Received(1).MoveWindowToPoint(window, rect);
 	}
 
-	[Theory, AutoSubstituteData<ProxyFloatingLayoutEngineCustomization>]
+	[Theory, AutoSubstituteData<FloatingWindowCustomization>]
 	internal void MoveWindowToPoint_FloatingInPlugin_WindowIsNew(
 		IContext context,
 		IInternalFloatingWindowPlugin plugin,
@@ -337,7 +318,7 @@ public class ProxyFloatingLayoutEngineTests
 		innerLayoutEngine.DidNotReceive().MoveWindowToPoint(window, rect);
 	}
 
-	[Theory, AutoSubstituteData<ProxyFloatingLayoutEngineCustomization>]
+	[Theory, AutoSubstituteData<FloatingWindowCustomization>]
 	internal void MoveWindowToPoint_FloatingInPlugin_WindowIsNotNew_SameRectangle(
 		IContext context,
 		IInternalFloatingWindowPlugin plugin,
@@ -363,7 +344,7 @@ public class ProxyFloatingLayoutEngineTests
 		innerLayoutEngine.DidNotReceive().MoveWindowToPoint(window, rect);
 	}
 
-	[Theory, AutoSubstituteData<ProxyFloatingLayoutEngineCustomization>]
+	[Theory, AutoSubstituteData<FloatingWindowCustomization>]
 	internal void MoveWindowToPoint_FloatingInPlugin_WindowIsNotNew_DifferentRectangle(
 		IContext context,
 		IInternalFloatingWindowPlugin plugin,
@@ -389,7 +370,7 @@ public class ProxyFloatingLayoutEngineTests
 		innerLayoutEngine.DidNotReceive().MoveWindowToPoint(window, rect);
 	}
 
-	[Theory, AutoSubstituteData<ProxyFloatingLayoutEngineCustomization>]
+	[Theory, AutoSubstituteData<FloatingWindowCustomization>]
 	internal void MoveWindowToPoint_FloatingInPlugin_CannotGetDwmRectangle(
 		IContext context,
 		IInternalFloatingWindowPlugin plugin,
@@ -420,7 +401,7 @@ public class ProxyFloatingLayoutEngineTests
 	#endregion
 
 	#region MoveWindowEdgesInDirection
-	[Theory, AutoSubstituteData<ProxyFloatingLayoutEngineCustomization>]
+	[Theory, AutoSubstituteData<FloatingWindowCustomization>]
 	internal void MoveWindowEdgesInDirection_UseInner(
 		IContext context,
 		IInternalFloatingWindowPlugin plugin,
@@ -442,7 +423,7 @@ public class ProxyFloatingLayoutEngineTests
 		innerLayoutEngine.Received(1).MoveWindowEdgesInDirection(direction, deltas, window);
 	}
 
-	[Theory, AutoSubstituteData<ProxyFloatingLayoutEngineCustomization>]
+	[Theory, AutoSubstituteData<FloatingWindowCustomization>]
 	internal void MoveWindowEdgesInDirection_UseInner_SameInner(
 		IContext context,
 		IInternalFloatingWindowPlugin plugin,
@@ -466,7 +447,7 @@ public class ProxyFloatingLayoutEngineTests
 		innerLayoutEngine.Received(1).MoveWindowEdgesInDirection(direction, deltas, window);
 	}
 
-	[Theory, AutoSubstituteData<ProxyFloatingLayoutEngineCustomization>]
+	[Theory, AutoSubstituteData<FloatingWindowCustomization>]
 	internal void MoveWindowEdgesInDirection_FloatingInPlugin_WindowIsNew(
 		IContext context,
 		IInternalFloatingWindowPlugin plugin,
@@ -489,7 +470,7 @@ public class ProxyFloatingLayoutEngineTests
 		innerLayoutEngine.DidNotReceive().MoveWindowEdgesInDirection(direction, deltas, window);
 	}
 
-	[Theory, AutoSubstituteData<ProxyFloatingLayoutEngineCustomization>]
+	[Theory, AutoSubstituteData<FloatingWindowCustomization>]
 	internal void MoveWindowEdgesInDirection_FloatingInPlugin_WindowIsNotNew_SameRectangle(
 		IContext context,
 		IInternalFloatingWindowPlugin plugin,
@@ -516,7 +497,7 @@ public class ProxyFloatingLayoutEngineTests
 		innerLayoutEngine.DidNotReceive().MoveWindowEdgesInDirection(direction, deltas, window);
 	}
 
-	[Theory, AutoSubstituteData<ProxyFloatingLayoutEngineCustomization>]
+	[Theory, AutoSubstituteData<FloatingWindowCustomization>]
 	internal void MoveWindowEdgesInDirection_FloatingInPlugin_WindowIsNotNew_DifferentRectangle(
 		IContext context,
 		IInternalFloatingWindowPlugin plugin,
@@ -543,7 +524,7 @@ public class ProxyFloatingLayoutEngineTests
 		innerLayoutEngine.DidNotReceive().MoveWindowEdgesInDirection(direction, deltas, window);
 	}
 
-	[Theory, AutoSubstituteData<ProxyFloatingLayoutEngineCustomization>]
+	[Theory, AutoSubstituteData<FloatingWindowCustomization>]
 	internal void MoveWindowEdgesInDirection_FloatingInPlugin_CannotGetDwmRectangle(
 		IContext context,
 		IInternalFloatingWindowPlugin plugin,
@@ -575,19 +556,22 @@ public class ProxyFloatingLayoutEngineTests
 	#endregion
 
 	#region DoLayout
-	[Theory, AutoSubstituteData<ProxyFloatingLayoutEngineCustomization>]
+	[Theory, AutoSubstituteData<FloatingWindowCustomization>]
 	internal void DoLayout(
 		IContext context,
+		MutableRootSector root,
 		IInternalFloatingWindowPlugin plugin,
 		ILayoutEngine innerLayoutEngine,
 		ILayoutEngine newInnerLayoutEngine,
-		IWindow window1,
-		IWindow window2,
-		IWindow floatingWindow,
 		IMonitor monitor
 	)
 	{
 		// Given the window has been added and the inner layout engine has a layout
+		IWindow[] allWindows = root.WindowSector.Windows.Values.ToArray();
+
+		IWindow window1 = allWindows[0];
+		IWindow window2 = allWindows[1];
+		IWindow floatingWindow = allWindows[2];
 		MarkWindowAsFloating(plugin, floatingWindow, innerLayoutEngine)
 			.Setup_RemoveWindow(innerLayoutEngine, floatingWindow, newInnerLayoutEngine);
 
@@ -667,7 +651,7 @@ public class ProxyFloatingLayoutEngineTests
 	#endregion
 
 	#region GetFirstWindow
-	[Theory, AutoSubstituteData<ProxyFloatingLayoutEngineCustomization>]
+	[Theory, AutoSubstituteData<FloatingWindowCustomization>]
 	internal void GetFirstWindow_NoInnerFirstWindow(
 		IContext context,
 		IInternalFloatingWindowPlugin plugin,
@@ -685,7 +669,7 @@ public class ProxyFloatingLayoutEngineTests
 		Assert.Null(firstWindow);
 	}
 
-	[Theory, AutoSubstituteData<ProxyFloatingLayoutEngineCustomization>]
+	[Theory, AutoSubstituteData<FloatingWindowCustomization>]
 	internal void GetFirstWindow_InnerFirstWindow(
 		IContext context,
 		IInternalFloatingWindowPlugin plugin,
@@ -704,7 +688,7 @@ public class ProxyFloatingLayoutEngineTests
 		Assert.Same(window, firstWindow);
 	}
 
-	[Theory, AutoSubstituteData<ProxyFloatingLayoutEngineCustomization>]
+	[Theory, AutoSubstituteData<FloatingWindowCustomization>]
 	internal void GetFirstWindow_FloatingFirstWindow(
 		IContext context,
 		IInternalFloatingWindowPlugin plugin,
@@ -730,7 +714,7 @@ public class ProxyFloatingLayoutEngineTests
 	#endregion
 
 	#region FocusWindowInDirection
-	[Theory, AutoSubstituteData<ProxyFloatingLayoutEngineCustomization>]
+	[Theory, AutoSubstituteData<FloatingWindowCustomization>]
 	internal void FocusWindowInDirection_UseInner(
 		IContext context,
 		IInternalFloatingWindowPlugin plugin,
@@ -754,7 +738,7 @@ public class ProxyFloatingLayoutEngineTests
 		Assert.IsType<ProxyFloatingLayoutEngine>(newEngine);
 	}
 
-	[Theory, AutoSubstituteData<ProxyFloatingLayoutEngineCustomization>]
+	[Theory, AutoSubstituteData<FloatingWindowCustomization>]
 	internal void FocusWindowInDirection_FloatingWindow_NullFirstWindow(
 		IContext context,
 		IInternalFloatingWindowPlugin plugin,
@@ -785,7 +769,7 @@ public class ProxyFloatingLayoutEngineTests
 		Assert.IsType<ProxyFloatingLayoutEngine>(newEngine);
 	}
 
-	[Theory, AutoSubstituteData<ProxyFloatingLayoutEngineCustomization>]
+	[Theory, AutoSubstituteData<FloatingWindowCustomization>]
 	internal void FocusWindowInDirection_FloatingWindow_DefinedFirstWindow(
 		IContext context,
 		IInternalFloatingWindowPlugin plugin,
@@ -820,7 +804,7 @@ public class ProxyFloatingLayoutEngineTests
 	#endregion
 
 	#region SwapWindowInDirection
-	[Theory, AutoSubstituteData<ProxyFloatingLayoutEngineCustomization>]
+	[Theory, AutoSubstituteData<FloatingWindowCustomization>]
 	internal void SwapWindowInDirection_UseInner(
 		IContext context,
 		IInternalFloatingWindowPlugin plugin,
@@ -841,7 +825,7 @@ public class ProxyFloatingLayoutEngineTests
 		Assert.IsType<ProxyFloatingLayoutEngine>(newEngine);
 	}
 
-	[Theory, AutoSubstituteData<ProxyFloatingLayoutEngineCustomization>]
+	[Theory, AutoSubstituteData<FloatingWindowCustomization>]
 	internal void SwapWindowInDirection_UseInner_SameInner(
 		IContext context,
 		IInternalFloatingWindowPlugin plugin,
@@ -864,7 +848,7 @@ public class ProxyFloatingLayoutEngineTests
 		Assert.IsType<ProxyFloatingLayoutEngine>(newEngine);
 	}
 
-	[Theory, AutoSubstituteData<ProxyFloatingLayoutEngineCustomization>]
+	[Theory, AutoSubstituteData<FloatingWindowCustomization>]
 	internal void SwapWindowInDirection_FloatingWindow(
 		IContext context,
 		IInternalFloatingWindowPlugin plugin,
@@ -891,7 +875,7 @@ public class ProxyFloatingLayoutEngineTests
 	#endregion
 
 	#region ContainsWindow
-	[Theory, AutoSubstituteData<ProxyFloatingLayoutEngineCustomization>]
+	[Theory, AutoSubstituteData<FloatingWindowCustomization>]
 	internal void ContainsWindow_UseInner(
 		IContext context,
 		IInternalFloatingWindowPlugin plugin,
@@ -910,7 +894,7 @@ public class ProxyFloatingLayoutEngineTests
 		innerLayoutEngine.Received(1).ContainsWindow(window);
 	}
 
-	[Theory, AutoSubstituteData<ProxyFloatingLayoutEngineCustomization>]
+	[Theory, AutoSubstituteData<FloatingWindowCustomization>]
 	internal void ContainsWindow_UseInner_SameInner(
 		IContext context,
 		IInternalFloatingWindowPlugin plugin,
@@ -930,7 +914,7 @@ public class ProxyFloatingLayoutEngineTests
 		innerLayoutEngine.Received(1).ContainsWindow(window);
 	}
 
-	[Theory, AutoSubstituteData<ProxyFloatingLayoutEngineCustomization>]
+	[Theory, AutoSubstituteData<FloatingWindowCustomization>]
 	internal void ContainsWindow_FloatingWindow(
 		IContext context,
 		IInternalFloatingWindowPlugin plugin,
@@ -954,7 +938,7 @@ public class ProxyFloatingLayoutEngineTests
 	#endregion
 
 	#region WindowWasFloating_ShouldBeGarbageCollectedByUpdateInner
-	[Theory, AutoSubstituteData<ProxyFloatingLayoutEngineCustomization>]
+	[Theory, AutoSubstituteData<FloatingWindowCustomization>]
 	internal void WindowWasFloating_AddWindow(
 		IContext context,
 		IInternalFloatingWindowPlugin plugin,
@@ -983,7 +967,7 @@ public class ProxyFloatingLayoutEngineTests
 		newInnerLayoutEngine.Received(1).AddWindow(window);
 	}
 
-	[Theory, AutoSubstituteData<ProxyFloatingLayoutEngineCustomization>]
+	[Theory, AutoSubstituteData<FloatingWindowCustomization>]
 	internal void WindowWasFloating_MoveWindowToPoint(
 		IContext context,
 		IInternalFloatingWindowPlugin plugin,
@@ -1012,7 +996,7 @@ public class ProxyFloatingLayoutEngineTests
 		newInnerLayoutEngine.Received(1).MoveWindowToPoint(window, new Rectangle<double>());
 	}
 
-	[Theory, AutoSubstituteData<ProxyFloatingLayoutEngineCustomization>]
+	[Theory, AutoSubstituteData<FloatingWindowCustomization>]
 	internal void WindowWasFloating_RemoveWindow(
 		IContext context,
 		IInternalFloatingWindowPlugin plugin,
@@ -1041,7 +1025,7 @@ public class ProxyFloatingLayoutEngineTests
 		newInnerLayoutEngine.Received(1).RemoveWindow(window);
 	}
 
-	[Theory, AutoSubstituteData<ProxyFloatingLayoutEngineCustomization>]
+	[Theory, AutoSubstituteData<FloatingWindowCustomization>]
 	internal void WindowWasFloating_MoveWindowEdgesInDirection(
 		IContext context,
 		IInternalFloatingWindowPlugin plugin,
@@ -1072,7 +1056,7 @@ public class ProxyFloatingLayoutEngineTests
 		newInnerLayoutEngine.Received(1).MoveWindowEdgesInDirection(Direction.Left, deltas, window);
 	}
 
-	[Theory, AutoSubstituteData<ProxyFloatingLayoutEngineCustomization>]
+	[Theory, AutoSubstituteData<FloatingWindowCustomization>]
 	internal void WindowWasFloating_SwapWindowInDirection(
 		IContext context,
 		IInternalFloatingWindowPlugin plugin,
@@ -1103,7 +1087,7 @@ public class ProxyFloatingLayoutEngineTests
 	#endregion
 
 	#region PerformCustomAction
-	[Theory, AutoSubstituteData<ProxyFloatingLayoutEngineCustomization>]
+	[Theory, AutoSubstituteData<FloatingWindowCustomization>]
 	internal void PerformCustomAction_UseInner(
 		IContext context,
 		IInternalFloatingWindowPlugin plugin,
@@ -1128,7 +1112,7 @@ public class ProxyFloatingLayoutEngineTests
 		Assert.IsType<ProxyFloatingLayoutEngine>(newEngine);
 	}
 
-	[Theory, AutoSubstituteData<ProxyFloatingLayoutEngineCustomization>]
+	[Theory, AutoSubstituteData<FloatingWindowCustomization>]
 	internal void PerformCustomAction_UseInner_WindowIsDefined(
 		IContext context,
 		IInternalFloatingWindowPlugin plugin,
@@ -1155,7 +1139,7 @@ public class ProxyFloatingLayoutEngineTests
 		Assert.IsType<ProxyFloatingLayoutEngine>(newEngine);
 	}
 
-	[Theory, AutoSubstituteData<ProxyFloatingLayoutEngineCustomization>]
+	[Theory, AutoSubstituteData<FloatingWindowCustomization>]
 	internal void PerformCustomAction_FloatingWindow(
 		IContext context,
 		IInternalFloatingWindowPlugin plugin,

--- a/src/Whim.FloatingWindow/FloatingUtils.cs
+++ b/src/Whim.FloatingWindow/FloatingUtils.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Immutable;
+using DotNext;
 
 namespace Whim.FloatingWindow;
 
@@ -33,7 +34,13 @@ internal static class FloatingUtils
 			return null;
 		}
 
-		IMonitor newMonitor = context.MonitorManager.GetMonitorAtPoint(newActualRectangle);
+		Result<IMonitor> newMonitorResult = context.Store.Pick(Pickers.PickMonitorByWindow(window.Handle));
+		if (!newMonitorResult.TryGet(out IMonitor newMonitor))
+		{
+			Logger.Error($"Could not obtain monitor for floating window {window}");
+			return null;
+		}
+
 		IRectangle<double> newUnitSquareRectangle = newMonitor.WorkingArea.NormalizeRectangle(newActualRectangle);
 		if (newUnitSquareRectangle.Equals(oldRectangle))
 		{

--- a/src/Whim.LayoutPreview.Tests/LayoutPreviewPluginTests.cs
+++ b/src/Whim.LayoutPreview.Tests/LayoutPreviewPluginTests.cs
@@ -24,8 +24,8 @@ public class LayoutPreviewPluginCustomization : StoreCustomization
 			_ctx,
 			_internalCtx,
 			_store._root.MutableRootSector,
-			new Point<int>(0, 0),
-			monitor
+			monitor,
+			new Point<int>(0, 0)
 		);
 		StoreTestUtils.PopulateMonitorWorkspaceMap(_ctx, _store._root.MutableRootSector, monitor, workspace);
 	}

--- a/src/Whim.TestUtils/StoreCustomization.cs
+++ b/src/Whim.TestUtils/StoreCustomization.cs
@@ -21,7 +21,7 @@ internal class StoreWrapper(IContext ctx, IInternalContext internalCtx) : Store(
 	}
 }
 
-[SuppressMessage("Design", "CA1001:Types that own disposable fields should be disposable", Justification = "<Pending>")]
+[SuppressMessage("Design", "CA1001:Types that own disposable fields should be disposable")]
 public class StoreCustomization : ICustomization
 {
 #pragma warning disable CA1051 // Do not declare visible instance fields

--- a/src/Whim.TestUtils/StoreTestUtils.cs
+++ b/src/Whim.TestUtils/StoreTestUtils.cs
@@ -159,7 +159,26 @@ internal static class StoreTestUtils
 			monitor.Handle,
 			workspace.Id
 		);
-		rootSector.MonitorSector.Monitors = rootSector.MonitorSector.Monitors.Add(monitor);
+
+		// If the monitor already exists, just update it.
+		int foundIdx = -1;
+		for (int idx = 0; idx < rootSector.MonitorSector.Monitors.Length; idx++)
+		{
+			if (rootSector.MonitorSector.Monitors[idx].Handle == monitor.Handle)
+			{
+				foundIdx = idx;
+				break;
+			}
+		}
+
+		if (foundIdx != -1)
+		{
+			rootSector.MonitorSector.Monitors = rootSector.MonitorSector.Monitors.SetItem(foundIdx, monitor);
+		}
+		else
+		{
+			rootSector.MonitorSector.Monitors = rootSector.MonitorSector.Monitors.Add(monitor);
+		}
 
 		if (rootSector.MonitorSector.Monitors.Length == 1)
 		{
@@ -187,8 +206,8 @@ internal static class StoreTestUtils
 		IContext ctx,
 		IInternalContext internalCtx,
 		MutableRootSector rootSector,
-		IPoint<int> point,
-		IMonitor monitor
+		IMonitor monitor,
+		IPoint<int>? point = null
 	)
 	{
 		// We need to compare the coordinates by value, so we can't pass in the `point` directly.
@@ -199,6 +218,11 @@ internal static class StoreTestUtils
 			)
 			.Returns(callInfo =>
 			{
+				if (point == null)
+				{
+					return monitor.Handle;
+				}
+
 				System.Drawing.Point calledPoint = callInfo.Arg<System.Drawing.Point>();
 				if (calledPoint.X == point.X && calledPoint.Y == point.Y)
 				{

--- a/src/Whim.TestUtils/Whim.TestUtils.csproj
+++ b/src/Whim.TestUtils/Whim.TestUtils.csproj
@@ -40,6 +40,7 @@
   </ItemGroup>
   <ItemGroup>
     <InternalsVisibleTo Include="Whim.Tests" />
+    <InternalsVisibleTo Include="Whim.FloatingWindow.Tests" />
     <InternalsVisibleTo Include="Whim.LayoutPreview.Tests" />
   </ItemGroup>
 </Project>

--- a/src/Whim.Tests/Monitor/MonitorHelpersTests.cs
+++ b/src/Whim.Tests/Monitor/MonitorHelpersTests.cs
@@ -222,6 +222,7 @@ public class MonitorHelpersTests
 	public static TheoryData<Rectangle<int>, Rectangle<int>, Rectangle<double>> NormalizeRectangle_Double =>
 		new()
 		{
+			// Monitor: 1920x1080, from the origin. Rectangle: at (192, 108).
 			{
 				new Rectangle<int>() { Width = 1920, Height = 1080 },
 				new Rectangle<int>()
@@ -239,6 +240,7 @@ public class MonitorHelpersTests
 					Height = 0.1,
 				}
 			},
+			// Monitor 1920x1080, from (100, 100). Rectangle: at (192, 108).
 			{
 				new Rectangle<int>()
 				{
@@ -262,6 +264,7 @@ public class MonitorHelpersTests
 					Height = 0.1,
 				}
 			},
+			// Monitor 1920x1080, from (-100, -100). Rectangle: at (98, 8).
 			{
 				new Rectangle<int>()
 				{
@@ -281,6 +284,42 @@ public class MonitorHelpersTests
 				{
 					X = 0.1,
 					Y = 0.1,
+					Width = 0.1,
+					Height = 0.1,
+				}
+			},
+			// Monitor 1920x1080, from the origin. Rectangle: at (-192, -108).
+			{
+				new Rectangle<int>() { Width = 1920, Height = 1080 },
+				new Rectangle<int>()
+				{
+					X = -192,
+					Y = -108,
+					Width = 192,
+					Height = 108,
+				},
+				new Rectangle<double>()
+				{
+					X = 0,
+					Y = 0,
+					Width = 0.1,
+					Height = 0.1,
+				}
+			},
+			// Monitor 1920x1080, from the origin. Rectangle at (1920 + 192, 1080 + 108).
+			{
+				new Rectangle<int>() { Width = 1920, Height = 1080 },
+				new Rectangle<int>()
+				{
+					X = 1920 + 192,
+					Y = 1080 + 108,
+					Width = 192,
+					Height = 108,
+				},
+				new Rectangle<double>()
+				{
+					X = 0.9,
+					Y = 0.9,
 					Width = 0.1,
 					Height = 0.1,
 				}

--- a/src/Whim.Tests/Store/MapSector/Transforms/MoveWindowToPointTransformTests.cs
+++ b/src/Whim.Tests/Store/MapSector/Transforms/MoveWindowToPointTransformTests.cs
@@ -24,7 +24,7 @@ public class MoveWindowToPointTransformTests
 		// Given there is no workspace for the monitor at the given point
 		IMonitor monitor = CreateMonitor((HMONITOR)10);
 		Point<int> point = new(10, 10);
-		SetupMonitorAtPoint(ctx, internalCtx, rootSector, point, monitor);
+		SetupMonitorAtPoint(ctx, internalCtx, rootSector, monitor, point);
 
 		MoveWindowToPointTransform sut = new((HWND)10, point);
 
@@ -45,7 +45,7 @@ public class MoveWindowToPointTransformTests
 		Point<int> point = new(10, 10);
 
 		AddWindowToSector(rootSector, window);
-		SetupMonitorAtPoint(ctx, internalCtx, rootSector, point, monitor);
+		SetupMonitorAtPoint(ctx, internalCtx, rootSector, monitor, point);
 		PopulateMonitorWorkspaceMap(ctx, rootSector, monitor, workspace);
 
 		MoveWindowToPointTransform sut = new(window.Handle, point);
@@ -71,7 +71,7 @@ public class MoveWindowToPointTransformTests
 		Point<int> point = new(10, 10);
 
 		AddWindowToSector(rootSector, window);
-		SetupMonitorAtPoint(ctx, internalCtx, rootSector, point, monitor);
+		SetupMonitorAtPoint(ctx, internalCtx, rootSector, monitor, point);
 		PopulateThreeWayMap(ctx, rootSector, monitor, workspace, window);
 
 		MoveWindowToPointTransform sut = new(window.Handle, point);
@@ -113,7 +113,7 @@ public class MoveWindowToPointTransformTests
 		Point<int> point = new(10, 10);
 
 		AddWindowToSector(rootSector, window);
-		SetupMonitorAtPoint(ctx, internalCtx, rootSector, point, targetMonitor);
+		SetupMonitorAtPoint(ctx, internalCtx, rootSector, targetMonitor, point);
 		PopulateThreeWayMap(ctx, rootSector, sourceMonitor, sourceWorkspace, window);
 		PopulateMonitorWorkspaceMap(ctx, rootSector, targetMonitor, targetWorkspace);
 

--- a/src/Whim/Monitor/IMonitor.cs
+++ b/src/Whim/Monitor/IMonitor.cs
@@ -106,8 +106,8 @@ public static class MonitorHelpers
 		int translatedX = rectangle.X - monitor.X;
 		int translatedY = rectangle.Y - monitor.Y;
 
-		double x = Math.Abs((double)translatedX / monitor.Width);
-		double y = Math.Abs((double)translatedY / monitor.Height);
+		double x = Math.Max((double)translatedX / monitor.Width, 0);
+		double y = Math.Max((double)translatedY / monitor.Height, 0);
 		double width = Math.Abs((double)rectangle.Width / monitor.Width);
 		double height = Math.Abs((double)rectangle.Height / monitor.Height);
 		return new Rectangle<double>()

--- a/src/Whim/Monitor/IMonitor.cs
+++ b/src/Whim/Monitor/IMonitor.cs
@@ -93,7 +93,7 @@ public static class MonitorHelpers
 
 	/// <summary>
 	/// Converts the <paramref name="rectangle"/> from the unit square to the
-	/// <paramref name="monitor"/>'s coordinate system.
+	/// <paramref name="monitor"/>'s coordinate system. The rectangle is clamped to the monitor's bounds.
 	/// </summary>
 	/// <param name="monitor"></param>
 	/// <param name="rectangle">The point to translate.</param>
@@ -106,10 +106,31 @@ public static class MonitorHelpers
 		int translatedX = rectangle.X - monitor.X;
 		int translatedY = rectangle.Y - monitor.Y;
 
-		double x = Math.Max((double)translatedX / monitor.Width, 0);
-		double y = Math.Max((double)translatedY / monitor.Height, 0);
+		double x = (double)translatedX / monitor.Width;
+		double y = (double)translatedY / monitor.Height;
+
 		double width = Math.Abs((double)rectangle.Width / monitor.Width);
 		double height = Math.Abs((double)rectangle.Height / monitor.Height);
+
+		// Clamp the rectangle to the monitor's bounds.
+		if (x < 0)
+		{
+			x = 0;
+		}
+		else if (x > 1)
+		{
+			x = 1 - width;
+		}
+
+		if (y < 0)
+		{
+			y = 0;
+		}
+		else if (y > 1)
+		{
+			y = 1 - height;
+		}
+
 		return new Rectangle<double>()
 		{
 			X = x,

--- a/src/Whim/Store/MapSector/Transforms/ActivateWorkspaceTransform.cs
+++ b/src/Whim/Store/MapSector/Transforms/ActivateWorkspaceTransform.cs
@@ -76,7 +76,10 @@ public record ActivateWorkspaceTransform(
 		}
 		else
 		{
-			ctx.Store.Dispatch(new DeactivateWorkspaceTransform(workspace.Id));
+			if (oldWorkspace is not null)
+			{
+				ctx.Store.Dispatch(new DeactivateWorkspaceTransform(oldWorkspace.Id));
+			}
 
 			// Temporarily focus the monitor's desktop HWND, to prevent another window from being focused.
 			ctx.Store.Dispatch(new FocusMonitorDesktopTransform(targetMonitorHandle));


### PR DESCRIPTION
The following changes will avoid the "window jump + size change" when you move a window in between monitors.

**Before**

https://github.com/user-attachments/assets/fdd3f6b0-86a7-46b6-82bd-cdee99d9d726

**After**

https://github.com/user-attachments/assets/03b4b249-d6c7-4cb0-a929-00cbc00fc932


- [x] This code is up-to-date with the `main` branch.
- [x] I have updated relevant (if any) areas in the docs.

P.S. Indeed, it does not fix the bug we discuss about move a window to another monitor using only edges, but it don't add it either. But at least we know it exists.