### PR TITLE
Handle Komorebi app rules rename

### DIFF
--- a/app_rules/generate_app_rules.py
+++ b/app_rules/generate_app_rules.py
@@ -85,8 +85,11 @@ class GenerateRules:
 
 	def generate_all_rules(self):
 		for app in self.komorebi_rules:
+			if "ignore_identifiers" in app:
+				# windows with matching `ignore_identifiers` are ignored by komorebi
+				Application(app["ignore_identifiers"], app["name"]).generate_rules()
 			if "float_identifiers" in app:
-				# windows with matching `float_identifiers` are ignored by komorebi
+				# also ignore `float_identifiers` for backwards compatibility
 				Application(app["float_identifiers"], app["name"]).generate_rules()
 
 


### PR DESCRIPTION
- [x] This code is up-to-date with the `main` branch.
- [x] I have updated relevant (if any) areas in the docs.

This PR fixes #1040

Both `ignore_identifiers` and `float_identifiers` rules add a `filter` rule on the Whim side. Duplicates are taken care of using the default de-deduplication handling in the script.

Some things to look out for in the future:

- For now there are no rules in https://github.com/LGUG2Z/komorebi-application-specific-configuration with the new identifier, so we could wait merging this PR. On the other hand, merging now should be harmless as it is backward compatible. In either case, I'll be monitoring the Komorebi-rules repo to make sure that all ignore-rules use one of the two identifiers

- It is not entirely clear to me at this point whether, `float_rules` will be eventually repurposed to mean "managed but starting as floating". If another change to this effect will be rolled we need to decide how to handle that on the Whim side
