### PR TITLE
Fix `SliceLayouts.CreateColumnLayout` creating a row layout

### DIFF
--- a/src/Whim.SliceLayout.Tests/AreaHelpers/DoLayoutTests.cs
+++ b/src/Whim.SliceLayout.Tests/AreaHelpers/DoLayoutTests.cs
@@ -238,6 +238,54 @@ public class DoLayoutTests
 			},
 		};
 
+	public static TheoryData<IRectangle<int>, ParentArea, IRectangle<int>[]> DoLayout_Column =>
+		new()
+		{
+			// Empty
+			{ new Rectangle<int>(0, 0, 100, 100), SliceLayouts.CreateColumnArea(), Array.Empty<IRectangle<int>>() },
+			// Single window
+			{
+				new Rectangle<int>(0, 0, 100, 100),
+				SliceLayouts.CreateColumnArea(),
+				new[] { new Rectangle<int>(0, 0, 100, 100) }
+			},
+			// Three windows
+			{
+				new Rectangle<int>(0, 0, 100, 100),
+				SliceLayouts.CreateColumnArea(),
+				new[]
+				{
+					new Rectangle<int>(0, 0, 100, 33),
+					new Rectangle<int>(0, 33, 100, 33),
+					new Rectangle<int>(0, 66, 100, 33),
+				}
+			},
+		};
+
+	public static TheoryData<IRectangle<int>, ParentArea, IRectangle<int>[]> DoLayout_Row =>
+		new()
+		{
+			// Empty
+			{ new Rectangle<int>(0, 0, 100, 100), SliceLayouts.CreateRowArea(), Array.Empty<IRectangle<int>>() },
+			// Single window
+			{
+				new Rectangle<int>(0, 0, 100, 100),
+				SliceLayouts.CreateRowArea(),
+				new[] { new Rectangle<int>(0, 0, 100, 100) }
+			},
+			// Three windows
+			{
+				new Rectangle<int>(0, 0, 100, 100),
+				SliceLayouts.CreateRowArea(),
+				new[]
+				{
+					new Rectangle<int>(0, 0, 33, 100),
+					new Rectangle<int>(33, 0, 33, 100),
+					new Rectangle<int>(66, 0, 33, 100),
+				}
+			},
+		};
+
 	[Theory]
 	[MemberAutoSubstituteData(nameof(DoLayout_PrimaryStack))]
 	[MemberAutoSubstituteData(nameof(DoLayout_MultiColumn))]
@@ -245,6 +293,8 @@ public class DoLayoutTests
 	[MemberAutoSubstituteData(nameof(DoLayout_OverflowColumn))]
 	[MemberAutoSubstituteData(nameof(DoLayout_OverflowRow))]
 	[MemberAutoSubstituteData(nameof(DoLayout_Nested))]
+	[MemberAutoSubstituteData(nameof(DoLayout_Column))]
+	[MemberAutoSubstituteData(nameof(DoLayout_Row))]
 	internal void DoLayout(
 		IRectangle<int> rectangle,
 		ParentArea area,

--- a/src/Whim.SliceLayout.Tests/SliceLayoutEngine/AreaTests.cs
+++ b/src/Whim.SliceLayout.Tests/SliceLayoutEngine/AreaTests.cs
@@ -1,0 +1,29 @@
+using Xunit;
+
+namespace Whim.SliceLayout.Tests;
+
+public class AreaTests
+{
+	[Fact]
+	public void ParentArea_Equals()
+	{
+		// Given
+		ParentArea area1 = new(isRow: true, (1, new OverflowArea(isRow: true)));
+		ParentArea area2 = new(isRow: true, (1, new OverflowArea(isRow: true)));
+
+		// Then
+		Assert.Equal(area1, area2);
+	}
+
+	[Fact]
+	public void ParentArea_GetHashCode()
+	{
+		// Given
+		ParentArea area1 = new(isRow: true, (1, new OverflowArea(isRow: true)));
+		ParentArea area2 = new(isRow: true, (1, new OverflowArea(isRow: true)));
+
+		// Then
+		Assert.NotEqual(0, area1.GetHashCode());
+		Assert.Equal(area1.GetHashCode(), area2.GetHashCode());
+	}
+}

--- a/src/Whim.SliceLayout.Tests/SliceLayoutEngine/AreaTests.cs
+++ b/src/Whim.SliceLayout.Tests/SliceLayoutEngine/AreaTests.cs
@@ -15,6 +15,30 @@ public class AreaTests
 		Assert.Equal(area1, area2);
 	}
 
