### PR TITLE
Report YAML errors during runtime

### DIFF
--- a/docs/configure/yaml-json-configuration.md
+++ b/docs/configure/yaml-json-configuration.md
@@ -51,3 +51,7 @@ To use the schema in your JSON file, add the following line at the top of your f
   ...
 }
 ```
+
+## Errors
+
+Your YAML/JSON file will be validated against the schema. If there are any errors, your text editor should show them. Whim will also open a window with any errors.

--- a/docs/configure/yaml-json-configuration.md
+++ b/docs/configure/yaml-json-configuration.md
@@ -27,7 +27,7 @@ using Whim.Yaml;
 void DoConfig(IContext context)
 {
     // Make sure to place this at the top of your config
-    YamlLoader.Load(context);
+    YamlLoader.Load(context, showErrorWindow: false);
 }
 ```
 

--- a/src/Whim.Runner/Whim.Runner.csproj
+++ b/src/Whim.Runner/Whim.Runner.csproj
@@ -131,6 +131,7 @@
 		<PackageReference Include="Microsoft.Windows.SDK.BuildTools" />
 		<Manifest Include="$(ApplicationManifest)" />
 	</ItemGroup>
+
 	<!-- Defining the "Msix" ProjectCapability here allows the Single-project MSIX Packaging
 		Tools extension to be activated for this project even if the Windows App SDK Nuget
 		package has not yet been restored -->
@@ -160,7 +161,8 @@
 			<Generator>MSBuild:Compile</Generator>
 		</Page>
 	</ItemGroup>
-	<!--Whim.Bar-->
+
+	<!-- Whim.Bar -->
 	<Target Name="CopyBarAfterBuild" AfterTargets="Build;Publish">
 		<ItemGroup>
 			<BarSourceFile Include="$(SolutionDir)\src\Whim.Bar\$(OutDir)\Whim.Bar\**\*" />
@@ -172,7 +174,8 @@
 		<Copy SourceFiles="$(SolutionDir)src\Whim.Bar\$(OutDir)Whim.Bar.dll"
 			DestinationFolder="$(TargetDir)plugins\Whim.Bar\" SkipUnchangedFiles="true" />
 	</Target>
-	<!--Whim.CommandPalette-->
+
+	<!-- Whim.CommandPalette -->
 	<Target Name="CopyCommandPaletteAfterBuild" AfterTargets="Build;Publish">
 		<ItemGroup>
 			<CommandPaletteSourceFile
@@ -185,12 +188,14 @@
 		<Copy SourceFiles="$(SolutionDir)src\Whim.CommandPalette\$(OutDir)Whim.CommandPalette.dll"
 			DestinationFolder="$(TargetDir)plugins\Whim.CommandPalette\" SkipUnchangedFiles="true" />
 	</Target>
-	<!--Whim.FloatingWindow-->
+
+	<!-- Whim.FloatingWindow -->
 	<Target Name="CopyFloatingWindowAfterBuild" AfterTargets="Build;Publish">
 		<Copy SourceFiles="$(SolutionDir)src\Whim.FloatingWindow\$(OutDir)Whim.FloatingWindow.dll"
 			DestinationFolder="$(TargetDir)plugins\Whim.FloatingWindow\" SkipUnchangedFiles="true" />
 	</Target>
-	<!--Whim.FocusIndicator-->
+
+	<!-- Whim.FocusIndicator -->
 	<Target Name="CopyFocusIndicatorAfterBuild" AfterTargets="Build;Publish">
 		<ItemGroup>
 			<FocusIndicatorSourceFile
@@ -203,12 +208,14 @@
 		<Copy SourceFiles="$(SolutionDir)src\Whim.FocusIndicator\$(OutDir)Whim.FocusIndicator.dll"
 			DestinationFolder="$(TargetDir)plugins\Whim.FocusIndicator\" SkipUnchangedFiles="true" />
 	</Target>
-	<!--Whim.Gaps-->
+
+	<!-- Whim.Gaps -->
 	<Target Name="CopyGapsAfterBuild" AfterTargets="Build;Publish">
 		<Copy SourceFiles="$(SolutionDir)src\Whim.Gaps\$(OutDir)Whim.Gaps.dll"
 			DestinationFolder="$(TargetDir)plugins\Whim.Gaps\" SkipUnchangedFiles="true" />
 	</Target>
-	<!--Whim.LayoutPreview-->
+
+	<!-- Whim.LayoutPreview -->
 	<Target Name="CopyLayoutPreviewAfterBuild" AfterTargets="Build;Publish">
 		<ItemGroup>
 			<LayoutPreviewSourceFile
@@ -221,17 +228,20 @@
 		<Copy SourceFiles="$(SolutionDir)src\Whim.LayoutPreview\$(OutDir)Whim.LayoutPreview.dll"
 			DestinationFolder="$(TargetDir)plugins\Whim.LayoutPreview\" SkipUnchangedFiles="true" />
 	</Target>
-	<!--Whim.SliceLayout-->
+
+	<!-- Whim.SliceLayout -->
 	<Target Name="CopySliceLayoutAfterBuild" AfterTargets="Build;Publish">
 		<Copy SourceFiles="$(SolutionDir)src\Whim.SliceLayout\$(OutDir)Whim.SliceLayout.dll"
 			DestinationFolder="$(TargetDir)plugins\Whim.SliceLayout\" SkipUnchangedFiles="true" />
 	</Target>
-	<!--Whim.TreeLayout-->
+
+	<!-- Whim.TreeLayout -->
 	<Target Name="CopyTreeLayoutAfterBuild" AfterTargets="Build;Publish">
 		<Copy SourceFiles="$(SolutionDir)src\Whim.TreeLayout\$(OutDir)Whim.TreeLayout.dll"
 			DestinationFolder="$(TargetDir)plugins\Whim.TreeLayout\" SkipUnchangedFiles="true" />
 	</Target>
-	<!--Whim.TreeLayout.Bar-->
+
+	<!-- Whim.TreeLayout.Bar -->
 	<Target Name="CopyTreeLayoutBarAfterBuild"
 		AfterTargets="Build;Publish;CopyBarAfterBuild;CopyTreeLayoutAfterBuild">
 		<ItemGroup>
