### PR TITLE
Expose window processors to C# scripts

### DIFF
--- a/docs/intro/troubleshooting.md
+++ b/docs/intro/troubleshooting.md
@@ -6,6 +6,8 @@ Some applications are difficult to manage. Whim will try to manage them as best 
 
 To get around this, Whim has <xref:Whim.IWindowProcessor>s. These are used to tell Whim to ignore specific window messages (see [Event Constants](https://learn.microsoft.com/en-us/windows/win32/winauto/event-constants)). For example, the <xref:Whim.FirefoxWindowProcessor> ignores all events until the first [`EVENT_OBJECT_CLOAKED`](https://learn.microsoft.com/en-us/windows/win32/winauto/event-constants#:~:text=EVENT_OBJECT_CLOAKED) event is received. The <xref:Whim.TeamsWindowProcessor> automatically minimizes any compact mode windows.
 
+These can be added to the <xref:Whim.IWindowProcessorManager>, via the <xref:Whim.IContext>. For more, see the [`IContext`](../script/architecture/context.md) scripting documentation.
+
 ## Window launch locations
 
 Windows can launch windows in different locations. Additionally, interacting with some untracked windows like the Windows Taskbar can break focus tracking in Whim.

--- a/src/Whim.Tests/Store/WindowSector/Processors/WindowProcessorManagerTests.cs
+++ b/src/Whim.Tests/Store/WindowSector/Processors/WindowProcessorManagerTests.cs
@@ -12,7 +12,7 @@ public class WindowProcessorManagerTests
 		WindowProcessorManager sut = new(ctx);
 
 		// When ShouldBeIgnored is called
-		bool result = sut.ShouldBeIgnored(window, default, default, default, default, default, default);
+		bool result = sut.ShouldBeIgnored(window, default, default, default, default, default);
 
 		// Then the result should be false
 		Assert.False(result);
@@ -26,7 +26,7 @@ public class WindowProcessorManagerTests
 		WindowProcessorManager sut = new(ctx);
 
 		// When ShouldBeIgnored is called for the first time
-		bool result = sut.ShouldBeIgnored(window, default, default, default, default, default, default);
+		bool result = sut.ShouldBeIgnored(window, default, default, default, default, default);
 
 		// Then the result should be true
 		Assert.True(result);
@@ -40,8 +40,8 @@ public class WindowProcessorManagerTests
 		WindowProcessorManager sut = new(ctx);
 
 		// When ShouldBeIgnored is called for the second time
-		sut.ShouldBeIgnored(window, default, PInvoke.EVENT_OBJECT_CLOAKED, 0, 0, 0, 0);
-		bool result = sut.ShouldBeIgnored(window, default, 0, 0, 0, 0, 0);
+		sut.ShouldBeIgnored(window, PInvoke.EVENT_OBJECT_CLOAKED, 0, 0, 0, 0);
+		bool result = sut.ShouldBeIgnored(window, 0, 0, 0, 0, 0);
 
 		// Then the processor should have been created by the second call, and the window should not be ignored
 		Assert.False(result);
@@ -55,9 +55,9 @@ public class WindowProcessorManagerTests
 		WindowProcessorManager sut = new(ctx);
 
 		// When ShouldBeIgnored is called for the second time
-		sut.ShouldBeIgnored(window, default, PInvoke.EVENT_OBJECT_CLOAKED, 0, 0, 0, 0);
-		bool firstProcessorResult = sut.ShouldBeIgnored(window, default, PInvoke.EVENT_OBJECT_DESTROY, 0, 0, 0, 0);
-		bool secondProcessorResult = sut.ShouldBeIgnored(window, default, 0, 0, 0, 0, 0);
+		sut.ShouldBeIgnored(window, PInvoke.EVENT_OBJECT_CLOAKED, 0, 0, 0, 0);
+		bool firstProcessorResult = sut.ShouldBeIgnored(window, PInvoke.EVENT_OBJECT_DESTROY, 0, 0, 0, 0);
+		bool secondProcessorResult = sut.ShouldBeIgnored(window, 0, 0, 0, 0, 0);
 
 		// Then the processor should have been removed by the second call, and the window should be ignored in the next call
 		Assert.False(firstProcessorResult);
@@ -72,7 +72,7 @@ public class WindowProcessorManagerTests
 		WindowProcessorManager sut = new(ctx);
 
 		// When ShouldBeIgnored is called with a ProcessAndRemove result
-		bool result = sut.ShouldBeIgnored(window, default, PInvoke.EVENT_OBJECT_LOCATIONCHANGE, 0, 0, 0, 0);
+		bool result = sut.ShouldBeIgnored(window, PInvoke.EVENT_OBJECT_LOCATIONCHANGE, 0, 0, 0, 0);
 
 		// Then the result should be true, and a LayoutAllActiveWorkspacesTransform should be dispatched
 		Assert.True(result);

--- a/src/Whim/Context/Context.cs
+++ b/src/Whim/Context/Context.cs
@@ -29,6 +29,8 @@ internal class Context : IContext
 
 	public IStore Store { get; }
 
+	public IWindowProcessorManager WindowProcessorManager { get; }
+
 	public event EventHandler<ExitEventArgs>? Exiting;
 	public event EventHandler<ExitEventArgs>? Exited;
 
@@ -55,6 +57,7 @@ internal class Context : IContext
 		PluginManager = new PluginManager(this, _commandManager);
 		KeybindManager = new KeybindManager(this);
 		NotificationManager = new NotificationManager(this);
+		WindowProcessorManager = new WindowProcessorManager(this);
 	}
 
 	public void Initialize()

--- a/src/Whim/Context/IContext.cs
+++ b/src/Whim/Context/IContext.cs
@@ -63,6 +63,9 @@ public interface IContext
 	/// <inheritdoc cref="IStore" />
 	IStore Store { get; }
 
+	/// <inheritdoc cref="IWindowProcessorManager" />
+	IWindowProcessorManager WindowProcessorManager { get; }
+
 	/// <summary>
 	/// This will be called by the Whim Runner.
 	/// You likely won't need to call it yourself.

--- a/src/Whim/Store/WindowSector/Processors/FirefoxWindowProcessor.cs
+++ b/src/Whim/Store/WindowSector/Processors/FirefoxWindowProcessor.cs
@@ -7,6 +7,12 @@ namespace Whim;
 /// </summary>
 public class FirefoxWindowProcessor : IWindowProcessor
 {
+	/// <summary>
+	/// Unique identifier for the Firefox window processor.
+	/// This is used to identify the processor in the <see cref="IWindowProcessorManager"/>.
+	/// </summary>
+	public static string Id => "firefox";
+
 	private readonly IContext _ctx;
 	private readonly int _startTime;
 	private bool _hasExceededStartTime;

--- a/src/Whim/Store/WindowSector/Processors/IWindowProcessor.cs
+++ b/src/Whim/Store/WindowSector/Processors/IWindowProcessor.cs
@@ -5,12 +5,18 @@ namespace Whim;
 /// For example, Firefox will try reset the window position on startup. The <see cref="FirefoxWindowProcessor"/>
 /// will ignore these events.
 /// </summary>
+/// <remarks>
+/// Window processors are expected to implement a method which accepts an <see cref="IContext"/> and an <see cref="IWindow"/>.
+/// If the window matches the processor, it should return an instance of the processor.
+/// Otherwise, it should return null.
+/// The processor will then be used to handle events for that window.
+/// </remarks>
 public interface IWindowProcessor
 {
 	/// <summary>
 	/// The window that this processor is for.
 	/// </summary>
-	public IWindow Window { get; }
+	IWindow Window { get; }
 
 	/// <summary>
 	/// Processes the given event.
@@ -25,7 +31,7 @@ public interface IWindowProcessor
 	/// <returns>
 	/// Whether the event should be ignored by Whim.
 	/// </returns>
-	public abstract WindowProcessorResult ProcessEvent(
+	WindowProcessorResult ProcessEvent(
 		uint eventType,
 		int idObject,
 		int idChild,

--- a/src/Whim/Store/WindowSector/Processors/IWindowProcessorManager.cs
+++ b/src/Whim/Store/WindowSector/Processors/IWindowProcessorManager.cs
@@ -1,0 +1,35 @@
+namespace Whim;
+
+/// <summary>
+/// The container for custom window processors.
+/// These are used to handle windows with non-standard behavior.
+/// For example, Firefox will try reset the window position on startup. The <see cref="FirefoxWindowProcessor"/>
+/// will ignore these events.
+/// </summary>
+public interface IWindowProcessorManager
+{
+	/// <summary>
+	/// All the processors that are currently registered.
+	/// By default, this will contain the <see cref="FirefoxWindowProcessor"/> and the <see cref="TeamsWindowProcessor"/>.
+	/// </summary>
+	IDictionary<string, Func<IContext, IWindow, IWindowProcessor?>> ProcessorCreators { get; }
+
+	/// <summary>
+	/// Checks if the given window should be ignored by Whim.
+	/// </summary>
+	/// <param name="window">The window to check.</param>
+	/// <param name="eventType">The event type.</param>
+	/// <param name="idObject">The object ID.</param>
+	/// <param name="idChild">The child ID.</param>
+	/// <param name="idEventThread">The event thread ID.</param>
+	/// <param name="dwmsEventTime">The event time.</param>
+	/// <returns>True if the window should be ignored; otherwise, false.</returns>
+	bool ShouldBeIgnored(
+		IWindow window,
+		uint eventType,
+		int idObject,
+		int idChild,
+		uint idEventThread,
+		uint dwmsEventTime
+	);
+}

--- a/src/Whim/Store/WindowSector/Processors/TeamsWindowProcessor.cs
+++ b/src/Whim/Store/WindowSector/Processors/TeamsWindowProcessor.cs
@@ -5,6 +5,12 @@ namespace Whim;
 /// </summary>
 public class TeamsWindowProcessor : IWindowProcessor
 {
+	/// <summary>
+	/// Unique identifier for the Teams window processor.
+	/// This is used to identify the processor in the <see cref="IWindowProcessorManager"/>.
+	/// </summary>
+	public static string Id => "teams";
+
 	/// <inheritdoc />
 	public IWindow Window { get; }
 

--- a/src/Whim/Store/WindowSector/WindowEventListener.cs
+++ b/src/Whim/Store/WindowSector/WindowEventListener.cs
@@ -20,14 +20,11 @@ internal class WindowEventListener : IDisposable
 	/// </summary>
 	private readonly WINEVENTPROC _hookDelegate;
 
-	private readonly WindowProcessorManager _processorManager;
-
 	public WindowEventListener(IContext ctx, IInternalContext internalCtx)
 	{
 		_ctx = ctx;
 		_internalCtx = internalCtx;
 		_hookDelegate = new WINEVENTPROC(WinEventProcWrapper);
-		_processorManager = new WindowProcessorManager(ctx);
 	}
 
 	public void Initialize()
@@ -136,9 +133,8 @@ internal class WindowEventListener : IDisposable
 		}
 
 		if (
-			_processorManager.ShouldBeIgnored(
+			_ctx.WindowProcessorManager.ShouldBeIgnored(
 				window,
-				_hWinEventHook,
 				eventType,
 				idObject,
 				idChild,


### PR DESCRIPTION
Expose the `IWindowProcessorManager` through the `IContext`, to allow customization through scripting.

`IWindowProcessor`s have a static `Id` string field which is used to identify them. This can be used to add or remove them from the `IWindowProcessorManager.ProcessorCreators` dictionary.