+	public static TheoryData<ParentArea, ParentArea> ParentArea_NotEqual =>
+		new()
+		{
+			{
+				new(isRow: true, (1, new OverflowArea(isRow: true))),
+				new(isRow: false, (1, new OverflowArea(isRow: true)))
+			},
+			{
+				new(isRow: true, (1, new OverflowArea(isRow: true))),
+				new(isRow: true, (1, new OverflowArea(isRow: false)))
+			},
+			{
+				new(isRow: true, (1, new OverflowArea(isRow: true))),
+				new(isRow: true, (1, new OverflowArea(isRow: true)), (1, new OverflowArea(isRow: true)))
+			},
+		};
+
+	[Theory, MemberData(nameof(ParentArea_NotEqual))]
+	public void ParentArea_Equals_NotEqual(ParentArea area1, ParentArea area2)
+	{
+		// Then
+		Assert.NotEqual(area1, area2);
+	}
+
 	[Fact]
 	public void ParentArea_GetHashCode()
 	{

--- a/src/Whim.SliceLayout.Tests/SliceLayoutEngine/AreaTests.cs
+++ b/src/Whim.SliceLayout.Tests/SliceLayoutEngine/AreaTests.cs
@@ -1,3 +1,4 @@
+using FluentAssertions;
 using Xunit;
 
 namespace Whim.SliceLayout.Tests;
@@ -12,7 +13,7 @@ public class AreaTests
 		ParentArea area2 = new(isRow: true, (1, new OverflowArea(isRow: true)));
 
 		// Then
-		Assert.Equal(area1, area2);
+		area1.Should().BeEquivalentTo(area2);
 	}
 
 	public static TheoryData<ParentArea, ParentArea> ParentArea_NotEqual =>
@@ -30,6 +31,10 @@ public class AreaTests
 				new(isRow: true, (1, new OverflowArea(isRow: true))),
 				new(isRow: true, (1, new OverflowArea(isRow: true)), (1, new OverflowArea(isRow: true)))
 			},
+			{
+				new(isRow: true, (1, new OverflowArea(isRow: true))),
+				new(isRow: true, (1, new SliceArea(order: 0, maxChildren: 0)))
+			},
 		};
 
 	[Theory, MemberData(nameof(ParentArea_NotEqual))]
@@ -37,17 +42,6 @@ public class AreaTests
 	{
 		// Then
 		Assert.NotEqual(area1, area2);
-	}
-
-	[Fact]
-	public void ParentArea_GetHashCode()
-	{
-		// Given
-		ParentArea area1 = new(isRow: true, (1, new OverflowArea(isRow: true)));
-		ParentArea area2 = new(isRow: true, (1, new OverflowArea(isRow: true)));
-
-		// Then
-		Assert.NotEqual(0, area1.GetHashCode());
-		Assert.Equal(area1.GetHashCode(), area2.GetHashCode());
+		area1.Should().NotBeEquivalentTo(area2);
 	}
 }

--- a/src/Whim.SliceLayout.Tests/SliceLayoutEngine/SliceLayoutEngineTests.cs
+++ b/src/Whim.SliceLayout.Tests/SliceLayoutEngine/SliceLayoutEngineTests.cs
@@ -95,6 +95,8 @@ public class SliceLayoutEngineTests
 	{
 		// Given
 		ILayoutEngine sut = new SliceLayoutEngine(ctx, plugin, identity, SampleSliceLayouts.CreateNestedLayout());
+		sut = sut.AddWindow(Substitute.For<IWindow>());
+		sut = sut.MinimizeWindowStart(Substitute.For<IWindow>());
 
 		// When
 		int hashCode = sut.GetHashCode();

--- a/src/Whim.SliceLayout.Tests/SliceLayoutEngine/SliceLayoutEngineTests.cs
+++ b/src/Whim.SliceLayout.Tests/SliceLayoutEngine/SliceLayoutEngineTests.cs
@@ -91,6 +91,20 @@ public class SliceLayoutEngineTests
 	}
 
 	[Theory, AutoSubstituteData]