@@ -245,7 +255,8 @@
 		<Copy SourceFiles="$(SolutionDir)src\Whim.TreeLayout.Bar\$(OutDir)Whim.TreeLayout.Bar.dll"
 			DestinationFolder="$(TargetDir)plugins\Whim.TreeLayout.Bar\" SkipUnchangedFiles="true" />
 	</Target>
-	<!--Whim.TreeLayout.CommandPalette-->
+
+	<!-- Whim.TreeLayout.CommandPalette -->
 	<Target Name="CopyTreeLayoutCommandPaletteAfterBuild"
 		AfterTargets="Build;Publish;CopyCommandPaletteAfterBuild;CopyTreeLayoutAfterBuild">
 		<Copy
@@ -253,6 +264,7 @@
 			DestinationFolder="$(TargetDir)plugins\Whim.TreeLayout.CommandPalette\"
 			SkipUnchangedFiles="true" />
 	</Target>
+
 	<!-- Whim.Updater -->
 	<Target Name="CopyUpdaterAfterBuild" AfterTargets="Build;Publish">
 		<ItemGroup>
@@ -265,15 +277,24 @@
 		<Copy SourceFiles="$(SolutionDir)src\Whim.Updater\$(OutDir)Whim.Updater.dll"
 			DestinationFolder="$(TargetDir)plugins\Whim.Updater\" SkipUnchangedFiles="true" />
 	</Target>
+
 	<!-- Whim.Yaml -->
 	<Target Name="CopyYamlAfterBuild" AfterTargets="Build;Publish">
 		<ItemGroup>
-			<YamlSourceFile Include="$(SolutionDir)\src\Whim.Yaml\schema.json" />
-			<YamlDestinationFile
-				Include="@(YamlSourceFile->'$(TargetDir)plugins\Whim.Yaml\%(Filename)%(Extension)')" />
+			<YamlSchemaSourceFile Include="$(SolutionDir)\src\Whim.Yaml\schema.json" />
+			<YamlSchemaDestinationFile
+				Include="@(YamlSchemaSourceFile->'$(TargetDir)plugins\Whim.Yaml\%(Filename)%(Extension)')" />
 		</ItemGroup>
-		<Copy SourceFiles="@(YamlSourceFile)" DestinationFiles="@(YamlDestinationFile)"
+		<ItemGroup>
+			<YamlSourceFile
+				Include="$(SolutionDir)\src\Whim.Yaml\$(OutDir)\Whim.Yaml\**\*" />
+			<YamlDestinationFile
+				Include="@(YamlSourceFile->'$(TargetDir)plugins\Whim.Yaml\%(RecursiveDir)%(Filename)%(Extension)')" />
+		</ItemGroup>
+		<Copy SourceFiles="@(YamlSchemaSourceFile)" DestinationFiles="@(YamlSchemaDestinationFile)"
 			SkipUnchangedFiles="true" />
+		<Copy SourceFiles="@(YamlSourceFile)"
+			DestinationFiles="@(YamlDestinationFile)" SkipUnchangedFiles="true" />
 		<Copy SourceFiles="$(SolutionDir)src\Whim.Yaml\$(OutDir)Whim.Yaml.dll"
 			DestinationFolder="$(TargetDir)plugins\Whim.Yaml\" SkipUnchangedFiles="true" />
 	</Target>

--- a/src/Whim.Yaml.Tests/Layouts/YamlLayoutEngineLoaderTests.cs
+++ b/src/Whim.Yaml.Tests/Layouts/YamlLayoutEngineLoaderTests.cs
@@ -36,7 +36,7 @@ public class YamlLayoutEngineLoaderTests
 		YamlLoaderTestUtils.SetupFileConfig(ctx, config, isYaml);
 
 		// When loading the layout engine
-		bool result = YamlLoader.Load(ctx);
+		bool result = YamlLoader.Load(ctx, showErrorWindow: false);
 
 		// Then the layout engine is not loaded
 		Assert.True(result);

--- a/src/Whim.Yaml.Tests/Layouts/YamlLayoutEngineLoader_FloatingLayoutEngineTests.cs
+++ b/src/Whim.Yaml.Tests/Layouts/YamlLayoutEngineLoader_FloatingLayoutEngineTests.cs
@@ -43,7 +43,7 @@ public class YamlLoader_LoadFloatingLayoutEngineTests
 		YamlLoaderTestUtils.SetupFileConfig(ctx, config, isYaml);
 
 		// When loading the layout engine
-		bool result = YamlLoader.Load(ctx);
+		bool result = YamlLoader.Load(ctx, showErrorWindow: false);
 
 		// Then the layout engine is loaded
 		Assert.True(result);

--- a/src/Whim.Yaml.Tests/Layouts/YamlLayoutEngineLoader_FocusLayoutEngineTests.cs
+++ b/src/Whim.Yaml.Tests/Layouts/YamlLayoutEngineLoader_FocusLayoutEngineTests.cs
@@ -96,7 +96,7 @@ public class YamlLoader_LoadFocusLayoutEngineTests
 		YamlLoaderTestUtils.SetupFileConfig(ctx, config, isYaml);
 
 		// When loading the layout engine
-		bool result = YamlLoader.Load(ctx);
+		bool result = YamlLoader.Load(ctx, showErrorWindow: false);
 
 		// Then the layout engine is loaded
 		Assert.True(result);
@@ -143,7 +143,7 @@ public class YamlLoader_LoadFocusLayoutEngineTests
 		YamlLoaderTestUtils.SetupFileConfig(ctx, config, isYaml);
 
 		// When loading the layout engine
-		bool result = YamlLoader.Load(ctx);
+		bool result = YamlLoader.Load(ctx, showErrorWindow: false);
 
 		// Then the layout engine is not loaded
 		Assert.True(result);

--- a/src/Whim.Yaml.Tests/Layouts/YamlLayoutEngineLoader_SliceLayoutEngineTests.cs
+++ b/src/Whim.Yaml.Tests/Layouts/YamlLayoutEngineLoader_SliceLayoutEngineTests.cs
@@ -48,7 +48,7 @@ public class YamlLayoutEngineLoader_SliceLayoutEngineTests
 		YamlLoaderTestUtils.SetupFileConfig(ctx, config, isYaml);
 
 		// When loading the layout engine
