### PR TITLE
Store logs in a dedicated configurable directory

### DIFF
--- a/docs/docs/customize/logging.md
+++ b/docs/docs/customize/logging.md
@@ -25,6 +25,4 @@ if (context.Logger.Config.DebugSink is SinkConfig debugSinkConfig)
 
 ## Logs Location
 
-By default logs will be located in the `.whim/logs` directory.
-
-To customize the location of the `logs` directory, set the `--logs-dir` CLI argument when starting Whim.
+Logs will be located in the `.whim/logs` directory, with respect to actual location of the `.whim` directory.

--- a/docs/docs/customize/logging.md
+++ b/docs/docs/customize/logging.md
@@ -22,3 +22,9 @@ if (context.Logger.Config.DebugSink is SinkConfig debugSinkConfig)
 
 > [!NOTE]
 > Logging can be changed during runtime to be more restrictive, but cannot be made more permissive than the initial configuration.
+
+## Logs Location
+
+By default logs will be located in the `.whim/logs` directory.
+
+To customize the location of the `logs` directory, set the `--logs-dir` CLI argument when starting Whim.

--- a/src/Whim.Tests/Files/FileManagerTests.cs
+++ b/src/Whim.Tests/Files/FileManagerTests.cs
@@ -12,6 +12,7 @@ public class FileManagerTests
 		Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
 		"test"
 	);
+	private static readonly string ExpectedWhimLogsDir = Path.Combine(ExpectedWhimDir, "logs");
 	private const string DIR_ARG = "--dir";
 
 	[Fact]
@@ -148,5 +149,31 @@ public class FileManagerTests
 
 		// Then
 		Assert.Equal(Path.Combine(ExpectedWhimDir, "test", "subdir"), whimFileDir);
+	}
+
+	[Fact]
+	public void GetWhimFileLogsDir()
+	{
+		// Given
+		FileManager fileManager = new([]);
+
+		// When
+		string whimFileLogsDir = fileManager.GetWhimFileLogsDir("test");
+
+		// Then
+		Assert.Equal(Path.Combine(ExpectedWhimLogsDir, "test"), whimFileLogsDir);
+	}
+
+	[Fact]
+	public void GetWhimFileLogsDir_WithSubDir()
+	{
+		// Given
+		FileManager fileManager = new([]);
+
+		// When
+		string whimFileLogsDir = fileManager.GetWhimFileLogsDir(Path.Combine("test", "subdir"));
+
+		// Then
+		Assert.Equal(Path.Combine(ExpectedWhimLogsDir, "test", "subdir"), whimFileLogsDir);
 	}
 }

--- a/src/Whim.Tests/Files/FileManagerTests.cs
+++ b/src/Whim.Tests/Files/FileManagerTests.cs
@@ -152,6 +152,19 @@ public class FileManagerTests
 	}
 
 	[Fact]
+	public void LogsDir()
+	{
+		// Given
+		FileManager fileManager = new([]);
+
+		// When
+		string logsDir = fileManager.LogsDir;
+
+		// Then
+		Assert.Equal(ExpectedWhimLogsDir, logsDir);
+	}
+
+	[Fact]
 	public void GetWhimFileLogsDir()
 	{
 		// Given

--- a/src/Whim/File/FileManager.cs
+++ b/src/Whim/File/FileManager.cs
@@ -7,7 +7,7 @@ internal class FileManager : IFileManager
 	public string WhimDir { get; } =
 		Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".whim");
 
-	public string LogsDir { get; }
+	public string LogsDir => Path.Combine(WhimDir, "logs");
 
 	public string SavedStateDir => Path.Combine(WhimDir, "state");
 
@@ -18,56 +18,31 @@ internal class FileManager : IFileManager
 		{
 			WhimDir = dir;
 		}
