### PR TITLE
Prevent gaps-triggered shifting for `FloatingLayoutEngine`

### DIFF
--- a/src/Whim.Gaps.Tests/GapsLayoutEngineTests.cs
+++ b/src/Whim.Gaps.Tests/GapsLayoutEngineTests.cs
@@ -1,6 +1,7 @@
 using FluentAssertions;
 using NSubstitute;
 using Whim.FloatingWindow;
+using Whim.SliceLayout;
 using Whim.TestUtils;
 using Windows.Win32.Foundation;
 using Windows.Win32.Graphics.Gdi;
@@ -99,11 +100,18 @@ public class GapsLayoutEngineTests
 	}
 
 	[Theory]
-	[MemberData(nameof(DoLayout_Data))]
-	public void DoLayout(GapsConfig gapsConfig, IWindow[] windows, int scale, IWindowState[] expectedWindowStates)
+	[MemberAutoSubstituteData(nameof(DoLayout_Data))]
+	public void DoLayout(
+		GapsConfig gapsConfig,
+		IWindow[] windows,
+		int scale,
+		IWindowState[] expectedWindowStates,
+		ISliceLayoutPlugin sliceLayoutPlugin,
+		IContext ctx
+	)
 	{
 		// Given
-		ILayoutEngine innerLayoutEngine = new ColumnLayoutEngine(_identity);
+		ILayoutEngine innerLayoutEngine = SliceLayouts.CreateRowLayout(ctx, sliceLayoutPlugin, _identity);
 
 		foreach (IWindow w in windows)
 		{

--- a/src/Whim.Gaps.Tests/Whim.Gaps.Tests.csproj
+++ b/src/Whim.Gaps.Tests/Whim.Gaps.Tests.csproj
@@ -44,6 +44,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Whim.Gaps\Whim.Gaps.csproj" />
+    <ProjectReference Include="..\Whim.SliceLayout\Whim.SliceLayout.csproj" />
     <ProjectReference Include="..\Whim.TestUtils\Whim.TestUtils.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
There was special handling for the `ProxyFloatingLayoutEngine`, but `FloatingLayoutEngine` was not included. As a result, windows could shift while using the `FloatingLayoutEngine`. This PR fixes this.