-		bool result = YamlLoader.Load(ctx);
+		bool result = YamlLoader.Load(ctx, showErrorWindow: false);
 
 		// Then the layout engine is loaded
 		Assert.True(result);
@@ -98,7 +98,7 @@ public class YamlLayoutEngineLoader_SliceLayoutEngineTests
 		YamlLoaderTestUtils.SetupFileConfig(ctx, config, isYaml);
 
 		// When loading the layout engine
-		bool result = YamlLoader.Load(ctx);
+		bool result = YamlLoader.Load(ctx, showErrorWindow: false);
 
 		// Then the layout engine is loaded
 		Assert.True(result);
@@ -148,7 +148,7 @@ public class YamlLayoutEngineLoader_SliceLayoutEngineTests
 		YamlLoaderTestUtils.SetupFileConfig(ctx, config, isYaml);
 
 		// When loading the layout engine
-		bool result = YamlLoader.Load(ctx);
+		bool result = YamlLoader.Load(ctx, showErrorWindow: false);
 
 		// Then the layout engine is loaded
 		Assert.True(result);
@@ -208,7 +208,7 @@ public class YamlLayoutEngineLoader_SliceLayoutEngineTests
 		YamlLoaderTestUtils.SetupFileConfig(ctx, config, isYaml);
 
 		// When loading the layout engine
-		bool result = YamlLoader.Load(ctx);
+		bool result = YamlLoader.Load(ctx, showErrorWindow: false);
 
 		// Then the layout engine is loaded
 		Assert.True(result);
@@ -307,7 +307,7 @@ public class YamlLayoutEngineLoader_SliceLayoutEngineTests
 		YamlLoaderTestUtils.SetupFileConfig(ctx, config, isYaml);
 
 		// When loading the layout engine
-		bool result = YamlLoader.Load(ctx);
+		bool result = YamlLoader.Load(ctx, showErrorWindow: false);
 
 		// Then the layout engine is loaded
 		Assert.True(result);
@@ -360,7 +360,7 @@ public class YamlLayoutEngineLoader_SliceLayoutEngineTests
 		YamlLoaderTestUtils.SetupFileConfig(ctx, config, isYaml);
 
 		// When loading the layout engine
-		bool result = YamlLoader.Load(ctx);
+		bool result = YamlLoader.Load(ctx, showErrorWindow: false);
 
 		// Then the layout engine is not loaded
 		Assert.True(result);

--- a/src/Whim.Yaml.Tests/Layouts/YamlLayoutEngineLoader_TreeLayoutEngineTests.cs
+++ b/src/Whim.Yaml.Tests/Layouts/YamlLayoutEngineLoader_TreeLayoutEngineTests.cs
@@ -154,7 +154,7 @@ public class YamlLayoutEngineLoader_TreeLayoutEngineTests
 		ctx.PluginManager.AddPlugin(Arg.Do<TreeLayoutPlugin>(t => plugin = t));
 
 		// When loading the layout engine
-		bool result = YamlLoader.Load(ctx);
+		bool result = YamlLoader.Load(ctx, showErrorWindow: false);
 
 		// Then the tree layout engine should be updated
 		Assert.True(result);

--- a/src/Whim.Yaml.Tests/Plugins/YamlLoader_LoadBarPluginTests.cs
+++ b/src/Whim.Yaml.Tests/Plugins/YamlLoader_LoadBarPluginTests.cs
@@ -53,7 +53,7 @@ public class YamlLoader_LoadBarPluginTests
 		YamlLoaderTestUtils.SetupFileConfig(ctx, schema, isYaml);
 
 		// When loading the config
-		bool result = YamlLoader.Load(ctx);
+		bool result = YamlLoader.Load(ctx, showErrorWindow: false);
 
 		// Then the result is true, and the bar plugin is loaded
 		Assert.True(result);
@@ -94,7 +94,7 @@ public class YamlLoader_LoadBarPluginTests
 		YamlLoaderTestUtils.SetupFileConfig(ctx, schema, isYaml);
 
 		// When loading the config
-		bool result = YamlLoader.Load(ctx);
+		bool result = YamlLoader.Load(ctx, showErrorWindow: false);
 
 		// Then the result is true, and the bar plugin is not loaded
 		Assert.True(result);
@@ -135,7 +135,7 @@ public class YamlLoader_LoadBarPluginTests
 		YamlLoaderTestUtils.SetupFileConfig(ctx, schema, isYaml);
 
 		// When loading the config
-		bool result = YamlLoader.Load(ctx);
+		bool result = YamlLoader.Load(ctx, showErrorWindow: false);
 
 		// Then the result is false, and the bar plugin is not loaded
 		Assert.True(result);
@@ -176,7 +176,7 @@ public class YamlLoader_LoadBarPluginTests
 		YamlLoaderTestUtils.SetupFileConfig(ctx, schema, isYaml);
 
 		// When loading the config
-		bool result = YamlLoader.Load(ctx);
+		bool result = YamlLoader.Load(ctx, showErrorWindow: false);
 
 		// Then the result is true, and the bar plugin has the height
 		Assert.True(result);
@@ -225,7 +225,7 @@ public class YamlLoader_LoadBarPluginTests
 		YamlLoaderTestUtils.SetupFileConfig(ctx, schema, isYaml);
 
 		// When loading the config
-		bool result = YamlLoader.Load(ctx);
+		bool result = YamlLoader.Load(ctx, showErrorWindow: false);
 
 		// Then the result is true, and the bar plugin has the active layout widget
 		Assert.True(result);
@@ -277,7 +277,7 @@ public class YamlLoader_LoadBarPluginTests
 		YamlLoaderTestUtils.SetupFileConfig(ctx, schema, isYaml);
 
 		// When loading the config
-		bool result = YamlLoader.Load(ctx);
+		bool result = YamlLoader.Load(ctx, showErrorWindow: false);
 
 		// Then the result is true, and the bar plugin has the battery widget
 		Assert.True(result);
@@ -379,7 +379,7 @@ public class YamlLoader_LoadBarPluginTests
 		YamlLoaderTestUtils.SetupFileConfig(ctx, schema, isYaml);
 
 		// When loading the config
