### PR TITLE
Add TeamsWindowProcessor for automatic minimization of compact windows

### DIFF
--- a/docs/intro/troubleshooting.md
+++ b/docs/intro/troubleshooting.md
@@ -4,7 +4,7 @@
 
 Some applications are difficult to manage. Whim will try to manage them as best as it can, but there are some limitations. For example, Firefox will try to remember its size and position, and will fight against Whim's attempts to manage it on first load.
 
-To get around this, Whim has <xref:Whim.IWindowProcessor>s. These are used to tell Whim to ignore specific window messages (see [Event Constants](https://learn.microsoft.com/en-us/windows/win32/winauto/event-constants)). For example, the <xref:Whim.FirefoxWindowProcessor> ignores all events until the first [`EVENT_OBJECT_CLOAKED`](https://learn.microsoft.com/en-us/windows/win32/winauto/event-constants#:~:text=EVENT_OBJECT_CLOAKED) event is received.
+To get around this, Whim has <xref:Whim.IWindowProcessor>s. These are used to tell Whim to ignore specific window messages (see [Event Constants](https://learn.microsoft.com/en-us/windows/win32/winauto/event-constants)). For example, the <xref:Whim.FirefoxWindowProcessor> ignores all events until the first [`EVENT_OBJECT_CLOAKED`](https://learn.microsoft.com/en-us/windows/win32/winauto/event-constants#:~:text=EVENT_OBJECT_CLOAKED) event is received. The <xref:Whim.TeamsWindowProcessor> automatically minimizes any compact mode windows.
 
 ## Window launch locations
 

--- a/src/Whim.Tests/Store/WindowSector/Processors/TeamsWindowProcessorTests.cs
+++ b/src/Whim.Tests/Store/WindowSector/Processors/TeamsWindowProcessorTests.cs
@@ -1,0 +1,67 @@
+using NSubstitute;
+using Whim;
+using Xunit;
+
+public class TeamsWindowProcessorTests
+{
+	[Theory, AutoSubstituteData]
+	public void Create_Failure(IContext ctx, IWindow window)
+	{
+		// Given a window which is not a Teams window
+		window.ProcessFileName.Returns("not-ms-teams.exe");
+
+		// When Create is called
+		IWindowProcessor? processor = TeamsWindowProcessor.Create(ctx, window);
+
+		// Then the processor should be null
+		Assert.Null(processor);
+	}
+
+	[Theory, AutoSubstituteData]
+	public void Create_Success(IContext ctx, IWindow window)
+	{
+		// Given a window which is a Teams window
+		window.ProcessFileName.Returns("ms-teams.exe");
+
+		// When Create is called
+		IWindowProcessor? processor = TeamsWindowProcessor.Create(ctx, window);
+
+		// Then the processor should not be null and its Window property equals the window
+		Assert.NotNull(processor);
+		Assert.Equal(window, processor!.Window);
+	}
+
+	[Theory, AutoSubstituteData]
+	public void ProcessEvent_MinimizesWindow_WhenTitleStartsWithMeetingCompact(IContext ctx, IWindow window)
+	{
+		// Given a Teams window with a title starting with "Meeting compact view"
+		window.ProcessFileName.Returns("ms-teams.exe");
+		window.Title.Returns("Meeting compact view - Sample Meeting");
+
+		IWindowProcessor processor = TeamsWindowProcessor.Create(ctx, window)!;
+
+		// When ProcessEvent is called
+		WindowProcessorResult result = processor.ProcessEvent(0, 0, 0, 0, 0);
+
+		// Then the window should be minimized and result should be Ignore
+		window.Received(1).ShowMinimized();
+		Assert.Equal(WindowProcessorResult.Ignore, result);
+	}
+
+	[Theory, AutoSubstituteData]
+	public void ProcessEvent_DoesNotMinimizeWindow_WhenTitleDoesNotMatch(IContext ctx, IWindow window)
+	{
+		// Given a Teams window with a title not starting with "Meeting compact view"
+		window.ProcessFileName.Returns("ms-teams.exe");
+		window.Title.Returns("Regular Meeting");
+
+		IWindowProcessor processor = TeamsWindowProcessor.Create(ctx, window)!;
+
+		// When ProcessEvent is called
+		WindowProcessorResult result = processor.ProcessEvent(0, 0, 0, 0, 0);
+
+		// Then the window should not be minimized and result should be Process
+		window.DidNotReceive().ShowMinimized();
+		Assert.Equal(WindowProcessorResult.Process, result);
+	}
+}

--- a/src/Whim/Store/WindowSector/Processors/TeamsWindowProcessor.cs
+++ b/src/Whim/Store/WindowSector/Processors/TeamsWindowProcessor.cs
@@ -1,0 +1,51 @@
+namespace Whim;
+
+/// <summary>
+/// Custom logic to immediately minimize any "Meeting compact view" window from Teams.
+/// </summary>
+public class TeamsWindowProcessor : IWindowProcessor
+{
+	/// <inheritdoc />
+	public IWindow Window { get; }
+
+	private TeamsWindowProcessor(IWindow window)
+	{
+		Window = window;
+	}
+
+	/// <summary>
+	/// Creates a new instance of the implementing class, if the given window matches the processor.
+	/// </summary>
+	/// <param name="ctx"></param>
+	/// <param name="window"></param>
+	/// <returns></returns>
+	public static IWindowProcessor? Create(IContext ctx, IWindow window) =>
+		window.ProcessFileName == "ms-teams.exe" ? new TeamsWindowProcessor(window) : null;
+
+	/// <summary>
+	/// If the window title starts with "Meeting compact view", minimize the window.
+	/// Otherwise, process the event.
+	/// </summary>
+	/// <param name="eventType"></param>
+	/// <param name="idObject"></param>
+	/// <param name="idChild"></param>
+	/// <param name="idEventThread"></param>
+	/// <param name="dwmsEventTime"></param>
+	/// <returns></returns>
+	public WindowProcessorResult ProcessEvent(
+		uint eventType,
+		int idObject,
+		int idChild,
+		uint idEventThread,
+		uint dwmsEventTime
+	)
+	{
+		if (Window.Title.StartsWith("Meeting compact view"))
+		{
+			Window.ShowMinimized();
+			return WindowProcessorResult.Ignore;
+		}
+
+		return WindowProcessorResult.Process;
+	}
+}

--- a/src/Whim/Store/WindowSector/Processors/WindowProcessorManager.cs
+++ b/src/Whim/Store/WindowSector/Processors/WindowProcessorManager.cs
@@ -14,6 +14,7 @@ internal class WindowProcessorManager
 	{
 		_ctx = ctx;
 		_processorCreators.Add(FirefoxWindowProcessor.Create);
+		_processorCreators.Add(TeamsWindowProcessor.Create);
 	}
 
 	internal bool ShouldBeIgnored(


### PR DESCRIPTION
Teams will create a "compact" window whenever a meeting window loses visibility. The `TeamsWindowProcessor` will automatically minimize these "compact" windows.