+	public void Equals_DifferentType(IContext ctx, SliceLayoutPlugin plugin)
+	{
+		// Given
+		ILayoutEngine a = new SliceLayoutEngine(ctx, plugin, identity, SampleSliceLayouts.CreateNestedLayout());
+		ILayoutEngine b = SliceLayouts.CreateColumnLayout(ctx, plugin, identity);
+
+		// When
+		bool equals = a.Equals(b);
+
+		// Then
+		Assert.False(equals);
+	}
+
+	[Theory, AutoSubstituteData]
 	public void SliceLayoutEngine_GetHashCode(IContext ctx, SliceLayoutPlugin plugin)
 	{
 		// Given

--- a/src/Whim.SliceLayout.Tests/SliceLayoutEngine/SliceLayoutEngineTests.cs
+++ b/src/Whim.SliceLayout.Tests/SliceLayoutEngine/SliceLayoutEngineTests.cs
@@ -64,6 +64,45 @@ public class SliceLayoutEngineTests
 		Assert.Equal(windowCount + minimizedWindowCount, sut.Count);
 	}
 
+	[Theory, AutoSubstituteData]
+	public void Equals_Null(IContext ctx, SliceLayoutPlugin plugin)
+	{
+		// Given
+		ILayoutEngine sut = new SliceLayoutEngine(ctx, plugin, identity, SampleSliceLayouts.CreateNestedLayout());
+
+		// When
+		bool equals = sut.Equals(null);
+
+		// Then
+		Assert.False(equals);
+	}
+
+	[Theory, AutoSubstituteData]
+	public void Equals_Same(IContext ctx, SliceLayoutPlugin plugin)
+	{
+		// Given
+		ILayoutEngine sut = new SliceLayoutEngine(ctx, plugin, identity, SampleSliceLayouts.CreateNestedLayout());
+
+		// When
+		bool equals = sut.Equals(sut);
+
+		// Then
+		Assert.True(equals);
+	}
+
+	[Theory, AutoSubstituteData]
+	public void SliceLayoutEngine_GetHashCode(IContext ctx, SliceLayoutPlugin plugin)
+	{
+		// Given
+		ILayoutEngine sut = new SliceLayoutEngine(ctx, plugin, identity, SampleSliceLayouts.CreateNestedLayout());
+
+		// When
+		int hashCode = sut.GetHashCode();
+
+		// Then
+		Assert.NotEqual(0, hashCode);
+	}
+
 	#region AddWindow
 	[Theory, AutoSubstituteData]
 	public void AddWindow(IContext ctx, SliceLayoutPlugin plugin, IWindow window)

--- a/src/Whim.SliceLayout.Tests/SliceLayoutsTests.cs
+++ b/src/Whim.SliceLayout.Tests/SliceLayoutsTests.cs
@@ -1,4 +1,3 @@
-using FluentAssertions;
 using Whim.TestUtils;
 using Xunit;
 
@@ -14,17 +13,18 @@ public class SliceLayoutsTests
 		ILayoutEngine sut = SliceLayouts.CreateColumnLayout(ctx, plugin, identity);
 
 		// Then
-		new SliceLayoutEngine(
-			ctx,
-			plugin,
-			identity,
-			new ParentArea(isRow: false, (1, new SliceArea(order: 0, maxChildren: 0)))
-		)
-		{
-			Name = "Column",
-		}
-			.Should()
-			.BeEquivalentTo(sut);
+		Assert.Equal(
+			new SliceLayoutEngine(
+				ctx,
+				plugin,
+				identity,
+				new ParentArea(isRow: false, (1, new OverflowArea(isRow: false)))
+			)
+			{
+				Name = "Column",
+			},
+			sut
+		);
 	}
 
 	[Theory, AutoSubstituteData]
@@ -35,18 +35,18 @@ public class SliceLayoutsTests
 		ILayoutEngine sut = SliceLayouts.CreateRowLayout(ctx, plugin, identity);
 
 		// Then
-		// Then
-		new SliceLayoutEngine(
-			ctx,
-			plugin,
-			identity,
-			new ParentArea(isRow: true, (1, new SliceArea(order: 0, maxChildren: 0)))
-		)
-		{
-			Name = "Row",
-		}
-			.Should()
-			.BeEquivalentTo(sut);
+		Assert.Equal(
+			new SliceLayoutEngine(
+				ctx,
+				plugin,
+				identity,
+				new ParentArea(isRow: true, (1, new OverflowArea(isRow: true)))
+			)
+			{
+				Name = "Row",
+			},
+			sut
+		);
 	}
 
 	[Theory, AutoSubstituteData]