-		bool result = YamlLoader.Load(ctx);
+		bool result = YamlLoader.Load(ctx, showErrorWindow: false);
 
 		// Then the result is true, and the bar plugin has the date and time widget
 		Assert.True(result);
@@ -481,7 +481,7 @@ public class YamlLoader_LoadBarPluginTests
 		YamlLoaderTestUtils.SetupFileConfig(ctx, schema, isYaml);
 
 		// When loading the config
-		bool result = YamlLoader.Load(ctx);
+		bool result = YamlLoader.Load(ctx, showErrorWindow: false);
 
 		// Then the result is true, and the bar plugin has the focused window widget
 		Assert.True(result);
@@ -544,7 +544,7 @@ public class YamlLoader_LoadBarPluginTests
 		YamlLoaderTestUtils.SetupFileConfig(ctx, schema, isYaml);
 
 		// When loading the config
-		bool result = YamlLoader.Load(ctx);
+		bool result = YamlLoader.Load(ctx, showErrorWindow: false);
 
 		// Then the result is true, and the bar plugin has the workspace widget
 		Assert.True(result);
@@ -596,7 +596,7 @@ public class YamlLoader_LoadBarPluginTests
 		YamlLoaderTestUtils.SetupFileConfig(ctx, schema, isYaml);
 
 		// When loading the config
-		bool result = YamlLoader.Load(ctx);
+		bool result = YamlLoader.Load(ctx, showErrorWindow: false);
 
 		// Then the result is true, and the bar plugin has the tree layout engine widget
 		Assert.True(result);
@@ -676,7 +676,7 @@ public class YamlLoader_LoadBarPluginTests
 		YamlLoaderTestUtils.SetupFileConfig(ctx, schema, isYaml);
 
 		// When loading the config
-		bool result = YamlLoader.Load(ctx);
+		bool result = YamlLoader.Load(ctx, showErrorWindow: false);
 
 		// Then the result is true, and the bar plugin has the multiple components
 		Assert.True(result);

--- a/src/Whim.Yaml.Tests/Plugins/YamlLoader_LoadCommandPalettePluginTests.cs
+++ b/src/Whim.Yaml.Tests/Plugins/YamlLoader_LoadCommandPalettePluginTests.cs
@@ -124,7 +124,7 @@ public class YamlPluginLoader_LoadCommandPalettePluginTests
 		YamlLoaderTestUtils.SetupFileConfig(ctx, schema, isYaml);
 
 		// When loading the config
-		bool result = YamlLoader.Load(ctx);
+		bool result = YamlLoader.Load(ctx, showErrorWindow: false);
 
 		// Then the result is true, and the command palette plugin is set
 		Assert.True(result);
@@ -333,7 +333,7 @@ public class YamlPluginLoader_LoadCommandPalettePluginTests
 		YamlLoaderTestUtils.SetupFileConfig(ctx, schema, isYaml);
 
 		// When loading the config
-		bool result = YamlLoader.Load(ctx);
+		bool result = YamlLoader.Load(ctx, showErrorWindow: false);
 
 		// Then the result is true, and the command palette plugin is set
 		Assert.True(result);
@@ -381,7 +381,7 @@ public class YamlPluginLoader_LoadCommandPalettePluginTests
 		YamlLoaderTestUtils.SetupFileConfig(ctx, schema, isYaml);
 
 		// When loading the config
-		bool result = YamlLoader.Load(ctx);
+		bool result = YamlLoader.Load(ctx, showErrorWindow: false);
 
 		// Then the result is true, and the command palette plugin is not set
 		Assert.True(result);
@@ -445,7 +445,7 @@ public class YamlPluginLoader_LoadCommandPalettePluginTests
 		YamlLoaderTestUtils.SetupFileConfig(ctx, schema, isYaml);
 
 		// When loading the config
-		bool result = YamlLoader.Load(ctx);
+		bool result = YamlLoader.Load(ctx, showErrorWindow: false);
 
 		// Then the result is true, and the command palette plugin is not set
 		Assert.True(result);
@@ -492,7 +492,7 @@ public class YamlPluginLoader_LoadCommandPalettePluginTests
 		ctx.PluginManager.LoadedPlugins.Returns([treeLayoutPlugin]);
 
 		// When loading the config
-		bool result = YamlLoader.Load(ctx);
+		bool result = YamlLoader.Load(ctx, showErrorWindow: false);
 
 		// Then the result is true, and the tree layout command palette plugin is set
 		Assert.True(result);

--- a/src/Whim.Yaml.Tests/Plugins/YamlLoader_LoadFloatingWindowPluginTests.cs
+++ b/src/Whim.Yaml.Tests/Plugins/YamlLoader_LoadFloatingWindowPluginTests.cs
@@ -41,7 +41,7 @@ public class YamlLoader_LoadFloatingWindowPluginTests
 		YamlLoaderTestUtils.SetupFileConfig(ctx, config, isYaml);
 
 		// When loading the config
-		bool result = YamlLoader.Load(ctx);
+		bool result = YamlLoader.Load(ctx, showErrorWindow: false);
 
 		// Then the result is true, and the floating window plugin is added
 		Assert.True(result);
@@ -104,7 +104,7 @@ public class YamlLoader_LoadFloatingWindowPluginTests
 		YamlLoaderTestUtils.SetupFileConfig(ctx, config, isYaml);
 
 		// When loading the config
-		bool result = YamlLoader.Load(ctx);
+		bool result = YamlLoader.Load(ctx, showErrorWindow: false);
 
 		// Then the result is true, and the floating window plugin is not added
 		Assert.True(result);

--- a/src/Whim.Yaml.Tests/Plugins/YamlLoader_LoadFocusIndicatorPluginTests.cs
+++ b/src/Whim.Yaml.Tests/Plugins/YamlLoader_LoadFocusIndicatorPluginTests.cs
@@ -173,7 +173,7 @@ public class YamlLoader_LoadFocusIndicatorPluginTests
 		YamlLoaderTestUtils.SetupFileConfig(ctx, config, isYaml);
 
 		// When loading the config
-		bool result = YamlLoader.Load(ctx);
+		bool result = YamlLoader.Load(ctx, showErrorWindow: false);
 
 		// Then the focus indicator configuration is loaded
 		Assert.True(result);
