### PR TITLE
Remove obsolete code usage from command palette

### DIFF
--- a/src/Whim.CommandPalette.Tests/CommandPaletteCommandsTests.cs
+++ b/src/Whim.CommandPalette.Tests/CommandPaletteCommandsTests.cs
@@ -206,19 +206,26 @@ public class CommandPaletteCommandsTests
 		wrapper.Plugin.Received(1).Activate(Arg.Any<MenuVariantConfig>());
 	}
 
-	[Fact]
-	public void MoveWindowToWorkspaceCommandCreator()
+	[Theory, AutoSubstituteData<Customization>]
+	internal void MoveWindowToWorkspaceCommandCreator(
+		IContext ctx,
+		MutableRootSector root,
+		ICommandPalettePlugin plugin,
+		CommandPaletteCommands commands
+	)
 	{
 		// Given
-		Wrapper wrapper = new();
-		CommandPaletteCommands commands = new(wrapper.Context, wrapper.Plugin);
+		(_, IWorkspace otherWorkspace) = SetupWorkspaces(ctx, root, plugin);
 
 		// When
-		ICommand command = commands.MoveWindowToWorkspaceCommandCreator(wrapper.Workspace);
+		ICommand command = commands.MoveWindowToWorkspaceCommandCreator(otherWorkspace);
 		command.TryExecute();
 
 		// Verify that MoveWindowToWorkspace was called with the workspace.
-		wrapper.Context.Butler.Received(1).MoveWindowToWorkspace(wrapper.Workspace);
+		Assert.Contains(
+			ctx.GetTransforms(),
+			t => (t as MoveWindowToWorkspaceTransform) == new MoveWindowToWorkspaceTransform(otherWorkspace.Id)
+		);
 	}
 
 	[Fact]

--- a/src/Whim.CommandPalette.Tests/CommandPaletteCommandsTests.cs
+++ b/src/Whim.CommandPalette.Tests/CommandPaletteCommandsTests.cs
@@ -190,24 +190,8 @@ public class CommandPaletteCommandsTests
 		);
 	}
 
-	[Fact]
-	public void MoveWindowToWorkspaceCommand()
-	{
-		// Given
-		Wrapper wrapper = new();
-		ICommand command = new PluginCommandsTestUtils(wrapper.Commands).GetCommand(
-			"whim.command_palette.move_window_to_workspace"
-		);
-
-		// When
-		command.TryExecute();
-
-		// Verify that the plugin was menu activated.
-		wrapper.Plugin.Received(1).Activate(Arg.Any<MenuVariantConfig>());
-	}
-
 	[Theory, AutoSubstituteData<Customization>]