-
-		string? logsDir = GetLogsDirFromArgs(args);
-
-		if (logsDir != null)
-		{
-			LogsDir = logsDir;
-		}
-		else
-		{
-			LogsDir = Path.Combine(WhimDir, "logs");
-		}
 	}
 
 	private static string? GetDirFromArgs(string[] args)
 	{
 		const string dirArg = "--dir";
-		return GetValueFromArgs(args, dirArg);
-	}
-
-	private static string? GetLogsDirFromArgs(string[] args)
-	{
-		const string logsDir = "--logs-dir";
-		return GetValueFromArgs(args, logsDir);
-	}
-
-	private static string? GetValueFromArgs(string[] args, string argName)
-	{
 		for (int i = 0; i < args.Length; i++)
 		{
 			string arg = args[i];
-
-			if (!arg.StartsWith(argName))
+			if (!arg.StartsWith(dirArg))
 			{
 				continue;
 			}
 
-			if (arg.Length > argName.Length + 1)
+			if (arg.Length > dirArg.Length + 1)
 			{
-				return arg[(argName.Length + 1)..];
+				return arg[(dirArg.Length + 1)..];
 			}
 
 			for (int j = i + 1; j < args.Length; j++)
 			{
 				string nextArg = args[j];
-
 				if (string.IsNullOrEmpty(nextArg))
 				{
 					continue;
 				}
-
 				if (nextArg.StartsWith("--"))
 				{
 					return null;

--- a/src/Whim/File/FileManager.cs
+++ b/src/Whim/File/FileManager.cs
@@ -7,6 +7,8 @@ internal class FileManager : IFileManager
 	public string WhimDir { get; } =
 		Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".whim");
 
+	public string LogsDir { get; }
+
 	public string SavedStateDir => Path.Combine(WhimDir, "state");
 
 	public FileManager(string[] args)
@@ -16,31 +18,56 @@ internal class FileManager : IFileManager
 		{
 			WhimDir = dir;
 		}
+
+		string? logsDir = GetLogsDirFromArgs(args);
+
+		if (logsDir != null)
+		{
+			LogsDir = logsDir;
+		}
+		else
+		{
+			LogsDir = Path.Combine(WhimDir, "logs");
+		}
 	}
 
 	private static string? GetDirFromArgs(string[] args)
 	{
 		const string dirArg = "--dir";
+		return GetValueFromArgs(args, dirArg);
+	}
+
+	private static string? GetLogsDirFromArgs(string[] args)
+	{
+		const string logsDir = "--logs-dir";
+		return GetValueFromArgs(args, logsDir);
+	}
+
+	private static string? GetValueFromArgs(string[] args, string argName)
+	{
 		for (int i = 0; i < args.Length; i++)
 		{
 			string arg = args[i];
-			if (!arg.StartsWith(dirArg))
+
+			if (!arg.StartsWith(argName))
 			{
 				continue;
 			}
 
-			if (arg.Length > dirArg.Length + 1)
+			if (arg.Length > argName.Length + 1)
 			{
-				return arg[(dirArg.Length + 1)..];
+				return arg[(argName.Length + 1)..];
 			}
 
 			for (int j = i + 1; j < args.Length; j++)
 			{
 				string nextArg = args[j];
+
 				if (string.IsNullOrEmpty(nextArg))
 				{
 					continue;
 				}
+
 				if (nextArg.StartsWith("--"))
 				{
 					return null;
@@ -64,6 +91,8 @@ internal class FileManager : IFileManager
 	public bool FileExists(string filePath) => File.Exists(filePath);
 
 	public string GetWhimFileDir(string fileName) => Path.Combine(WhimDir, fileName);
+
+	public string GetWhimFileLogsDir(string fileName) => Path.Combine(LogsDir, fileName);
 
 	public Stream OpenRead(string filePath) => File.OpenRead(filePath);
 

--- a/src/Whim/File/IFileManager.cs
+++ b/src/Whim/File/IFileManager.cs
@@ -13,6 +13,11 @@ public interface IFileManager
 	string WhimDir { get; }
 
 	/// <summary>
+	/// The path to the Whim logs directory.
+	/// </summary>
+	string LogsDir { get; }
+
+	/// <summary>
 	/// The path to the saved state directory.
 	/// </summary>
 	string SavedStateDir { get; }
@@ -36,6 +41,13 @@ public interface IFileManager
 	/// <param name="fileName">The file name.</param>
 	/// <returns>The file path.</returns>
 	string GetWhimFileDir(string fileName);
+
+	/// <summary>
+	/// Gets a file path in the Whim logs directory.
+	/// </summary>
+	/// <param name="fileName">The file name.</param>
+	/// <returns>The file path inside the logs directory.</returns>
+	string GetWhimFileLogsDir(string fileName);
 
 	/// <summary>
 	/// Opens an existing file for reading.

--- a/src/Whim/Logging/Logger.cs
+++ b/src/Whim/Logging/Logger.cs
@@ -50,7 +50,9 @@ public class Logger : IDisposable
 
 		if (fileSink != null)
 		{
-			string loggerFilePath = fileManager.GetWhimFileDir(fileSink.FileName);
+			fileManager.EnsureDirExists(fileManager.LogsDir);
+			string loggerFilePath = fileManager.GetWhimFileLogsDir(fileSink.FileName);
+
 			_loggerConfiguration.WriteTo.File(
 				loggerFilePath,
 				levelSwitch: fileSink.MinLogLevelSwitch,


### PR DESCRIPTION
<!--
* Thanks for submitting a pull request.
* Before making this pull request, please make sure that there's a
* corresponding bug or feature request which can be associated with this Pull
* Request.
-->

- [X] This code is up-to-date with the `main` branch.
- [x] I have updated relevant (if any) areas in the docs.

This PR fixes #674

Updated the file manager to store logs in a '.whim/logs' directory and to account for `--logs-dir` argument, storing logs in a custom directory. Updated logger initialization to make sure logs directory exists.