### PR TITLE
Fix accidental deactivation of the wrong workspace

### DIFF
--- a/src/Whim/Store/MapSector/Transforms/ActivateWorkspaceTransform.cs
+++ b/src/Whim/Store/MapSector/Transforms/ActivateWorkspaceTransform.cs
@@ -76,7 +76,10 @@ public record ActivateWorkspaceTransform(
 		}
 		else
 		{
-			ctx.Store.Dispatch(new DeactivateWorkspaceTransform(workspace.Id));
+			if (oldWorkspace is not null)
+			{
+				ctx.Store.Dispatch(new DeactivateWorkspaceTransform(oldWorkspace.Id));
+			}
 
 			// Temporarily focus the monitor's desktop HWND, to prevent another window from being focused.
 			ctx.Store.Dispatch(new FocusMonitorDesktopTransform(targetMonitorHandle));


### PR DESCRIPTION
In #991, there was a change in `ActivateWorkspaceTransform.cs`:

```diff
- oldWorkspace?.Deactivate();
+ ctx.Dispatch(new DeactivateWorkspaceTransform(workspace.Id));
```

This change was incorrect as it deactivated the new workspace instead of the old one. This only occurred when swapping workspaces in the same monitor.

This PR fixes this error.
