### PR TITLE
Slice plugin: redraw on window minimized event

### DIFF
--- a/src/Whim.SliceLayout/SliceLayoutPlugin.cs
+++ b/src/Whim.SliceLayout/SliceLayoutPlugin.cs
@@ -35,7 +35,16 @@ public class SliceLayoutPlugin(IContext context) : ISliceLayoutPlugin
 	public WindowInsertionType WindowInsertionType { get; set; }
 
 	/// <inheritdoc />
-	public void PreInitialize() { }
+	public void PreInitialize()
+	{
+		_context.Store.WindowEvents.WindowMinimizeStarted += WindowEvents_WindowMinimizeStarted;
+	}
+
+	private void WindowEvents_WindowMinimizeStarted(object? sender, WindowEventArgs e)
+	{
+		System.Guid workspaceId = _context.Store.Pick(Pickers.PickActiveWorkspaceId());
+		_context.Store.Dispatch(new DoWorkspaceLayoutTransform(workspaceId));
+	}
 
 	/// <inheritdoc />
 	public void PostInitialize() { }


### PR DESCRIPTION
closes issue #1175

<!--
* Thanks for submitting a pull request.
* Before making this pull request, please make sure that there's a
* corresponding bug or feature request which can be associated with this Pull
* Request.
-->

- [x] This code is up-to-date with the `main` branch.
- [x] I have updated relevant (if any) areas in the docs.

This PR fixes #1175

In slice layouts, listen for and redraw on window minimized event.