@@ -221,7 +221,7 @@ public class YamlLoader_LoadFocusIndicatorPluginTests
 		YamlLoaderTestUtils.SetupFileConfig(ctx, config, isYaml);
 
 		// When loading the config
-		bool result = YamlLoader.Load(ctx);
+		bool result = YamlLoader.Load(ctx, showErrorWindow: false);
 
 		// Then the focus indicator configuration is not loaded
 		Assert.True(result);

--- a/src/Whim.Yaml.Tests/Plugins/YamlLoader_LoadGapsPluginTests.cs
+++ b/src/Whim.Yaml.Tests/Plugins/YamlLoader_LoadGapsPluginTests.cs
@@ -97,7 +97,7 @@ public class YamlLoader_LoadGapsPluginTests
 		YamlLoaderTestUtils.SetupFileConfig(ctx, config, isYaml);
 
 		// When loading the config
-		bool result = YamlLoader.Load(ctx);
+		bool result = YamlLoader.Load(ctx, showErrorWindow: false);
 
 		// Then the result is true, and the gaps plugin is set
 		Assert.True(result);
@@ -146,7 +146,7 @@ public class YamlLoader_LoadGapsPluginTests
 		YamlLoaderTestUtils.SetupFileConfig(ctx, config, isYaml);
 
 		// When loading the config
-		bool result = YamlLoader.Load(ctx);
+		bool result = YamlLoader.Load(ctx, showErrorWindow: false);
 
 		// Then the result is true, and the gaps plugin is not set
 		Assert.True(result);
@@ -275,7 +275,7 @@ public class YamlLoader_LoadGapsPluginTests
 		YamlLoaderTestUtils.SetupFileConfig(ctx, config, isYaml);
 
 		// When loading the config
-		bool result = YamlLoader.Load(ctx);
+		bool result = YamlLoader.Load(ctx, showErrorWindow: false);
 
 		// Then the result is false, and the gaps plugin is not set
 		Assert.True(result);

--- a/src/Whim.Yaml.Tests/Plugins/YamlLoader_LoadLayoutPreviewPluginTests.cs
+++ b/src/Whim.Yaml.Tests/Plugins/YamlLoader_LoadLayoutPreviewPluginTests.cs
@@ -64,7 +64,7 @@ public class YamlLoader_LoadLayoutPreviewPluginTests
 		YamlLoaderTestUtils.SetupFileConfig(ctx, yaml, isYaml);
 
 		// When loading the config
-		bool result = YamlLoader.Load(ctx);
+		bool result = YamlLoader.Load(ctx, showErrorWindow: false);
 
 		// Then the result is true, and the layout preview plugin is set
 		Assert.True(result);
@@ -105,7 +105,7 @@ public class YamlLoader_LoadLayoutPreviewPluginTests
 		YamlLoaderTestUtils.SetupFileConfig(ctx, schema, isYaml);
 
 		// When loading the config
-		bool result = YamlLoader.Load(ctx);
+		bool result = YamlLoader.Load(ctx, showErrorWindow: false);
 
 		// Then the result is true, and the layout preview plugin is not set
 		Assert.True(result);

--- a/src/Whim.Yaml.Tests/Plugins/YamlLoader_LoadSliceLayoutPluginTests.cs
+++ b/src/Whim.Yaml.Tests/Plugins/YamlLoader_LoadSliceLayoutPluginTests.cs
@@ -60,7 +60,7 @@ public class YamlPluginLoader_LoadSliceLayoutPluginTests
 		YamlLoaderTestUtils.SetupFileConfig(ctx, schema, isYaml);
 
 		// When loading the config
-		bool result = YamlLoader.Load(ctx);
+		bool result = YamlLoader.Load(ctx, showErrorWindow: false);
 
 		// Then the result is true, and the slice layout plugin is set
 		Assert.True(result);
@@ -101,7 +101,7 @@ public class YamlPluginLoader_LoadSliceLayoutPluginTests
 		YamlLoaderTestUtils.SetupFileConfig(ctx, schema, isYaml);
 
 		// When loading the config
-		bool result = YamlLoader.Load(ctx);
+		bool result = YamlLoader.Load(ctx, showErrorWindow: false);
 
 		// Then the result is true, and the slice layout plugin is not set
 		Assert.True(result);
@@ -142,7 +142,7 @@ public class YamlPluginLoader_LoadSliceLayoutPluginTests
 		YamlLoaderTestUtils.SetupFileConfig(ctx, schema, isYaml);
 
 		// When loading the config
-		bool result = YamlLoader.Load(ctx);
+		bool result = YamlLoader.Load(ctx, showErrorWindow: false);
 
 		// Then the result is false, and the slice layout plugin is not set
 		Assert.True(result);

--- a/src/Whim.Yaml.Tests/Plugins/YamlLoader_LoadTreeLayoutPluginTests.cs
+++ b/src/Whim.Yaml.Tests/Plugins/YamlLoader_LoadTreeLayoutPluginTests.cs
@@ -60,7 +60,7 @@ public class YamlPluginLoader_TreeLayoutPluginTests
 		YamlLoaderTestUtils.SetupFileConfig(ctx, schema, isYaml);
 
 		// When loading the config
-		bool result = YamlLoader.Load(ctx);
+		bool result = YamlLoader.Load(ctx, showErrorWindow: false);
 
 		// Then the result is true, and the tree layout plugin is set
 		Assert.True(result);
@@ -101,7 +101,7 @@ public class YamlPluginLoader_TreeLayoutPluginTests
 		YamlLoaderTestUtils.SetupFileConfig(ctx, schema, isYaml);
 
 		// When loading the config
-		bool result = YamlLoader.Load(ctx);
+		bool result = YamlLoader.Load(ctx, showErrorWindow: false);
 
 		// Then the result is true, and the tree layout plugin is not set
 		Assert.True(result);
@@ -142,7 +142,7 @@ public class YamlPluginLoader_TreeLayoutPluginTests
 		YamlLoaderTestUtils.SetupFileConfig(ctx, schema, isYaml);
 
 		// When loading the config
-		bool result = YamlLoader.Load(ctx);
+		bool result = YamlLoader.Load(ctx, showErrorWindow: false);
 
 		// Then the result is false, and the tree layout plugin is not set
 		Assert.True(result);

