### PR TITLE
Update WorkspaceWidget to support sticky workspaces

### DIFF
--- a/docs/configure/plugins/bar.md
+++ b/docs/configure/plugins/bar.md
@@ -79,7 +79,10 @@ The `FocusedWindowWidget` displays the title of the focused window.
 
 ### Workspace Widget
 
-The `WorkspaceWidget` displays the name of the current workspace.
+The `WorkspaceWidget` displays:
+
+- the active workspace on the bar's monitor
+- the workspaces which can be opened on the monitor - i.e., [sticky workspaces for the monitor](../core/workspaces.md#sticky-workspaces) and non-sticky workspaces
 
 ### Tree Layout Widget
 

--- a/docs/script/plugins/bar.md
+++ b/docs/script/plugins/bar.md
@@ -34,6 +34,8 @@ List<BarComponent> rightComponents = new()
 - [FocusedWindowWidget](<xref:Whim.Bar.FocusedWindowWidget.CreateComponent(System.Func{Whim.IWindow,System.String})>)
 - [WorkspaceWidget](xref:Whim.Bar.WorkspaceWidget.CreateComponent)
 
+More information about each widget can be found [here](../../configure/plugins/bar.md#widgets).
+
 ## Example Config
 
 ```csharp

--- a/src/Whim.Bar/Workspace/WorkspaceWidgetViewModel.cs
+++ b/src/Whim.Bar/Workspace/WorkspaceWidgetViewModel.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading;
 
 namespace Whim.Bar;
 

--- a/src/Whim.Tests/Store/MapSector/MapPickersTests.cs
+++ b/src/Whim.Tests/Store/MapSector/MapPickersTests.cs
@@ -422,7 +422,7 @@ public class MapPickersTests
 	}
 }
 
-public class PickValidMonitorForWorkspaceTests
+public class PickValidMonitorByWorkspaceTests
 {
 	[Theory, AutoSubstituteData<StoreCustomization>]
 	internal void TargetMonitorIsValid(IContext ctx, MutableRootSector root)
@@ -438,7 +438,7 @@ public class PickValidMonitorForWorkspaceTests
 		);
 
 		// When we get the monitor
-		var result = ctx.Store.Pick(Pickers.PickValidMonitorForWorkspace(workspace.Id, (HMONITOR)1));
+		var result = ctx.Store.Pick(Pickers.PickValidMonitorByWorkspace(workspace.Id, (HMONITOR)1));
 
 		// Then we get the target monitor
 		Assert.True(result.IsSuccessful);
@@ -464,7 +464,7 @@ public class PickValidMonitorForWorkspaceTests
 		);
 
 		// When we try to use monitor 1
-		var result = ctx.Store.Pick(Pickers.PickValidMonitorForWorkspace(workspace.Id, (HMONITOR)1));
+		var result = ctx.Store.Pick(Pickers.PickValidMonitorByWorkspace(workspace.Id, (HMONITOR)1));
 
 		// Then we get monitor 2 since it's the last valid monitor used
 		Assert.True(result.IsSuccessful);
@@ -490,7 +490,7 @@ public class PickValidMonitorForWorkspaceTests
 		);
 
 		// When we try to use monitor 2
-		var result = ctx.Store.Pick(Pickers.PickValidMonitorForWorkspace(workspace.Id, (HMONITOR)2));
+		var result = ctx.Store.Pick(Pickers.PickValidMonitorByWorkspace(workspace.Id, (HMONITOR)2));
 
 		// Then we get monitor 1 as it's the first valid monitor
 		Assert.True(result.IsSuccessful);
@@ -513,7 +513,7 @@ public class PickValidMonitorForWorkspaceTests
 		);
 
 		// When we try to get a valid monitor
-		var result = ctx.Store.Pick(Pickers.PickValidMonitorForWorkspace(workspace.Id));
+		var result = ctx.Store.Pick(Pickers.PickValidMonitorByWorkspace(workspace.Id));
 
 		// Then we get an error since there are no valid monitors and no fallback monitors
 		Assert.False(result.IsSuccessful);
@@ -531,7 +531,7 @@ public class PickValidMonitorForWorkspaceTests
 		root.MonitorSector.ActiveMonitorHandle = (HMONITOR)2;
 
 		// When we don't specify a target monitor
-		var result = ctx.Store.Pick(Pickers.PickValidMonitorForWorkspace(workspace.Id));
+		var result = ctx.Store.Pick(Pickers.PickValidMonitorByWorkspace(workspace.Id));
 
 		// Then we get the active monitor
 		Assert.True(result.IsSuccessful);
@@ -545,7 +545,7 @@ public class PickValidMonitorForWorkspaceTests
 		Guid nonExistentWorkspaceId = Guid.NewGuid();
 
 		// When we try to get a valid monitor
-		var result = ctx.Store.Pick(Pickers.PickValidMonitorForWorkspace(nonExistentWorkspaceId));
+		var result = ctx.Store.Pick(Pickers.PickValidMonitorByWorkspace(nonExistentWorkspaceId));
 
 		// Then we get an error
 		Assert.False(result.IsSuccessful);

--- a/src/Whim.Tests/Store/MapSector/MapPickersTests.cs
+++ b/src/Whim.Tests/Store/MapSector/MapPickersTests.cs
@@ -582,8 +582,8 @@ public class PickStickyWorkspacesByMonitorTests
 		AddMonitorsToManager(ctx, root, monitor);
 
 		root.MapSector.StickyWorkspaceMonitorIndexMap = root
-			.MapSector.StickyWorkspaceMonitorIndexMap.SetItem(workspace1.Id, [0])
-			.SetItem(workspace2.Id, [0]);
+			.MapSector.StickyWorkspaceMonitorIndexMap.SetItem(workspace1.Id, [0, 1])
+			.SetItem(workspace2.Id, [0, 4]);
 
 		// When we get the workspaces for the monitor
 		var result = ctx.Store.Pick(Pickers.PickStickyWorkspacesByMonitor(monitor.Handle));
@@ -617,30 +617,6 @@ public class PickStickyWorkspacesByMonitorTests
 		Assert.Equal(workspace1, result.Value[0]);
 		Assert.Equal(workspace2, result.Value[1]);
 		Assert.Equal(workspace3, result.Value[2]);
-	}
-
-	[Theory, AutoSubstituteData<StoreCustomization>]
-	internal void OrphanedWorkspacesCanGoOnAnyMonitor(IContext ctx, MutableRootSector root)
-	{
-		// Given we have a workspace sticky to a non-existent monitor index
-		var workspace = CreateWorkspace(ctx);
-		AddWorkspacesToManager(ctx, root, workspace);
-
-		IMonitor monitor = CreateMonitor((HMONITOR)1);
-		AddMonitorsToManager(ctx, root, monitor);
-
-		root.MapSector.StickyWorkspaceMonitorIndexMap = root.MapSector.StickyWorkspaceMonitorIndexMap.SetItem(
-			workspace.Id,
-			[99]
-		); // Non-existent monitor index
-
-		// When we get the workspaces for the monitor
-		var result = ctx.Store.Pick(Pickers.PickStickyWorkspacesByMonitor(monitor.Handle));
-
-		// Then the orphaned workspace is included
-		Assert.True(result.IsSuccessful);
-		Assert.Single(result.Value);
-		Assert.Equal(workspace, result.Value[0]);
 	}
 
 	[Theory, AutoSubstituteData<StoreCustomization>]

--- a/src/Whim/Store/MapSector/Transforms/ActivateWorkspaceTransform.cs
+++ b/src/Whim/Store/MapSector/Transforms/ActivateWorkspaceTransform.cs
@@ -31,7 +31,7 @@ public record ActivateWorkspaceTransform(
 		}
 
 		Result<HMONITOR> targetMonitorHandleResult = ctx.Store.Pick(
-			PickValidMonitorForWorkspace(workspace.Id, MonitorHandle)
+			PickValidMonitorByWorkspace(workspace.Id, MonitorHandle)
 		);
 		if (!targetMonitorHandleResult.TryGet(out HMONITOR targetMonitorHandle))
 		{


### PR DESCRIPTION
The `WorkspaceWidget` now shows the workspaces which can be opened on the monitor the `Bar` is open on.

The legacy API was removed from `WorkspaceWidgetViewModel` as part of this work.
