### PR TITLE
Prevent crashes when creating new workspaces with a YAML config

### DIFF
--- a/src/Whim.TreeLayout.Tests/TreeLayoutPluginTests.cs
+++ b/src/Whim.TreeLayout.Tests/TreeLayoutPluginTests.cs
@@ -207,6 +207,7 @@ public class TreeLayoutPluginTests
 	public void SetAddWindowDirection_DirectionNotSet(IContext ctx, IMonitor monitor, IWorkspace workspace)
 	{
 		// Given
+		NativeManagerUtils.SetupTryEnqueue(ctx);
 		ctx.Butler.Pantry.GetWorkspaceForMonitor(monitor).Returns(workspace);
 
 		TreeLayoutPlugin plugin = new(ctx);
@@ -236,6 +237,7 @@ public class TreeLayoutPluginTests
 	public void SetAddWindowDirection_DirectionAlreadySet(IContext ctx, IMonitor monitor, IWorkspace workspace)
 	{
 		// Given
+		NativeManagerUtils.SetupTryEnqueue(ctx);
 		ctx.Butler.Pantry.GetWorkspaceForMonitor(monitor).Returns(workspace);
 
 		TreeLayoutPlugin plugin = new(ctx);

--- a/src/Whim.TreeLayout/TreeLayoutPlugin.cs
+++ b/src/Whim.TreeLayout/TreeLayoutPlugin.cs
@@ -76,14 +76,18 @@ public class TreeLayoutPlugin(IContext context) : ITreeLayoutPlugin
 			: DefaultAddNodeDirection;
 
 		_addNodeDirections[engine.Identity] = direction;
-		AddWindowDirectionChanged?.Invoke(
-			this,
-			new AddWindowDirectionChangedEventArgs()
-			{
-				CurrentDirection = direction,
-				PreviousDirection = previousDirection,
-				TreeLayoutEngine = engine,
-			}
+
+		context.NativeManager.TryEnqueue(
+			() =>
+				AddWindowDirectionChanged?.Invoke(
+					this,
+					new AddWindowDirectionChangedEventArgs()
+					{
+						CurrentDirection = direction,
+						PreviousDirection = previousDirection,
+						TreeLayoutEngine = engine,
+					}
+				)
 		);
 	}
 


### PR DESCRIPTION
This PR fixes a critical crash which would occur when creating a workspace during runtime (after startup).

The issue was that a `TreeLayoutPlugin` event was not enqueued onto the WinUI dispatcher.