@@ -57,17 +57,18 @@ public class SliceLayoutsTests
 		ILayoutEngine sut = SliceLayouts.CreatePrimaryStackLayout(ctx, plugin, identity);
 
 		// Then
-		new SliceLayoutEngine(
-			ctx,
-			plugin,
-			identity,
-			new ParentArea(isRow: true, (0.5, new SliceArea(order: 0, maxChildren: 0)), (0.5, new OverflowArea()))
-		)
-		{
-			Name = "Primary stack",
-		}
-			.Should()
-			.BeEquivalentTo(sut);
+		Assert.Equal(
+			new SliceLayoutEngine(
+				ctx,
+				plugin,
+				identity,
+				new ParentArea(isRow: true, (0.5, new SliceArea(order: 0, maxChildren: 1)), (0.5, new OverflowArea()))
+			)
+			{
+				Name = "Primary stack",
+			},
+			sut
+		);
 	}
 
 	[Fact]
@@ -77,14 +78,56 @@ public class SliceLayoutsTests
 		ParentArea sut = SliceLayouts.CreateMultiColumnArea([2, 1, 0, 0]);
 
 		// Then
-		new ParentArea(
-			isRow: true,
-			(0.25, new SliceArea(order: 0, maxChildren: 2)),
-			(0.25, new SliceArea(order: 1, maxChildren: 1)),
-			(0.25, new SliceArea(order: 2, maxChildren: 0)),
-			(0.25, new OverflowArea())
-		)
-			.Should()
-			.BeEquivalentTo(sut);
+		Assert.Equal(
+			new ParentArea(
+				isRow: true,
+				(0.25, new SliceArea(order: 0, maxChildren: 2)),
+				(0.25, new SliceArea(order: 1, maxChildren: 1)),
+				(0.25, new SliceArea(order: 2, maxChildren: 0)),
+				(0.25, new OverflowArea())
+			),
+			sut
+		);
+	}
+
+	// TODO: SecondaryPrimaryArea
+	[Theory]
+	[InlineAutoSubstituteData(1, 2)]
+	[InlineAutoSubstituteData(3, 1)]
+	public void CreateSecondaryPrimaryLayout(
+		uint primaryCount,
+		uint secondaryCount,
+		IContext ctx,
+		ISliceLayoutPlugin plugin
+	)
+	{
+		// Given
+		LayoutEngineIdentity identity = new();
+		ILayoutEngine sut = SliceLayouts.CreateSecondaryPrimaryLayout(
+			ctx,
+			plugin,
+			identity,
+			primaryCount,
+			secondaryCount
+		);
+
+		// Then
+		Assert.Equal(
+			new SliceLayoutEngine(
+				ctx,
+				plugin,
+				identity,
+				new ParentArea(
+					isRow: true,
+					(0.25, new SliceArea(order: 1, maxChildren: secondaryCount)),
+					(0.5, new SliceArea(order: 0, maxChildren: primaryCount)),
+					(0.25, new OverflowArea())
+				)
+			)
+			{
+				Name = "Secondary primary",
+			},
+			sut
+		);
 	}
 }

--- a/src/Whim.SliceLayout.Tests/SliceLayoutsTests.cs
+++ b/src/Whim.SliceLayout.Tests/SliceLayoutsTests.cs
@@ -1,3 +1,4 @@
+using FluentAssertions;
 using Whim.TestUtils;
 using Xunit;
 
@@ -10,21 +11,15 @@ public class SliceLayoutsTests
 	{
 		// Given
 		LayoutEngineIdentity identity = new();
-		ILayoutEngine sut = SliceLayouts.CreateColumnLayout(ctx, plugin, identity);
+		SliceLayoutEngine sut = (SliceLayoutEngine)SliceLayouts.CreateColumnLayout(ctx, plugin, identity);
 
 		// Then
-		Assert.Equal(
-			new SliceLayoutEngine(
-				ctx,
-				plugin,
-				identity,
-				new ParentArea(isRow: false, (1, new OverflowArea(isRow: false)))
-			)
-			{
-				Name = "Column",
-			},
-			sut
-		);
+		new SliceLayoutEngine(ctx, plugin, identity, new ParentArea(isRow: false, (1, new OverflowArea(isRow: false))))
+		{
+			Name = "Column",
+		}
+			.Should()
+			.BeEquivalentTo(sut);
 	}
 
 	[Theory, AutoSubstituteData]
