### PR TITLE
Enforce keybind primary

### DIFF
--- a/src/Whim/Keybind/IKeybindManager.cs
+++ b/src/Whim/Keybind/IKeybindManager.cs
@@ -13,7 +13,7 @@ public interface IKeybindManager
 	/// Defaults to <c>true</c>.
 	/// </summary>
 	/// <remarks>
-	/// When this is set to <c>true</c>, all of the existing keybinds will be re-added in a unified
+	/// When this is set to <c>true</c>, all the existing keybinds will be re-added in a unified
 	/// form.
 	/// All new keybinds will also be unified.
 	/// </remarks>
@@ -22,7 +22,7 @@ public interface IKeybindManager
 	/// <summary>
 	/// All the modifiers which are currently being used.
 	/// </summary>
-	IEnumerable<VIRTUAL_KEY> Modifiers { get; }
+	IReadOnlyList<VIRTUAL_KEY> Modifiers { get; }
 
 	/// <summary>
 	/// Sets a keybind.

--- a/src/Whim/Keybind/KeybindManager.cs
+++ b/src/Whim/Keybind/KeybindManager.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using Windows.Win32.UI.Input.KeyboardAndMouse;
 
 namespace Whim;
@@ -24,8 +25,8 @@ internal class KeybindManager(IContext context) : IKeybindManager
 		}
 	}
 
-	private readonly HashSet<VIRTUAL_KEY> _modifiers = [];
-	public IEnumerable<VIRTUAL_KEY> Modifiers => _modifiers;
+	private VIRTUAL_KEY[] _modifiers = [];
+	public IReadOnlyList<VIRTUAL_KEY> Modifiers => _modifiers;
 
 	private void UnifyKeybinds()
 	{
@@ -57,7 +58,7 @@ internal class KeybindManager(IContext context) : IKeybindManager
 
 		value.Add(commandId);
 		_commandsKeybindsMap[commandId] = keybind;
-		_modifiers.UnionWith(keybind.Mods);
+		_modifiers = _modifiers.Union(keybind.Mods).ToArray();
 	}
 
 	public ICommand[] GetCommands(IKeybind keybind)
@@ -92,7 +93,7 @@ internal class KeybindManager(IContext context) : IKeybindManager
 	public IKeybind? TryGetKeybind(string commandId)
 	{
 		Logger.Debug($"Getting keybind for command '{commandId}'");
-		return _commandsKeybindsMap.TryGetValue(commandId, out IKeybind? keybind) ? keybind : null;
+		return _commandsKeybindsMap.GetValueOrDefault(commandId);
 	}
 
 	public bool Remove(string commandId)

--- a/src/Whim/Native/CoreNativeManager.cs
+++ b/src/Whim/Native/CoreNativeManager.cs
@@ -31,6 +31,16 @@ internal class CoreNativeManager(IContext context) : ICoreNativeManager
 
 	public short GetKeyState(int nVirtKey) => PInvoke.GetKeyState(nVirtKey);
 
+	public bool GetKeyboardState(byte[] lpKeyState)
+	{
+		if (lpKeyState.Length != 256)
+		{
+			throw new ArgumentException("lpKeyState must be 256 bytes long");
+		}
+
+		return PInvoke.GetKeyboardState(lpKeyState);
+	}
+
 	public BOOL GetCursorPos(out IPoint<int> lpPoint)
 	{
 		bool res = PInvoke.GetCursorPos(out Point point);

--- a/src/Whim/Native/ICoreNativeManager.cs
+++ b/src/Whim/Native/ICoreNativeManager.cs
@@ -63,6 +63,20 @@ internal interface ICoreNativeManager
 	short GetKeyState(int nVirtKey);
 
 	/// <summary>
+	/// Copies the status of the 256 virtual keys to the specified buffer. The status of each key is either 0 (up) or 1 (down).
+	/// </summary>
+	/// <param name="lpKeyState">
+	/// The buffer that receives the key state information. The buffer must be 256 bytes in size.
+	/// </param>
+	/// <returns>
+	/// <b>true</b> if the function succeeds; otherwise, <b>false</b>.
+	/// </returns>
+	/// <remarks>
+	/// For more, see https://learn.microsoft.com/windows/win32/api/winuser/nf-winuser-getkeystate
+	/// </remarks>
+	bool GetKeyboardState(byte[] lpKeyState);
+
+	/// <summary>
 	/// Set the <see cref="PInvoke.GetCursorPos(out System.Drawing.Point)"/> <br/>
 	///
 	/// For more, see https://docs.microsoft.com/windows/win32/api/winuser/nf-winuser-getcursorpos

--- a/src/Whim/NativeMethods.txt
+++ b/src/Whim/NativeMethods.txt
@@ -35,6 +35,7 @@ GetCursorPos
 GetDesktopWindow
 GetDpiForMonitor
 GetForegroundWindow
+GetKeyboardState
 GetKeyState
 GetMonitorInfo
 GetShellWindow


### PR DESCRIPTION
---

- This still isn't working - Windows still takes keybinds before Whim can complete processing.
- Disabling `DoKeyboardEvent` shows that commands are eaten immediately - I think this means that commands are too slow and Windows is bypassing the hook.
- [ ] Create a managed [`ThreadPool`](https://dev.to/theramoliya/threadpool-in-c-practical-examples-ak6) somewhere
  - [ ] Use the thread pool in the `KeybindHook` and `Store`