-	internal void MoveWindowToWorkspaceCommandCreator(
+	internal void MoveWindowToWorkspaceCommand(
 		IContext ctx,
 		MutableRootSector root,
 		ICommandPalettePlugin plugin,
@@ -215,11 +199,18 @@ public class CommandPaletteCommandsTests
 	)
 	{
 		// Given
-		(_, IWorkspace otherWorkspace) = SetupWorkspaces(ctx, root, plugin);
+		ICommand command = new PluginCommandsTestUtils(commands).GetCommand(
+			"whim.command_palette.move_window_to_workspace"
+		);
+		InterceptConfig<MenuVariantConfig> interceptor = InterceptConfig<MenuVariantConfig>.Create(plugin);
+		(IWorkspace activeWorkspace, IWorkspace otherWorkspace) = SetupWorkspaces(ctx, root, plugin);
 
 		// When
-		ICommand command = commands.MoveWindowToWorkspaceCommandCreator(otherWorkspace);
 		command.TryExecute();
+
+		// Call the callback.
+		ICommand moveWindowCommand = interceptor.Config!.Commands.First();
+		moveWindowCommand.TryExecute();
 
 		// Verify that MoveWindowToWorkspace was called with the workspace.
 		Assert.Contains(

--- a/src/Whim.CommandPalette/CommandPaletteCommands.cs
+++ b/src/Whim.CommandPalette/CommandPaletteCommands.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using Microsoft.UI.Xaml;
 using Windows.Win32.UI.Input.KeyboardAndMouse;
 
 namespace Whim.CommandPalette;
@@ -137,8 +136,9 @@ public class CommandPaletteCommands : PluginCommands
 						{
 							Hint = "Find window",
 							ConfirmButtonText = "Focus",
+
 							Commands = _ctx
-								.WorkspaceManager.SelectMany(w => w.Windows)
+								.Store.Pick(Pickers.PickAllWindows())
 								.Select(w => FocusWindowCommandCreator(w)),
 						}
 					)
@@ -255,16 +255,16 @@ public class CommandPaletteCommands : PluginCommands
 			title: window.Title,
 			callback: () =>
 			{
-				IWorkspace? workspace = _ctx.Butler.Pantry.GetWorkspaceForWindow(window);
+				IWorkspace? workspace = _ctx.Store.Pick(Pickers.PickWorkspaceByWindow(window.Handle)).ValueOrDefault;
 				if (workspace == null)
 				{
 					return;
 				}
 
-				if (_ctx.Butler.Pantry.GetMonitorForWorkspace(workspace) is null)
+				if (_ctx.Store.Pick(Pickers.PickMonitorByWorkspace(workspace.Id)).ValueOrDefault is null)
 				{
 					// The workspace is not active, and is not visible.
-					_ctx.Butler.Activate(workspace);
+					_ctx.Store.Dispatch(new ActivateWorkspaceTransform(workspace.Id));
 				}
 
 				FocusWindow(window);

--- a/src/Whim.CommandPalette/CommandPaletteCommands.cs
+++ b/src/Whim.CommandPalette/CommandPaletteCommands.cs
@@ -55,7 +55,7 @@ public class CommandPaletteCommands : PluginCommands
 					_commandPalettePlugin.Activate(
 						new FreeTextVariantConfig()
 						{
-							Callback = (name) => _ctx.WorkspaceManager.Add(name),
+							Callback = (name) => _ctx.Store.Dispatch(new AddWorkspaceTransform(name)),
 							Hint = "Enter new workspace name",
 							Prompt = "Create workspace",
 						}

--- a/src/Whim.CommandPalette/CommandPaletteCommands.cs
+++ b/src/Whim.CommandPalette/CommandPaletteCommands.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Windows.Win32.UI.Input.KeyboardAndMouse;
@@ -35,9 +36,14 @@ public class CommandPaletteCommands : PluginCommands
 					_commandPalettePlugin.Activate(
 						new FreeTextVariantConfig()
 						{
-							Callback = (text) => _ctx.WorkspaceManager.ActiveWorkspace.Name = text,
+							Callback = (text) =>
+							{
+								Guid activeWorkspaceId = _ctx.Store.Pick(Pickers.PickActiveWorkspaceId());
+								_ctx.Store.Dispatch(new SetWorkspaceNameTransform(activeWorkspaceId, text));
+							},
 							Hint = "Enter new workspace name",
-							InitialText = _ctx.WorkspaceManager.ActiveWorkspace.Name,
+
+							InitialText = _ctx.Store.Pick(Pickers.PickActiveWorkspace()).BackingName,
 							Prompt = "Rename workspace",
 						}
 					)

--- a/src/Whim.CommandPalette/CommandPaletteCommands.cs
+++ b/src/Whim.CommandPalette/CommandPaletteCommands.cs
@@ -179,20 +179,20 @@ public class CommandPaletteCommands : PluginCommands
 	public SelectOption[] CreateMoveWindowsToWorkspaceOptions()
 	{
 		// All the windows in all the workspaces.
-		IEnumerable<IWindow> windows = _ctx
-			.WorkspaceManager.Select(w => w.Windows)
-			.SelectMany(w => w)
-			.OrderBy(w => w.Title);
-
-		return windows
-			.Select(w => new SelectOption()
-			{
-				Id = $"{PluginName}.move_multiple_windows_to_workspace.{w.Title}",
-				Title = w.Title,
-				IsEnabled = true,
-				IsSelected = false,
-			})
-			.ToArray();
+		return
+		[
+			.. _ctx
+				.Store.Pick(Pickers.PickAllWindows())
+				.OrderBy(w => w.Title)
+				.Select(w => new SelectOption()
+				{
+					Id = $"{PluginName}.move_multiple_windows_to_workspace.{w.Title}",
+					Title = w.Title,
+					IsEnabled = true,
+					IsSelected = false,
+				}),
+		];
+		;
 	}
 
 	/// <summary>

--- a/src/Whim.CommandPalette/CommandPaletteCommands.cs
+++ b/src/Whim.CommandPalette/CommandPaletteCommands.cs
@@ -66,11 +66,11 @@ public class CommandPaletteCommands : PluginCommands
 				title: "Move window to workspace",
 				callback: () =>
 				{
-					IWorkspace activeWorkspace = _ctx.WorkspaceManager.ActiveWorkspace;
+					IWorkspace activeWorkspace = _ctx.Store.Pick(Pickers.PickActiveWorkspace());
 					List<ICommand> items = [];
-					foreach (IWorkspace workspace in _ctx.WorkspaceManager)
+					foreach (IWorkspace workspace in _ctx.Store.Pick(Pickers.PickWorkspaces()))
 					{
-						if (workspace != activeWorkspace)
+						if (workspace.Id != activeWorkspace.Id)
 						{
 							items.Add(MoveWindowToWorkspaceCommandCreator(workspace));
 						}

--- a/src/Whim.CommandPalette/CommandPaletteCommands.cs
+++ b/src/Whim.CommandPalette/CommandPaletteCommands.cs
@@ -220,9 +220,9 @@ public class CommandPaletteCommands : PluginCommands
 	/// <returns>The move window to workspace command.</returns>
 	internal ICommand MoveWindowToWorkspaceCommandCreator(IWorkspace workspace) =>
 		new Command(
-			identifier: $"{PluginName}.move_window_to_workspace.{workspace.Name}",
-			title: $"Move window to workspace \"{workspace.Name}\"",
-			callback: () => _ctx.Butler.MoveWindowToWorkspace(workspace)
+			identifier: $"{PluginName}.move_window_to_workspace.{workspace.BackingName}",
+			title: $"Move window to workspace \"{workspace.BackingName}\"",
+			callback: () => _ctx.Store.Dispatch(new MoveWindowToWorkspaceTransform(workspace.Id))
 		);
 
 	/// <summary>

--- a/src/Whim.CommandPalette/CommandPalettePlugin.cs
+++ b/src/Whim.CommandPalette/CommandPalettePlugin.cs
@@ -57,7 +57,7 @@ public class CommandPalettePlugin : ICommandPalettePlugin
 	{
 		_commandPaletteWindow?.Activate(
 			config: config ?? Config.ActivationConfig,
-			monitor: _context.MonitorManager.ActiveMonitor
+			monitor: _context.Store.Pick(Pickers.PickActiveMonitor())
 		);
 	}
 

--- a/src/Whim.CommandPalette/CommandPaletteWindow.xaml.cs
+++ b/src/Whim.CommandPalette/CommandPaletteWindow.xaml.cs
@@ -35,7 +35,8 @@ internal sealed partial class CommandPaletteWindow : Microsoft.UI.Xaml.Window, I
 	{
 		Logger.Debug("Hiding command palette");
 		_window.Hide();
-		_context.WorkspaceManager.ActiveWorkspace.FocusLastFocusedWindow();
+		Guid activeWorkspaceId = _context.Store.Pick(Pickers.PickActiveWorkspaceId());
+		_context.Store.Dispatch(new FocusWorkspaceTransform(activeWorkspaceId));
 	}
 
 	private void ViewModel_FocusTextBoxRequested(object? sender, EventArgs e)

--- a/src/Whim.CommandPalette/CommandPaletteWindowViewModel.cs
+++ b/src/Whim.CommandPalette/CommandPaletteWindowViewModel.cs
@@ -131,7 +131,7 @@ internal class CommandPaletteWindowViewModel : ICommandPaletteWindowViewModel
 		}
 
 		ActivationConfig = config;
-		Monitor = monitor ?? _context.MonitorManager.ActiveMonitor;
+		Monitor = monitor ?? _context.Store.Pick(Pickers.PickActiveMonitor());
 
 		ConfirmButtonText = ActivationConfig.ConfirmButtonText ?? "Confirm";
 		Text = ActivationConfig.InitialText ?? "";

--- a/src/Whim.TestUtils/Whim.TestUtils.csproj
+++ b/src/Whim.TestUtils/Whim.TestUtils.csproj
@@ -41,6 +41,7 @@
 	<ItemGroup>
 		<InternalsVisibleTo Include="Whim.Tests" />
 		<InternalsVisibleTo Include="Whim.Bar.Tests" />
+		<InternalsVisibleTo Include="Whim.CommandPalette.Tests" />
 		<InternalsVisibleTo Include="Whim.Gaps.Tests" />
 		<InternalsVisibleTo Include="Whim.FloatingWindow.Tests" />
 		<InternalsVisibleTo Include="Whim.LayoutPreview.Tests" />

--- a/src/Whim/Whim.csproj
+++ b/src/Whim/Whim.csproj
@@ -49,6 +49,7 @@
 	<ItemGroup>
 		<InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
 		<InternalsVisibleTo Include="Whim.Bar.Tests" />
+		<InternalsVisibleTo Include="Whim.CommandPalette.Tests" />
 		<InternalsVisibleTo Include="Whim.FloatingWindow.Tests" />
 		<InternalsVisibleTo Include="Whim.Gaps.Tests" />
 		<InternalsVisibleTo Include="Whim.LayoutPreview.Tests" />


### PR DESCRIPTION
Replaced all usage of obsolete methods and classes in the command palette with transforms and pickers.