@@ -32,34 +27,41 @@ public class SliceLayoutsTests
 	{
 		// Given
 		LayoutEngineIdentity identity = new();
-		ILayoutEngine sut = SliceLayouts.CreateRowLayout(ctx, plugin, identity);
+		SliceLayoutEngine sut = (SliceLayoutEngine)SliceLayouts.CreateRowLayout(ctx, plugin, identity);
 
 		// Then
-		Assert.Equal(
-			new SliceLayoutEngine(
-				ctx,
-				plugin,
-				identity,
-				new ParentArea(isRow: true, (1, new OverflowArea(isRow: true)))
-			)
-			{
-				Name = "Row",
-			},
-			sut
-		);
+		new SliceLayoutEngine(ctx, plugin, identity, new ParentArea(isRow: true, (1, new OverflowArea(isRow: true))))
+		{
+			Name = "Row",
+		}
+			.Should()
+			.BeEquivalentTo(sut);
 	}
 
 	[Theory, AutoSubstituteData]
-	public void RowNotEqualToColumn(IContext ctx, ISliceLayoutPlugin plugin)
+	public void SanityCheck_RowNotEqualToColumn(IContext ctx, ISliceLayoutPlugin plugin)
 	{
 		// A sanity check to ensure that the two layouts are not equal.
 		// Given
 		LayoutEngineIdentity identity = new();
-		ILayoutEngine row = SliceLayouts.CreateRowLayout(ctx, plugin, identity);
-		ILayoutEngine column = SliceLayouts.CreateColumnLayout(ctx, plugin, identity);
+		SliceLayoutEngine row = (SliceLayoutEngine)SliceLayouts.CreateRowLayout(ctx, plugin, identity);
+		SliceLayoutEngine column = (SliceLayoutEngine)SliceLayouts.CreateColumnLayout(ctx, plugin, identity);
 
 		// Then
-		Assert.NotEqual(row, column);
+		row.Should().NotBeEquivalentTo(column);
+	}
+
+	[Theory, AutoSubstituteData]
+	public void SanityCheck_RowsNotEqual(IContext ctx, ISliceLayoutPlugin plugin)
+	{
+		// Given
+		LayoutEngineIdentity identity = new();
+		SliceLayoutEngine row1 =
+			new(ctx, plugin, identity, new ParentArea(isRow: true, (1, new OverflowArea(isRow: true))));
+		SliceLayoutEngine row2 = new(ctx, plugin, identity, new ParentArea(isRow: true, (1, new SliceArea(0, 0))));
+
+		// Then
+		row1.Should().NotBeEquivalentTo(row2);
 	}
 
 	[Theory, AutoSubstituteData]
@@ -67,21 +69,20 @@ public class SliceLayoutsTests
 	{
 		// Given
 		LayoutEngineIdentity identity = new();
-		ILayoutEngine sut = SliceLayouts.CreatePrimaryStackLayout(ctx, plugin, identity);
+		SliceLayoutEngine sut = (SliceLayoutEngine)SliceLayouts.CreatePrimaryStackLayout(ctx, plugin, identity);
 
 		// Then
-		Assert.Equal(
-			new SliceLayoutEngine(
-				ctx,
-				plugin,
-				identity,
-				new ParentArea(isRow: true, (0.5, new SliceArea(order: 0, maxChildren: 1)), (0.5, new OverflowArea()))
-			)
-			{
-				Name = "Primary stack",
-			},
-			sut
-		);
+		new SliceLayoutEngine(
+			ctx,
+			plugin,
+			identity,
+			new ParentArea(isRow: true, (0.5, new SliceArea(order: 0, maxChildren: 1)), (0.5, new OverflowArea()))
+		)
+		{
+			Name = "Primary stack",
+		}
+			.Should()
+			.BeEquivalentTo(sut);
 	}
 
 	[Fact]
