### PR TITLE
Add format rules for Python

### DIFF
--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -8,22 +8,26 @@ on:
       - ".github/workflows/commit.yml"
       - "src/**"
       - "scripts/**"
+      - "**.py"
       - "whim-installer.iss"
       - "Whim.sln"
       - "Directory.Packages.props"
       - ".csharpierrc"
       - ".xamlstylerrc"
+      - ".ruff.toml"
       - ".config/dotnet-tools.json"
   pull_request:
     paths:
       - ".github/workflows/commit.yml"
       - "src/**"
       - "scripts/**"
+      - "**.py"
       - "whim-installer.iss"
       - "Whim.sln"
       - "Directory.Packages.props"
       - ".csharpierrc"
       - ".xamlstylerrc"
+      - ".ruff.toml"
       - ".config/dotnet-tools.json"
 
 env:
@@ -74,6 +78,16 @@ jobs:
       #   - name: Check analyzers
       #     run: |
       #       dotnet format analyzers Whim.sln --verify-no-changes --no-restore
+
+      - name: Check Python formatting
+        uses: astral-sh/ruff-action@v1
+        with:
+          args: format --check
+
+      - name: Lint Python code
+        uses: astral-sh/ruff-action@v1
+        with:
+          args: check
 
       - name: Add msbuild to PATH
         uses: microsoft/setup-msbuild@v2.0.0

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,0 +1,21 @@
+# Same as csharpierrc
+line-length = 120
+indent-width = 4
+
+# Same as in GHA workflow
+target-version = "py311"
+
+[lint]
+# Enable standard rules in editor
+select = ["F", "E4", "E7", "E9", "I", "B", "ARG"]
+
+# Allow auto-fix for import order
+fixable = ["I"]
+
+[format]
+# Use double quotes for strings
+quote-style = "double"
+
+# Same as csharpierrc
+indent-style = "tab"
+


### PR DESCRIPTION
- [x] This code is up-to-date with the `main` branch.
- [x] I have updated relevant (if any) areas in the docs.

This adds some baseline formatting rules for Python scripts. For now, this only affects `app_rules/generate_app_rules.py` so we could also move it there. But I like having formatter rules at the repo root to ensure consistency.