--- a/src/Whim.Yaml.Tests/Plugins/YamlLoader_LoadUpdaterPluginTests.cs
+++ b/src/Whim.Yaml.Tests/Plugins/YamlLoader_LoadUpdaterPluginTests.cs
@@ -78,7 +78,7 @@ public class YamlLoader_LoadUpdaterPluginTests
 		YamlLoaderTestUtils.SetupFileConfig(ctx, schema, isYaml);
 
 		// When loading the config
-		bool result = YamlLoader.Load(ctx);
+		bool result = YamlLoader.Load(ctx, showErrorWindow: false);
 
 		// Then the updater plugin is loaded
 		Assert.True(result);
@@ -168,7 +168,7 @@ public class YamlLoader_LoadUpdaterPluginTests
 		YamlLoaderTestUtils.SetupFileConfig(ctx, schema, isYaml);
 
 		// When loading the config
-		bool result = YamlLoader.Load(ctx);
+		bool result = YamlLoader.Load(ctx, showErrorWindow: false);
 
 		// Then the updater plugin is not loaded
 		Assert.True(result);

--- a/src/Whim.Yaml.Tests/YamlLoader/YamlLoaderTests.cs
+++ b/src/Whim.Yaml.Tests/YamlLoader/YamlLoaderTests.cs
@@ -39,7 +39,7 @@ public class YamlLoaderTests
 	{
 		// Given no config file exists
 		// When
-		bool result = YamlLoader.Load(ctx);
+		bool result = YamlLoader.Load(ctx, showErrorWindow: false);
 
 		// Then
 		Assert.False(result);
@@ -55,7 +55,7 @@ public class YamlLoaderTests
 		ctx.FileManager.ReadAllText(Arg.Any<string>()).Returns(yaml);
 
 		// When loading the config
-		bool result = YamlLoader.Load(ctx);
+		bool result = YamlLoader.Load(ctx, showErrorWindow: false);
 
 		// Then the result is true, and no keybinds are set
 		Assert.True(result);
@@ -71,7 +71,7 @@ public class YamlLoaderTests
 		ctx.FileManager.ReadAllText(Arg.Any<string>()).Returns(json);
 
 		// When loading the config
-		bool result = YamlLoader.Load(ctx);
+		bool result = YamlLoader.Load(ctx, showErrorWindow: false);
 
 		// Then the result is true, and no keybinds are set
 		Assert.True(result);
@@ -87,7 +87,7 @@ public class YamlLoaderTests
 		ctx.FileManager.ReadAllText(Arg.Any<string>()).Returns(yaml);
 
 		// When loading the config
-		bool result = YamlLoader.Load(ctx);
+		bool result = YamlLoader.Load(ctx, showErrorWindow: false);
 
 		// Then the result is false, and no keybinds are set
 		Assert.False(result);

--- a/src/Whim.Yaml.Tests/YamlLoader/YamlLoader_LoadFiltersTests.cs
+++ b/src/Whim.Yaml.Tests/YamlLoader/YamlLoader_LoadFiltersTests.cs
@@ -60,7 +60,7 @@ public class YamlLoader_LoadFiltersTests
 		YamlLoaderTestUtils.SetupFileConfig(ctx, config, isYaml);
 
 		// When loading the config
-		bool result = YamlLoader.Load(ctx);
+		bool result = YamlLoader.Load(ctx, showErrorWindow: false);
 
 		// Then the filters should be updated
 		Assert.True(result);
@@ -124,7 +124,7 @@ public class YamlLoader_LoadFiltersTests
 		YamlLoaderTestUtils.SetupFileConfig(ctx, config, isYaml);
 
 		// When loading the config
-		bool result = YamlLoader.Load(ctx);
+		bool result = YamlLoader.Load(ctx, showErrorWindow: false);
 
 		// Then the filters should not be updated
 		Assert.True(result);

--- a/src/Whim.Yaml.Tests/YamlLoader/YamlLoader_LoadKeybindsTests.cs
+++ b/src/Whim.Yaml.Tests/YamlLoader/YamlLoader_LoadKeybindsTests.cs
@@ -55,7 +55,7 @@ public class YamlLoader_LoadKeybindsTests
 		YamlLoaderTestUtils.SetupFileConfig(ctx, config, isYaml);
 
 		// When loading the config
-		bool result = YamlLoader.Load(ctx);
+		bool result = YamlLoader.Load(ctx, showErrorWindow: false);
 
 		// Then the result is true, and keybinds are set
 		Assert.True(result);
@@ -157,7 +157,7 @@ public class YamlLoader_LoadKeybindsTests
 		YamlLoaderTestUtils.SetupFileConfig(ctx, config, isYaml);
 
 		// When loading the config
-		bool result = YamlLoader.Load(ctx);
+		bool result = YamlLoader.Load(ctx, showErrorWindow: false);
 
 		// Then the result is true, and no keybinds are set
 		Assert.True(result);
@@ -210,7 +210,7 @@ public class YamlLoader_LoadKeybindsTests
 		YamlLoaderTestUtils.SetupFileConfig(ctx, config, isYaml);
 
 		// When loading the config
-		bool result = YamlLoader.Load(ctx);
+		bool result = YamlLoader.Load(ctx, showErrorWindow: false);
 
 		// Then the result is true, and unifyKeyModifiers is set
 		Assert.True(result);

--- a/src/Whim.Yaml.Tests/YamlLoader/YamlLoader_LoadRoutersTests.cs
+++ b/src/Whim.Yaml.Tests/YamlLoader/YamlLoader_LoadRoutersTests.cs
@@ -68,7 +68,7 @@ public class YamlLoader_LoadRoutersTests
 		YamlLoaderTestUtils.SetupFileConfig(ctx, config, isYaml);
 
 		// When loading the config
-		bool result = YamlLoader.Load(ctx);
+		bool result = YamlLoader.Load(ctx, showErrorWindow: false);
 
 		// Then the routers are updated
 		Assert.True(result);
@@ -116,7 +116,7 @@ public class YamlLoader_LoadRoutersTests
 		YamlLoaderTestUtils.SetupFileConfig(ctx, config, isYaml);
 
 		// When loading the config
-		bool result = YamlLoader.Load(ctx);
+		bool result = YamlLoader.Load(ctx, showErrorWindow: false);
 
 		// Then the routers are not updated
 		Assert.True(result);
@@ -147,7 +147,7 @@ public class YamlLoader_LoadRoutersTests
 		ctx.FileManager.ReadAllText(Arg.Any<string>()).Returns(config);
 
 		// When loading the config
-		bool result = YamlLoader.Load(ctx);
+		bool result = YamlLoader.Load(ctx, showErrorWindow: false);
 
 		// Then the router option is updated
 		Assert.True(result);
@@ -166,7 +166,7 @@ public class YamlLoader_LoadRoutersTests
 		ctx.FileManager.ReadAllText(Arg.Any<string>()).Returns(config);
 
 		// When loading the config
-		bool result = YamlLoader.Load(ctx);
+		bool result = YamlLoader.Load(ctx, showErrorWindow: false);
 
 		// Then the router option is not updated
 		Assert.True(result);

--- a/src/Whim.Yaml.Tests/YamlLoader/YamlLoader_LoadWorkspacesTests.cs
+++ b/src/Whim.Yaml.Tests/YamlLoader/YamlLoader_LoadWorkspacesTests.cs
@@ -69,7 +69,7 @@ public class YamlLoader_LoadWorkspacesTests
 		YamlLoaderTestUtils.SetupFileConfig(ctx, config, isYaml);
 
 		// When loading the workspaces
-		bool result = YamlLoader.Load(ctx);
+		bool result = YamlLoader.Load(ctx, showErrorWindow: false);
 
 		// Then the workspaces are loaded
 		Assert.True(result);
@@ -141,7 +141,7 @@ public class YamlLoader_LoadWorkspacesTests
 		YamlLoaderTestUtils.SetupFileConfig(ctx, config, isYaml);
 
 		// When loading the workspaces
-		bool result = YamlLoader.Load(ctx);
+		bool result = YamlLoader.Load(ctx, showErrorWindow: false);
 
 		// Then the workspaces are loaded
 		Assert.True(result);

--- a/src/Whim.Yaml/ErrorWindow.xaml
+++ b/src/Whim.Yaml/ErrorWindow.xaml
@@ -13,24 +13,25 @@
 			VerticalAlignment="Center"
 			Spacing="12">
 
-			<TextBlock FontSize="20"
-					Text="Whim encountered errors while parsing the YAML/JSON config:"/>
+			<TextBlock FontSize="20" Text="Whim encountered and ignored errors with the YAML/JSON config:" />
 
 			<!--  Text block  -->
-			<StackPanel Padding="20"
-					CornerRadius="8">
+			<StackPanel Padding="20" CornerRadius="8">
 				<TextBlock
 					FontFamily="Cascadia Code"
 					IsTextSelectionEnabled="True"
 					LineHeight="20"
 					Text="{x:Bind Message}"
-					TextWrapping="WrapWholeWords"/>
+					TextWrapping="WrapWholeWords" />
 			</StackPanel>
 
 			<!--  Quit button  -->
-			<StackPanel HorizontalAlignment="Right">
-				<Button x:Name="Quit"
-						Click="Quit_Click">Quit</Button>
+			<StackPanel
+				HorizontalAlignment="Right"
+				Orientation="Horizontal"
+				Spacing="2">
+				<Button x:Name="Ignore" Click="Ignore_Click">Ignore</Button>
+				<Button x:Name="Quit" Click="Quit_Click">Quit</Button>
 			</StackPanel>
 
 		</StackPanel>

--- a/src/Whim.Yaml/ErrorWindow.xaml
+++ b/src/Whim.Yaml/ErrorWindow.xaml
@@ -1,0 +1,38 @@
+﻿<Window
+	x:Class="Whim.Yaml.ErrorWindow"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	mc:Ignorable="d">
+
+	<Grid>
+		<StackPanel
+			MaxWidth="1200"
+			Margin="24"
+			VerticalAlignment="Center"
+			Spacing="12">
+
+			<TextBlock FontSize="20"
+					Text="Whim encountered errors while parsing the YAML/JSON config:"/>
+
+			<!--  Text block  -->
+			<StackPanel Padding="20"
+					CornerRadius="8">
+				<TextBlock
+					FontFamily="Cascadia Code"
+					IsTextSelectionEnabled="True"
+					LineHeight="20"
+					Text="{x:Bind Message}"
+					TextWrapping="WrapWholeWords"/>
+			</StackPanel>
+
+			<!--  Quit button  -->
+			<StackPanel HorizontalAlignment="Right">
+				<Button x:Name="Quit"
+						Click="Quit_Click">Quit</Button>
+			</StackPanel>
+
+		</StackPanel>
+	</Grid>
+</Window>

--- a/src/Whim.Yaml/ErrorWindow.xaml.cs
+++ b/src/Whim.Yaml/ErrorWindow.xaml.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using Microsoft.UI.Xaml;
+
+namespace Whim.Yaml;
+
+/// <summary>
+/// Exposes YAML errors encountered during parsing to the user.
+/// </summary>
+public sealed partial class ErrorWindow : Microsoft.UI.Xaml.Window, IDisposable
+{
+	private readonly IContext _ctx;
+	private readonly WindowBackdropController _backdropController;
+
+	/// <summary>
+	/// The errors.
+	/// </summary>
+	public string Message { get; }
+
+	/// <summary>
+	/// Exposes YAML errors encountered during parsing to the user.
+	/// </summary>
+	/// <param name="ctx">The context.</param>
+	/// <param name="errors">The YAML errors.</param>
+	public ErrorWindow(IContext ctx, string errors)
+	{
+		UIElementExtensions.InitializeComponent(this, "Whim.Yaml", "ErrorWindow");
+
+		_ctx = ctx;
+
+		Title = "Whim YAML/JSON error";
+		Message = errors;
+
+		_backdropController = new(this, new WindowBackdropConfig(BackdropType.Mica, AlwaysShowBackdrop: false));
+	}
+
+	private void Quit_Click(object sender, RoutedEventArgs e)
+	{
+		Close();
+		_ctx.Exit(new ExitEventArgs() { Reason = ExitReason.Error, Message = Message });
+	}
+
+	/// <inheritdoc/>
+	public void Dispose()
+	{
+		_backdropController.Dispose();
+	}
+}

--- a/src/Whim.Yaml/ErrorWindow.xaml.cs
+++ b/src/Whim.Yaml/ErrorWindow.xaml.cs
@@ -28,15 +28,22 @@ public sealed partial class ErrorWindow : Microsoft.UI.Xaml.Window, IDisposable
 		_ctx = ctx;
 
 		Title = "Whim YAML/JSON error";
+
+		ctx.FilterManager.AddTitleFilter(this.Title);
 		Message = errors;
 
 		_backdropController = new(this, new WindowBackdropConfig(BackdropType.Mica, AlwaysShowBackdrop: false));
 	}
 