@@ -91,19 +92,17 @@ public class SliceLayoutsTests
 		ParentArea sut = SliceLayouts.CreateMultiColumnArea([2, 1, 0, 0]);
 
 		// Then
-		Assert.Equal(
-			new ParentArea(
-				isRow: true,
-				(0.25, new SliceArea(order: 0, maxChildren: 2)),
-				(0.25, new SliceArea(order: 1, maxChildren: 1)),
-				(0.25, new SliceArea(order: 2, maxChildren: 0)),
-				(0.25, new OverflowArea())
-			),
-			sut
-		);
+		new ParentArea(
+			isRow: true,
+			(0.25, new SliceArea(order: 0, maxChildren: 2)),
+			(0.25, new SliceArea(order: 1, maxChildren: 1)),
+			(0.25, new SliceArea(order: 2, maxChildren: 0)),
+			(0.25, new OverflowArea())
+		)
+			.Should()
+			.BeEquivalentTo(sut);
 	}
 
-	// TODO: SecondaryPrimaryArea
 	[Theory]
 	[InlineAutoSubstituteData(1, 2)]
 	[InlineAutoSubstituteData(3, 1)]
@@ -116,31 +115,25 @@ public class SliceLayoutsTests
 	{
 		// Given
 		LayoutEngineIdentity identity = new();
-		ILayoutEngine sut = SliceLayouts.CreateSecondaryPrimaryLayout(
+		SliceLayoutEngine sut = (SliceLayoutEngine)
+			SliceLayouts.CreateSecondaryPrimaryLayout(ctx, plugin, identity, primaryCount, secondaryCount);
+
+		// Then
+		new SliceLayoutEngine(
 			ctx,
 			plugin,
 			identity,
-			primaryCount,
-			secondaryCount
-		);
-
-		// Then
-		Assert.Equal(
-			new SliceLayoutEngine(
-				ctx,
-				plugin,
-				identity,
-				new ParentArea(
-					isRow: true,
-					(0.25, new SliceArea(order: 1, maxChildren: secondaryCount)),
-					(0.5, new SliceArea(order: 0, maxChildren: primaryCount)),
-					(0.25, new OverflowArea())
-				)
+			new ParentArea(
+				isRow: true,
+				(0.25, new SliceArea(order: 1, maxChildren: secondaryCount)),
+				(0.5, new SliceArea(order: 0, maxChildren: primaryCount)),
+				(0.25, new OverflowArea())
 			)
-			{
-				Name = "Secondary primary",
-			},
-			sut
-		);
+		)
+		{
+			Name = "Secondary primary",
+		}
+			.Should()
+			.BeEquivalentTo(sut);
 	}
 }

--- a/src/Whim.SliceLayout.Tests/SliceLayoutsTests.cs
+++ b/src/Whim.SliceLayout.Tests/SliceLayoutsTests.cs
@@ -50,6 +50,19 @@ public class SliceLayoutsTests
 	}
 
 	[Theory, AutoSubstituteData]
+	public void RowNotEqualToColumn(IContext ctx, ISliceLayoutPlugin plugin)
+	{
+		// A sanity check to ensure that the two layouts are not equal.
+		// Given
+		LayoutEngineIdentity identity = new();
+		ILayoutEngine row = SliceLayouts.CreateRowLayout(ctx, plugin, identity);
+		ILayoutEngine column = SliceLayouts.CreateColumnLayout(ctx, plugin, identity);
+
+		// Then
+		Assert.NotEqual(row, column);
+	}
+
+	[Theory, AutoSubstituteData]
 	public void CreatePrimaryStackLayout(IContext ctx, ISliceLayoutPlugin plugin)
 	{
 		// Given

--- a/src/Whim.SliceLayout/Area.cs
+++ b/src/Whim.SliceLayout/Area.cs
@@ -1,6 +1,4 @@
-using System;
 using System.Collections.Immutable;
-using System.Linq;
 
 namespace Whim.SliceLayout;
 
@@ -66,44 +64,6 @@ public record ParentArea : BaseArea
 		IsRow = isRow;
 		Weights = weights;
 		Children = children;
-	}
-
-	/// <summary>
-	/// Determines whether the specified object is equal to the current object. This compares
-	/// the contents of the weights and children.
-	/// </summary>
-	/// <param name="other"></param>
-	/// <returns></returns>
-	public virtual bool Equals(ParentArea? other)
-	{
-		if (other is null)
-		{
-			return false;
-		}
-
-		if (ReferenceEquals(this, other))
-		{
-			return true;
-		}
-
-		return IsRow == other.IsRow && Weights.SequenceEqual(other.Weights) && Children.SequenceEqual(other.Children);
-	}
-
-	/// <inheritdoc/>
-	public override int GetHashCode()
-	{
-		// Get the hash code of the weights and children
-		int hash = HashCode.Combine(IsRow);
-		foreach (double weight in Weights)
-		{
-			hash = HashCode.Combine(hash, weight);
-		}
-		foreach (IArea child in Children)
-		{
-			hash = HashCode.Combine(hash, child);
-		}
-
-		return hash;
 	}
 }
 

