### PR TITLE
Fix issues in Bug Issue Template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -25,7 +25,7 @@ body:
 
   - type: textarea
     attributes:
-      label: Config
+      label: C# Config
       description: A `whim.config.csx` that can be used to reproduce the issue.
       placeholder: |
         #r "WHIM_PATH\whim.dll"
@@ -41,7 +41,7 @@ body:
 
   - type: textarea
     attributes:
-      label: Config
+      label: YAML Config
       description: A `whim.config.yaml` that can be used to reproduce the issue.
       placeholder: |
         # yaml-language-server: $schema=WHIM_PATH\plugins\Whim.Yaml\schema.json


### PR DESCRIPTION
<!--
* Thanks for submitting a pull request.
* Before making this pull request, please make sure that there's a
* corresponding bug or feature request which can be associated with this Pull
* Request.
-->

- [x] This code is up-to-date with the `main` branch.
- [x] I have updated relevant (if any) areas in the docs.

This PR fixes #1113

There are two text area sections for the C# and YAML config files both labelled "Config" which produces a validation error for the issue template, causing it to be unavailable when opening issues.

This PR differentiates the labels for the C# and YAML config sections.
![image](https://github.com/user-attachments/assets/fa4ca1b3-b4c2-44f1-826c-61e56c8a4db5)