+	private void Ignore_Click(object sender, RoutedEventArgs e)
+	{
+		Close();
+	}
+
 	private void Quit_Click(object sender, RoutedEventArgs e)
 	{
 		Close();
-		_ctx.Exit(new ExitEventArgs() { Reason = ExitReason.Error, Message = Message });
+		_ctx.Exit(new ExitEventArgs() { Reason = ExitReason.User, Message = Message });
 	}
 
 	/// <inheritdoc/>

--- a/src/Whim.Yaml/Whim.Yaml.csproj
+++ b/src/Whim.Yaml/Whim.Yaml.csproj
@@ -28,7 +28,6 @@
 		<UseWinUI>true</UseWinUI>
 		<Version>0.7.0</Version>
 	</PropertyGroup>
-
 	<ItemGroup>
 		<ProjectReference Include="..\Whim.Bar\Whim.Bar.csproj" />
 		<ProjectReference Include="..\Whim.CommandPalette\Whim.CommandPalette.csproj" />
@@ -53,6 +52,16 @@
 		<PackageReference Include="Corvus.Json.ExtendedTypes" />
 		<PackageReference Include="Yaml2JsonNode" />
 		<PackageReference Include="YamlDotNet" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<None Remove="ErrorWindow.xaml" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<Page Update="ErrorWindow.xaml">