--- a/src/Whim.SliceLayout/Area.cs
+++ b/src/Whim.SliceLayout/Area.cs
@@ -1,4 +1,6 @@
+using System;
 using System.Collections.Immutable;
+using System.Linq;
 
 namespace Whim.SliceLayout;
 
@@ -64,6 +66,44 @@ public record ParentArea : BaseArea
 		IsRow = isRow;
 		Weights = weights;
 		Children = children;
+	}
+
+	/// <summary>
+	/// Determines whether the specified object is equal to the current object. This compares
+	/// the contents of the weights and children.
+	/// </summary>
+	/// <param name="other"></param>
+	/// <returns></returns>
+	public virtual bool Equals(ParentArea? other)
+	{
+		if (other is null)
+		{
+			return false;
+		}
+
+		if (ReferenceEquals(this, other))
+		{
+			return true;
+		}
+
+		return IsRow == other.IsRow && Weights.SequenceEqual(other.Weights) && Children.SequenceEqual(other.Children);
+	}
+
+	/// <inheritdoc/>
+	public override int GetHashCode()
+	{
+		// Get the hash code of the weights and children
+		int hash = HashCode.Combine(IsRow);
+		foreach (double weight in Weights)
+		{
+			hash = HashCode.Combine(hash, weight);
+		}
+		foreach (IArea child in Children)
+		{
+			hash = HashCode.Combine(hash, child);
+		}
+
+		return hash;
 	}
 }
 

--- a/src/Whim.SliceLayout/SliceLayoutEngine.cs
+++ b/src/Whim.SliceLayout/SliceLayoutEngine.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
@@ -101,6 +102,42 @@ public partial record SliceLayoutEngine : ILayoutEngine
 
 		(_rootArea, _windowAreas) = rootArea.SetStartIndexes();
 		_prunedRootArea = _rootArea.Prune(_windows.Count);
+	}
+
+	/// <inheritdoc />
+	public virtual bool Equals(SliceLayoutEngine? other)
+	{
+		if (other is null)
+		{
+			return false;
+		}
+
+		if (ReferenceEquals(this, other))
+		{
+			return true;
+		}
+
+		return _windows.SequenceEqual(other._windows)
+			&& _minimizedWindows.SequenceEqual(other._minimizedWindows)
+			&& _rootArea.Equals(other._rootArea)
+			&& Name == other.Name
+			&& Identity.Equals(other.Identity);
+	}
+
+	/// <inheritdoc />
+	public override int GetHashCode()
+	{
+		int hash = HashCode.Combine(_context, _plugin, Name, Identity);
+		foreach (IWindow window in _windows)
+		{
+			hash = HashCode.Combine(hash, window);
+		}
+		foreach (IWindow window in _minimizedWindows)
+		{
+			hash = HashCode.Combine(hash, window);
+		}
+		hash = HashCode.Combine(hash, _rootArea);
+		return hash;
 	}
 
 	/// <inheritdoc />

--- a/src/Whim.SliceLayout/SliceLayouts.cs
+++ b/src/Whim.SliceLayout/SliceLayouts.cs
@@ -45,18 +45,14 @@ public static class SliceLayouts
 	/// <param name="context"></param>
 	/// <param name="plugin"></param>
 	/// <param name="identity"></param>
-	/// <param name="leftToRight"></param>
 	/// <returns></returns>
 	public static ILayoutEngine CreateColumnLayout(
 		IContext context,
 		ISliceLayoutPlugin plugin,
-		LayoutEngineIdentity identity,
-		bool leftToRight = true
-	) =>
-		new SliceLayoutEngine(context, plugin, identity, new(isRow: false, (1, new OverflowArea())))
-		{
-			Name = "Column",
-		};
+		LayoutEngineIdentity identity
+	) => new SliceLayoutEngine(context, plugin, identity, CreateColumnArea()) { Name = "Column" };
+
+	internal static ParentArea CreateColumnArea() => new(isRow: false, (1, new OverflowArea()));
 
 	/// <summary>
 	/// Creates a row layout, where windows are stacked horizontally.
@@ -103,7 +99,9 @@ public static class SliceLayouts
 		IContext context,
 		ISliceLayoutPlugin plugin,
 		LayoutEngineIdentity identity
-	) => new SliceLayoutEngine(context, plugin, identity, new(isRow: true, (1, new OverflowArea()))) { Name = "Row" };
+	) => new SliceLayoutEngine(context, plugin, identity, CreateRowArea()) { Name = "Row" };
+
+	internal static ParentArea CreateRowArea() => new(isRow: true, (1, new OverflowArea(isRow: true)));
 
 	/// <summary>
 	/// Creates a primary stack layout, where the first window takes up half the screen, and the
@@ -165,7 +163,7 @@ public static class SliceLayouts
 		new(isRow: true, (0.5, new SliceArea(order: 0, maxChildren: 1)), (0.5, new OverflowArea()));
 
 	/// <summary>
-	/// Creates a multi-column layout with the given number of columns.
+	/// Creates a multi-column layout with the given number of windows in each column.
 	/// <br />
 	/// For example, new <c>uint[] { 2, 1, 0 }</c> will create a layout with 3 columns, where the
 	/// first column has 2 rows, the second column has 1 row, and the third column has infinite rows.

--- a/src/Whim.Tests/Store/MonitorSector/MonitorEventListenerTests.cs
+++ b/src/Whim.Tests/Store/MonitorSector/MonitorEventListenerTests.cs
@@ -98,7 +98,7 @@ public class MonitorEventListenerTests
 	internal async Task WindowMessageMonitor_SessionChanged(IContext ctx, IInternalContext internalCtx)
 	{
 		// Given the listener is initialized
-		MonitorEventListener listener = new(ctx, internalCtx);
+		MonitorEventListener listener = new(ctx, internalCtx, 500);
 		listener.Initialize();
 
 		NativeManagerUtils.SetupTryEnqueue(ctx);
@@ -108,7 +108,7 @@ public class MonitorEventListenerTests
 			ctx.Store.MonitorEvents,
 			_windowMessageArgs
 		);
-		await Task.Delay(5200);
+		await Task.Delay(2000);
 
 		// Then a dispatch to the store was triggered
 		ctx.Store.Received(1).Dispatch(new MonitorsChangedTransform());

--- a/src/Whim/Store/MonitorSector/MonitorEventListener.cs
+++ b/src/Whim/Store/MonitorSector/MonitorEventListener.cs
@@ -2,10 +2,11 @@ using System.Threading.Tasks;
 
 namespace Whim;
 
-internal class MonitorEventListener(IContext ctx, IInternalContext internalCtx) : IDisposable
+internal class MonitorEventListener(IContext ctx, IInternalContext internalCtx, int delayMs = 5000) : IDisposable
 {
 	private readonly IContext _ctx = ctx;
 	private readonly IInternalContext _internalCtx = internalCtx;
+	private readonly int _delayMs = delayMs;
 	private bool _disposedValue;
 
 	public void Initialize()
@@ -29,7 +30,7 @@ internal class MonitorEventListener(IContext ctx, IInternalContext internalCtx) 
 		// This gives Windows some to figure out the correct working area.
 		_ctx.NativeManager.TryEnqueue(async () =>
 		{
-			await Task.Delay(5000).ConfigureAwait(true);
+			await Task.Delay(_delayMs).ConfigureAwait(true);
 			WindowMessageMonitor_MonitorsChanged(sender, e);
 		});
 	}


### PR DESCRIPTION
The tests previously succeeded because:

- the `SliceLayoutEngine` record didn't expose the root area, which meant they were not included in the generated `record` `Equals`
- apparently casting `ILayoutEngine` to `SliceLayoutEngine` matters 🤷