+			<Generator>MSBuild:Compile</Generator>
+		</Page>
 	</ItemGroup>
 
 	<Target Name="GenerateSchema" BeforeTargets="BeforeCompile">

--- a/src/Whim.Yaml/YamlLoader.cs
+++ b/src/Whim.Yaml/YamlLoader.cs
@@ -81,9 +81,18 @@ public static class YamlLoader
 		}
 
 		StringBuilder sb = new();
+		int idx = 0;
 		foreach (ValidationResult error in result.Results)
 		{
+			if (error.Valid)
+			{
+				continue;
+			}
+
+			sb.AppendFormat("Error {0}:\n", idx + 1);
 			sb.AppendLine(error.Message);
+			sb.AppendFormat("Violated {0}\n", error.Location.TryGetValue(out var location) ? location.ValidationLocation.ToString() : "unknown schema");
+			idx += 1;
 		}
 		string errors = sb.ToString();
 

--- a/src/Whim.Yaml/YamlLoader.cs
+++ b/src/Whim.Yaml/YamlLoader.cs
@@ -1,3 +1,4 @@
+using System.Text;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using Corvus.Json;
@@ -27,6 +28,8 @@ public static class YamlLoader
 		{
 			return false;
 		}
+
+		ValidateConfig(ctx, schema);
 
 		UpdateWorkspaces(ctx, schema);
 
@@ -67,6 +70,25 @@ public static class YamlLoader
 
 		Logger.Debug("No configuration file found.");
 		return null;
+	}
+
+	private static void ValidateConfig(IContext ctx, Schema schema)
+	{
+		ValidationContext result = schema.Validate(ValidationContext.ValidContext, ValidationLevel.Detailed);
+		if (result.IsValid)
+		{
+			return;
+		}
+
+		StringBuilder sb = new();
+		foreach (ValidationResult error in result.Results)
+		{
+			sb.AppendLine(error.Message);
+		}
+		string errors = sb.ToString();
+
+		using ErrorWindow window = new(ctx, errors);
+		window.Activate();
 	}
 
 	private static void UpdateWorkspaces(IContext ctx, Schema schema)

--- a/src/Whim.Yaml/YamlLoader.cs
+++ b/src/Whim.Yaml/YamlLoader.cs
@@ -91,10 +91,16 @@ public static class YamlLoader
 
 			sb.AppendFormat("Error {0}:\n", idx + 1);
 			sb.AppendLine(error.Message);
-			sb.AppendFormat("Violated {0}\n", error.Location.TryGetValue(out var location) ? location.ValidationLocation.ToString() : "unknown schema");
+			sb.AppendFormat(
+				"Violated {0}\n",
+				error.Location.TryGetValue(out var location) ? location.ValidationLocation.ToString() : "unknown schema"
+			);
 			idx += 1;
 		}
 		string errors = sb.ToString();
+
+		Logger.Error("Configuration file is not valid.");
+		Logger.Error(errors);
 
 		using ErrorWindow window = new(ctx, errors);
 		window.Activate();

--- a/src/Whim.Yaml/YamlLoader.cs
+++ b/src/Whim.Yaml/YamlLoader.cs
@@ -19,17 +19,21 @@ public static class YamlLoader
 	/// Loads and applies the declarative configuration from a JSON or YAML file.
 	/// </summary>
 	/// <param name="ctx">The <see cref="IContext"/> to operate on.</param>
+	/// <param name="showErrorWindow">Whether to show an error window if the configuration is invalid.</param>
 	/// <returns>
 	/// <see langword="true"/> if the configuration was parsed successfully; otherwise, <see langword="false"/>.
 	/// </returns>
-	public static bool Load(IContext ctx)
+	public static bool Load(IContext ctx, bool showErrorWindow = true)
 	{
 		if (Parse(ctx) is not Schema schema)
 		{
 			return false;
 		}
 
-		ValidateConfig(ctx, schema);
+		if (showErrorWindow)
+		{
+			ValidateConfig(ctx, schema);
+		}
 
 		UpdateWorkspaces(ctx, schema);
 


### PR DESCRIPTION
While parsing the YAML/JSON config, errors will be surfaced in the logs and in a dedicated window.
